### PR TITLE
Align MAC blocks when using half datatype. v_pk_fma is a 64-bit opcod…

### DIFF
--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -3019,6 +3019,8 @@ class KernelWriterAssembly(KernelWriter):
   def macIter(self, kernel, black):
     if not self.do["MAC"]: return ""
     kStr = ""
+    if kernel["ProblemType"]["DataType"].isHalf():
+      kStr += ".align32 8, 0xbf800001\n"   # Align v_pk_fma instructions used in MAC_ blocks
     kStr += "MAC_%ux%u" % (kernel["ThreadTile0"],kernel["ThreadTile1"])
     if black:
       kStr += "_BLK"


### PR DESCRIPTION
…e, get better I$ behavior when opcodes are aligned. Need to revisit in the future in case we use other 64-bit opcodes.