### PR TITLE
dgemm asm_lite, source for k<=128

### DIFF
--- a/Tensile/Configs/rocblas_dgemm_asm_lite.yaml
+++ b/Tensile/Configs/rocblas_dgemm_asm_lite.yaml
@@ -37,6 +37,29 @@ BenchmarkProblems:
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
       BenchmarkCommonParameters:
+        - KernelLanguage: ["Source"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - WorkGroupMapping: [8]
+        - PrefetchLocalRead: [True]
+        - PrefetchGlobalRead: [True]
+        - VectorWidth: [-1]
+      ForkParameters:
+        - ThreadTile:
+          - [ 4, 4 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+        - DepthU: [ 8 ]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [64], [64], [1], [128] ] #source for k<=128
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
         - KernelLanguage: ["Assembly"]
         - EdgeType: ["ShiftPtr"]
         - LoopTail: [True]
@@ -55,7 +78,32 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [64], [64], [1], [64] ]
+          - Range: [ [64], [64], [1], [256] ]
+
+    - # BenchmarkProblemSizeGroup - M,N < VW
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Source"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - WorkGroupMapping: [8]
+        - PrefetchLocalRead: [True]
+        - PrefetchGlobalRead: [True]
+        - VectorWidth: [-1]
+      ForkParameters:
+        - ThreadTile:
+          - [ 4, 4 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+        - DepthU: [ 4 ]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [1], [1], [1], [128] ] #source for k<=128
+          - Range: [ [1], [64], [1], [128] ] #source for k<=128
+          - Range: [ [64], [1], [1], [128] ] #source for k<=128
 
     - # BenchmarkProblemSizeGroup - M,N < VW
       InitialSolutionParameters:
@@ -78,9 +126,9 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [1], [1], [1], [64] ]
-          - Range: [ [1], [64], [1], [64] ]
-          - Range: [ [64], [1], [1], [64] ]
+          - Range: [ [1], [1], [1], [256] ]
+          - Range: [ [1], [64], [1], [256] ]
+          - Range: [ [64], [1], [1], [256] ]
 
   ########################################
   # NT
@@ -97,6 +145,29 @@ BenchmarkProblems:
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
       BenchmarkCommonParameters:
+        - KernelLanguage: ["Source"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - WorkGroupMapping: [8]
+        - PrefetchLocalRead: [True]
+        - PrefetchGlobalRead: [True]
+        - VectorWidth: [-1]
+      ForkParameters:
+        - ThreadTile:
+          - [ 4, 4 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+        - DepthU: [ 8 ]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [64], [64], [1], [128] ] # source for k<=128
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
         - KernelLanguage: ["Assembly"]
         - EdgeType: ["ShiftPtr"]
         - LoopTail: [True]
@@ -115,7 +186,32 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [64], [64], [1], [64] ]
+          - Range: [ [64], [64], [1], [256] ]
+
+    - # BenchmarkProblemSizeGroup - M,N < VW
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Source"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - WorkGroupMapping: [8]
+        - PrefetchLocalRead: [True]
+        - PrefetchGlobalRead: [True]
+        - VectorWidth: [-1]
+      ForkParameters:
+        - ThreadTile:
+          - [ 4, 4 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+        - DepthU: [ 4 ]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [1], [1], [1], [128] ] # source for k<=128
+          - Range: [ [1], [64], [1], [128] ] # source for k<=128
+          - Range: [ [64], [1], [1], [128] ] # source for k<=128
 
     - # BenchmarkProblemSizeGroup - M,N < VW
       InitialSolutionParameters:
@@ -138,9 +234,10 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [1], [1], [1], [64] ]
-          - Range: [ [1], [64], [1], [64] ]
-          - Range: [ [64], [1], [1], [64] ]
+          - Range: [ [1], [1], [1], [256] ]
+          - Range: [ [1], [64], [1], [256] ]
+          - Range: [ [64], [1], [1], [256] ]
+
 
   ########################################
   # TN
@@ -157,7 +254,7 @@ BenchmarkProblems:
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
       BenchmarkCommonParameters:
-        - KernelLanguage: ["Assembly"]
+        - KernelLanguage: ["Source"]
         - EdgeType: ["ShiftPtr"]
         - LoopTail: [True]
         - WorkGroupMapping: [8]
