### PR TITLE
set default GlobalReadVectorWidth=-1

### DIFF
--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -324,7 +324,7 @@ defaultBenchmarkCommonParameters = [
     {"VectorWidth":               [ -1 ] },
     # use 1 by default since this enables other important optimizations including:
     # DirectToLds, preciseBoundsCheck, and useSgrpForGRO
-    {"GlobalReadVectorWidth":     [ 1 ] },
+    {"GlobalReadVectorWidth":     [ -1 ] },
     {"GlobalReadCoalesceVectorA": [ True ] },
     {"GlobalReadCoalesceVectorB": [ True ] },
     {"GlobalReadCoalesceGroupA":  [ True ] },


### PR DESCRIPTION
Performance improves with GlobalReadVectorWidth default value set to -1. Setting GRVW to -1 means it will batch VW. 