### PR TITLE
Bumping the rocm version used for build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@
 parallel rocm_fiji: {
 
   currentBuild.result = "SUCCESS"
-  node('rocm-1.5&& fiji')
+  node('rocm-1.6 && fiji')
   {
     def scm_dir = pwd()
     def build_dir_debug = "${scm_dir}/test/debug"


### PR DESCRIPTION
ROCm v1.6 has been released, test & build on the latest
runtime as the kernels for all the build machines have
already been upgraded