### PR TITLE
Add DirectToLDS option [Initial Checkin]

### DIFF
--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -120,6 +120,7 @@ globalParameters["ScriptPath"] = os.path.dirname(os.path.realpath(__file__))    
 globalParameters["SourcePath"] = os.path.join(globalParameters["ScriptPath"], "Source") # path to Tensile/Source/
 globalParameters["HccVersion"] = "0,0,0"
 globalParameters["AsmHasExplicitCO"] = {}
+globalParameters["AsmHasDirectToLds"] = {}
 
 # default runtime is selected based on operating system, user can override
 if os.name == "nt":
@@ -532,11 +533,18 @@ def assignGlobalParameters( config ):
       asmCmd = "%s -x assembler -target amdgcn-amdhsa -mcpu=%s -" \
                  % (globalParameters["AssemblerPath"], isaVersion)
       globalParameters["AsmHasExplicitCO"][v] = \
-              not os.system ("echo \"v_add_co_u32 v0,vcc,v0,v0\" | %s %s" % \
-              (asmCmd, \
-              "" if globalParameters["PrintLevel"] >=2 else "> /dev/null 2>&1"))
+              not os.system ("echo \"v_add_co_u32 v0,vcc,v0,v0\" \
+                      | %s %s" % \
+                      (asmCmd, "" if globalParameters["PrintLevel"] >=2 else "> /dev/null 2>&1"))
+      globalParameters["AsmHasDirectToLds"][v] = \
+              not os.system ("echo \"buffer_load_dword v40, v36, s[24:27], s28 offen offset:0 lds\" \
+                             | %s %s" % \
+                             (asmCmd, "" if globalParameters["PrintLevel"] >=2 else "> /dev/null 2>&1"))
 
-      print1 ("# Asm caps for %s: AsmHasExplicitCO=%d" % (isaVersion, globalParameters["AsmHasExplicitCO"][v]))
+      print1 ("# Asm caps for %s: AsmHasExplicitCO=%d AsmHasDirectToLds=%d" \
+              % (isaVersion, \
+                  globalParameters["AsmHasExplicitCO"][v], \
+                  globalParameters["AsmHasDirectToLds"][v]))
 
 
 

--- a/Tensile/KernelWriter.py
+++ b/Tensile/KernelWriter.py
@@ -577,6 +577,14 @@ class KernelWriter:
     if kernel["LoopTail"]:
       kStr += self.comment3("Tail Loop")
 
+      # Update local write pointers in case the upcoming global reads are writing directly to LDS:
+      if self.enable["LocalWrite"]:
+        if kernel["PrefetchGlobalRead"]:
+          kStr += self.comment("local write reset offsets a")
+          kStr += self.localWriteResetOffsets(kernel, tensorParametersA)
+          kStr += self.comment("local write reset offsets b")
+          kStr += self.localWriteResetOffsets(kernel, tensorParametersB)
+
       if self.enable["GlobalRead"]:
         # tail: global read
         kStr += self.calculateLoopNumIter(kernel, -1)
@@ -590,11 +598,6 @@ class KernelWriter:
         kStr += self.syncThreads(kernel)
       if self.enable["LocalWrite"]:
         # tail: local write
-        if kernel["PrefetchGlobalRead"]:
-          kStr += self.comment("local write reset offsets a")
-          kStr += self.localWriteResetOffsets(kernel, tensorParametersA)
-          kStr += self.comment("local write reset offsets b")
-          kStr += self.localWriteResetOffsets(kernel, tensorParametersB)
         kStr += self.comment("local write init pointers a")
         kStr += self.localWriteInitPointers(kernel, tensorParametersA)
         kStr += self.comment("local write init pointers b")
@@ -1171,7 +1174,7 @@ class KernelWriter:
       tP["nlpv"] = self.numReadsPerpVecCompA                # num vector components perpendicular to coalesced; =1 or VW
       # NEW
       tP["nrt"] = self.numReadsTileA                        # number of reads along tile dimension
-      tP["nrtv"] = self.numReadsTileVecCompA                # number of vector components along tile dimension; =1 or VW                
+      tP["nrtv"] = self.numReadsTileVecCompA                # number of vector components along tile dimension; =1 or VW
       tP["nru"] = self.numReadsUnrollA                      # number of reads along unroll dimension
       tP["nruv"] = self.numReadsUnrollVecCompA              # number of vector components along unroll dimension; =1 or VW
       tP["nrc"] = kernel["NumLoadsCoalescedA"]              # number of reads along coalesced dimension

