### PR TITLE
intercept selection logic and call HIP kernel

### DIFF
--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -538,6 +538,21 @@ def writeLogic(outputPath, logicData, solutionWriter ):
           s += "    hipGetDeviceProperties(&deviceProperties, deviceId);\n"
           s += "    std::string name = deviceProperties.name;\n"
 
+        s += "\n"
+        s += "//  intercept schedule selection and call HIP (source) kernel\n"
+        s += "    if((strideA2K == 0) || (strideB2K == 0))\n"
+        s += "    {\n"
+        numSchedules = len(schedules)
+        schedule = reordered_schedules[numSchedules-1]
+        scheduleName  = schedule[0]
+        s += "        return tensileGetSolution%s_%s_%s(" \
+              % ( returnType, scheduleName, problemType)
+        for i in range(0, len(argListSizes)):
+          s += "%s%s" \
+              % (argListSizes[i][1],
+                  ", " if i < len(argListSizes)-1 else ");\n")
+        s += "    }\n"
+
         s += "\n    "
         for scheduleIdx in range(0, numSchedules):
           schedule = reordered_schedules[scheduleIdx]
@@ -553,7 +568,7 @@ def writeLogic(outputPath, logicData, solutionWriter ):
                 s += " || "
               s += "name == \"%s\"" % deviceName
             s += ")"
-          s += "{\n"
+          s += "\n    {\n"
           s += "        return tensileGetSolution%s_%s_%s(" \
               % ( returnType, scheduleName, problemType)
           for i in range(0, len(argListSizes)):


### PR DESCRIPTION
Call HIP kernel in place of assembly kernel when strideA2K == 0 || strideB2k == 0.

Note that the HIP kernel is only called in the rocblas/build/release/Tensile/Tensile.cpp file. You will not see this in the Tensile/build/4_LibraryClient/build/Tensile/Tensile.cpp file. This is because in Tensile you build for a specific schedule, which may be vega10, r9nano, or hip. In rocBLAS you build for multiple schedules, vega10+r9nano+hip. 