### PR TITLE
set GLVW=VW=1 in HIP kernels to avoid any error when GLVW>1

### DIFF
--- a/Tensile/Configs/rocblas_sgemm_hip_lite.yaml
+++ b/Tensile/Configs/rocblas_sgemm_hip_lite.yaml
@@ -53,6 +53,7 @@ BenchmarkProblems:
         - GlobalSplitU: [1]
         - DepthU: [ 4, 8, 16 ]
         - VectorWidth: [1]
+        - GlobalReadVectorWidth: [1]  # in some cases GRVW>1 is broken, so set GRVW=VW=1
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
@@ -92,6 +93,7 @@ BenchmarkProblems:
         - GlobalSplitU: [1]
         - DepthU: [ 4, 8, 16 ]
         - VectorWidth: [1]
+        - GlobalReadVectorWidth: [1]  # in some cases GRVW>1 is broken, so set GRVW=VW=1
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
@@ -131,6 +133,7 @@ BenchmarkProblems:
         - GlobalSplitU: [1]
         - DepthU: [ 8, 12, 16, 24, 32 ]
         - VectorWidth: [1]
+        - GlobalReadVectorWidth: [1]  # in some cases GRVW>1 is broken, so set GRVW=VW=1
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
@@ -170,6 +173,7 @@ BenchmarkProblems:
         - GlobalSplitU: [1]
         - DepthU: [ 4, 8, 16 ]
         - VectorWidth: [1]
+        - GlobalReadVectorWidth: [1]  # in some cases GRVW>1 is broken, so set GRVW=VW=1
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:


### PR DESCRIPTION
It looks like GLVW>1 is broken for some cases, even in HIP (source) version. Set GLVW=VW=1 for HIP kernels.