### PR TITLE
Preliminary patch for gfx9xx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,6 @@
 *.vscode
 *~
 Tensile.egg-info
-build
+build*
 dist
 .cache

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -103,7 +103,7 @@ globalParameters["MaxLDS"] = 65536                # max LDS a kernel should atte
 globalParameters["MaxDepthU"] = 256               # max DepthU value to allow
 globalParameters["ShortNames"] = False            # on windows kernel names can get too long; =True will convert solution/kernel names to serial ids
 globalParameters["MergeFiles"] = True             # F=store every solution and kernel in sepperate file; T=store all solutions in single file
-globalParameters["SupportedISA"] = [(8,0,3), (9,0,0)]             # assembly kernels writer supports these architectures
+globalParameters["SupportedISA"] = [(8,0,3), (9,0,0), (9,0,6)]             # assembly kernels writer supports these architectures
 globalParameters["BenchmarkProblemsPath"] = "1_BenchmarkProblems" # subdirectory for benchmarking phases
 globalParameters["BenchmarkDataPath"] = "2_BenchmarkData"         # subdirectory for storing final benchmarking data
 globalParameters["LibraryLogicPath"] = "3_LibraryLogic"           # subdirectory for library logic produced by analysis

--- a/Tensile/Configs/rocblas_cgemm.yaml
+++ b/Tensile/Configs/rocblas_cgemm.yaml
@@ -1,5 +1,5 @@
 GlobalParameters:
-  MinimumRequiredVersion: 3.0.0
+  MinimumRequiredVersion: 4.0.2
   PrintLevel: 1
   ForceRedoBenchmarkProblems: True
   ForceRedoLibraryLogic: True

--- a/Tensile/Configs/rocblas_dgemm_asm_lite.yaml
+++ b/Tensile/Configs/rocblas_dgemm_asm_lite.yaml
@@ -1,5 +1,5 @@
 GlobalParameters:
-  MinimumRequiredVersion: 3.0.0
+  MinimumRequiredVersion: 4.0.2
   PrintLevel: 1
   ForceRedoBenchmarkProblems: True
   ForceRedoLibraryLogic: True

--- a/Tensile/Configs/rocblas_dgemm_asm_lite.yaml
+++ b/Tensile/Configs/rocblas_dgemm_asm_lite.yaml
@@ -262,9 +262,13 @@ BenchmarkProblems:
           - Range: [ [64], [1], [1], [64] ]
 
 LibraryLogic:
-    ScheduleName: "vega10"
-    DeviceNames: ["Device 6863", "Device 6862", "Device 687f"]
-    ArchitectureName: "gfx900"
+    ScheduleName: "vega20"
+    DeviceNames: ["Device 66a0"]
+    ArchitectureName: "gfx906"
+
+#   ScheduleName: "vega10"
+#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f"]
+#   ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"
 #   DeviceNames: ["Device 6860"]

--- a/Tensile/Configs/rocblas_dgemm_asm_lite.yaml
+++ b/Tensile/Configs/rocblas_dgemm_asm_lite.yaml
@@ -262,13 +262,13 @@ BenchmarkProblems:
           - Range: [ [64], [1], [1], [64] ]
 
 LibraryLogic:
-    ScheduleName: "vega20"
-    DeviceNames: ["Device 66a0"]
-    ArchitectureName: "gfx906"
+#   ScheduleName: "vega20"
+#   DeviceNames: ["Device 66a0"]
+#   ArchitectureName: "gfx906"
 
-#   ScheduleName: "vega10"
-#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f"]
-#   ArchitectureName: "gfx900"
+    ScheduleName: "vega10"
+    DeviceNames: ["Device 6863", "Device 6862", "Device 687f"]
+    ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"
 #   DeviceNames: ["Device 6860"]

--- a/Tensile/Configs/rocblas_dgemm_asm_single_kernel.yaml
+++ b/Tensile/Configs/rocblas_dgemm_asm_single_kernel.yaml
@@ -1,5 +1,5 @@
 GlobalParameters:
-  MinimumRequiredVersion: 3.3.0
+  MinimumRequiredVersion: 4.0.2
   PrintLevel: 1
   ForceRedoBenchmarkProblems: True
   ForceRedoLibraryLogic: True

