### PR TITLE
Enable CodeFromFiles by default except when creating the Tensile library

### DIFF
--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -46,7 +46,7 @@ globalParameters["PrintLevel"] = 1                # how much info to print. 0=no
 # benchmarking
 globalParameters["KernelTime"] = False            # T=use device timers, F=use host timers
 globalParameters["PreciseKernelTime"] = True     # T=On hip, use the timestamps for kernel start and stop rather than separate events.  Can provide more accurate kernel timing.
-globalParameters["CodeFromFiles"] = False          # if False byte arrays will be generated during Benchmarking phase as before
+globalParameters["CodeFromFiles"] = True          # if False byte arrays will be generated during Benchmarking phase as before
 globalParameters["PinClocks"] = False             # T=pin gpu clocks and fan, F=don't
 globalParameters["NumBenchmarks"] = 1             # how many benchmark data points to collect per problem/solution
 globalParameters["SyncsPerBenchmark"] = 1         # how iterations of the stream synchronization for-loop to do per benchmark data point

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -861,6 +861,7 @@ def TensileCreateLibrary():
   arguments["MergeFiles"] = args.MergeFiles
   arguments["ShortNames"] = args.ShortNames
   arguments["LibraryPrintDebug"] = args.LibraryPrintDebug
+  arguments["CodeFromFiles"] = False
   assignGlobalParameters(arguments)
 
   if not os.path.exists(logicPath):


### PR DESCRIPTION
Enable CodeFromFiles by default in Common.py, except when creating the Tensile library.  This way rocBLAS build will still have byte arrays in Kernels.cpp, and a rocBLAS build will not be affected by the change.