### PR TITLE
modify .yaml files for different devices and architectures

### DIFF
--- a/Tensile/Configs/rocblas_sgemm_asm_single_kernel.yaml
+++ b/Tensile/Configs/rocblas_sgemm_asm_single_kernel.yaml
@@ -60,3 +60,6 @@ BenchmarkProblems:
 
   ########################################
 
+LibraryLogic:
+
+LibraryClient:

--- a/Tensile/KernelWriterSource.py
+++ b/Tensile/KernelWriterSource.py
@@ -2016,6 +2016,7 @@ class KernelWriterSource(KernelWriter):
       kStr += "#undef GLOBAL_LOAD_VECTOR_WIDTH_A%s" % (self.endLine)
       kStr += "#undef GLOBAL_LOAD_VECTOR_WIDTH_B%s" % (self.endLine)
       kStr += "#undef GLOBAL_WRITE_VECTOR_WIDTH%s" % (self.endLine)
+      kStr += "#undef MAC%s" % (self.endLine)
       kStr += "#undef TYPE_MAC%s" % (self.endLine)
       kStr += "#undef TYPE_MAC_WRITE%s" % (self.endLine)
       kStr += "#undef GLOBAL_SPLITU%s" % (self.endLine)

--- a/Tensile/Source/CMakeLists.txt
+++ b/Tensile/Source/CMakeLists.txt
@@ -56,8 +56,6 @@ else()
   message(STATUS "Making LibraryClient")
   option( Tensile_SHORT_FILE_NAMES "Use short file names (for MSVC)" OFF)
   option( Tensile_LIBRARY_PRINT_DEBUG "TensileLib to print debug info" OFF)
