### PR TITLE
Add serial-in-u DataInitTypeAB mode (5=serial-in-u)

### DIFF
--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -64,11 +64,15 @@ globalParameters["ForceRedoLibraryClient"] = True     # if False and library cli
 ########################################
 globalParameters["CMakeBuildType"] = "Release"            # whether benchmark clients and library client should be release or debug
 globalParameters["PrintSolutionRejectionReason"] = False  # when a solution is marked as invalid, print why
+
 # how to initialize tensor data
-globalParameters["DataInitTypeAB"] = 3            # 0=0, 1=1, 2=serial, 3=rand, 4=NaN.  Can be overridden by the DataInitTypeA or DataInitTypeB.  Eventually DataInitTypeAB will be retired.
-globalParameters["DataInitTypeA"] = -1            # 0=0, 1=1, 2=serial, 3=rand, 4=NaN.  -1 uses value from DataInitTypeAB
-globalParameters["DataInitTypeB"] = -1            # 0=0, 1=1, 2=serial, 3=rand, 4=NaN.  -1 uses value from DataInitTypeAB
-globalParameters["DataInitTypeC"]  = 3            # 0=0, 1=1, 2=serial, 3=rand, 4=NaN
+# serial-in-u will use a sequence that increments in the K dimension
+# This is a predictable patterns that can be checked as the kernel runs to detect
+# when the wrong data is being used.
+globalParameters["DataInitTypeAB"] = 3            # 0=0, 1=1, 2=serial, 3=rand, 4=NaN, 5=serial-in-u.  Can be overridden by the DataInitTypeA or DataInitTypeB.  Eventually DataInitTypeAB will be retired.
+globalParameters["DataInitTypeA"] = -1            # 0=0, 1=1, 2=serial, 3=rand, 4=NaN, 5=serial-in-u.  -1 uses value from DataInitTypeAB
+globalParameters["DataInitTypeB"] = -1            # 0=0, 1=1, 2=serial, 3=rand, 4=NaN, 5=serial-in-u.  -1 uses value from DataInitTypeAB
+globalParameters["DataInitTypeC"]  = 3            # 0=0, 1=1, 2=serial, 3=rand, 4=Na, 5=serial-in-uN
 globalParameters["DataInitTypeAlpha"] = 2         # 0=0, 1=1, 2=2, 3=rand, 4=NaN
 globalParameters["DataInitTypeBeta"] = 2          # 0=0, 1=1, 2=2, 3=rand, 4=NaN
 # build parameters


### PR DESCRIPTION
- Will initialize matrix so serial index is in the K dimension

- Use common initialization routine for A/B/C.
   - Now support NAN inits for A and B

- Refactor init logic so it resets the data values for each matrix, which
is a new requirement of this mode.
  - Separate copyData function to copy A/B
  - specializeAB to track if the matrix init is same for all sizes (old
    modes) or "specialized" for matrix dims (this new mode).