@@ -175,44 +272,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [64], [64], [1], [64] ]
-
-    - # BenchmarkProblemSizeGroup - M,N < VW
-      InitialSolutionParameters:
-      BenchmarkCommonParameters:
-        - KernelLanguage: ["Assembly"]
-        - EdgeType: ["ShiftPtr"]
-        - LoopTail: [True]
-        - WorkGroupMapping: [8]
-        - PrefetchLocalRead: [True]
-        - PrefetchGlobalRead: [True]
-        - VectorWidth: [-1]
-      ForkParameters:
-        - ThreadTile:
-          - [ 4, 4 ]
-        - WorkGroup:
-          - [ 16, 16,  1 ]
-        - DepthU: [ 4 ]
-      BenchmarkForkParameters:
-      JoinParameters:
-      BenchmarkJoinParameters:
-      BenchmarkFinalParameters:
-        - ProblemSizes:
-          - Range: [ [1], [1], [1], [64] ]
-          - Range: [ [1], [64], [1], [64] ]
-          - Range: [ [64], [1], [1], [64] ]
-
-  ########################################
-  # TT
-  ########################################
-  -
-    - # ProblemType
-      OperationType: GEMM
-      DataType: d
-      TransposeA: True
-      TransposeB: True
-      UseBeta: True
-      Batched: True
+          - Range: [ [64], [64], [1], [128] ] # source for k<=128
 
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
@@ -235,7 +295,32 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [64], [64], [1], [64] ]
+          - Range: [ [64], [64], [1], [256] ]
+
+    - # BenchmarkProblemSizeGroup - M,N < VW
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Source"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - WorkGroupMapping: [8]
+        - PrefetchLocalRead: [True]
+        - PrefetchGlobalRead: [True]
+        - VectorWidth: [-1]
+      ForkParameters:
+        - ThreadTile:
+          - [ 4, 4 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+        - DepthU: [ 4 ]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [1], [1], [1], [128] ] # source for k<=128
+          - Range: [ [1], [64], [1], [128] ] # source for k<=128
+          - Range: [ [64], [1], [1], [128] ] # source for k<=128
 
     - # BenchmarkProblemSizeGroup - M,N < VW
       InitialSolutionParameters:
@@ -258,9 +343,118 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [1], [1], [1], [64] ]
-          - Range: [ [1], [64], [1], [64] ]
-          - Range: [ [64], [1], [1], [64] ]
+          - Range: [ [1], [1], [1], [256] ]
+          - Range: [ [1], [64], [1], [256] ]
+          - Range: [ [64], [1], [1], [256] ]
+
+  ########################################
+  # TT
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: d
+      TransposeA: True
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Source"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - WorkGroupMapping: [8]
+        - PrefetchLocalRead: [True]
+        - PrefetchGlobalRead: [True]
+        - VectorWidth: [-1]
+      ForkParameters:
+        - ThreadTile:
+          - [ 4, 4 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+        - DepthU: [ 8 ]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [64], [64], [1], [128] ] # source for k<=128
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - WorkGroupMapping: [8]
+        - PrefetchLocalRead: [True]
+        - PrefetchGlobalRead: [True]
+        - VectorWidth: [-1]
+      ForkParameters:
+        - ThreadTile:
+          - [ 4, 4 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+        - DepthU: [ 8 ]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [64], [64], [1], [256] ]
+
+    - # BenchmarkProblemSizeGroup - M,N < VW
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Source"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - WorkGroupMapping: [8]
+        - PrefetchLocalRead: [True]
+        - PrefetchGlobalRead: [True]
+        - VectorWidth: [-1]
+      ForkParameters:
+        - ThreadTile:
+          - [ 4, 4 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+        - DepthU: [ 4 ]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [1], [1], [1], [128] ] # source for k<=128
+          - Range: [ [1], [64], [1], [128] ] # source for k<=128
+          - Range: [ [64], [1], [1], [128] ] # source for k<=128
+
+    - # BenchmarkProblemSizeGroup - M,N < VW
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - WorkGroupMapping: [8]
+        - PrefetchLocalRead: [True]
+        - PrefetchGlobalRead: [True]
+        - VectorWidth: [-1]
+      ForkParameters:
+        - ThreadTile:
+          - [ 4, 4 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+        - DepthU: [ 4 ]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [1], [1], [1], [256] ]
+          - Range: [ [1], [64], [1], [256] ]
+          - Range: [ [64], [1], [1], [256] ]
+
 
 LibraryLogic:
     ScheduleName: "vega10"


### PR DESCRIPTION
Add k based kernel selection to rocblas_dgemm_asm_lite.yaml to call dgemm source kernels for k<128. This is a workaround for incorrect results from assembly kernels for stride_a == 0 || stride_b == 0 when batch_count > 1 and k < 128. The source kernels give the correct result for these sizes.