-  #set( Tensile_ISA gfx803;gfx900 CACHE STRING "List of gpu architectures to target" )
-  set( Tensile_ISA gfx900 CACHE STRING "List of gpu architectures to target" ) # hgemm doesn't work on 803 b/c packed instructions
   add_executable( ${ClientName}
     Client.cpp
     MathTemplates.cpp
@@ -119,7 +117,6 @@ if(NOT Tensile_CLIENT_BENCHMARK)
   TensileCreateLibrary(
     ${Tensile_LOGIC_PATH}           # path
     ${Tensile_RUNTIME_LANGUAGE}     # OCL or HIP
-    "${Tensile_ISA}"     # gfx803;gfx900;...
     ${Tensile_MERGE_FILES}          # ON or OFF
     ${Tensile_SHORT_FILE_NAMES}     # ON or OFF
     ${Tensile_LIBRARY_PRINT_DEBUG}  # ON or OFF

--- a/Tensile/Source/TensileConfig.cmake
+++ b/Tensile/Source/TensileConfig.cmake
@@ -27,7 +27,6 @@ include(CMakeParseArguments)
 function(TensileCreateLibrary
     Tensile_LOGIC_PATH
     Tensile_RUNTIME_LANGUAGE
-    Tensile_ISA
     Tensile_MERGE_FILES
     Tensile_SHORT_FILE_NAMES
     Tensile_LIBRARY_PRINT_DEBUG )
@@ -67,11 +66,6 @@ function(TensileCreateLibrary
     set(Tensile_CREATE_COMMAND ${Tensile_CREATE_COMMAND} "--no-library-print-debug")
   endif()
 
-  foreach( target ${Tensile_ISA} )
-    set(Tensile_CREATE_COMMAND ${Tensile_CREATE_COMMAND} "--isa;${target}")
-  endforeach()
-
-
   # TensileLibraryWriter positional arguments
   set(Tensile_CREATE_COMMAND ${Tensile_CREATE_COMMAND}
     ${Tensile_LOGIC_PATH}
@@ -109,7 +103,8 @@ function(TensileCreateLibrary
   set(options)
   add_library(Tensile ${options} ${Tensile_SOURCE_FILES})
   # specify gpu targets
-  foreach( target ${Tensile_ISA} )
+  set(Tensile_HIP_ISA "gfx803" "gfx900")
+  foreach( target ${Tensile_HIP_ISA} )
     target_link_libraries( Tensile PRIVATE --amdgpu-target=${target} )
   endforeach()
   if( Tensile_MERGE_FILES )

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -373,37 +373,57 @@ def writeLogic(outputPath, logicData, solutionWriter ):
             ",\n" if i < len(argListStream)-1 else ") {\n")
 
       # choose from schedules based on device name
+#     print logicData
       schedules = logicData[problemType]
       numSchedules = len(schedules)
       if numSchedules > 1:
+
+        reordered_schedules = []
+        for scheduleIdx in range(0, numSchedules):
+          schedule = schedules[scheduleIdx]
+          deviceNames = schedule[1]
+          if deviceNames != ["fallback"]:
+            reordered_schedules.append(schedule)
+        for scheduleIdx in range(0, numSchedules):
+          schedule = schedules[scheduleIdx]
+          deviceNames = schedule[1]
+          if deviceNames == ["fallback"]:
+            reordered_schedules.append(schedule)
 
         # get device name
         if globalParameters["RuntimeLanguage"] == "OCL":
           s += "get device name opencl;\n"
         else:
-          s += "get device name hip;\n"
+          s += "\n//  get device name hip;\n"
+          s += "    int deviceId;\n"
+          s += "    hipCtxGetDevice(&deviceId);\n"
+          s += "    hipDeviceProp_t deviceProperties;\n"
+          s += "    hipGetDeviceProperties(&deviceProperties, deviceId);\n"
+          s += "    std::string name = deviceProperties.name;\n"
 
+        s += "\n    "
         for scheduleIdx in range(0, numSchedules):
-          schedule = schedules[scheduleIdx]
+          schedule = reordered_schedules[scheduleIdx]
+          scheduleName  = schedule[0]
           deviceNames = schedule[1]
           if scheduleIdx > 0:
-            s += "else "
+            s += "    else "
           if scheduleIdx < numSchedules-1:
             s += "if ("
             for deviceNameIdx in range(0, len(deviceNames)):
               deviceName = deviceNames[deviceNameIdx]
               if deviceNameIdx > 0:
                 s += " && "
-                s += "name == \"%s\"" % deviceName
+              s += "name == \"%s\"" % deviceName
             s += ")"
-          s += "{"
-          s += "  return tensileGetSolution%s_%s_%s(" \
+          s += "{\n"
+          s += "        return tensileGetSolution%s_%s_%s(" \
               % ( returnType, scheduleName, problemType)
           for i in range(0, len(argListSizes)):
             s += "%s%s" \
                 % (argListSizes[i][1],
                     ", " if i < len(argListSizes)-1 else ");\n")
-            s += "}"
+          s += "    }\n"
       else: # == 1
         schedule = schedules[0]
         scheduleName = schedule[0]

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -717,8 +717,6 @@ def TensileCreateLibrary():
       action="store_true")
   argParser.add_argument("--no-library-print-debug", dest="LibraryPrintDebug", \
       action="store_false")
-  argParser.add_argument("--isa", dest="isa", action="append",
-      help="which architectures for assembly kernels to target" )
   args = argParser.parse_args()
 
   logicPath = args.LogicPath
@@ -730,21 +728,6 @@ def TensileCreateLibrary():
   arguments["MergeFiles"] = args.MergeFiles
   arguments["ShortNames"] = args.ShortNames
   arguments["LibraryPrintDebug"] = args.LibraryPrintDebug
-  if args.isa:
-    newISA = []
-    for isa in args.isa:
-      gfxIdx = isa.find("gfx")
-      if gfxIdx >= 0:
-        major = int(isa[gfxIdx+3:gfxIdx+4])
-        minor = int(isa[gfxIdx+4:gfxIdx+5])
-        step  = int(isa[gfxIdx+5:gfxIdx+6])
-        isaTuple = (major,minor,step)
-        if isaTuple in globalParameters["SupportedISA"] and isaTuple not in newISA:
-          print1("# User-Specified ISA: gfx%u%u%u" % (major,minor,step))
-          newISA.append(isaTuple)
-      else:
-        printWarning("isa parameter must be formed as: --isa gfx803")
-    arguments["SupportedISA"] = newISA
   assignGlobalParameters(arguments)
 
   if not os.path.exists(logicPath):
@@ -789,19 +772,6 @@ def TensileCreateLibrary():
         kernelsBetaOnly.append(kernel)
 
   # if any kernels are assembly, append every ISA supported
-  if globalParameters["RuntimeLanguage"] == "HIP":
-    newKernels = []
-    for kernel in kernels:
-      if kernel["KernelLanguage"] == "Assembly":
-        kernel["ISA"] = globalParameters["SupportedISA"][0]
-        for i in range(1, len(globalParameters["SupportedISA"])):
-          newKernel = deepcopy(kernel)
-          newKernel["ISA"] = globalParameters["SupportedISA"][i]
-          newKernels.append(newKernel)
-      else:
-        kernel["ISA"] = (0,0,0)
-    kernels.extend(newKernels)
-
 
   if globalParameters["ShortNames"] and not globalParameters["MergeFiles"]:
     solutionSerialNaming = Solution.getSerialNaming(solutions)

--- a/Tensile/YAMLIO.py
+++ b/Tensile/YAMLIO.py
@@ -125,6 +125,8 @@ def writeLibraryLogicForSchedule( filePath, schedulePrefix, deviceNames, \
   data.append({"MinimumRequiredVersion":__version__})
   # schedule name
   data.append(schedulePrefix)
+  architectureName = "gfx000"
+  data.append(architectureName)
   # schedule device names
   data.append(deviceNames)
   # problem type
@@ -180,12 +182,13 @@ def readLibraryLogicForSchedule( filename ):
   # parse out objects
   versionString     = data[0]["MinimumRequiredVersion"]
   scheduleName      = data[1]
-  deviceNames       = data[2]
-  problemTypeState  = data[3]
-  solutionStates    = data[4]
-  indexOrder        = data[5]
-  exactLogic        = data[6]
-  rangeLogic        = data[7]
+  architectureName  = data[2]
+  deviceNames       = data[3]
+  problemTypeState  = data[4]
+  solutionStates    = data[5]
+  indexOrder        = data[6]
+  exactLogic        = data[7]
+  rangeLogic        = data[8]
 
   # does version match
   if not versionIsCompatible(versionString):
@@ -198,6 +201,13 @@ def readLibraryLogicForSchedule( filename ):
   solutions = []
   for i in range(0, len(solutionStates)):
     solutionState = solutionStates[i]
+    if solutionState["KernelLanguage"] == "Assembly":
+      isa0 = int(architectureName[3])
+      isa1 = int(architectureName[4])
+      isa2 = int(architectureName[5])
+      solutionState["ISA"] = (isa0, isa1, isa2)
+    else:
+      solutionState["ISA"] = (0, 0, 0)
     solutionObject = Solution(solutionState)
     if solutionObject["ProblemType"] != problemType:
       printExit("ProblemType of file doesn't match solution: %s != %s" \


### PR DESCRIPTION
Select kernel based on device on which executable is running.
* There are library .yaml files for vega10, mi25, r9nano, and fallback.
* These contain tuning information of the name device.
* For vega10, mi25 and r9nano assembly code is used where possible.
* When Tensile.a is built (for standalone Tensile, or for inclusion in rocBLAS), it will contain kernels for these devices.
* The library .yaml file for the fallback device builds kernels from source code.
* The fallback kernels are designed to run on any device.
* Source code is also used for hgemm on r9nano since gfx803 does not contain the instructions used in the hgemm assembly code.
