### PR TITLE
Fix bug in BufferLoad mode related to writing too many registers

### DIFF
--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -279,7 +279,7 @@ defaultBenchmarkCommonParameters = [
     {"LocalWrite2B":              [ True ] },
     {"LocalRead2A":               [ True ] },
     {"LocalRead2B":               [ True ] },
-    {"BufferLoad":                [ False ] },
+    {"BufferLoad":                [ True ] },
     {"GlobalSplitU":              [ 1 ] },
     {"GlobalSplitUSummationAssignmentRoundRobin": [ True ] },
     {"GlobalSplitUWorkGroupMappingRoundRobin":    [ False ] },


### PR DESCRIPTION
In Buffer modes, only 32-bits is allocated to store the offset.
GLOBAL_OFFSET macros were writing 64 bit offsets.
Change so these only write 32-bits when the Buffer modes are enabled