### PR TITLE
make ctu tests report UNSTABLE (yellow) not FAIL (red)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -247,38 +247,45 @@ def build_pipeline( compiler_data compiler_args, docker_data docker_args, projec
 }
 
 // The following launches 3 builds in parallel: hcc-ctu, hcc-rocm and cuda
-parallel hcc_ctu:
+hcc_ctu:
 {
-  node( 'docker && rocm && jenkins-rocm-0' )
+  try
   {
-    def docker_args = new docker_data(
-        from_image:'compute-artifactory:5001/rocm-developer-tools/hip/master/hip-hcc-ctu-ubuntu-16.04:latest',
-        build_docker_file:'dockerfile-build-hip-hcc-ctu-ubuntu-16.04',
-        install_docker_file:'dockerfile-tensile-hip-hcc-ctu-ubuntu-16.04',
-        docker_run_args:'--device=/dev/kfd --device=/dev/dri --group-add=video',
-        docker_build_args:' --pull' )
+    node( 'docker && rocm && jenkins-rocm-0' )
+    {
+      def docker_args = new docker_data(
+          from_image:'compute-artifactory:5001/rocm-developer-tools/hip/master/hip-hcc-ctu-ubuntu-16.04:latest',
+          build_docker_file:'dockerfile-build-hip-hcc-ctu-ubuntu-16.04',
+          install_docker_file:'dockerfile-tensile-hip-hcc-ctu-ubuntu-16.04',
+          docker_run_args:'--device=/dev/kfd --device=/dev/dri --group-add=video',
+          docker_build_args:' --pull' )
 
-    def compiler_args = new compiler_data(
-        compiler_name:'hcc-ctu',
-        build_config:'Release',
-        compiler_path:'/opt/rocm/bin/hcc' )
+      def compiler_args = new compiler_data(
+          compiler_name:'hcc-ctu',
+          build_config:'Release',
+          compiler_path:'/opt/rocm/bin/hcc' )
 
-    def tensile_paths = new project_paths(
-        project_name:'tensile',
-        src_prefix:'src',
-        build_prefix:'src' )
+      def tensile_paths = new project_paths(
+          project_name:'tensile',
+          src_prefix:'src',
+          build_prefix:'src' )
+  
+      def print_version_closure = {
+        sh  """
+            set -x
+            /opt/rocm/bin/rocm_agent_enumerator -t ALL
+            /opt/rocm/bin/hcc --version
+          """
+      }
 
-    def print_version_closure = {
-      sh  """
-          set -x
-          /opt/rocm/bin/rocm_agent_enumerator -t ALL
-          /opt/rocm/bin/hcc --version
-        """
+      build_pipeline( compiler_args, docker_args, tensile_paths, print_version_closure )
     }
-
-    build_pipeline( compiler_args, docker_args, tensile_paths, print_version_closure )
   }
-},
+  catch( err )
+  {
+    currentBuild.result = 'UNSTABLE'
+  }
+}
 hcc_rocm:
 {
   node( 'docker && rocm && jenkins-rocm-2' )


### PR DESCRIPTION
With update to ROCm 1.7.1 the hcc_ctu tests are failing, and the hcc_ubuntu tests are passing. Change the condition from FAIL to UNSTABLE for the hcc_ctu tests so they show yellow. This makes it easier to distinguish which tests are failing, noting that a hcc_ubuntu failure is more important than a hcc_ctu failure. 