### PR TITLE
adding rocblas_sgemm_asm_lite.yaml to rocblas_sgemm_asm_miopen.yaml

### DIFF
--- a/Tensile/Configs/rocblas_sgemm_asm_miopen.yaml
+++ b/Tensile/Configs/rocblas_sgemm_asm_miopen.yaml
@@ -7,25 +7,22 @@ GlobalParameters:
   CMakeBuildType: Release
   EnqueuesPerSync: 1
   SyncsPerBenchmark: 1
+  LibraryPrintDebug: False
   NumElementsToValidate: 0
   ValidationMaxToPrint: 4
   ValidationPrintValids: False
+  ShortNames: False
+  MergeFiles: True
   Platform: 0
   Device: 0
   KernelTime: True
   PinClocks: True
   SleepPercent: 200
   DataInitTypeBeta : 0
-  SolutionSelectionAlg: 1  # keepWinnerSolutions
 
 BenchmarkProblems:
-
   ########################################
-  ########################################
-  ###
-  ###   NN
-  ###
-  ########################################
+  # NN - standard
   ########################################
   -
     - # ProblemType
@@ -34,51 +31,72 @@ BenchmarkProblems:
       TransposeA: False
       TransposeB: False
       UseBeta: True
-      Batched: True 
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - ProblemSizes:
+          - Exact: [ 5504, 5504, 1, 3104 ]
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - PrefetchLocalRead: [True]
+      ForkParameters:
+        - PrefetchGlobalRead: [False, True]
+        - ThreadTile:
+          - [ 4, 4 ]
+          - [ 8, 4 ]
+          - [ 4, 8 ]
+          - [ 8, 8 ]
+        - WorkGroup:
+          - [ 16, 16, 1 ]
+          - [ 8, 8, 4 ]
+        - WorkGroupMapping: [1, 8]
+        - GlobalSplitU: [1, 2, 4, 8]
+        - DepthU: [ 8, 16, 32 ]
+        - VectorWidth: [-1]
+      BenchmarkForkParameters:
+      JoinParameters:
+        - MacroTile
+        - GlobalSplitU
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [64, 64, 64, 7000], [64, 64, 64, 7000], [1], [3104] ]
 
   ########################################
-  # NN - NonBatched
+  # NN - VectorWidth Correctness
   ########################################
-    - # Benchmark Group - ResNet 1x1:
+    - # Benchmark Group
       InitialSolutionParameters:
       BenchmarkCommonParameters:
         - EdgeType: ["ShiftPtr"]
         - LoopTail: [True]
         - KernelLanguage: ["Assembly"]
+        - PrefetchGlobalRead: [True]
+        - PrefetchLocalRead: [True]
+        - WorkGroupMapping: [1]
       ForkParameters:
-        - PrefetchGlobalRead: [ False, True ]
-        - PrefetchLocalRead: [ False, True ]
         - ThreadTile:
-          - [ 4, 4 ]
-          - [ 4, 8 ]
-          - [ 8, 4 ]
+          - [ 2, 2 ]
         - WorkGroup:
-          - [ 16,  8, 1 ]
-          - [ 8, 32, 1 ]
-          - [ 16, 16, 1 ]
-          - [ 32,  8, 1 ]
-        - WorkGroupMapping: [1, 8]
-        - DepthU: [ 8, 16 ]
-        - VectorWidth: [1,2,4]
-        - GlobalReadVectorWidth: [1,4]
-        - LdsPadB: [0,1,2,4]
+          - [ 4, 4, 4 ]
+        - GlobalSplitU: [2, 4, 8]
+        - DepthU: [ -1 ]
+        - VectorWidth: [-1]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [  12544,  256, 1, 1024 ]
-          - Exact: [  50176,  512, 1,  128 ]
-          - Exact: [   3136,  512, 1, 2048 ]
-          - Exact: [  12544, 1024, 1,  256 ]
-          - Exact: [   3136, 2048, 1,  512 ]
-          - Exact: [ 193600,  256, 1,   64 ]
-          - Exact: [ 193600,   64, 1,   64 ]
+          - Range: [ [4], [4], [1], [3104] ] # corner
+          - Range: [ [4], [64, 64, 64, 7000], [1], [3104] ] # skinny-0
+          - Range: [ [64, 64, 64, 7000], [4], [1], [3104] ] # skinny-1
 
   ########################################
-  # NN - Batch
+  # NN - ResNet 1x1
   ########################################
-    - # Benchmark Group - ResNet 1x1:
       InitialSolutionParameters:
       BenchmarkCommonParameters:
         - EdgeType: ["ShiftPtr"]
@@ -109,10 +127,231 @@ BenchmarkProblems:
           - Exact: [  196,  256, 64, 1024 ]
           - Exact: [  784,  512, 64,  128 ]
           - Exact: [   49,  512, 64, 2048 ]
+          - Exact: [ 3136,  512,  1, 2048 ]
           - Exact: [  196, 1024, 64,  256 ]
           - Exact: [   49, 2048, 64,  512 ]
+          - Exact: [ 3136, 2048,  1,  512 ]
           - Exact: [ 3025,  256, 64,   64 ]
           - Exact: [ 3025,   64, 64,   64 ]
