### PR TITLE
Revert "Don't shift pointers if ASEM guarantees no partial vector loads"

### DIFF
--- a/Tensile/KernelWriter.py
+++ b/Tensile/KernelWriter.py
@@ -122,15 +122,10 @@ class KernelWriter:
 
       # tile edges
       if kernel["EdgeType"] == "ShiftPtr":
-        # don't shift if ASEM guarantees it is not needed:
-        noPartialA = kernel["AssertSummationElementMultiple"]%kernel["GlobalLoadVectorWidthA"]==0
-        noPartialB = kernel["AssertSummationElementMultiple"]%kernel["GlobalLoadVectorWidthB"]==0
-        if not noPartialA:
-            kStr += self.comment("global read addresses: shift a")
-            kStr += self.graShift(kernel, tensorParametersA)
-        if not noPartialB:
-            kStr += self.comment("global read addresses: shift b")
-            kStr += self.graShift(kernel, tensorParametersB)
+        kStr += self.comment("global read addresses: shift a")
+        kStr += self.graShift(kernel, tensorParametersA)
+        kStr += self.comment("global read addresses: shift b")
+        kStr += self.graShift(kernel, tensorParametersB)
       elif kernel["EdgeType"] == "Branch":
         kStr += self.comment("global read addresses: branch a")
         kStr += self.graBranch(kernel, tensorParametersA)
@@ -673,21 +668,12 @@ class KernelWriter:
       # Shift Vector Components
       ####################################
       if kernel["EdgeType"] == "ShiftPtr":
-
-        # noPartial means each component in the vector loads is always valid.  In this case we
-        # don't need the awkward unshift code
-        noPartialA = kernel["AssertSummationElementMultiple"]%kernel["GlobalLoadVectorWidthA"]==0
-        noPartialB = kernel["AssertSummationElementMultiple"]%kernel["GlobalLoadVectorWidthB"]==0
-        # TODO : the unshift code is complex and currently appears broken.  Long-term want to use
-        # the AssertSummationElementMultiple>glvw code as often as possible, or use buffer-load-x1
-        # in cases where it can't be used.  Then can remove this path.
-
         # shift vector components d0
-        if not noPartialA and self.readTileDimVectorA and kernel["GlobalLoadVectorWidthA"] > 1:
+        if self.readTileDimVectorA and kernel["GlobalLoadVectorWidthA"] > 1:
           kStr += self.comment("shift vector components d0")
           kStr += self.shiftVectorComponents(kernel, tensorParametersA)
         # shift vector components d1
-        if not noPartialB and self.readTileDimVectorB and kernel["GlobalLoadVectorWidthB"] > 1:
+        if self.readTileDimVectorB and kernel["GlobalLoadVectorWidthB"] > 1:
           kStr += self.comment("shift vector components d1")
           kStr += self.shiftVectorComponents(kernel, tensorParametersB)
 

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -2341,17 +2341,15 @@ class KernelWriterAssembly(KernelWriter):
   # Global Read Addresses: Shift A/B
   ##############################################################################
   def graShift(self, kernel, tP):
-    # PBC doesn't shift pointers, uses a difference edge detect mechanism
-    # FractionalLoad maps addresses in a different way?
-    if kernel["PreciseBoundsCheck"] : return ""
+    if kernel["PreciseBoundsCheck"]: return ""
 
     kStr = ""
     # edge value
     margin = tP["glvw"] if tP["rtv"] else 1
     edge = self.vgprPool.checkOut(1)
 
+
     if kernel["BufferLoad"] and kernel["PreciseBoundsCheck"]:
-      # dead code?  We don't run this if PBC=1
       # Go to the edge. we can rely on preciseboundscheck to keep things inline
       # Results in more loads of 0 which is better for power and debug
       kStr += inst("v_mov_b32", vgpr(edge), sgpr("SizesFree+%u"%tP["idx"]), \
@@ -2488,14 +2486,15 @@ class KernelWriterAssembly(KernelWriter):
 
               if self.checkGRO:
                 # Debug mode to verify that the computed offsets are offset by the expected scalar
+
                 print tc, "tileStride=", tileStride, "unrollStride=", unrollStride, \
                       "Strides%s="%tc
 
                 kStr += self.assert_vector_diff(vgpr("GlobalReadOffset%s+%u"%(tc,0)), \
                                                 vgpr("GlobalReadOffset%s+%u"%(tc,graIdx)), \
                                                 sgpr(scalarGro))
-
               #-- End UseSgprForGRO
+
             # dump final offsets
             # BufferLoad flavor:
             #if tP["isA"]:
@@ -4161,7 +4160,7 @@ class KernelWriterAssembly(KernelWriter):
       kStr += inst("_v_add_co_u32", vgpr(vReg), "vcc", vgpr(mvReg), vgpr(vReg), "vId = 2 components")
       self.vgprPool.checkIn(mvReg)
       self.vgprPool.checkIn(vRegD)
-
+    
     kStr += inst("v_cmp_eq_u32", sgpr(tmpSgpr,2), vgpr(thread), \
         vgpr(eReg), "mask" )
     kStr += inst("v_mov_b32", vgpr(tmpVgpr+0), sgpr(tmpSgpr+0), "")


### PR DESCRIPTION
This reverts commit 7bfb61cab0d9019dff21b4ea62e216f8f13c80a4.

This commit generated HIP code that hit memory access fault on 20 rocblas-test tests.  The bail-out error message was:
"Memory access fault by GPU node-1 (Agent handle: 0x16e1a70) on address 0x806e1f000. Reason: Page not present or supervisor privilege."
The 20 tests that hit this memory access fault when HIP backup kernel was in use were:

checkin_blas3_NaN/parameterized_gemm_NaN.float/6
checkin_blas3_NaN/parameterized_gemm_NaN.float/7
daily_blas3_large/parameterized_gemm.float/50
daily_blas3_large/parameterized_gemm.float/51
daily_blas3_large/parameterized_gemm.float/54
daily_blas3_large/parameterized_gemm.float/55
daily_blas3_large/parameterized_gemm.float/58
daily_blas3_large/parameterized_gemm.float/59
checkin_blas3/gemm_strided_batched.float/75
checkin_blas3/gemm_strided_batched.float/79
checkin_blas3/gemm_strided_batched.float/91
checkin_blas3/gemm_strided_batched.float/95
checkin_blas3/gemm_strided_batched.float/106
checkin_blas3/gemm_strided_batched.float/110
checkin_blas3/gemm_strided_batched.float/122
checkin_blas3/gemm_strided_batched.float/126
checkin_blas3/gemm_strided_batched.double/66
checkin_blas3/gemm_strided_batched.double/82
daily_blas3/trsm_gtest.trsm_gtest_float/2
daily_blas3/trsm_gtest.trsm_gtest_float/5

We need to back this commit out ASAP because we have another hipMalloc issue to resolve.
