### PR TITLE
Add fractional global load capability

### DIFF
--- a/Tensile/BenchmarkProblems.py
+++ b/Tensile/BenchmarkProblems.py
@@ -239,7 +239,12 @@ def benchmarkProblemType( problemTypeConfig, problemSizeGroupConfig, \
         solution = solutionsForHardcoded[j]
         solutionList.append(solution)
     if len(solutionList) == 0:
-        printExit("Your parameters resulted in 0 valid solutions.\nYou should re-run with \"PrintSolutionRejectionReason: True\" to see why each parameter combination was rejected.")
+        msg = "Your parameters resulted in 0 valid solutions."
+        if globalParameters["PrintSolutionRejectionReason"]:
+            msg += "\nExamine reject and backtrace messages above to see why and where solutions were rejected."
+        else:
+            msg += "\nYou should re-run with \"PrintSolutionRejectionReason: True\" to see why each parameter combination was rejected."
+        printExit(msg)
     if globalParameters["PrintLevel"] >= 1:
       for i in range(0, len(solutions)):
         solutionsForHardcoded = solutions[i]

--- a/Tensile/Source/TensorUtils.h
+++ b/Tensile/Source/TensorUtils.h
@@ -173,7 +173,7 @@ void printTensor(
     //unsigned printMode=PrintRowAddress + PrintRowElementCoord + PrintElementIndex + PrintElementValue + PrintElementValueHex) {
     //unsigned printMode= PrintRowElementCoord + PrintElementIndex + PrintElementValue + PrintElementValueHex) {
     //unsigned printMode= PrintRowElementCoord + PrintElementIndex + PrintElementValue + PrintElementValueHex) {
-    unsigned printMode=PrintRowElementCoord+PrintElementValue) {
+    unsigned printMode=PrintElementValueHex+PrintRowElementCoord+PrintElementValue) {
 
     TensorDims td(name, numIndices, firstSummationIndex, indexedSizes, indexAssignments);
 


### PR DESCRIPTION
- Decouple the load tile dimensions from the number of work-items.
  Work-items can load differing numbers of bytes from global mem.

  To conserve VGPR and simplify the address math tile, this mode uses
  a single GlobalReadOffset (GRO) for the tile.  All loads are constants
  (compile-time offsets or SGPR) from the base GRO.  TO fit this
  requirement, load instructions never wrap to new rows of the tile.
  Additional load instructions are added as needed.  Efficient buffer
  mode addressing is used to constrain loads which would be outside the
  tile dimension.

- By default FractionalLoad=0, which is same behavior as before.

- Refactor DirectToLds enablement code
  - Check if tile dims can be implemented with 256 bytes/wavefront

Details:
- Support broader range of DepthU, including odd numbers.
- Define "reject" function in SolutionStruct
  Print the speciied reject: message and a short stack backtrace so easy to
  tell which line of code generated the error.

  The new function also encapsulated the PrintSolutionRejectionReason
  check and the (optional) setting of state so overall error checking
  code is cleaner and easier to read.

- Refactor SolutionStruct code that sets load tile dims

  - Use subroutines to handle A and B (replace replicated code)
  - Partition into 2 subroutines, document purpose and outputs
  - Add setGlobalLoadTileDimFractional

- FractionalLoad: Add clipping for LocalWriteOffset

- Refactor DirectToLds for fractional and clarify wavefront logic
- Step down GRVW if possible
- DepthU < 0 restrictions based on GRVW and only apply if
  FractionalLoad=0
- Has DirectToLds disabled and ConservativeWaitCnt enabled - FIXME

- Compute LWO mask correctly for half
- Fix initLds for non-float values
- Try to fix checkvalue for half