+
+  ########################################
+  # NT - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: s
+      TransposeA: False
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - ProblemSizes:
+          - Exact: [ 5504, 5504, 1, 3104 ]
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - PrefetchLocalRead: [True]
+      ForkParameters:
+        - PrefetchGlobalRead: [False, True]
+        - ThreadTile:
+          - [ 4, 4 ]
+          - [ 8, 4 ]
+          - [ 4, 8 ]
+          - [ 8, 8 ]
+        - WorkGroup:
+          - [ 16, 16, 1 ]
+          - [ 8, 8, 4 ]
+        - WorkGroupMapping: [1, 8]
+        - GlobalSplitU: [1, 2, 4, 8]
+        - DepthU: [ 8, 16, 32 ]
+        - VectorWidth: [-1]
+      BenchmarkForkParameters:
+      JoinParameters:
+        - MacroTile
+        - GlobalSplitU
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [64, 64, 64, 7000], [64, 64, 64, 7000], [1], [3104] ]
+
+  ########################################
+  # NT - VectorWidth Correctness
+  ########################################
+    - # Benchmark Group
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - KernelLanguage: ["Assembly"]
+        - PrefetchGlobalRead: [True]
+        - PrefetchLocalRead: [True]
+        - WorkGroupMapping: [1]
+      ForkParameters:
+        - ThreadTile:
+          - [ 2, 2 ]
+        - WorkGroup:
+          - [ 4, 4, 4 ]
+        - GlobalSplitU: [2, 4, 8]
+        - DepthU: [ -1 ]
+        - VectorWidth: [-1]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [4], [4], [1], [3104] ] # corner
+          - Range: [ [4], [64, 64, 64, 7000], [1], [3104] ] # skinny-0
+          - Range: [ [64, 64, 64, 7000], [4], [1], [3104] ] # skinny-1
+
+  ########################################
+  # TN - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: s
+      TransposeA: True
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - ProblemSizes:
+          - Exact: [ 5504, 5504, 1, 3104 ]
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - PrefetchLocalRead: [True]
+      ForkParameters:
+        - PrefetchGlobalRead: [False, True]
+        - ThreadTile:
+          - [ 4, 4 ]
+          - [ 8, 4 ]
+          - [ 4, 8 ]
+          - [ 8, 8 ]
+        - WorkGroup:
+          - [ 16, 16, 1 ]
+          - [ 8, 8, 4 ]
+        - WorkGroupMapping: [1, 8]
+        - GlobalSplitU: [1, 2, 4, 8]
+        - DepthU: [ 8, 16, 32 ]
+        - VectorWidth: [-1]
+      BenchmarkForkParameters:
+      JoinParameters:
+        - MacroTile
+        - GlobalSplitU
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [64, 64, 64, 7000], [64, 64, 64, 7000], [1], [3104] ]
+
+  ########################################
+  # TN - VectorWidth Correctness
+  ########################################
+    - # Benchmark Group
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - KernelLanguage: ["Assembly"]
+        - PrefetchGlobalRead: [True]
+        - PrefetchLocalRead: [True]
+        - WorkGroupMapping: [1]
+      ForkParameters:
+        - ThreadTile:
+          - [ 2, 2 ]
+        - WorkGroup:
+          - [ 4, 4, 4 ]
+        - GlobalSplitU: [2, 4, 8]
+        - DepthU: [ -1 ]
+        - VectorWidth: [-1]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [4], [4], [1], [3104] ] # corner
+          - Range: [ [4], [64, 64, 64, 7000], [1], [3104] ] # skinny-0
+          - Range: [ [64, 64, 64, 7000], [4], [1], [3104] ] # skinny-1
+
+  ########################################
+  # TT - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: s
+      TransposeA: True
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - ProblemSizes:
+          - Exact: [ 5504, 5504, 1, 3104 ]
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - PrefetchLocalRead: [True]
+      ForkParameters:
+        - PrefetchGlobalRead: [False, True]
+        - ThreadTile:
+          - [ 4, 4 ]
+          - [ 8, 4 ]
+          - [ 4, 8 ]
+          - [ 8, 8 ]
+        - WorkGroup:
+          - [ 16, 16, 1 ]
+          - [ 8, 8, 4 ]
+        - WorkGroupMapping: [-1, -4]
+        - GlobalSplitU: [1, 2, 4, 8]
+        - DepthU: [ 8, 16, 32 ]
+        - VectorWidth: [-1]
+      BenchmarkForkParameters:
+      JoinParameters:
+        - MacroTile
+        - GlobalSplitU
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [64, 64, 64, 7000], [64, 64, 64, 7000], [1], [3104] ]
+
+  ########################################
+  # TT - VectorWidth Correctness
+  ########################################
+    - # Benchmark Group
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - KernelLanguage: ["Assembly"]
+        - PrefetchGlobalRead: [True]
+        - PrefetchLocalRead: [True]
+        - WorkGroupMapping: [-1]
+      ForkParameters:
+        - ThreadTile:
+          - [ 2, 2 ]
+        - WorkGroup:
+          - [ 4, 4, 4 ]
+        - GlobalSplitU: [2, 4, 8]
+        - DepthU: [ -1 ]
+        - VectorWidth: [-1]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [4], [4], [1], [3104] ] # corner
+          - Range: [ [4], [64, 64, 64, 7000], [1], [3104] ] # skinny-0
+          - Range: [ [64, 64, 64, 7000], [4], [1], [3104] ] # skinny-1
 
 
 LibraryLogic:


### PR DESCRIPTION
Add BenchmarkProblems from rocblas_sgemm_asm_lite.yaml. This will add assembly kernels for Range and Exact as specified in rocblas_sgemm_asm_lite.yaml. These are expected to be general good assembly kernels to replace the generally good hip kernels.