### PR TITLE
make ThreadTile optimal

### DIFF
--- a/Tensile/Configs/rocblas_dgemm_asm_single_kernel.yaml
+++ b/Tensile/Configs/rocblas_dgemm_asm_single_kernel.yaml
@@ -43,7 +43,7 @@ BenchmarkProblems:
       ForkParameters:
         - PrefetchGlobalRead: [True]
         - ThreadTile:
-          - [ 8, 8 ]
+          - [ 4, 4 ]
         - WorkGroup:
           - [ 16, 16, 1 ]
         - WorkGroupMapping: [8]


### PR DESCRIPTION
For the dgemm 5760 NT case, ThreadTile should have been 4x4.