### PR TITLE
__hfma no longer needed

### DIFF
--- a/Tensile/KernelWriterSource.py
+++ b/Tensile/KernelWriterSource.py
@@ -367,10 +367,7 @@ class KernelWriterSource(KernelWriter):
     if self.language == "OCL":
       kStr += "#define MAC(A,B,DST) mad(A,B,DST)"
     else:
-      if kernel["ProblemType"]["DataType"].isHalf():
-        kStr += "#define MAC(A,B,DST) DST = __hfma(A,B,DST)"
-      else:
-        kStr += "#define MAC(A,B,DST) DST += A*B"
+      kStr += "#define MAC(A,B,DST) DST += A*B"
     kStr += self.endLine
 
     if self.language == "HIP" and kernel["ProblemType"]["DataType"].isComplex():

--- a/Tensile/Source/KernelHeader.h
+++ b/Tensile/Source/KernelHeader.h
@@ -28,8 +28,6 @@ typedef __fp16 __half;
 
 extern "C" half2 llvm_fma_v2f16(half2, half2, half2) __asm("llvm.fma.v2f16");
 
-__device__ __half __hfma(__half a, __half b, __half c);
-
 __device__ inline half2 tensile_fmadd_half2(half2 multiplier, half2 multiplicand, half2 addend)
 {
     half2 result;


### PR DESCRIPTION
Identical assembly code was generated using either __hfma or C += A*B.
There is no need to depend on __hfma anymore.