### PR TITLE
Add printTensor debug routine

### DIFF
--- a/Tensile/BenchmarkProblems.py
+++ b/Tensile/BenchmarkProblems.py
@@ -118,6 +118,7 @@ def benchmarkProblemType( problemTypeConfig, problemSizeGroupConfig, \
         "Client.h",
         "CMakeLists.txt",
         "DeviceStats.h",
+        "TensorUtils.h",
         "MathTemplates.cpp",
         "MathTemplates.h",
         "TensileTypes.h",

--- a/Tensile/ClientWriter.py
+++ b/Tensile/ClientWriter.py
@@ -47,6 +47,7 @@ def main( config ):
       "Client.h",
       "DeviceStats.h",
       "ReferenceCPU.h",
+      "TensorUtils.h",
       "MathTemplates.cpp",
       "MathTemplates.h",
       "KernelHeader.h",
@@ -225,6 +226,11 @@ def writeRunScript(path, libraryLogicPath, forBenchmark):
   return runScriptName
 
 
+def toCppBool(yamlBool):
+  return "true" if yamlBool else "false"
+
+
+
 ################################################################################
 # Write Generated Benchmark Parameters
 ################################################################################
@@ -273,6 +279,11 @@ def writeClientParameters(forBenchmark, solutions, problemSizes, stepName, \
   h += "#endif\n"
   h += "} DataTypeEnum;\n"
   h += "\n"
+
+  h += "// Debug Params\n";
+  h += "const bool printTensorA=%s;\n" % toCppBool(globalParameters["PrintTensorA"])
+  h += "const bool printTensorB=%s;\n" % toCppBool(globalParameters["PrintTensorB"])
+  h += "\n";
 
   h += "const char indexChars[%u] = \"%s" \
       % (len(globalParameters["IndexChars"])+1, \

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -74,6 +74,17 @@ globalParameters["CMakeCXXFlags"] = ""            # pass flags to cmake
 globalParameters["CMakeCFlags"] = ""              # pass flags to cmake
 globalParameters["DebugKernel"] = False           # assembly only, kernel gets buffer for debug "printing"; kernel writes data to memory, gets coppied to host and printed
 globalParameters["LibraryPrintDebug"] = False     # solutions will print enqueue info when enqueueing a kernel
+
+# Tensor printing controls:
+globalParameters["PrintTensorA"] = False          # Print TensorA after initialization
+globalParameters["PrintTensorB"] = False          # Print TensorB after initialization
+# PrintMaxCols applies to dimensions where multiple cols are printed per line.
+# PrintMaxRows applies to dimensions where one row is printed per line
+# If PrintMax* is greater than the dimension, the middle elements will be repaced with "..."
+globalParameters["PrintMaxCols"] = -1             # Max number of cols to print. 
+globalParameters["PrintMaxRows"] = -1             # Max number of rows to print. 
+
+
 # device selection
 globalParameters["Platform"] = 0                  # select opencl platform
 globalParameters["Device"] = 0                    # select hip device or opencl device within platform

--- a/Tensile/Source/Client.cpp
+++ b/Tensile/Source/Client.cpp
@@ -61,6 +61,7 @@ int main( int argc, char *argv[] ) {
     float *deviceOnHostC_float;
     initData(&initialC_float, &initialA_float, &initialB_float, &alpha_float,
         &beta_float, &referenceC_float, &deviceOnHostC_float);
+
     for (unsigned int i = 0; i < numBenchmarks; i++) {
 #if Tensile_CLIENT_BENCHMARK
       invalids = benchmarkProblemSizes(initialC_float, initialA_float,

--- a/Tensile/Source/Client.h
+++ b/Tensile/Source/Client.h
@@ -203,11 +203,14 @@ bool callLibrary(
     totalFlops *= userSizes[i]; }
 
   if (printTensorA) {
-    printTensor("A", initialA, numIndicesAB[problemTypeIdx], sizes, 
+    printTensor("A", initialA, numIndicesAB[problemTypeIdx],
+                  numIndicesC[problemTypeIdx],
+                  sizes, 
                   indexAssignmentsA[problemTypeIdx]);
   }
   if (printTensorB) {
-    printTensor("B", initialB, numIndicesAB[problemTypeIdx], sizes, 
+    printTensor("B", initialB, numIndicesAB[problemTypeIdx],
+                  numIndicesC[problemTypeIdx],
                   indexAssignmentsB[problemTypeIdx]);
   }
 
@@ -543,6 +546,17 @@ bool benchmarkAllSolutionsForSize(
     totalFlops *= sizes[i]; }
   file << ", " << totalFlops;
 
+  if (printTensorA) {
+    printTensor("A", initialA, numIndicesAB[problemTypeIdx],
+                numIndicesC[problemTypeIdx], sizes,
+                indexAssignmentsA[problemTypeIdx]);
+  }
+  if (printTensorB) {
+    printTensor("B", initialB, numIndicesAB[problemTypeIdx],
+                numIndicesC[problemTypeIdx], sizes, 
+                indexAssignmentsB[problemTypeIdx]);
+  }
+
   // pre-compute referenceCPU if validating
   if (numElementsToValidate) {
     memcpy(referenceC, initialC, sizeToCopy);
@@ -574,18 +588,12 @@ bool benchmarkAllSolutionsForSize(
         alpha, beta);
 
   }
+
+
   fastestGFlops = 0;
   for (unsigned int solutionIdx = solutionStartIdx; solutionIdx < solutionStartIdx + numSolutions; solutionIdx ++) {
     bool solutionIsValid = true;
 
-    if (printTensorA) {
-      printTensor("A", initialA, numIndicesAB[solutionIdx], sizes, 
-                    indexAssignmentsA[solutionIdx]);
-    }
-    if (printTensorB) {
-      printTensor("B", initialB, numIndicesAB[solutionIdx], sizes, 
-                    indexAssignmentsB[solutionIdx]);
-    }
 
     // copy data in language
 #if Tensile_RUNTIME_LANGUAGE_OCL

--- a/Tensile/Source/TensileTypes.h
+++ b/Tensile/Source/TensileTypes.h
@@ -31,6 +31,7 @@
 #define tensileStatusFailure -1
 #define TensileComplexFloat cl_float2
 #define TensileComplexDouble cl_double2
+#define TensileHalf cl_half
 
 // HIP
 #else
@@ -41,6 +42,12 @@
 #define TensileComplexFloat float2
 #define TensileComplexDouble double2
 #define TensileHalf __fp16
+
+inline std::ostream& operator<<(std::ostream& os, const __fp16& dt)  
+{  
+   os << (float)(dt);
+   return os;  
+}
 
 #endif
 

--- a/Tensile/Source/TensorUtils.h
+++ b/Tensile/Source/TensorUtils.h
@@ -1,0 +1,235 @@
+/*******************************************************************************
+* Copyright (C) 2016 Advanced Micro Devices, Inc. All rights reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell cop-
+* ies of the Software, and to permit persons to whom the Software is furnished
+* to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM-
+* PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+* FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+* COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+* IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNE-
+* CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*******************************************************************************/
+
+#include <vector>
+#include <iostream>
+
+
+class TensorDims {
+public:
+  TensorDims(
+    const std::string name,
+    unsigned int numIndices,
+    const unsigned int *indexedSizes,
+    const unsigned int *indexAssignments);
+
+  void print() const;
+
+  size_t computeMemoryOffset(size_t elementIndex);
+
+public:
+  // Sizes for each dimension of the matrix
+  // First size is the coalesced dimension with fastest-changing address
+  std::vector<unsigned int> sizes;
+
+  size_t totalSize;
+
+  // strides in logical element dimension, these do not necessarily correspond to memory location 
+  std::vector<unsigned int> elementStrides;
+
+  // strides in memory, useful for calculating address
+  std::vector<unsigned int> memoryStrides;
+
+private:
+  const std::string _name;
+  unsigned int _numIndices;
+  std::vector<unsigned int> _indexAssignment;
+
+};
+
+TensorDims::TensorDims(
+  const std::string name,
+  unsigned int numIndices,
+  const unsigned int *indexedSizes,
+  const unsigned int *indexAssignments) :
+    _name(name),
+    _numIndices(numIndices),
+    sizes(numIndices,0),
+    elementStrides(numIndices, 0),
+    memoryStrides(numIndices, 0),
+    _indexAssignment(numIndices, 0) {
+
+  totalSize = 1;
+  for (unsigned int i=0; i<numIndices; i++) {
+    _indexAssignment[i] = indexAssignments[i];
+    sizes[i] = indexedSizes[indexAssignments[i]];
+    totalSize *= sizes[i];
+  }
+
+  for (unsigned int i=0; i<numIndices; i++) {
+    elementStrides[i] = 1;
+    for (unsigned int j=0; j<i; j++) {
+      elementStrides[i] *= sizes[j];
+    }
+  }
+
+  // Assume memoryStrides are same as elementStrides.
+  // Changing this would require some modest changes to add a
+  // YAML parm and pipe it through the client testbench.
+  for (unsigned int i=0; i<numIndices; i++) {
+    memoryStrides[i] = 1;
+    for (unsigned int j=0; j<i; j++) {
+      memoryStrides[i] *= sizes[j];
+    }
+  }
+}
+
+
+void TensorDims::print() const {
+
+  std::cout << "Matrix:" << _name << "  indexAssignments:";
+  for (unsigned int i=0; i<_numIndices; i++) {
+    if (i != 0) {
+      std::cout << ", ";
+    }
+    std::cout << _indexAssignment[i];
+  }
+  std::cout << "\n";
+
+  for (unsigned int i=0; i<_numIndices; i++) {
+    std::cout << "  size[" << i << "]="<<sizes[i]<<"\n";
+  }
+  for (unsigned int i=0; i<_numIndices; i++) {
+    std::cout << "  elementStrides[" << i << "]="<<elementStrides[i]<<"\n";
+  }
+  for (unsigned int i=0; i<_numIndices; i++) {
+    std::cout << "  memoryStrides[" << i << "]="<<memoryStrides[i]<<"\n";
+  }
+};
+
+
+size_t TensorDims::computeMemoryOffset(size_t elementIndex) {
+
+  size_t r = elementIndex;
+  size_t offset = 0;
+  for (int j=_numIndices-1; j>=0; j--) {
+    offset += r / elementStrides[j] * memoryStrides[j];
+    r = r % elementStrides[j];
+  }
+
+  return offset;
+}
+
+
+const unsigned PrintElementIndex   = 0x1;
+const unsigned PrintElementOffset = 0x2;
+const unsigned PrintElementValue   = 0x4;
+
+// Tensile_LIBRARY_PRINT_DEBUG  ??
+#if 1
+/*******************************************************************************
+ * Print Tensor.
+ * Elements from index[0] should appear on one row.
+ * Matrix start "[" and stop "]" markers are printed at appropriate points,
+ * when the indexing crosses a dimension boundary.  The markers are indented
+ * to indicate which dimension is changing
+ ******************************************************************************/
+template< typename Type >
+void printTensor(
+    const std::string &name,
+    const Type *data,
+    unsigned int numIndices,
+    const unsigned int *indexedSizes,
+    const unsigned int *indexAssignments,
+    //unsigned printMode=PrintElementIndex | PrintElementValue) {
+    unsigned printMode=PrintElementValue) {
+
+    TensorDims td(name, numIndices, indexedSizes, indexAssignments);
+
+    td.print();
+
+
+    // Lower-numbered indices have more leading spaces
+    // Highest index has zero and is aligned to left column
+    std::vector<std::string> leadingSpaces(numIndices, "");
+    for (unsigned int i=0; i<numIndices; i++) {
+      for (unsigned int j=numIndices-1; j>i; j--) {
+        leadingSpaces[i] += "  ";
+      }
+    }
+
+    bool dbPrint = false;
+
+    // Print the elements 
+    for (size_t e=0; e<td.totalSize; e++) {
+
+      // see if we are at an interesting boundary:
+      for (int n=numIndices-1; n>=1; n--) {
+        if (e % td.elementStrides[n] == 0) {
+          // first element in this dimension:
+          if (n==1) {
+            // Label the row:
+            std::cout << leadingSpaces[n];
+            size_t r = e;
+            for (int m=numIndices-1; m>=1; m--) {
+              std::cout << r / td.elementStrides[m] ;
+              r = r % td.elementStrides[m];
+              if (m == 1) {
+                std::cout << ",x : ";
+              } else {
+                std::cout << ",";
+              }
+            }
+          } 
+          std::cout << leadingSpaces[n] << "[ ";
+          
+          if (dbPrint) {
+            unsigned int iter = e / td.elementStrides[n];
+            std::cout << "// Start index=" << n 
+                      <<  " iter=" << iter << " / " << td.elementStrides[n] << "\n"; 
+          } 
+          if (n>1) {
+            std::cout << "\n";
+          }
+        }
+      }
+
+      // actually print the element:
+      std::cout << "  ";
+      size_t eo = td.computeMemoryOffset(e);
+      if (printMode & PrintElementIndex) {
+        std::cout  << e << ":";
+      }
+      if (printMode & PrintElementOffset) {
+        std::cout << eo << ":";
+      }
+      if (printMode & PrintElementValue) {
+        std::cout << data[eo];
+      }
+
+      for (int n=1; n<numIndices; n++) {
+        if (e % td.elementStrides[n] == td.elementStrides[n]-1) {
+          unsigned int iter = e / td.elementStrides[n];
+
+          // last element in the index:
+          std::cout << leadingSpaces[n]  << "]\n";
+          if (dbPrint) {
+            std::cout << "// End index=" << n 
+                      << " iter=" << iter << " / " << td.elementStrides[n] << "\n";
+          }
+        } 
+      }
+    }
+      
+
+    std::cout << "\n";
+}
+#endif

--- a/Tensile/Source/TensorUtils.h
+++ b/Tensile/Source/TensorUtils.h
@@ -28,6 +28,7 @@ public:
   TensorDims(
     const std::string name,
     unsigned int numIndices,
+    unsigned int firstSummationIndex,
     const unsigned int *indexedSizes,
     const unsigned int *indexAssignments);
 
@@ -51,6 +52,7 @@ public:
 private:
   const std::string _name;
   unsigned int _numIndices;
+  unsigned int _firstSummationIndex;
   std::vector<unsigned int> _indexAssignment;
 
 };
@@ -58,10 +60,12 @@ private:
 TensorDims::TensorDims(
   const std::string name,
   unsigned int numIndices,
+  unsigned int firstSummationIndex,
   const unsigned int *indexedSizes,
   const unsigned int *indexAssignments) :
     _name(name),
     _numIndices(numIndices),
+    _firstSummationIndex(firstSummationIndex),
     sizes(numIndices,0),
     elementStrides(numIndices, 0),
     memoryStrides(numIndices, 0),
@@ -101,11 +105,17 @@ void TensorDims::print() const {
       std::cout << ", ";
     }
     std::cout << _indexAssignment[i];
+    if (_indexAssignment[i] >= _firstSummationIndex) 
+        std::cout << "(sum)";
+    else
+        std::cout << "(free)";
   }
   std::cout << "\n";
 
   for (unsigned int i=0; i<_numIndices; i++) {
-    std::cout << "  size[" << i << "]="<<sizes[i]<<"\n";
+    std::cout << "  size[" << i << "]=" << sizes[i] 
+              << (_indexAssignment[i] >= _firstSummationIndex ? " (sum)" : " (free)")
+              << "\n";
   }
   for (unsigned int i=0; i<_numIndices; i++) {
     std::cout << "  elementStrides[" << i << "]="<<elementStrides[i]<<"\n";
@@ -147,12 +157,13 @@ void printTensor(
     const std::string &name,
     const Type *data,
     unsigned int numIndices,
+    unsigned int firstSummationIndex,
     const unsigned int *indexedSizes,
     const unsigned int *indexAssignments,
     //unsigned printMode=PrintElementIndex | PrintElementValue) {
     unsigned printMode=PrintElementValue) {
 
-    TensorDims td(name, numIndices, indexedSizes, indexAssignments);
+    TensorDims td(name, numIndices, firstSummationIndex, indexedSizes, indexAssignments);
 
     td.print();
 

--- a/Tensile/Source/TensorUtils.h
+++ b/Tensile/Source/TensorUtils.h
@@ -22,6 +22,8 @@
 #include <vector>
 #include <iostream>
 
+extern const char indexChars[];
+
 
 class TensorDims {
 public:
@@ -115,6 +117,7 @@ void TensorDims::print() const {
   for (unsigned int i=0; i<_numIndices; i++) {
     std::cout << "  size[" << i << "]=" << sizes[i] 
               << (_indexAssignment[i] >= _firstSummationIndex ? " (sum)" : " (free)")
+              << ",\'" << indexChars[_indexAssignment[i]] << "\'"
               << "\n";
   }
   for (unsigned int i=0; i<_numIndices; i++) {
@@ -167,8 +170,9 @@ void printTensor(
     unsigned int firstSummationIndex,
     const unsigned int *indexedSizes,
     const unsigned int *indexAssignments,
-    //unsigned printMode=PrintRowAddress + PrintElementIndex + PrintElementValue | PrintElementValueHex) {
-    //unsigned printMode=PrintRowAddress + PrintRowAddress + PrintElementIndex + PrintElementValue | PrintElementValueHex) {
+    //unsigned printMode=PrintRowAddress + PrintRowElementCoord + PrintElementIndex + PrintElementValue + PrintElementValueHex) {
+    //unsigned printMode= PrintRowElementCoord + PrintElementIndex + PrintElementValue + PrintElementValueHex) {
+    //unsigned printMode= PrintRowElementCoord + PrintElementIndex + PrintElementValue + PrintElementValueHex) {
     unsigned printMode=PrintRowElementCoord+PrintElementValue) {
 
     TensorDims td(name, numIndices, firstSummationIndex, indexedSizes, indexAssignments);

--- a/Tensile/Source/TensorUtils.h
+++ b/Tensile/Source/TensorUtils.h
@@ -139,9 +139,10 @@ size_t TensorDims::computeMemoryOffset(size_t elementIndex) {
 }
 
 
-const unsigned PrintElementIndex   = 0x1;
-const unsigned PrintElementOffset = 0x2;
-const unsigned PrintElementValue   = 0x4;
+static const unsigned PrintElementIndex   = 0x1;
+static const unsigned PrintElementOffset = 0x2;
+static const unsigned PrintElementValue   = 0x4;
+
 
 // Tensile_LIBRARY_PRINT_DEBUG  ??
 #if 1
@@ -167,6 +168,9 @@ void printTensor(
 
     td.print();
 
+    const unsigned int maxCols = 50;
+    const unsigned int maxRows = 100;
+
 
     // Lower-numbered indices have more leading spaces
     // Highest index has zero and is aligned to left column
@@ -178,6 +182,17 @@ void printTensor(
     }
 
     bool dbPrint = false;
+
+
+#if 0
+    if (maxCols != -1) {
+        if (maxCols > 10) {
+            colAfterElipse=5;
+        } else {
+            colAfterElipse=1;
+        }
+    }
+#endif
 
     // Print the elements 
     for (size_t e=0; e<td.totalSize; e++) {


### PR DESCRIPTION
- Add new TensorUtils.h files.
- Define TensorDim class to translate indexAssignments to size/stride
  - removes a level of indirection to make subsequent parsing easier.
  - Used in printTensor and will be used in other applications too
- Pipe the print controls through the stack to new YAML options PrintTensor[AB]