--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -1219,7 +1219,7 @@ class Solution:
         and state["ProblemType"]["TransposeB"] \
         and ((state["LSCB"] * state["ProblemType"]["DataType"].numBytes()) % 256 == 0):
         state["DirectToLdsB"] = True
-        state["LocalWriteUseSgprA"] = True
+        state["LocalWriteUseSgprB"] = True
 
       if 0:
         print "A: TLU=", state["ProblemType"]["TLUA"], " MT=", state["MacroTile0"], \

--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -1203,30 +1203,33 @@ class Solution:
     # TODO - currently only support Single but could be extended to 2 halfs or part of a double
     state["DirectToLdsA"] = False
     state["DirectToLdsB"] = False
+    state["LocalWriteUseSgprA"] = False
+    state["LocalWriteUseSgprB"] = False
 
     if state["KernelLanguage"] == "Assembly" \
-        and state["BufferLoad"] \
-        and state["ProblemType"]["DataType"].isSingle():
-
+      and state["BufferLoad"] \
+      and state["ProblemType"]["DataType"].isSingle():
       if state["GlobalLoadVectorWidthA"] == 1 \
-          and not state["ProblemType"]["TransposeA"] \
-          and ((state["LSCA"] * state["ProblemType"]["DataType"].numBytes()) % 256 == 0):
+        and not state["ProblemType"]["TransposeA"] \
+        and ((state["LSCA"] * state["ProblemType"]["DataType"].numBytes()) % 256 == 0):
         state["DirectToLdsA"] = True
+        state["LocalWriteUseSgprA"] = True
 
       if state["GlobalLoadVectorWidthB"] == 1 \
-          and state["ProblemType"]["TransposeB"] \
-          and ((state["LSCB"] * state["ProblemType"]["DataType"].numBytes()) % 256 == 0):
+        and state["ProblemType"]["TransposeB"] \
+        and ((state["LSCB"] * state["ProblemType"]["DataType"].numBytes()) % 256 == 0):
         state["DirectToLdsB"] = True
+        state["LocalWriteUseSgprA"] = True
 
-        if 0:
-          print "A: TLU=", state["ProblemType"]["TLUA"], " MT=", state["MacroTile0"], \
-                 " LSCA=", state["LSCA"], "GLVB_A=", state["GlobalLoadVectorWidthA"], \
-                 " dataTypeNumBytes=", state["ProblemType"]["DataType"].numBytes(), \
-                 "  ->DirectToLdsA=", state["DirectToLdsA"]
-          print "B: TLU=", state["ProblemType"]["TLUB"], " MT=", state["MacroTile1"], \
-                 " LSCB=", state["LSCB"], "GLVB_B=", state["GlobalLoadVectorWidthB"], \
-                 " dataTypeNumBytes=", state["ProblemType"]["DataType"].numBytes(), \
-                 "  ->DirectToLdsB=", state["DirectToLdsB"]
+      if 0:
+        print "A: TLU=", state["ProblemType"]["TLUA"], " MT=", state["MacroTile0"], \
+               " LSCA=", state["LSCA"], "GLVB_A=", state["GlobalLoadVectorWidthA"], \
+               " dataTypeNumBytes=", state["ProblemType"]["DataType"].numBytes(), \
+               "  ->DirectToLdsA=", state["DirectToLdsA"]
+        print "B: TLU=", state["ProblemType"]["TLUB"], " MT=", state["MacroTile1"], \
+               " LSCB=", state["LSCB"], "GLVB_B=", state["GlobalLoadVectorWidthB"], \
+               " dataTypeNumBytes=", state["ProblemType"]["DataType"].numBytes(), \
+               "  ->DirectToLdsB=", state["DirectToLdsB"]
 
 
     state["AssignedDerivedParameters"] = True


### PR DESCRIPTION
If possible, returned data flows directly into LDS rather than
through VGPRs.  Save registers and latency.

- Determine if vector width and transpose op support DirectToLDS.
- Disable allocation of staging GLA and GLB registers (unless
  KeepDirectToLdsAlloc=1).  Can save ~16 VGPRS depending on
  tile size.
- Separate computation of lds write offset into calculateLdsWriteOffset
- Write m0 with LDS offset
- Test with new assembler,
- Uses dummy vgpr for DirectToLds

- Enable tail loop
- Increment m0 only when necessary
- Cleanup
- Only enable DirectToLds if coalesced loads fetch 256 consecutive bytes
  of memory.