### PR TITLE
get 1.6.4 rocm-terminal for ROCm 1.6.4 Jenkins machines

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -284,7 +284,7 @@ hcc_rocm:
   node( 'docker && rocm && !dkms' )
   {
     def hcc_docker_args = new docker_data(
-        from_image:'rocm/rocm-terminal:latest',
+        from_image:'rocm/rocm-terminal:1.6.4',
         build_docker_file:'dockerfile-build-rocm-terminal',
         install_docker_file:'dockerfile-tensile-rocm-terminal',
         docker_run_args:'--device=/dev/kfd --device=/dev/dri --group-add=video',


### PR DESCRIPTION
Machines jenkins-rocm-1 and jenkins-rocm-2 have ROCm 1.6.4 and the docker container is for ROCm 1.7.1. With the ROCm version mismatch tests are failing. Reomve Jenkins testing on these machines.