### PR TITLE
hipCtxGetDevice->hipGetDevice

### DIFF
--- a/Tensile/Configs/rocblas_hgemm_asm_full.yaml
+++ b/Tensile/Configs/rocblas_hgemm_asm_full.yaml
@@ -8,7 +8,7 @@ GlobalParameters:
   EnqueuesPerSync: 1
   SyncsPerBenchmark: 1
   LibraryPrintDebug: False
-  NumElementsToValidate: 128
+  NumElementsToValidate: 0
   ValidationMaxToPrint: 4
   ValidationPrintValids: False
   ShortNames: False
@@ -68,6 +68,8 @@ BenchmarkProblems:
         - GlobalSplitU: [1]
         - DepthU: [ 8, 16, 32, 64 ]
         - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [2]
+        - AssertFree0ElementMultiple: [2]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
@@ -156,6 +158,8 @@ BenchmarkProblems:
         - GlobalSplitU: [1]
         - DepthU: [ 8, 16, 24, 32, 64 ]
         - VectorWidth: [ 2, 4, 8 ]
+        - AssertSummationElementMultiple: [2]
+        - AssertFree0ElementMultiple: [2]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
@@ -231,6 +235,8 @@ BenchmarkProblems:
         - GlobalSplitU: [1]
         - DepthU: [ 8, 16, 24, 32, 64 ]
         - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [2]
+        - AssertFree0ElementMultiple: [2]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
@@ -333,10 +339,10 @@ BenchmarkProblems:
           - [ 8, 6 ]
           - [ 8, 8 ]
         - WorkGroup:
-          - [ 8, 8, 1 ]
+#         - [ 8, 8, 1 ]
           - [ 16, 16, 1 ]
         - WorkGroupMapping: [8]            # 1 removed for training performance
-        - DepthU: [ 8, 16, 24, 32, 64 ]
+        - DepthU: [ 8, 16, 24, 32 ]
         - VectorWidth: [-1]
       BenchmarkForkParameters:
       JoinParameters:
@@ -368,6 +374,8 @@ BenchmarkProblems:
         - WorkGroupMapping: [8]            # 1 removed for training performance
         - DepthU: [ 8, 16, 24, 32, 64 ]
         - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [2]
+        - AssertFree0ElementMultiple: [2]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
@@ -512,6 +520,8 @@ BenchmarkProblems:
         - GlobalSplitU: [1]
         - DepthU: [ 8, 16, 24, 32, 64 ]
         - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [2]
+        - AssertFree0ElementMultiple: [2]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
@@ -550,8 +560,10 @@ BenchmarkProblems:
         - WorkGroupMapping: [1, 8]
         - DepthU: [ 8, 16, 24, 32, 64, 128 ]
         - VectorWidth: [2, 4, 8]
-        - GlobalReadVectorWidth: [4]
+#       - GlobalReadVectorWidth: [4]
         - LdsPadB: [0,1,2,4]
+        - AssertSummationElementMultiple: [2]
+        - AssertFree0ElementMultiple: [2]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
@@ -593,6 +605,8 @@ BenchmarkProblems:
         - VectorWidth: [2, 4, 8]
 #       - GlobalReadVectorWidth: [1, 4]
         - LdsPadB: [0,1,2,4]
+        - AssertSummationElementMultiple: [2]
+        - AssertFree0ElementMultiple: [2]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
@@ -654,6 +668,8 @@ BenchmarkProblems:
         - GlobalSplitU: [1]
         - DepthU: [ 8, 16, 32, 64 ]
         - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [2]
+        - AssertFree0ElementMultiple: [2]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
@@ -706,6 +722,8 @@ BenchmarkProblems:
         - GlobalSplitU: [1]
         - DepthU: [ 8, 16, 24, 32, 64 ]
         - VectorWidth: [2, 4, 8]
+        - AssertSummationElementMultiple: [2]
+        - AssertFree0ElementMultiple: [2]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
@@ -777,6 +795,8 @@ BenchmarkProblems:
         - GlobalSplitU: [1]
         - DepthU: [ 8, 16, 24, 32, 64 ]
         - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [2]
+        - AssertFree0ElementMultiple: [2]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
@@ -841,11 +861,11 @@ BenchmarkProblems:
           - [ 8, 6 ]
           - [ 8, 8 ]
         - WorkGroup:
-#         - [ 8, 8, 1 ]                   # vmfaults/1
+#         - [ 8, 8, 1 ]
           - [ 16, 16, 1 ]
         - WorkGroupMapping: [8]
 #       - WorkGroupMapping: [1, 8]
-        - DepthU: [ 8, 16, 24, 32, 64 ]
+        - DepthU: [ 8, 16, 24, 32 ]
         - VectorWidth: [-1]
       BenchmarkForkParameters:
       JoinParameters:
@@ -878,6 +898,8 @@ BenchmarkProblems:
 #       - WorkGroupMapping: [1, 8]
         - DepthU: [ 8, 16, 24, 32, 64 ]
         - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [2]
+        - AssertFree0ElementMultiple: [2]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
@@ -1016,6 +1038,8 @@ BenchmarkProblems:
         - GlobalSplitU: [1]
         - DepthU: [ 8, 16, 24, 32, 64 ]
         - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [2]
+        - AssertFree0ElementMultiple: [2]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
@@ -1102,6 +1126,8 @@ BenchmarkProblems:
         - GlobalSplitU: [1]
         - DepthU: [ 8, 16, 24, 32, 64 ]
         - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [2]
+        - AssertFree0ElementMultiple: [2]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
@@ -1136,11 +1162,11 @@ BenchmarkProblems:
           - [ 8, 6 ]
           - [ 8, 8 ]
         - WorkGroup:
