### PR TITLE
set VectorAtomicWidth to 1

### DIFF
--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -428,7 +428,7 @@ defaultBenchmarkCommonParameters = [
     {"MacroTileShapeMax":         [ 64 ] },
     {"PersistentKernel":          [ 0 ] },
     {"FractionalLoad":            [ 0 ] },
-    {"VectorAtomicWidth":         [ -1 ] },
+    {"VectorAtomicWidth":         [ 1 ] },
 
     {"NumLoadsCoalescedA":        [ 1 ] },
     {"NumLoadsCoalescedB":        [ 1 ] },


### PR DESCRIPTION
Turn off VectorAtomicWidth to avoid rocBLAS test failures caused by commit "Initial vector atomic implementation (WIP) "  https://github.com/ROCmSoftwarePlatform/Tensile/pull/282/commits/0891e6342fa8053292fbd312c0d7a08f19dfeffb

