### PR TITLE
add mi25 Device 6860 to vega10

### DIFF
--- a/Tensile/Configs/rocblas_cgemm.yaml
+++ b/Tensile/Configs/rocblas_cgemm.yaml
@@ -177,7 +177,7 @@ BenchmarkProblems:
 
 LibraryLogic:
     ScheduleName: "vega10"
-    DeviceNames: ["Device 6863", "Device 6862", "Device 687f"]
+    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860"]
     ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/rocblas_dgemm_asm_lite.yaml
+++ b/Tensile/Configs/rocblas_dgemm_asm_lite.yaml
@@ -263,7 +263,7 @@ BenchmarkProblems:
 
 LibraryLogic:
     ScheduleName: "vega10"
-    DeviceNames: ["Device 6863", "Device 6862", "Device 687f"]
+    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860"]
     ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/rocblas_dgemm_hip_lite.yaml
+++ b/Tensile/Configs/rocblas_dgemm_hip_lite.yaml
@@ -163,7 +163,7 @@ BenchmarkProblems:
 
 LibraryLogic:
 #   ScheduleName: "vega10"
-#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f"]
+#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860"]
 #   ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/rocblas_hgemm_asm_lite.yaml
+++ b/Tensile/Configs/rocblas_hgemm_asm_lite.yaml
@@ -304,7 +304,7 @@ BenchmarkProblems:
 
 LibraryLogic:
     ScheduleName: "vega10"
-    DeviceNames: ["Device 6863", "Device 6862", "Device 687f"]
+    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860"]
     ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/rocblas_hgemm_hip_lite.yaml
+++ b/Tensile/Configs/rocblas_hgemm_hip_lite.yaml
@@ -157,7 +157,7 @@ BenchmarkProblems:
 
 LibraryLogic:
 #   ScheduleName: "vega10"
-#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f"]
+#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860"]
 #   ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/rocblas_sgemm_asm_full.yaml
+++ b/Tensile/Configs/rocblas_sgemm_asm_full.yaml
@@ -1092,7 +1092,7 @@ BenchmarkProblems:
 
 LibraryLogic:
     ScheduleName: "vega10"
-    DeviceNames: ["Device 6863", "Device 6862", "Device 687f"]
+    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860"]
     ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/rocblas_sgemm_asm_lite.yaml
+++ b/Tensile/Configs/rocblas_sgemm_asm_lite.yaml
@@ -315,7 +315,7 @@ BenchmarkProblems:
 
 LibraryLogic:
     ScheduleName: "vega10"
-    DeviceNames: ["Device 6863", "Device 6862", "Device 687f"]
+    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860"]
     ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/rocblas_sgemm_hip_lite.yaml
+++ b/Tensile/Configs/rocblas_sgemm_hip_lite.yaml
@@ -178,7 +178,7 @@ BenchmarkProblems:
 
 LibraryLogic:
 #   ScheduleName: "vega10"
-#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f"]
+#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860"]
 #   ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/rocblas_zgemm.yaml
+++ b/Tensile/Configs/rocblas_zgemm.yaml
@@ -177,7 +177,7 @@ BenchmarkProblems:
 
 LibraryLogic:
     ScheduleName: "vega10"
-    DeviceNames: ["Device 6863", "Device 6862", "Device 687f"]
+    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860"]
     ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/test_convolution.yaml
+++ b/Tensile/Configs/test_convolution.yaml
@@ -54,7 +54,7 @@ BenchmarkProblems:
 
 LibraryLogic:
     ScheduleName: "vega10"
-    DeviceNames: ["Device 6863", "Device 6862", "Device 687f"]
+    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860"]
     ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/test_dgemm.yaml
+++ b/Tensile/Configs/test_dgemm.yaml
@@ -269,7 +269,7 @@ LibraryLogic:
     SolutionImportanceMin: 0
 
     ScheduleName: "vega10"
-    DeviceNames: ["Device 6863", "Device 6862", "Device 687f"]
+    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860"]
     ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/test_dgemm_asm.yaml
