### PR TITLE
reordered_schedules not always move fallback schedule to the end

### DIFF
--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -519,12 +519,12 @@ def writeLogic(outputPath, logicData, solutionWriter ):
         for scheduleIdx in range(0, numSchedules):
           schedule = schedules[scheduleIdx]
           deviceNames = schedule[1]
-          if deviceNames != ["fallback"]:
+          if deviceNames != ["fallback"] and deviceNames != ["Device 0000"]:
             reordered_schedules.append(schedule)
         for scheduleIdx in range(0, numSchedules):
           schedule = schedules[scheduleIdx]
           deviceNames = schedule[1]
-          if deviceNames == ["fallback"]:
+          if deviceNames == ["fallback"] or deviceNames == ["Device 0000"]:
             reordered_schedules.append(schedule)
 
         # get device name


### PR DESCRIPTION
Our hip_lite YAML logic files underwent a change, generated with

    ScheduleName: "hip"
    DeviceNames: [fallback]
    ArchitectureName: "gfx000"
to

    ScheduleName: "hip"
    DeviceNames: ["Device 0000"]
    ArchitectureName: "fallback"

reordered_schedules logic in TensileCreateLibrary.py assumes the fallback logic always has DeviceNames of [fallback] while all current YAML files have DeviceNames ["Device 0000"].

The failure to move the fallback schedules to the end of reordered_schedules caused the intercept logic in Tensile.cpp to pick up non-fallback schedules in error.