### PR TITLE
Fix sync with DirectToLds when PrefetchLocalRead=0

### DIFF
--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -791,7 +791,7 @@ class Solution:
         state["Valid"] = False
         return
 
-    # GlobalSplitU doesn't work with
+    # GlobalSplitU doesn't work with some other things:
     if state["GlobalSplitU"] > 1:
       if not state["GlobalSplitUSummationAssignmentRoundRobin"] \
           and state["LoopTail"]:


### PR DESCRIPTION
Need to ensure prior reads lds LDS have finished before launching
buffer loads that may write to same LDS locations.

Also add ConservativeWaitCnt chicken bit

And print warnings if chicken bits that may impact perf are enabled