--- a/Tensile/Configs/rocblas_dgemm_hip_lite.yaml
+++ b/Tensile/Configs/rocblas_dgemm_hip_lite.yaml
@@ -1,5 +1,5 @@
 GlobalParameters:
-  MinimumRequiredVersion: 3.0.0
+  MinimumRequiredVersion: 4.0.2
   PrintLevel: 1
   ForceRedoBenchmarkProblems: True
   ForceRedoLibraryLogic: True

--- a/Tensile/Configs/rocblas_hgemm_asm_lite.yaml
+++ b/Tensile/Configs/rocblas_hgemm_asm_lite.yaml
@@ -303,13 +303,13 @@ BenchmarkProblems:
 
 
 LibraryLogic:
-    ScheduleName: "vega20"
-    DeviceNames: ["Device 66a0"]
-    ArchitectureName: "gfx906"
+#   ScheduleName: "vega20"
+#   DeviceNames: ["Device 66a0"]
+#   ArchitectureName: "gfx906"
 
-#   ScheduleName: "vega10"
-#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f"]
-#   ArchitectureName: "gfx900"
+    ScheduleName: "vega10"
+    DeviceNames: ["Device 6863", "Device 6862", "Device 687f"]
+    ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"
 #   DeviceNames: ["Device 6860"]

--- a/Tensile/Configs/rocblas_hgemm_asm_lite.yaml
+++ b/Tensile/Configs/rocblas_hgemm_asm_lite.yaml
@@ -303,9 +303,13 @@ BenchmarkProblems:
 
 
 LibraryLogic:
-    ScheduleName: "vega10"
-    DeviceNames: ["Device 6863", "Device 6862", "Device 687f"]
-    ArchitectureName: "gfx900"
+    ScheduleName: "vega20"
+    DeviceNames: ["Device 66a0"]
+    ArchitectureName: "gfx906"
+
+#   ScheduleName: "vega10"
+#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f"]
+#   ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"
 #   DeviceNames: ["Device 6860"]

--- a/Tensile/Configs/rocblas_hgemm_asm_lite.yaml
+++ b/Tensile/Configs/rocblas_hgemm_asm_lite.yaml
@@ -1,5 +1,5 @@
 GlobalParameters:
-  MinimumRequiredVersion: 3.3.0
+  MinimumRequiredVersion: 4.0.2
   PrintLevel: 1
   ForceRedoBenchmarkProblems: True
   ForceRedoLibraryLogic: True

--- a/Tensile/Configs/rocblas_hgemm_hip_lite.yaml
+++ b/Tensile/Configs/rocblas_hgemm_hip_lite.yaml
@@ -1,5 +1,5 @@
 GlobalParameters:
-  MinimumRequiredVersion: 3.0.0
+  MinimumRequiredVersion: 4.0.2
   PrintLevel: 1
   ForceRedoBenchmarkProblems: True
   ForceRedoLibraryLogic: True

--- a/Tensile/Configs/rocblas_sgemm_asm_full.yaml
+++ b/Tensile/Configs/rocblas_sgemm_asm_full.yaml
@@ -1,5 +1,5 @@
 GlobalParameters:
-  MinimumRequiredVersion: 3.3.0
+  MinimumRequiredVersion: 4.0.2
   PrintLevel: 1
   ForceRedoBenchmarkProblems: True
   ForceRedoLibraryLogic: True

--- a/Tensile/Configs/rocblas_sgemm_asm_lite.yaml
+++ b/Tensile/Configs/rocblas_sgemm_asm_lite.yaml
@@ -314,13 +314,13 @@ BenchmarkProblems:
 
 
 LibraryLogic:
-    ScheduleName: "vega20"
-    DeviceNames: ["Device 66a0"]
-    ArchitectureName: "gfx906"
+#   ScheduleName: "vega20"
+#   DeviceNames: ["Device 66a0"]
+#   ArchitectureName: "gfx906"
 
-#   ScheduleName: "vega10"
-#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f"]
-#   ArchitectureName: "gfx900"
+    ScheduleName: "vega10"
+    DeviceNames: ["Device 6863", "Device 6862", "Device 687f"]
+    ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"
 #   DeviceNames: ["Device 6860"]