+++ b/Tensile/Configs/test_dgemm_asm.yaml
@@ -269,7 +269,7 @@ LibraryLogic:
     SolutionImportanceMin: 0
 
     ScheduleName: "vega10"
-    DeviceNames: ["Device 6863", "Device 6862", "Device 687f"]
+    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860"]
     ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/test_dgemm_defaults.yaml
+++ b/Tensile/Configs/test_dgemm_defaults.yaml
@@ -33,7 +33,7 @@ BenchmarkProblems:
 
 LibraryLogic:
     ScheduleName: "vega10"
-    DeviceNames: ["Device 6863", "Device 6862", "Device 687f"]
+    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860"]
     ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/test_hgemm.yaml
+++ b/Tensile/Configs/test_hgemm.yaml
@@ -300,7 +300,7 @@ BenchmarkProblems:
 
 LibraryLogic:
     ScheduleName: "vega10"
-    DeviceNames: ["Device 6863", "Device 6862", "Device 687f"]
+    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860"]
     ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/test_hgemm_asm.yaml
+++ b/Tensile/Configs/test_hgemm_asm.yaml
@@ -266,7 +266,7 @@ BenchmarkProblems:
 
 LibraryLogic:
     ScheduleName: "vega10"
-    DeviceNames: ["Device 6863", "Device 6862", "Device 687f"]
+    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860"]
     ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/test_hgemm_defaults.yaml
+++ b/Tensile/Configs/test_hgemm_defaults.yaml
@@ -33,7 +33,7 @@ BenchmarkProblems:
 
 LibraryLogic:
     ScheduleName: "vega10"
-    DeviceNames: ["Device 6863", "Device 6862", "Device 687f"]
+    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860"]
     ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/test_hgemm_vectors.yaml
+++ b/Tensile/Configs/test_hgemm_vectors.yaml
@@ -300,7 +300,7 @@ BenchmarkProblems:
 
 LibraryLogic:
     ScheduleName: "vega10"
-    DeviceNames: ["Device 6863", "Device 6862", "Device 687f"]
+    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860"]
     ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/test_sgemm.yaml
+++ b/Tensile/Configs/test_sgemm.yaml
@@ -409,7 +409,7 @@ BenchmarkProblems:
 
 LibraryLogic:
     ScheduleName: "vega10"
-    DeviceNames: ["Device 6863", "Device 6862", "Device 687f"]
+    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860"]
     ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/test_sgemm_asm.yaml
+++ b/Tensile/Configs/test_sgemm_asm.yaml
@@ -273,7 +273,7 @@ LibraryLogic:
     SolutionImportanceMin: 0
 
     ScheduleName: "vega10"
-    DeviceNames: ["Device 6863", "Device 6862", "Device 687f"]
+    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860"]
     ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/test_sgemm_defaults.yaml
+++ b/Tensile/Configs/test_sgemm_defaults.yaml
@@ -33,7 +33,7 @@ BenchmarkProblems:
 
 LibraryLogic:
     ScheduleName: "vega10"
-    DeviceNames: ["Device 6863", "Device 6862", "Device 687f"]
+    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860"]
     ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/test_sgemm_vectors.yaml
+++ b/Tensile/Configs/test_sgemm_vectors.yaml
@@ -300,7 +300,7 @@ BenchmarkProblems:
 
 LibraryLogic:
     ScheduleName: "vega10"
-    DeviceNames: ["Device 6863", "Device 6862", "Device 687f"]
+    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860"]
     ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/test_tensor_contraction.yaml
+++ b/Tensile/Configs/test_tensor_contraction.yaml
@@ -158,7 +158,7 @@ BenchmarkProblems:
 
 LibraryLogic:
     ScheduleName: "vega10"
-    DeviceNames: ["Device 6863", "Device 6862", "Device 687f"]
+    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860"]
     ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"


### PR DESCRIPTION
Add mi25  Device 6860  to list of vega10 devices so that all tuning for vega10 is also used for mi25. 