### PR TITLE
Solution selection for multiple devices and architectures

### DIFF
--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -347,8 +347,8 @@ defaultBenchmarkFinalProblemSizes = [{"Range": [
 ################################################################################
 defaultAnalysisParameters = {
     "ScheduleName":       "Tensile",
-    "DeviceNames":  ["Unspecified"],
-    #"BranchPenalty":              0, # microseconds / kernel
+    "DeviceNames":  "fallback",
+    "ArchitectureName": "gfx000",
     "SolutionImportanceMin":      0.01, # = 0.01=1% total time saved by keeping this solution
     }
 

--- a/Tensile/Configs/rocblas_cgemm.yaml
+++ b/Tensile/Configs/rocblas_cgemm.yaml
@@ -176,5 +176,20 @@ BenchmarkProblems:
           - Range: [ [32, 32, 32, 400], [32, 32, 32, 400], [2], [1536] ]
 
 LibraryLogic:
+    ScheduleName: "vega10"
+    DeviceNames: ["Device 6863", "Device 6862"]
+    ArchitectureName: "gfx900"
+
+#   ScheduleName: "mi25"
+#   DeviceNames: ["Device 6860"]
+#   ArchitectureName: "gfx900"
+
+#   ScheduleName: "r9nano"
+#   DeviceNames: ["Device 7300"]
+#   ArchitectureName: "gfx803"
+
+#   ScheduleName: "hip"
+#   DeviceNames: ["Device 0000"]
+#   ArchitectureName: "fallback"
 
 LibraryClient:

--- a/Tensile/Configs/rocblas_dgemm_asm_lite.yaml
+++ b/Tensile/Configs/rocblas_dgemm_asm_lite.yaml
@@ -262,5 +262,20 @@ BenchmarkProblems:
           - Range: [ [64], [1], [1], [64] ]
 
 LibraryLogic:
+    ScheduleName: "vega10"
+    DeviceNames: ["Device 6863", "Device 6862"]
+    ArchitectureName: "gfx900"
+
+#   ScheduleName: "mi25"
+#   DeviceNames: ["Device 6860"]
+#   ArchitectureName: "gfx900"
+
+#   ScheduleName: "r9nano"
+#   DeviceNames: ["Device 7300"]
+#   ArchitectureName: "gfx803"
+
+#   ScheduleName: "hip"
+#   DeviceNames: ["Device 0000"]
+#   ArchitectureName: "fallback"
 
 LibraryClient:

--- a/Tensile/Configs/rocblas_dgemm_hip_lite.yaml
+++ b/Tensile/Configs/rocblas_dgemm_hip_lite.yaml
@@ -162,5 +162,20 @@ BenchmarkProblems:
           - Range: [ [64], [64], [2], [64] ]
 
 LibraryLogic:
+#   ScheduleName: "vega10"
+#   DeviceNames: ["Device 6863", "Device 6862"]
+#   ArchitectureName: "gfx900"
+
+#   ScheduleName: "mi25"
+#   DeviceNames: ["Device 6860"]
+#   ArchitectureName: "gfx900"
+
+#   ScheduleName: "r9nano"
+#   DeviceNames: ["Device 7300"]
+#   ArchitectureName: "gfx803"
+
+    ScheduleName: "hip"
+    DeviceNames: ["Device 0000"]
+    ArchitectureName: "fallback"
 
 LibraryClient:

--- a/Tensile/Configs/rocblas_hgemm_asm_lite.yaml
+++ b/Tensile/Configs/rocblas_hgemm_asm_lite.yaml
@@ -303,5 +303,20 @@ BenchmarkProblems:
 
 
 LibraryLogic:
+    ScheduleName: "vega10"
+    DeviceNames: ["Device 6863", "Device 6862"]
+    ArchitectureName: "gfx900"
+
+#   ScheduleName: "mi25"
+#   DeviceNames: ["Device 6860"]
+#   ArchitectureName: "gfx900"
+
+#   ScheduleName: "r9nano"
+#   DeviceNames: ["Device 7300"]
+#   ArchitectureName: "gfx803"
+
+#   ScheduleName: "hip"
+#   DeviceNames: ["Device 0000"]
+#   ArchitectureName: "fallback"
 
 LibraryClient:

--- a/Tensile/Configs/rocblas_hgemm_hip_lite.yaml
+++ b/Tensile/Configs/rocblas_hgemm_hip_lite.yaml
@@ -156,5 +156,20 @@ BenchmarkProblems:
           - Range: [ [5504], 0, [1], 0 ]
 
 LibraryLogic:
+#   ScheduleName: "vega10"
+#   DeviceNames: ["Device 6863", "Device 6862"]
+#   ArchitectureName: "gfx900"
+
+#   ScheduleName: "mi25"
+#   DeviceNames: ["Device 6860"]
+#   ArchitectureName: "gfx900"
+
+#   ScheduleName: "r9nano"
+#   DeviceNames: ["Device 7300"]
+#   ArchitectureName: "gfx803"
+
+    ScheduleName: "hip"
+    DeviceNames: ["Device 0000"]
+    ArchitectureName: "fallback"
 
 LibraryClient:

--- a/Tensile/Configs/rocblas_sgemm_asm_full.yaml
+++ b/Tensile/Configs/rocblas_sgemm_asm_full.yaml
@@ -950,5 +950,20 @@ BenchmarkProblems:
           - Range: [ [64, 64, 64, 7000], [4], [1], [3104] ] # skinny-1
 
 LibraryLogic:
+    ScheduleName: "vega10"
+    DeviceNames: ["Device 6863", "Device 6862"]
+    ArchitectureName: "gfx900"
+
+#   ScheduleName: "mi25"
+#   DeviceNames: ["Device 6860"]
+#   ArchitectureName: "gfx900"
+
+#   ScheduleName: "r9nano"
+#   DeviceNames: ["Device 7300"]
+#   ArchitectureName: "gfx803"
+
+#   ScheduleName: "hip"
+#   DeviceNames: ["Device 0000"]
+#   ArchitectureName: "fallback"
 
 LibraryClient:

--- a/Tensile/Configs/rocblas_sgemm_asm_lite.yaml
+++ b/Tensile/Configs/rocblas_sgemm_asm_lite.yaml
@@ -314,5 +314,20 @@ BenchmarkProblems:
 
 
 LibraryLogic:
+    ScheduleName: "vega10"
+    DeviceNames: ["Device 6863", "Device 6862"]
+    ArchitectureName: "gfx900"
+
+#   ScheduleName: "mi25"
+#   DeviceNames: ["Device 6860"]
+#   ArchitectureName: "gfx900"
+
+#   ScheduleName: "r9nano"
+#   DeviceNames: ["Device 7300"]
+#   ArchitectureName: "gfx803"
+
+#   ScheduleName: "hip"
+#   DeviceNames: ["Device 0000"]
+#   ArchitectureName: "fallback"
 
 LibraryClient:

--- a/Tensile/Configs/rocblas_sgemm_asm_single_kernel.yaml
+++ b/Tensile/Configs/rocblas_sgemm_asm_single_kernel.yaml
@@ -59,7 +59,3 @@ BenchmarkProblems:
           - Range: [ [5760], [5760], [1], [5760] ]
 
   ########################################
-
-LibraryLogic:
-
-LibraryClient:

--- a/Tensile/Configs/rocblas_sgemm_asm_single_kernel.yaml
+++ b/Tensile/Configs/rocblas_sgemm_asm_single_kernel.yaml
@@ -60,3 +60,6 @@ BenchmarkProblems:
 
   ########################################
 
+LibraryLogic:
+
+LibraryClient:

--- a/Tensile/Configs/rocblas_sgemm_hip_lite.yaml
+++ b/Tensile/Configs/rocblas_sgemm_hip_lite.yaml
@@ -177,5 +177,20 @@ BenchmarkProblems:
           - Range: [ [5504], 0, [1], 0 ]
 
 LibraryLogic:
+#   ScheduleName: "vega10"
+#   DeviceNames: ["Device 6863", "Device 6862"]
+#   ArchitectureName: "gfx900"
+
+#   ScheduleName: "mi25"
+#   DeviceNames: ["Device 6860"]
+#   ArchitectureName: "gfx900"
+
+#   ScheduleName: "r9nano"
+#   DeviceNames: ["Device 7300"]
+#   ArchitectureName: "gfx803"
+
+    ScheduleName: "hip"
+    DeviceNames: ["Device 0000"]
+    ArchitectureName: "fallback"
 
 LibraryClient:

--- a/Tensile/Configs/rocblas_zgemm.yaml
+++ b/Tensile/Configs/rocblas_zgemm.yaml
@@ -176,5 +176,20 @@ BenchmarkProblems:
           - Range: [ [32, 32, 32, 2000], [32, 32, 32, 2000], [2], [1536] ]
 
 LibraryLogic:
+    ScheduleName: "vega10"
+    DeviceNames: ["Device 6863", "Device 6862"]
+    ArchitectureName: "gfx900"
+
+#   ScheduleName: "mi25"
+#   DeviceNames: ["Device 6860"]
+#   ArchitectureName: "gfx900"
+
+#   ScheduleName: "r9nano"
+#   DeviceNames: ["Device 7300"]
+#   ArchitectureName: "gfx803"
+
+#   ScheduleName: "hip"
+#   DeviceNames: ["Device 0000"]
+#   ArchitectureName: "fallback"
 
 LibraryClient:

--- a/Tensile/Configs/test_convolution.yaml
+++ b/Tensile/Configs/test_convolution.yaml
@@ -53,5 +53,20 @@ BenchmarkProblems:
           - Range: [ [63,1,65], [2,1,3], [63,1,65], [2,1,3], [2,1,3], [2,1,3], [15,1,17] ]
 
 LibraryLogic:
+    ScheduleName: "vega10"
+    DeviceNames: ["Device 6863", "Device 6862"]
+    ArchitectureName: "gfx900"
+
+#   ScheduleName: "mi25"
+#   DeviceNames: ["Device 6860"]
+#   ArchitectureName: "gfx900"
+
+#   ScheduleName: "r9nano"
+#   DeviceNames: ["Device 7300"]
+#   ArchitectureName: "gfx803"
+
+#   ScheduleName: "hip"
+#   DeviceNames: ["Device 0000"]
+#   ArchitectureName: "fallback"
 
 LibraryClient:

--- a/Tensile/Configs/test_dgemm_asm.yaml
+++ b/Tensile/Configs/test_dgemm_asm.yaml
@@ -266,5 +266,21 @@ BenchmarkProblems:
           - Range: [ [127,1,129], 0, [2], [63,1,65] ]
 
 LibraryLogic:
-  SolutionImportanceMin: 0
+    SolutionImportanceMin: 0
+
+    ScheduleName: "vega10"
+    DeviceNames: ["Device 6863", "Device 6862"]
+    ArchitectureName: "gfx900"
+
+#   ScheduleName: "mi25"
+#   DeviceNames: ["Device 6860"]
+#   ArchitectureName: "gfx900"
+
+#   ScheduleName: "r9nano"
+#   DeviceNames: ["Device 7300"]
+#   ArchitectureName: "gfx803"
+
+#   ScheduleName: "hip"
+#   DeviceNames: ["Device 0000"]
+#   ArchitectureName: "fallback"
 LibraryClient:

--- a/Tensile/Configs/test_dgemm_defaults.yaml
+++ b/Tensile/Configs/test_dgemm_defaults.yaml
@@ -31,3 +31,19 @@ BenchmarkProblems:
       TransposeB: True
       UseBeta: True
 
+LibraryLogic:
+    ScheduleName: "vega10"
+    DeviceNames: ["Device 6863", "Device 6862"]
+    ArchitectureName: "gfx900"
+
+#   ScheduleName: "mi25"
+#   DeviceNames: ["Device 6860"]
+#   ArchitectureName: "gfx900"
+
+#   ScheduleName: "r9nano"
+#   DeviceNames: ["Device 7300"]
+#   ArchitectureName: "gfx803"
+
+#   ScheduleName: "hip"
+#   DeviceNames: ["Device 0000"]
+#   ArchitectureName: "fallback"

--- a/Tensile/Configs/test_hgemm.yaml
+++ b/Tensile/Configs/test_hgemm.yaml
@@ -299,5 +299,20 @@ BenchmarkProblems:
           - Range: [ [8, 32, 0, 75], [8, 32, 0, 75], [63, 1, 64] ]
 
 LibraryLogic:
+    ScheduleName: "vega10"
+    DeviceNames: ["Device 6863", "Device 6862"]
+    ArchitectureName: "gfx900"
+
+#   ScheduleName: "mi25"
+#   DeviceNames: ["Device 6860"]
+#   ArchitectureName: "gfx900"
+
+#   ScheduleName: "r9nano"
+#   DeviceNames: ["Device 7300"]
+#   ArchitectureName: "gfx803"
+
+#   ScheduleName: "hip"
+#   DeviceNames: ["Device 0000"]
+#   ArchitectureName: "fallback"
 
 LibraryClient:

--- a/Tensile/Configs/test_hgemm_asm.yaml
+++ b/Tensile/Configs/test_hgemm_asm.yaml
@@ -265,4 +265,20 @@ BenchmarkProblems:
           - Range: [ [127,1,129], 0, [2], [63,1,65] ]
 
 LibraryLogic:
+    ScheduleName: "vega10"
+    DeviceNames: ["Device 6863", "Device 6862"]
+    ArchitectureName: "gfx900"
+
+#   ScheduleName: "mi25"
+#   DeviceNames: ["Device 6860"]
+#   ArchitectureName: "gfx900"
+
+#   ScheduleName: "r9nano"
+#   DeviceNames: ["Device 7300"]
+#   ArchitectureName: "gfx803"
+
+#   ScheduleName: "hip"
+#   DeviceNames: ["Device 0000"]
+#   ArchitectureName: "fallback"
+
 LibraryClient:

--- a/Tensile/Configs/test_hgemm_defaults.yaml
+++ b/Tensile/Configs/test_hgemm_defaults.yaml
@@ -31,3 +31,19 @@ BenchmarkProblems:
       TransposeB: True
       UseBeta: True
 
+LibraryLogic:
+    ScheduleName: "vega10"
+    DeviceNames: ["Device 6863", "Device 6862"]
+    ArchitectureName: "gfx900"
+
+#   ScheduleName: "mi25"
+#   DeviceNames: ["Device 6860"]
+#   ArchitectureName: "gfx900"
+
+#   ScheduleName: "r9nano"
+#   DeviceNames: ["Device 7300"]
+#   ArchitectureName: "gfx803"
+
+#   ScheduleName: "hip"
+#   DeviceNames: ["Device 0000"]
+#   ArchitectureName: "fallback"

--- a/Tensile/Configs/test_hgemm_vectors.yaml
+++ b/Tensile/Configs/test_hgemm_vectors.yaml
@@ -299,5 +299,20 @@ BenchmarkProblems:
           - Range: [ [8, 32, 0, 75], [8, 32, 0, 75], [63, 1, 64] ]
 
 LibraryLogic:
+    ScheduleName: "vega10"
+    DeviceNames: ["Device 6863", "Device 6862"]
+    ArchitectureName: "gfx900"
+
+#   ScheduleName: "mi25"
+#   DeviceNames: ["Device 6860"]
+#   ArchitectureName: "gfx900"
+
+#   ScheduleName: "r9nano"
+#   DeviceNames: ["Device 7300"]
+#   ArchitectureName: "gfx803"
+
+#   ScheduleName: "hip"
+#   DeviceNames: ["Device 0000"]
+#   ArchitectureName: "fallback"
 
 LibraryClient:

--- a/Tensile/Configs/test_sgemm.yaml
+++ b/Tensile/Configs/test_sgemm.yaml
@@ -299,5 +299,20 @@ BenchmarkProblems:
           - Range: [ [8, 32, 0, 75], [8, 32, 0, 75], [63, 1, 64] ]
 
 LibraryLogic:
+    ScheduleName: "vega10"
+    DeviceNames: ["Device 6863", "Device 6862"]
+    ArchitectureName: "gfx900"
+
+#   ScheduleName: "mi25"
+#   DeviceNames: ["Device 6860"]
+#   ArchitectureName: "gfx900"
+
+#   ScheduleName: "r9nano"
+#   DeviceNames: ["Device 7300"]
+#   ArchitectureName: "gfx803"
+
+#   ScheduleName: "hip"
+#   DeviceNames: ["Device 0000"]
+#   ArchitectureName: "fallback"
 
 LibraryClient:

--- a/Tensile/Configs/test_sgemm_asm.yaml
+++ b/Tensile/Configs/test_sgemm_asm.yaml
@@ -270,5 +270,22 @@ BenchmarkProblems:
           - Range: [ [127,1,129], 0, [2], [63,1,65] ]
 
 LibraryLogic:
-  SolutionImportanceMin: 0
+    SolutionImportanceMin: 0
+
+    ScheduleName: "vega10"
+    DeviceNames: ["Device 6863", "Device 6862"]
+    ArchitectureName: "gfx900"
+
+#   ScheduleName: "mi25"
+#   DeviceNames: ["Device 6860"]
+#   ArchitectureName: "gfx900"
+
+#   ScheduleName: "r9nano"
+#   DeviceNames: ["Device 7300"]
+#   ArchitectureName: "gfx803"
+
+#   ScheduleName: "hip"
+#   DeviceNames: ["Device 0000"]
+#   ArchitectureName: "fallback"
+
 LibraryClient:

--- a/Tensile/Configs/test_sgemm_defaults.yaml
+++ b/Tensile/Configs/test_sgemm_defaults.yaml
@@ -31,3 +31,19 @@ BenchmarkProblems:
       TransposeB: True
       UseBeta: True
 
+LibraryLogic:
+    ScheduleName: "vega10"
+    DeviceNames: ["Device 6863", "Device 6862"]
+    ArchitectureName: "gfx900"
+
+#   ScheduleName: "mi25"
+#   DeviceNames: ["Device 6860"]
+#   ArchitectureName: "gfx900"
+
+#   ScheduleName: "r9nano"
+#   DeviceNames: ["Device 7300"]
+#   ArchitectureName: "gfx803"
+
+#   ScheduleName: "hip"
+#   DeviceNames: ["Device 0000"]
+#   ArchitectureName: "fallback"

--- a/Tensile/Configs/test_sgemm_vectors.yaml
+++ b/Tensile/Configs/test_sgemm_vectors.yaml
@@ -299,5 +299,20 @@ BenchmarkProblems:
           - Range: [ [8, 32, 0, 75], [8, 32, 0, 75], [63, 1, 64] ]
 
 LibraryLogic:
+    ScheduleName: "vega10"
+    DeviceNames: ["Device 6863", "Device 6862"]
+    ArchitectureName: "gfx900"
+
+#   ScheduleName: "mi25"
+#   DeviceNames: ["Device 6860"]
+#   ArchitectureName: "gfx900"
+
+#   ScheduleName: "r9nano"
+#   DeviceNames: ["Device 7300"]
+#   ArchitectureName: "gfx803"
+
+#   ScheduleName: "hip"
+#   DeviceNames: ["Device 0000"]
+#   ArchitectureName: "fallback"
 
 LibraryClient:

--- a/Tensile/Configs/test_tensor_contraction.yaml
+++ b/Tensile/Configs/test_tensor_contraction.yaml
@@ -157,5 +157,20 @@ BenchmarkProblems:
           - Range: [ [63,1,65], [2,1,3], [63,1,65], [2,1,3], [2,1,3], [15,1,17] ]
 
 LibraryLogic:
+    ScheduleName: "vega10"
+    DeviceNames: ["Device 6863", "Device 6862"]
+    ArchitectureName: "gfx900"
+
+#   ScheduleName: "mi25"
+#   DeviceNames: ["Device 6860"]
+#   ArchitectureName: "gfx900"
+
+#   ScheduleName: "r9nano"
+#   DeviceNames: ["Device 7300"]
+#   ArchitectureName: "gfx803"
+
+#   ScheduleName: "hip"
+#   DeviceNames: ["Device 0000"]
+#   ArchitectureName: "fallback"
 
 LibraryClient:

--- a/Tensile/KernelWriterSource.py
+++ b/Tensile/KernelWriterSource.py
@@ -2016,6 +2016,7 @@ class KernelWriterSource(KernelWriter):
       kStr += "#undef GLOBAL_LOAD_VECTOR_WIDTH_A%s" % (self.endLine)
       kStr += "#undef GLOBAL_LOAD_VECTOR_WIDTH_B%s" % (self.endLine)
       kStr += "#undef GLOBAL_WRITE_VECTOR_WIDTH%s" % (self.endLine)
+      kStr += "#undef MAC%s" % (self.endLine)
       kStr += "#undef TYPE_MAC%s" % (self.endLine)
       kStr += "#undef TYPE_MAC_WRITE%s" % (self.endLine)
       kStr += "#undef GLOBAL_SPLITU%s" % (self.endLine)

--- a/Tensile/LibraryLogic.py
+++ b/Tensile/LibraryLogic.py
@@ -1267,21 +1267,12 @@ def main(  config ):
       #if problemTypeTuple not in problemTypeTuples:
       #  problemTypeTuples.append(problemTypeTuple)
 
-  # Run Analysis
-  #schedulePrefix = globalParameters["Name"]
-  if "ScheduleName" in config:
-    schedulePrefix = config["ScheduleName"]
-  else:
-    schedulePrefix = "Tensile"
-  if "DeviceNames" in config:
-    deviceNamesForSchedule = config["DeviceNames"]
-  else:
-    deviceNamesForSchedule = "default"
   for problemType in problemTypes:
     logicTuple = analyzeProblemType( problemType, problemTypes[problemType], \
         analysisParameters )
     YAMLIO.writeLibraryLogicForSchedule(globalParameters["WorkingPath"], \
-        schedulePrefix, deviceNamesForSchedule, logicTuple)
+        analysisParameters["ScheduleName"], analysisParameters["ArchitectureName"], \
+        analysisParameters["DeviceNames"], logicTuple)
 
   popWorkingPath()
 

--- a/Tensile/Source/CMakeLists.txt
+++ b/Tensile/Source/CMakeLists.txt
@@ -56,8 +56,6 @@ else()
   message(STATUS "Making LibraryClient")
   option( Tensile_SHORT_FILE_NAMES "Use short file names (for MSVC)" OFF)
   option( Tensile_LIBRARY_PRINT_DEBUG "TensileLib to print debug info" OFF)
-  #set( Tensile_ISA gfx803;gfx900 CACHE STRING "List of gpu architectures to target" )
-  set( Tensile_ISA gfx900 CACHE STRING "List of gpu architectures to target" ) # hgemm doesn't work on 803 b/c packed instructions
   add_executable( ${ClientName}
     Client.cpp
     MathTemplates.cpp
@@ -119,7 +117,6 @@ if(NOT Tensile_CLIENT_BENCHMARK)
   TensileCreateLibrary(
     ${Tensile_LOGIC_PATH}           # path
     ${Tensile_RUNTIME_LANGUAGE}     # OCL or HIP
-    "${Tensile_ISA}"     # gfx803;gfx900;...
     ${Tensile_MERGE_FILES}          # ON or OFF
     ${Tensile_SHORT_FILE_NAMES}     # ON or OFF
     ${Tensile_LIBRARY_PRINT_DEBUG}  # ON or OFF

--- a/Tensile/Source/TensileConfig.cmake
+++ b/Tensile/Source/TensileConfig.cmake
@@ -27,7 +27,6 @@ include(CMakeParseArguments)
 function(TensileCreateLibrary
     Tensile_LOGIC_PATH
     Tensile_RUNTIME_LANGUAGE
-    Tensile_ISA
     Tensile_MERGE_FILES
     Tensile_SHORT_FILE_NAMES
     Tensile_LIBRARY_PRINT_DEBUG )
@@ -67,11 +66,6 @@ function(TensileCreateLibrary
     set(Tensile_CREATE_COMMAND ${Tensile_CREATE_COMMAND} "--no-library-print-debug")
   endif()
 
-  foreach( target ${Tensile_ISA} )
-    set(Tensile_CREATE_COMMAND ${Tensile_CREATE_COMMAND} "--isa;${target}")
-  endforeach()
-
-
   # TensileLibraryWriter positional arguments
   set(Tensile_CREATE_COMMAND ${Tensile_CREATE_COMMAND}
     ${Tensile_LOGIC_PATH}
@@ -109,7 +103,8 @@ function(TensileCreateLibrary
   set(options)
   add_library(Tensile ${options} ${Tensile_SOURCE_FILES})
   # specify gpu targets
-  foreach( target ${Tensile_ISA} )
+  set(Tensile_HIP_ISA "gfx803" "gfx900")
+  foreach( target ${Tensile_HIP_ISA} )
     target_link_libraries( Tensile PRIVATE --amdgpu-target=${target} )
   endforeach()
   if( Tensile_MERGE_FILES )

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -373,37 +373,57 @@ def writeLogic(outputPath, logicData, solutionWriter ):
             ",\n" if i < len(argListStream)-1 else ") {\n")
 
       # choose from schedules based on device name
+#     print logicData
       schedules = logicData[problemType]
       numSchedules = len(schedules)
       if numSchedules > 1:
+
+        reordered_schedules = []
+        for scheduleIdx in range(0, numSchedules):
+          schedule = schedules[scheduleIdx]
+          deviceNames = schedule[1]
+          if deviceNames != ["fallback"]:
+            reordered_schedules.append(schedule)
+        for scheduleIdx in range(0, numSchedules):
+          schedule = schedules[scheduleIdx]
+          deviceNames = schedule[1]
+          if deviceNames == ["fallback"]:
+            reordered_schedules.append(schedule)
 
         # get device name
         if globalParameters["RuntimeLanguage"] == "OCL":
           s += "get device name opencl;\n"
         else:
-          s += "get device name hip;\n"
+          s += "\n//  get device name hip;\n"
+          s += "    int deviceId;\n"
+          s += "    hipCtxGetDevice(&deviceId);\n"
+          s += "    hipDeviceProp_t deviceProperties;\n"
+          s += "    hipGetDeviceProperties(&deviceProperties, deviceId);\n"
+          s += "    std::string name = deviceProperties.name;\n"
 
+        s += "\n    "
         for scheduleIdx in range(0, numSchedules):
-          schedule = schedules[scheduleIdx]
+          schedule = reordered_schedules[scheduleIdx]
+          scheduleName  = schedule[0]
           deviceNames = schedule[1]
           if scheduleIdx > 0:
-            s += "else "
+            s += "    else "
           if scheduleIdx < numSchedules-1:
             s += "if ("
             for deviceNameIdx in range(0, len(deviceNames)):
               deviceName = deviceNames[deviceNameIdx]
               if deviceNameIdx > 0:
                 s += " && "
-                s += "name == \"%s\"" % deviceName
+              s += "name == \"%s\"" % deviceName
             s += ")"
-          s += "{"
-          s += "  return tensileGetSolution%s_%s_%s(" \
+          s += "{\n"
+          s += "        return tensileGetSolution%s_%s_%s(" \
               % ( returnType, scheduleName, problemType)
           for i in range(0, len(argListSizes)):
             s += "%s%s" \
                 % (argListSizes[i][1],
                     ", " if i < len(argListSizes)-1 else ");\n")
-            s += "}"
+          s += "    }\n"
       else: # == 1
         schedule = schedules[0]
         scheduleName = schedule[0]

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -717,8 +717,6 @@ def TensileCreateLibrary():
       action="store_true")
   argParser.add_argument("--no-library-print-debug", dest="LibraryPrintDebug", \
       action="store_false")
-  argParser.add_argument("--isa", dest="isa", action="append",
-      help="which architectures for assembly kernels to target" )
   args = argParser.parse_args()
 
   logicPath = args.LogicPath
@@ -730,21 +728,6 @@ def TensileCreateLibrary():
   arguments["MergeFiles"] = args.MergeFiles
   arguments["ShortNames"] = args.ShortNames
   arguments["LibraryPrintDebug"] = args.LibraryPrintDebug
-  if args.isa:
-    newISA = []
-    for isa in args.isa:
-      gfxIdx = isa.find("gfx")
-      if gfxIdx >= 0:
-        major = int(isa[gfxIdx+3:gfxIdx+4])
-        minor = int(isa[gfxIdx+4:gfxIdx+5])
-        step  = int(isa[gfxIdx+5:gfxIdx+6])
-        isaTuple = (major,minor,step)
-        if isaTuple in globalParameters["SupportedISA"] and isaTuple not in newISA:
-          print1("# User-Specified ISA: gfx%u%u%u" % (major,minor,step))
-          newISA.append(isaTuple)
-      else:
-        printWarning("isa parameter must be formed as: --isa gfx803")
-    arguments["SupportedISA"] = newISA
   assignGlobalParameters(arguments)
 
   if not os.path.exists(logicPath):
@@ -789,19 +772,6 @@ def TensileCreateLibrary():
         kernelsBetaOnly.append(kernel)
 
   # if any kernels are assembly, append every ISA supported
-  if globalParameters["RuntimeLanguage"] == "HIP":
-    newKernels = []
-    for kernel in kernels:
-      if kernel["KernelLanguage"] == "Assembly":
-        kernel["ISA"] = globalParameters["SupportedISA"][0]
-        for i in range(1, len(globalParameters["SupportedISA"])):
-          newKernel = deepcopy(kernel)
-          newKernel["ISA"] = globalParameters["SupportedISA"][i]
-          newKernels.append(newKernel)
-      else:
-        kernel["ISA"] = (0,0,0)
-    kernels.extend(newKernels)
-
 
   if globalParameters["ShortNames"] and not globalParameters["MergeFiles"]:
     solutionSerialNaming = Solution.getSerialNaming(solutions)

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -413,7 +413,7 @@ def writeLogic(outputPath, logicData, solutionWriter ):
             for deviceNameIdx in range(0, len(deviceNames)):
               deviceName = deviceNames[deviceNameIdx]
               if deviceNameIdx > 0:
-                s += " && "
+                s += " || "
               s += "name == \"%s\"" % deviceName
             s += ")"
           s += "{\n"

--- a/Tensile/YAMLIO.py
+++ b/Tensile/YAMLIO.py
@@ -109,7 +109,7 @@ def readSolutions( filename ):
 # 1 yaml per problem type
 # problemType, skinny0, skinny1, diagonal
 ################################################################################
-def writeLibraryLogicForSchedule( filePath, schedulePrefix, deviceNames, \
+def writeLibraryLogicForSchedule( filePath, schedulePrefix, architectureName, deviceNames, \
     logicTuple):
   problemType   = logicTuple[0]
   solutions     = logicTuple[1]
@@ -124,8 +124,7 @@ def writeLibraryLogicForSchedule( filePath, schedulePrefix, deviceNames, \
   # Tensile version
   data.append({"MinimumRequiredVersion":__version__})
   # schedule name
-  data.append(schedulePrefix)
-  architectureName = "gfx000"
+  data.append(schedulePrefix)     # change from Tensile to vega10
   data.append(architectureName)
   # schedule device names
   data.append(deviceNames)

--- a/Tensile/YAMLIO.py
+++ b/Tensile/YAMLIO.py
@@ -125,6 +125,8 @@ def writeLibraryLogicForSchedule( filePath, schedulePrefix, deviceNames, \
   data.append({"MinimumRequiredVersion":__version__})
   # schedule name
   data.append(schedulePrefix)
+  architectureName = "gfx000"
+  data.append(architectureName)
   # schedule device names
   data.append(deviceNames)
   # problem type
@@ -180,12 +182,13 @@ def readLibraryLogicForSchedule( filename ):
   # parse out objects
   versionString     = data[0]["MinimumRequiredVersion"]
   scheduleName      = data[1]
-  deviceNames       = data[2]
-  problemTypeState  = data[3]
-  solutionStates    = data[4]
-  indexOrder        = data[5]
-  exactLogic        = data[6]
-  rangeLogic        = data[7]
+  architectureName  = data[2]
+  deviceNames       = data[3]
+  problemTypeState  = data[4]
+  solutionStates    = data[5]
+  indexOrder        = data[6]
+  exactLogic        = data[7]
+  rangeLogic        = data[8]
 
   # does version match
   if not versionIsCompatible(versionString):
@@ -198,6 +201,13 @@ def readLibraryLogicForSchedule( filename ):
   solutions = []
   for i in range(0, len(solutionStates)):
     solutionState = solutionStates[i]
+    if solutionState["KernelLanguage"] == "Assembly":
+      isa0 = int(architectureName[3])
+      isa1 = int(architectureName[4])
+      isa2 = int(architectureName[5])
+      solutionState["ISA"] = (isa0, isa1, isa2)
+    else:
+      solutionState["ISA"] = (0, 0, 0)
     solutionObject = Solution(solutionState)
     if solutionObject["ProblemType"] != problemType:
       printExit("ProblemType of file doesn't match solution: %s != %s" \


### PR DESCRIPTION
Modify kernel selection logic to enable selection of kernel based on device. Kernels are tuned for specific devices. There are also fallback kernels that will work on any device. For specific devices there will be assembly kernels where possible. The fallback kernels are source code. The fallback kernels will be used for hgemm on r9nano because it uses gfx803 ISA, and the needed instructions are in gfx900ISA. 

Benchmark .yaml files in Tensile/Tensile/Configs
* have names like
  * rocblas_sgemm_asm_full.yaml
  * rocblas_sgemm_asm_lite.yaml
  * rocblas_sgemm_hip_lite.yaml
* the \_asm\_ files contain information like below
  * KernelLanguage: ["Assembly"]
  * ScheduleName: "vega10"
  * DeviceNames: ["Device 6863", "Device 6862"]
  * ArchitectureName: "gfx900"
* this tells Tensile to build assembly kernels for architecture "gfx900"
* for vega10, mi25 and r9nano assembly code is used where possible for s,d,hgemm.
* for hgemm on r9nano source code must be used since gfx803 does not contain the instructions used in the hgemm assembly code.
* the \_hip\_ files contains information like below
  * KernelLanguage: ["Source"]
  * ScheduleName: "hip"
  * DeviceNames: ["Device 0000"]
  * ArchitectureName: "fallback"
* this tells Tensile to build source kernels that are the fallback kernels for any architecture and device

Library .yaml files in 3_LibraryLogic
* will have a name like vega10_Cijk_Ailk_Bljk_SB.yaml
* they can be built for for vega10, mi25, r9nano, and fallback.