--- a/Tensile/Configs/rocblas_sgemm_asm_lite.yaml
+++ b/Tensile/Configs/rocblas_sgemm_asm_lite.yaml
@@ -1,5 +1,5 @@
 GlobalParameters:
-  MinimumRequiredVersion: 3.3.0
+  MinimumRequiredVersion: 4.0.2
   PrintLevel: 1
   ForceRedoBenchmarkProblems: True
   ForceRedoLibraryLogic: True

--- a/Tensile/Configs/rocblas_sgemm_asm_lite.yaml
+++ b/Tensile/Configs/rocblas_sgemm_asm_lite.yaml
@@ -314,9 +314,13 @@ BenchmarkProblems:
 
 
 LibraryLogic:
-    ScheduleName: "vega10"
-    DeviceNames: ["Device 6863", "Device 6862", "Device 687f"]
-    ArchitectureName: "gfx900"
+    ScheduleName: "vega20"
+    DeviceNames: ["Device 66a0"]
+    ArchitectureName: "gfx906"
+
+#   ScheduleName: "vega10"
+#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f"]
+#   ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"
 #   DeviceNames: ["Device 6860"]

--- a/Tensile/Configs/rocblas_sgemm_asm_single_kernel.yaml
+++ b/Tensile/Configs/rocblas_sgemm_asm_single_kernel.yaml
@@ -1,5 +1,5 @@
 GlobalParameters:
-  MinimumRequiredVersion: 3.3.0
+  MinimumRequiredVersion: 4.0.2
   PrintLevel: 1
   ForceRedoBenchmarkProblems: True
   ForceRedoLibraryLogic: True

--- a/Tensile/Configs/rocblas_sgemm_hip_lite.yaml
+++ b/Tensile/Configs/rocblas_sgemm_hip_lite.yaml
@@ -1,5 +1,5 @@
 GlobalParameters:
-  MinimumRequiredVersion: 3.3.0
+  MinimumRequiredVersion: 4.0.2
   PrintLevel: 1
   ForceRedoBenchmarkProblems: True
   ForceRedoLibraryLogic: True

--- a/Tensile/Configs/rocblas_zgemm.yaml
+++ b/Tensile/Configs/rocblas_zgemm.yaml
@@ -1,5 +1,5 @@
 GlobalParameters:
-  MinimumRequiredVersion: 3.0.0
+  MinimumRequiredVersion: 4.0.2
   PrintLevel: 1
   ForceRedoBenchmarkProblems: True
   ForceRedoLibraryLogic: True

--- a/Tensile/Configs/test_convolution.yaml
+++ b/Tensile/Configs/test_convolution.yaml
@@ -1,5 +1,5 @@
 GlobalParameters:
-  MinimumRequiredVersion: 3.0.0
+  MinimumRequiredVersion: 4.0.2
   PrintLevel: 1
   ForceRedoBenchmarkProblems: True
   ForceRedoLibraryLogic: True

--- a/Tensile/Configs/test_dgemm.yaml
+++ b/Tensile/Configs/test_dgemm.yaml
@@ -1,6 +1,6 @@
 # benchmark assembly and source kernels
 GlobalParameters:
-  MinimumRequiredVersion: 5.0.1
+  MinimumRequiredVersion: 4.0.2
   CMakeBuildType: Release
   PrintLevel: 1
   ForceRedoBenchmarkProblems: True

--- a/Tensile/Configs/test_dgemm_asm.yaml
+++ b/Tensile/Configs/test_dgemm_asm.yaml
@@ -1,6 +1,6 @@
 # benchmark assembly and source kernels
 GlobalParameters:
-  MinimumRequiredVersion: 5.0.1
+  MinimumRequiredVersion: 4.0.2
   CMakeBuildType: Release
   PrintLevel: 1
   ForceRedoBenchmarkProblems: True

--- a/Tensile/Configs/test_hgemm.yaml
+++ b/Tensile/Configs/test_hgemm.yaml
@@ -2,7 +2,7 @@ GlobalParameters:
   PrintLevel: 1
   ForceRedoBenchmarkProblems: True
   PrintSolutionRejectionReason: False
-  MinimumRequiredVersion: 3.0.0
+  MinimumRequiredVersion: 4.0.2
   NumElementsToValidate: -1
   ValidationMaxToPrint: 4
   DataInitTypeAB: 1