-          - [ 8, 8, 1 ]
+#         - [ 8, 8, 1 ]
           - [ 16, 16, 1 ]
         - WorkGroupMapping: [8]
 #       - WorkGroupMapping: [1, 8]
-        - DepthU: [ 8, 16, 24, 32, 64 ]
+        - DepthU: [ 8, 16, 24, 32 ]
         - VectorWidth: [-1]
       BenchmarkForkParameters:
       JoinParameters:
@@ -1173,6 +1199,8 @@ BenchmarkProblems:
 #       - WorkGroupMapping: [1, 8]
         - DepthU: [ 8, 16, 24, 32, 64 ]
         - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [2]
+        - AssertFree0ElementMultiple: [2]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
@@ -1236,6 +1264,8 @@ BenchmarkProblems:
         - GlobalSplitU: [1]
         - DepthU: [ 8, 16, 24, 32, 64 ]
         - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [2]
+        - AssertFree0ElementMultiple: [2]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
@@ -1325,6 +1355,8 @@ BenchmarkProblems:
         - GlobalSplitU: [1]
         - DepthU: [ 8, 16, 24, 32, 64 ]
         - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [2]
+        - AssertFree0ElementMultiple: [2]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
@@ -1389,6 +1421,8 @@ BenchmarkProblems:
         - WorkGroupMapping: [-1, -4]
         - DepthU: [ 8, 16, 24, 32, 64 ]
         - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [2]
+        - AssertFree0ElementMultiple: [2]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
@@ -1446,6 +1480,8 @@ BenchmarkProblems:
         - GlobalSplitU: [1]
         - DepthU: [ 8, 16, 24, 32, 64 ]
         - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [2]
+        - AssertFree0ElementMultiple: [2]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:

--- a/Tensile/SolutionWriter.py
+++ b/Tensile/SolutionWriter.py
@@ -139,7 +139,7 @@ class SolutionWriter:
     s += "%sconst unsigned int numKernels = %u; // 1 or 4\n" % (t, len(kernels))
 
     s += "%sint deviceId;\n" % (t)
-    s += "%shipCtxGetDevice(&deviceId);\n" % (t)
+    s += "%shipGetDevice(&deviceId);\n" % (t)
     if solution["KernelLanguage"] == "Source" and globalParameters["RuntimeLanguage"] == "OCL":
       s += "%sconst char *kernelSources[numKernels] = {\n" % (t)
       t += "  "

--- a/Tensile/Source/EnableWarnings.cmake
+++ b/Tensile/Source/EnableWarnings.cmake
@@ -108,7 +108,7 @@ else()
                 -Wdangling-field
                 -Wdangling-initializer-list
                 -Wdelete-incomplete
-                # -Wdeprecated  # disable deprecated until we migrate hipCtx APIs
+                -Wdeprecated
                 -Wdivision-by-zero
                 -Wduplicate-decl-specifier
                 -Wduplicate-enum

--- a/Tensile/Source/SolutionHelper.cpp
+++ b/Tensile/Source/SolutionHelper.cpp
@@ -113,7 +113,7 @@ void tensileGetCompiledOpenCLKernel(
 //  // is function already loaded?
 //  hipDevice_t currentDevice; // caller guaranteed that current device
 //                             // matches handle/stream device
-//  status = hipCtxGetDevice(&currentDevice);
+//  status = hipGetDevice(&currentDevice);
 //  tensileStatusCheck(status);
 //  KernelMapKey key = std::make_tuple(currentDevice, functionName);
 //

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -555,9 +555,11 @@ def writeLogic(outputPath, logicData, solutionWriter ):
         s += "\n"
 
         if problemType["DataType"].isHalf() :
+          free0Index = problemType["IndicesFree"][0]
+          free0Char = globalParameters["IndexChars"][free0Index]
           s += "\n"
           s += "//  intercept schedule selection and call HIP (source) kernel\n"
-          s += "    if((sizeL %2 == 1) && ((name == \"Device 66a0\") || (name == \"Device 66a7\")))\n"
+          s += "    if((((sizeL & 1) == 1) || ((size%s & 1) == 1)))\n"%(free0Char)
           s += "    {\n"
           numSchedules = len(schedules)
           schedule = reordered_schedules[numSchedules-1]

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -555,10 +555,13 @@ def writeLogic(outputPath, logicData, solutionWriter ):
         s += "\n"
 
         if problemType["DataType"].isHalf() :
+          # "first" free index, usually the letter "I"
           free0Index = problemType["IndicesFree"][0]
           free0Char = globalParameters["IndexChars"][free0Index]
           s += "\n"
           s += "//  intercept schedule selection and call HIP (source) kernel\n"
+          s += "//  if either the summation size or the 'first' free index size"
+          s += " is odd\n"
           s += "    if((((sizeL & 1) == 1) || ((size%s & 1) == 1)))\n"%(free0Char)
           s += "    {\n"
           numSchedules = len(schedules)

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -533,7 +533,7 @@ def writeLogic(outputPath, logicData, solutionWriter ):
         else:
           s += "\n//  get device name hip;\n"
           s += "    int deviceId;\n"
-          s += "    hipCtxGetDevice(&deviceId);\n"
+          s += "    hipGetDevice(&deviceId);\n"
           s += "    hipDeviceProp_t deviceProperties;\n"
           s += "    hipGetDeviceProperties(&deviceProperties, deviceId);\n"
           s += "    std::string name = deviceProperties.name;\n"


### PR DESCRIPTION
-  hipCtxGetDevice->hipGetDevice; re-enable -Wdeprecated warning
-  use HIP kernel in half precision if either psem or pf0em is odd
-  add assertions in hgemm_asm_full YAML file for all assembly kernels
