### PR TITLE
test hcc_rocm on gfx900; add python-yaml python-pytest to build_image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -318,7 +318,7 @@ parallel hcc_ctu:
 },
 hcc_rocm:
 {
-  node( 'docker && rocm && jenkins-rocm-2' )
+  node( 'docker && rocm && gfx900' )
   {
     def hcc_docker_args = new docker_data(
         from_image:'rocm/rocm-terminal:1.7.1',

--- a/docker/dockerfile-build-hip-hcc-ctu-ubuntu-16.04
+++ b/docker/dockerfile-build-hip-hcc-ctu-ubuntu-16.04
@@ -23,7 +23,9 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     pkg-config \
     python2.7 \
     python-pip \
+    python-pytest \
     python-setuptools \
+    python-yaml \
     libnuma1 \
     && \
     apt-get clean && \

--- a/docker/dockerfile-build-nvidia-cuda-8
+++ b/docker/dockerfile-build-nvidia-cuda-8
@@ -26,7 +26,9 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     pkg-config \
     python2.7 \
     python-pip \
+    python-pytest \
     python-setuptools \
+    python-yaml \
     libnuma1 \
     hip_hcc \
     && \

--- a/docker/dockerfile-build-rocm-terminal
+++ b/docker/dockerfile-build-rocm-terminal
@@ -22,7 +22,9 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     pkg-config \
     python2.7 \
     python-pip \
+    python-pytest \
     python-setuptools \
+    python-yaml \
     libnuma1 \
     && \
     apt-get clean && \


### PR DESCRIPTION
+ Enable hcc_rocm to test on any gfx900 Jenkins machines.
+ Add python-pytest and python-yaml to the list of packages in docker/dockerfile-build-*.

Made sure build_image for hcc_rocm succeeded on all of Jenkins-rocm-{0,2,3,4}.
Ran nightly.py in the docker image on Jenkins-rocm-3, pre-checkin.py in the docker image on Jenkins-rocm-{2,4}.  All passed.