--- a/Tensile/Configs/test_hgemm_asm.yaml
+++ b/Tensile/Configs/test_hgemm_asm.yaml
@@ -1,6 +1,6 @@
 # benchmark assembly and source kernels
 GlobalParameters:
-  MinimumRequiredVersion: 5.0.1
+  MinimumRequiredVersion: 4.0.2
   CMakeBuildType: Release
   PrintLevel: 1
   ForceRedoBenchmarkProblems: True

--- a/Tensile/Configs/test_hgemm_vectors.yaml
+++ b/Tensile/Configs/test_hgemm_vectors.yaml
@@ -2,7 +2,7 @@ GlobalParameters:
   PrintLevel: 1
   ForceRedoBenchmarkProblems: True
   PrintSolutionRejectionReason: False
-  MinimumRequiredVersion: 3.0.0
+  MinimumRequiredVersion: 4.0.2
   NumElementsToValidate: -1
   ValidationMaxToPrint: 4
   DataInitTypeAB: 1

--- a/Tensile/Configs/test_sgemm.yaml
+++ b/Tensile/Configs/test_sgemm.yaml
@@ -2,7 +2,7 @@ GlobalParameters:
   PrintLevel: 1
   ForceRedoBenchmarkProblems: True
   PrintSolutionRejectionReason: False
-  MinimumRequiredVersion: 3.0.0
+  MinimumRequiredVersion: 4.0.2
   NumElementsToValidate: -1
   ValidationMaxToPrint: 4
   DataInitTypeAB: 1

--- a/Tensile/Configs/test_sgemm_asm.yaml
+++ b/Tensile/Configs/test_sgemm_asm.yaml
@@ -1,6 +1,6 @@
 # benchmark assembly and source kernels
 GlobalParameters:
-  MinimumRequiredVersion: 5.0.1
+  MinimumRequiredVersion: 4.0.2
   CMakeBuildType: Release
   PrintLevel: 1
   ForceRedoBenchmarkProblems: True

--- a/Tensile/Configs/test_sgemm_vectors.yaml
+++ b/Tensile/Configs/test_sgemm_vectors.yaml
@@ -2,7 +2,7 @@ GlobalParameters:
   PrintLevel: 1
   ForceRedoBenchmarkProblems: True
   PrintSolutionRejectionReason: False
-  MinimumRequiredVersion: 3.0.0
+  MinimumRequiredVersion: 4.0.2
   NumElementsToValidate: -1
   ValidationMaxToPrint: 4
   DataInitTypeAB: 1

--- a/Tensile/Configs/test_tensor_contraction.yaml
+++ b/Tensile/Configs/test_tensor_contraction.yaml
@@ -1,5 +1,5 @@
 GlobalParameters:
-  MinimumRequiredVersion: 3.0.0
+  MinimumRequiredVersion: 4.0.2
   PrintLevel: 1
   ForceRedoBenchmarkProblems: True
   ForceRedoLibraryLogic: True

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -566,7 +566,17 @@ class KernelWriterAssembly(KernelWriter):
             ds_read_b64, ds_read2_b32, ds_read_b32 ],
           "LocalWrite": [ ds_write_b128, ds_write2_b64,
             ds_write_b64, ds_write2_b32, ds_write_b32, ds_write_b16 ]
-          } # 900
+          }, # 900
+        (9,0,6): {
+          "GlobalRead": [ chosen_load_dwordx4, chosen_load_dwordx2,
+            chosen_load_dword ],
+          "GlobalWrite": [ flat_store_dwordx4, flat_store_dwordx2,
+            flat_store_dword ],
+          "LocalRead": [ ds_read_b128, ds_read2_b64,
+            ds_read_b64, ds_read2_b32, ds_read_b32 ],
+          "LocalWrite": [ ds_write_b128, ds_write2_b64,
+            ds_write_b64, ds_write2_b32, ds_write_b32, ds_write_b16 ]
+          } # 906
         }
 
 
@@ -1509,7 +1519,7 @@ class KernelWriterAssembly(KernelWriter):
                   bStr = "v[%s+%u]" \
                       % ("vgprValuB" if m==0 else "vgprValuBlkB", blockB)
                   kStr += "v_mac_f16 %s, %s, %s%s" % (cStr, aStr, bStr, self.endLine) # FIXME op_sel
-            elif self.version == (9,0,0):
+            elif self.version == (9,0,0) or self.version == (9,0,6):
               if kernel["ProblemType"]["HighPrecisionAccumulate"]:
                 # we treat HighPrecisionAccumulate as expanded packed math
                 b = blockB*2

--- a/Tensile/Source/Client.h
+++ b/Tensile/Source/Client.h
@@ -613,7 +613,7 @@ bool callLibrary(
 
   float perfScaling = 1.f;
 #if Tensile_RUNTIME_LANGUAGE_HIP
-  perfScaling = 1.f * expectedClockRate / avgCoreClock; // if clock speeds drop
+//  perfScaling = 1.f * expectedClockRate / avgCoreClock; // if clock speeds drop
 #endif
   double gflops = solutionIsValid ? perfScaling * totalFlops / timeNs : 0;
 
@@ -1012,7 +1012,7 @@ bool benchmarkAllSolutionsForSize(
 
     float perfScaling = 1.f;
 #if Tensile_RUNTIME_LANGUAGE_HIP
-    perfScaling = 1.f * expectedClockRate / avgCoreClock; // if clock speeds drop
+//    perfScaling = 1.f * expectedClockRate / avgCoreClock; // if clock speeds drop
 #endif
     double gflops = solutionIsValid ? perfScaling * totalFlops / timeNs : 0;
     //std::cout << gflops << " gflops = " << totalFlops << " flops / " << timeNs << " ns" << std::endl;

--- a/Tensile/Source/TensileConfig.cmake
+++ b/Tensile/Source/TensileConfig.cmake
@@ -103,7 +103,7 @@ function(TensileCreateLibrary
   set(options)
   add_library(Tensile ${options} ${Tensile_SOURCE_FILES})
   # specify gpu targets
-  set(Tensile_HIP_ISA "gfx803" "gfx900")
+  set(Tensile_HIP_ISA "gfx803" "gfx900" "gfx906")
   foreach( target ${Tensile_HIP_ISA} )
     target_link_libraries( Tensile PRIVATE --amdgpu-target=${target} )
   endforeach()

--- a/Tensile/__init__.py
+++ b/Tensile/__init__.py
@@ -20,4 +20,4 @@
 ################################################################################
 
 # hardcoded tensile version; also in Tensile/Source/TensileConfigVersion.cmake
-__version__ = "5.0.1"
+__version__ = "4.0.2"

--- a/bump-version.sh
+++ b/bump-version.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# the convention is master has even leading digit, and develop has odd leading digit
+#
+# Note that for changes in minor version number it may not be necessary to update
+# MinimumRequiredVersion in .yaml files, it may only be necessary to update __init__.py
+#
+# It is necessary to get the even number for master branch and Odd number for 
+# develop branch correct. This applies also to .yaml files
+
+OLD_VERSION="5.0.1"
+NEW_VERSION="4.0.2"
+
+OLD_MINIMUM_REQUIRED_VERSION="MinimumRequiredVersion: 5.0.1"
+NEW_MINIMUM_REQUIRED_VERSION="MinimumRequiredVersion: 4.0.2"
+
+sed -i "s/${OLD_VERSION}/${NEW_VERSION}/g" Tensile/__init__.py
+
+for FILE in Tensile/Configs/*yaml
+do
+  sed -i "s/${OLD_MINIMUM_REQUIRED_VERSION}/${NEW_MINIMUM_REQUIRED_VERSION}/" $FILE
+done


### PR DESCRIPTION
Preliminary patch for gfx9xx

+ .gitignore now includes "build*" instead of just "build"
+ Tensile/Source/Client.h has scaling by expectedClockRate/avgCoreClock disabled for now
+ all remaining changes concerned gfx906 support

The 6 tests in nightly.py beyond what's tested in pre-checkin.py passed after updating the version number to 5.0.1:

test/incr.py::test_hgemm PASSED
test/incr.py::test_sgemm PASSED
test/incr.py::test_hgemm_vectors PASSED
test/incr.py::test_sgemm_vectors PASSED
test/incr.py::test_tensor_convolution PASSED
test/incr.py::test_tensor_contraction PASSED
