### PR TITLE
hgemm source,VW=2,VW=1 for m,n,k<=32; m,n,k=1

### DIFF
--- a/Tensile/Configs/rocblas_hgemm_asm_full.yaml
+++ b/Tensile/Configs/rocblas_hgemm_asm_full.yaml
@@ -183,38 +183,6 @@ BenchmarkProblems:
       BenchmarkCommonParameters:
         - EdgeType: ["ShiftPtr"]
         - LoopTail: [True]
-        - KernelLanguage: ["Source"]
-        - PrefetchGlobalRead: [True]
-        - PrefetchLocalRead: [True]
-      ForkParameters:
-        - ThreadTile:
-          - [ 2, 2 ]
-          - [ 4, 2 ]
-          - [ 4, 4 ]
-          - [ 8, 4 ]
-          - [ 8, 8 ]
-        - WorkGroup:
-          - [ 8, 8, 1 ]
-          - [ 16, 8, 1 ]
-          - [ 16, 4, 1 ]
-          - [ 32, 4, 1 ]
-        - WorkGroupMapping: [1, 8]
-        - GlobalSplitU: [1]
-        - DepthU: [ 8, 16, 24, 32, 64 ]
-        - VectorWidth: [-1]
-      BenchmarkForkParameters:
-      JoinParameters:
-      BenchmarkJoinParameters:
-      BenchmarkFinalParameters:
-        - ProblemSizes:
-          - Range: [ [64, 128], [64, 64, 64, 7000], [1], [128] ] # skinny-0, source code for k<=128
-          - Range: [ [64, 64, 64, 7000], [64, 128], [1], [128] ] # skinny-1, source code for k<=128
-          - Range: [ [64, 64, 64, 700], [64, 64, 64, 700], [1], [128] ] # small, source code for k<=128
-    - # Benchmark Group
-      InitialSolutionParameters:
-      BenchmarkCommonParameters:
-        - EdgeType: ["ShiftPtr"]
-        - LoopTail: [True]
         - KernelLanguage: ["Assembly"]
         - PrefetchGlobalRead: [True]
         - PrefetchLocalRead: [True]
@@ -242,9 +210,9 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [64, 128], [64, 64, 64, 7000], [1], [256, 1024, 1024, 4096] ] # skinny-0
-          - Range: [ [64, 64, 64, 7000], [64, 128], [1], [256, 1024, 1024, 4096] ] # skinny-1
-          - Range: [ [64, 64, 64, 700], [64, 64, 64, 700], [1], [256, 1024, 1024, 4096] ] # small
+          - Range: [          [64, 128], [64, 64, 64, 7000], [1], [256, 1024, 1024, 4096] ] # skinny-0
+          - Range: [ [64, 64, 64, 7000],          [64, 128], [1], [256, 1024, 1024, 4096] ] # skinny-1
+          - Range: [ [64, 64, 64,  700], [64, 64, 64,  700], [1], [256, 1024, 1024, 4096] ] # small
           - Exact: [ 64, 1, 1, 1216 ]
           - Exact: [ 128, 1, 1, 1024 ]
           - Exact: [ 128, 1, 1, 1408 ]
@@ -321,36 +289,6 @@ BenchmarkProblems:
   ########################################
   # NN - Large
   ########################################
-    - # Benchmark Group
-      InitialSolutionParameters:
-      BenchmarkCommonParameters:
-        - EdgeType: ["ShiftPtr"]
-        - LoopTail: [True]
-        - KernelLanguage: ["Source"]
-        - PrefetchLocalRead: [True]
-        - GlobalSplitU: [1]
-      ForkParameters:
-        - PrefetchGlobalRead: [False, True]
-        - ThreadTile:
-          - [ 4, 4 ]
-          - [ 4, 8 ]
-          - [ 6, 8 ]
-          - [ 8, 4 ]
-          - [ 8, 6 ]
-          - [ 8, 8 ]
-        - WorkGroup:
-#         - [ 8, 8, 1 ]
-          - [ 16, 16, 1 ]
-        - WorkGroupMapping: [8]            # 1 removed for training performance
-        - DepthU: [ 8, 16, 24, 32 ]
-        - VectorWidth: [-1]
-      BenchmarkForkParameters:
-      JoinParameters:
-      BenchmarkJoinParameters:
-      BenchmarkFinalParameters:
-        - ProblemSizes:
-          - Range: [ [64, 64, 64, 7000], [64, 64, 64, 7000], [1], [128] ] # large, source code for k<=128
-
     - # Benchmark Group
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -479,33 +417,6 @@ BenchmarkProblems:
       BenchmarkCommonParameters:
         - EdgeType: ["ShiftPtr"]
         - LoopTail: [True]
-        - KernelLanguage: ["Source"]
-        - PrefetchGlobalRead: [True]
-        - PrefetchLocalRead: [True]
-        - WorkGroupMapping: [1]
-      ForkParameters:
-        - ThreadTile:
-          - [ 2, 2 ]
-          - [ 4, 4 ]
-        - WorkGroup:
-          - [ 8, 8, 1 ]
-        - GlobalSplitU: [1]
-        - DepthU: [ 8, 16, 24, 32, 64 ]
-        - VectorWidth: [-1]
-      BenchmarkForkParameters:
-      JoinParameters:
-      BenchmarkJoinParameters:
-      BenchmarkFinalParameters:
-        - ProblemSizes:
-          - Range: [ [4], [4], [1], [128] ] # corner, source code for k<=128
-          - Range: [ [4], [64, 64, 64, 7000], [1], [128] ] # skinny-0, source code for k<=128
-          - Range: [ [64, 64, 64, 7000], [4], [1], [128] ] # skinny-1, source code for k<=128
-
-    - # Benchmark Group
-      InitialSolutionParameters:
-      BenchmarkCommonParameters:
-        - EdgeType: ["ShiftPtr"]
-        - LoopTail: [True]
         - KernelLanguage: ["Assembly"]
         - PrefetchGlobalRead: [True]
         - PrefetchLocalRead: [True]
@@ -527,9 +438,9 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [4], [4], [1], [256, 1024, 1024, 4096] ] # corner
-          - Range: [ [4], [64, 64, 64, 7000], [1], [256, 1024, 1024, 4096] ] # skinny-0
-          - Range: [ [64, 64, 64, 7000], [4], [1], [256, 1024, 1024, 4096] ] # skinny-1
+          - Range: [               [64],               [64], [1], [256, 1024, 1024, 4096] ] # corner
+          - Range: [               [64], [64, 64, 64, 7000], [1], [256, 1024, 1024, 4096] ] # skinny-0
+          - Range: [ [64, 64, 64, 7000],               [64], [1], [256, 1024, 1024, 4096] ] # skinny-1
 
   ########################################
   # NN - VGPR refactor
@@ -621,6 +532,73 @@ BenchmarkProblems:
           - Exact: [ 3136, 2048,  1,  512 ]
           - Exact: [ 3025,  256, 64,   64 ]
           - Exact: [ 3025,   64, 64,   64 ]
+
+  ########################################
+  # NN - Source kernels
+  ########################################
+    - # BenchmarkProblemSizeGroup - VW=2 for m,n,k<=4
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Source"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - VectorWidth: [2]
+        - WorkGroupMapping: [8]
+      ForkParameters:
+        - ThreadTile:
+          - [ 8, 8 ]
+          - [ 4, 8 ]
+          - [ 4, 4 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+        - PrefetchGlobalRead: [False, True]
+        - PrefetchLocalRead: [False, True]
+        - DepthU: [ 4, 8, 16, 32 ]
+        - VectorWidth: [2]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [               [32],               [32], [1],                    [32] ]
+          - Range: [               [32], [64, 64, 64, 7000], [1], [256, 1024, 1024, 4096] ]
+          - Range: [ [64, 64, 64, 7000],               [32], [1], [256, 1024, 1024, 4096] ]
+          - Range: [ [64, 64, 64, 7000], [64, 64, 64, 7000], [1],                    [32] ]
+          - Range: [               [32],               [32], [1], [256, 1024, 1024, 4096] ]
+          - Range: [               [32], [64, 64, 64, 7000], [1],                    [32] ]
+          - Range: [ [64, 64, 64, 7000],               [32], [1],                    [32] ]
+
+    - # BenchmarkProblemSizeGroup - VW=1 for m,n,k==1
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Source"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - VectorWidth: [1]
+        - WorkGroupMapping: [8]
+      ForkParameters:
+        - ThreadTile:
+          - [ 8, 8 ]
+          - [ 4, 8 ]
+          - [ 4, 4 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+        - PrefetchGlobalRead: [False, True]
+        - PrefetchLocalRead: [False, True]
+        - DepthU: [ 4, 8, 16, 32 ]
+        - VectorWidth: [1]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [                [1],                [1], [1],                     [1] ]
+          - Range: [                [1], [64, 64, 64, 7000], [1], [256, 1024, 1024, 4096] ]
+          - Range: [ [64, 64, 64, 7000],                [1], [1], [256, 1024, 1024, 4096] ]
+          - Range: [ [64, 64, 64, 7000], [64, 64, 64, 7000], [1],                     [1] ]
+          - Range: [                [1],                [1], [1], [256, 1024, 1024, 4096] ]
+          - Range: [                [1], [64, 64, 64, 7000], [1],                     [1] ]
+          - Range: [ [64, 64, 64, 7000],                [1], [1],                     [1] ]
 
   ########################################
   ########################################
@@ -742,39 +720,6 @@ BenchmarkProblems:
       BenchmarkCommonParameters:
         - EdgeType: ["ShiftPtr"]
         - LoopTail: [True]
-        - KernelLanguage: ["Source"]
-        - PrefetchGlobalRead: [True]
-        - PrefetchLocalRead: [True]
-      ForkParameters:
-        - ThreadTile:
-          - [ 2, 2 ]
-          - [ 4, 2 ]
-          - [ 4, 4 ]
-          - [ 8, 4 ]
-          - [ 8, 8 ]
-        - WorkGroup:
-          - [ 8, 8, 1 ]
-          - [ 16, 8, 1 ]
-          - [ 16, 4, 1 ]
-          - [ 32, 4, 1 ]
-        - WorkGroupMapping: [1, 8]
-        - GlobalSplitU: [1]
-        - DepthU: [ 8, 16, 24, 32, 64 ]
-        - VectorWidth: [-1]
-      BenchmarkForkParameters:
-      JoinParameters:
-      BenchmarkJoinParameters:
-      BenchmarkFinalParameters:
-        - ProblemSizes:
-          - Range: [ [64, 128], [64, 64, 64, 7000], [1], [128] ] # skinny-0, source code for k<128
-          - Range: [ [64, 64, 64, 7000], [64, 128], [1], [128] ] # skinny-1, source code for k<128
-          - Range: [ [64, 64, 64, 700], [64, 64, 64, 700], [1], [128] ] # small, source code for k<128
-
-    - # Benchmark Group
-      InitialSolutionParameters:
-      BenchmarkCommonParameters:
-        - EdgeType: ["ShiftPtr"]
-        - LoopTail: [True]
         - KernelLanguage: ["Assembly"]
         - PrefetchGlobalRead: [True]
         - PrefetchLocalRead: [True]
@@ -802,9 +747,9 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [64, 128], [64, 64, 64, 7000], [1], [256, 1024, 1024, 4096] ] # skinny-0
-          - Range: [ [64, 64, 64, 7000], [64, 128], [1], [256, 1024, 1024, 4096] ] # skinny-1
-          - Range: [ [64, 64, 64, 700], [64, 64, 64, 700], [1], [256, 1024, 1024, 4096] ] # small
+          - Range: [          [64, 128], [64, 64, 64, 7000], [1], [256, 1024, 1024, 4096] ] # skinny-0
+          - Range: [ [64, 64, 64, 7000],          [64, 128], [1], [256, 1024, 1024, 4096] ] # skinny-1
+          - Range: [ [64, 64, 64,  700], [64, 64, 64,  700], [1], [256, 1024, 1024, 4096] ] # small
           - Exact: [ 1760, 16, 1, 1760 ]
           - Exact: [ 3072, 16, 1, 1024 ]
           - Exact: [ 2048, 16, 1, 2048 ]
@@ -843,37 +788,6 @@ BenchmarkProblems:
   ########################################
   # TN - Large
   ########################################
-    - # Benchmark Group
-      InitialSolutionParameters:
-      BenchmarkCommonParameters:
-        - EdgeType: ["ShiftPtr"]
-        - LoopTail: [True]
-        - KernelLanguage: ["Source"]
-        - PrefetchGlobalRead: [True]
-        - PrefetchLocalRead: [True]
-        - GlobalSplitU: [1]
-      ForkParameters:
-        - ThreadTile:
-          - [ 4, 4 ]
-          - [ 4, 8 ]
-          - [ 6, 8 ]
-          - [ 8, 4 ]
-          - [ 8, 6 ]
-          - [ 8, 8 ]
-        - WorkGroup:
-#         - [ 8, 8, 1 ]
-          - [ 16, 16, 1 ]
-        - WorkGroupMapping: [8]
-#       - WorkGroupMapping: [1, 8]
-        - DepthU: [ 8, 16, 24, 32 ]
-        - VectorWidth: [-1]
-      BenchmarkForkParameters:
-      JoinParameters:
-      BenchmarkJoinParameters:
-      BenchmarkFinalParameters:
-        - ProblemSizes:
-          - Range: [ [64, 64, 64, 7000], [64, 64, 64, 7000], [1], [128] ] # large, source code for k<=128
-
     - # Benchmark Group
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -997,33 +911,6 @@ BenchmarkProblems:
       BenchmarkCommonParameters:
         - EdgeType: ["ShiftPtr"]
         - LoopTail: [True]
-        - KernelLanguage: ["Source"]
-        - PrefetchGlobalRead: [True]
-        - PrefetchLocalRead: [True]
-        - WorkGroupMapping: [1]
-      ForkParameters:
-        - ThreadTile:
-          - [ 2, 2 ]
-          - [ 4, 4 ]
-        - WorkGroup:
-          - [ 8, 8, 1 ]
-        - GlobalSplitU: [1]
-        - DepthU: [ 8, 16, 24, 32, 64 ]
-        - VectorWidth: [-1]
-      BenchmarkForkParameters:
-      JoinParameters:
-      BenchmarkJoinParameters:
-      BenchmarkFinalParameters:
-        - ProblemSizes:
-          - Range: [ [4], [4], [1], [128] ] # corner, source code for k<=128
-          - Range: [ [4], [64, 64, 64, 7000], [1], [128] ] # skinny-0, source code for k<=128
-          - Range: [ [64, 64, 64, 7000], [4], [1], [128] ] # skinny-1, source code for k<=128
-
-    - # Benchmark Group
-      InitialSolutionParameters:
-      BenchmarkCommonParameters:
-        - EdgeType: ["ShiftPtr"]
-        - LoopTail: [True]
         - KernelLanguage: ["Assembly"]
         - PrefetchGlobalRead: [True]
         - PrefetchLocalRead: [True]
@@ -1045,9 +932,76 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [4], [4], [1], [256, 1024, 1024, 4096] ] # corner
-          - Range: [ [4], [64, 64, 64, 7000], [1], [256, 1024, 1024, 4096] ] # skinny-0
-          - Range: [ [64, 64, 64, 7000], [4], [1], [256, 1024, 1024, 4096] ] # skinny-1
+          - Range: [               [64],               [64], [1], [256, 1024, 1024, 4096] ] # corner
+          - Range: [               [64], [64, 64, 64, 7000], [1], [256, 1024, 1024, 4096] ] # skinny-0
+          - Range: [ [64, 64, 64, 7000],               [64], [1], [256, 1024, 1024, 4096] ] # skinny-1
+
+  ########################################
+  # TN - Source kernels
+  ########################################
+    - # BenchmarkProblemSizeGroup - VW=2 for m,n,k<=4
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Source"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - VectorWidth: [2]
+        - WorkGroupMapping: [8]
+      ForkParameters:
+        - ThreadTile:
+          - [ 8, 8 ]
+          - [ 4, 8 ]
+          - [ 4, 4 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+        - PrefetchGlobalRead: [False, True]
+        - PrefetchLocalRead: [False, True]
+        - DepthU: [ 4, 8, 16, 32 ]
+        - VectorWidth: [2]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [               [32],               [32], [1],                    [32] ]
+          - Range: [               [32], [64, 64, 64, 7000], [1], [256, 1024, 1024, 4096] ]
+          - Range: [ [64, 64, 64, 7000],               [32], [1], [256, 1024, 1024, 4096] ]
+          - Range: [ [64, 64, 64, 7000], [64, 64, 64, 7000], [1],                    [32] ]
+          - Range: [               [32],               [32], [1], [256, 1024, 1024, 4096] ]
+          - Range: [               [32], [64, 64, 64, 7000], [1],                    [32] ]
+          - Range: [ [64, 64, 64, 7000],               [32], [1],                    [32] ]
+
+    - # BenchmarkProblemSizeGroup - VW=1 for m,n,k==1
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Source"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - VectorWidth: [1]
+        - WorkGroupMapping: [8]
+      ForkParameters:
+        - ThreadTile:
+          - [ 8, 8 ]
+          - [ 4, 8 ]
+          - [ 4, 4 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+        - PrefetchGlobalRead: [False, True]
+        - PrefetchLocalRead: [False, True]
+        - DepthU: [ 4, 8, 16, 32 ]
+        - VectorWidth: [1]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [                [1],                [1], [1],                     [1] ]
+          - Range: [                [1], [64, 64, 64, 7000], [1], [256, 1024, 1024, 4096] ]
+          - Range: [ [64, 64, 64, 7000],                [1], [1], [256, 1024, 1024, 4096] ]
+          - Range: [ [64, 64, 64, 7000], [64, 64, 64, 7000], [1],                     [1] ]
+          - Range: [                [1],                [1], [1], [256, 1024, 1024, 4096] ]
+          - Range: [                [1], [64, 64, 64, 7000], [1],                     [1] ]
+          - Range: [ [64, 64, 64, 7000],                [1], [1],                     [1] ]
 
   ########################################
   ########################################
@@ -1068,39 +1022,6 @@ BenchmarkProblems:
   ########################################
   # NT - Small or Skinny
   ########################################
-    - # Benchmark Group
-      InitialSolutionParameters:
-      BenchmarkCommonParameters:
-        - EdgeType: ["ShiftPtr"]
-        - LoopTail: [True]
-        - KernelLanguage: ["Source"]
-        - PrefetchGlobalRead: [True]
-        - PrefetchLocalRead: [True]
-      ForkParameters:
-        - ThreadTile:
-          - [ 2, 2 ]
-          - [ 4, 2 ]
-          - [ 4, 4 ]
-          - [ 8, 4 ]
-          - [ 8, 8 ]
-        - WorkGroup:
-          - [ 8, 8, 1 ]
-          - [ 16, 8, 1 ]
-          - [ 16, 4, 1 ]
-          - [ 32, 4, 1 ]
-        - WorkGroupMapping: [1, 8]
-        - GlobalSplitU: [1]
-        - DepthU: [ 8, 16, 24, 32, 64 ]
-        - VectorWidth: [-1]
-      BenchmarkForkParameters:
-      JoinParameters:
-      BenchmarkJoinParameters:
-      BenchmarkFinalParameters:
-        - ProblemSizes:
-          - Range: [ [64, 128], [64, 64, 64, 7000], [1], [128] ] # skinny-0, source code for k<=128
-          - Range: [ [64, 64, 64, 7000], [64, 128], [1], [128] ] # skinny-1, source code for k<=128
-          - Range: [ [64, 64, 64, 700], [64, 64, 64, 700], [1], [128] ] # small, source code for k<=128
-
     - # Benchmark Group
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -1133,9 +1054,9 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [64, 128], [64, 64, 64, 7000], [1], [256, 1024, 1024, 4096] ] # skinny-0
-          - Range: [ [64, 64, 64, 7000], [64, 128], [1], [256, 1024, 1024, 4096] ] # skinny-1
-          - Range: [ [64, 64, 64, 700], [64, 64, 64, 700], [1], [256, 1024, 1024, 4096] ] # small
+          - Range: [          [64, 128], [64, 64, 64, 7000], [1], [256, 1024, 1024, 4096] ] # skinny-0
+          - Range: [ [64, 64, 64, 7000],          [64, 128], [1], [256, 1024, 1024, 4096] ] # skinny-1
+          - Range: [ [64, 64, 64,  700], [64, 64, 64,  700], [1], [256, 1024, 1024, 4096] ] # small
           - Exact: [ 512, 16, 1, 512 ]
           - Exact: [ 512, 32, 1, 512 ]
           - Exact: [ 1024, 16, 1, 512 ]
@@ -1144,37 +1065,6 @@ BenchmarkProblems:
   ########################################
   # NT - Large
   ########################################
-    - # Benchmark Group
-      InitialSolutionParameters:
-      BenchmarkCommonParameters:
-        - EdgeType: ["ShiftPtr"]
-        - LoopTail: [True]
-        - KernelLanguage: ["Source"]
-        - PrefetchGlobalRead: [True]
-        - PrefetchLocalRead: [True]
-        - GlobalSplitU: [1]
-      ForkParameters:
-        - ThreadTile:
-          - [ 4, 4 ]
-          - [ 4, 8 ]
-          - [ 6, 8 ]
-          - [ 8, 4 ]
-          - [ 8, 6 ]
-          - [ 8, 8 ]
-        - WorkGroup:
-#         - [ 8, 8, 1 ]
-          - [ 16, 16, 1 ]
-        - WorkGroupMapping: [8]
-#       - WorkGroupMapping: [1, 8]
-        - DepthU: [ 8, 16, 24, 32 ]
-        - VectorWidth: [-1]
-      BenchmarkForkParameters:
-      JoinParameters:
-      BenchmarkJoinParameters:
-      BenchmarkFinalParameters:
-        - ProblemSizes:
-          - Range: [ [64, 64, 64, 7000], [64, 64, 64, 7000], [1], [128] ] # large, source code for k<=128
-
     - # Benchmark Group
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -1223,33 +1113,6 @@ BenchmarkProblems:
       BenchmarkCommonParameters:
         - EdgeType: ["ShiftPtr"]
         - LoopTail: [True]
-        - KernelLanguage: ["Source"]
-        - PrefetchGlobalRead: [True]
-        - PrefetchLocalRead: [True]
-        - WorkGroupMapping: [1]
-      ForkParameters:
-        - ThreadTile:
-          - [ 2, 2 ]
-          - [ 4, 4 ]
-        - WorkGroup:
-          - [ 8, 8, 1 ]
-        - GlobalSplitU: [1]
-        - DepthU: [ 8, 16, 24, 32, 64 ]
-        - VectorWidth: [-1]
-      BenchmarkForkParameters:
-      JoinParameters:
-      BenchmarkJoinParameters:
-      BenchmarkFinalParameters:
-        - ProblemSizes:
-          - Range: [ [4], [4], [1], [128] ] # corner, source code for k<=128
-          - Range: [ [4], [64, 64, 64, 7000], [1], [128] ] # skinny-0, source code for k<=128
-          - Range: [ [64, 64, 64, 7000], [4], [1], [128] ] # skinny-1, source code for k<=128
-
-    - # Benchmark Group
-      InitialSolutionParameters:
-      BenchmarkCommonParameters:
-        - EdgeType: ["ShiftPtr"]
-        - LoopTail: [True]
         - KernelLanguage: ["Assembly"]
         - PrefetchGlobalRead: [True]
         - PrefetchLocalRead: [True]
@@ -1271,9 +1134,76 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [4], [4], [1], [256, 1024, 1024, 4096] ] # corner
-          - Range: [ [4], [64, 64, 64, 7000], [1], [256, 1024, 1024, 4096] ] # skinny-0
-          - Range: [ [64, 64, 64, 7000], [4], [1], [256, 1024, 1024, 4096] ] # skinny-1
+          - Range: [               [64],               [64], [1], [256, 1024, 1024, 4096] ] # corner
+          - Range: [               [64], [64, 64, 64, 7000], [1], [256, 1024, 1024, 4096] ] # skinny-0
+          - Range: [ [64, 64, 64, 7000],               [64], [1], [256, 1024, 1024, 4096] ] # skinny-1
+
+  ########################################
+  # NT - Source kernels
+  ########################################
+    - # BenchmarkProblemSizeGroup - VW=2 for m,n,k<=4
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Source"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - VectorWidth: [2]
+        - WorkGroupMapping: [8]
+      ForkParameters:
+        - ThreadTile:
+          - [ 8, 8 ]
+          - [ 4, 8 ]
+          - [ 4, 4 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+        - PrefetchGlobalRead: [False, True]
+        - PrefetchLocalRead: [False, True]
+        - DepthU: [ 4, 8, 16, 32 ]
+        - VectorWidth: [2]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [               [32],               [32], [1],                    [32] ]
+          - Range: [               [32], [64, 64, 64, 7000], [1], [256, 1024, 1024, 4096] ]
+          - Range: [ [64, 64, 64, 7000],               [32], [1], [256, 1024, 1024, 4096] ]
+          - Range: [ [64, 64, 64, 7000], [64, 64, 64, 7000], [1],                    [32] ]
+          - Range: [               [32],               [32], [1], [256, 1024, 1024, 4096] ]
+          - Range: [               [32], [64, 64, 64, 7000], [1],                    [32] ]
+          - Range: [ [64, 64, 64, 7000],               [32], [1],                    [32] ]
+
+    - # BenchmarkProblemSizeGroup - VW=1 for m,n,k==1
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Source"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - VectorWidth: [1]
+        - WorkGroupMapping: [8]
+      ForkParameters:
+        - ThreadTile:
+          - [ 8, 8 ]
+          - [ 4, 8 ]
+          - [ 4, 4 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+        - PrefetchGlobalRead: [False, True]
+        - PrefetchLocalRead: [False, True]
+        - DepthU: [ 4, 8, 16, 32 ]
+        - VectorWidth: [1]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [                [1],                [1], [1],                     [1] ]
+          - Range: [                [1], [64, 64, 64, 7000], [1], [256, 1024, 1024, 4096] ]
+          - Range: [ [64, 64, 64, 7000],                [1], [1], [256, 1024, 1024, 4096] ]
+          - Range: [ [64, 64, 64, 7000], [64, 64, 64, 7000], [1],                     [1] ]
+          - Range: [                [1],                [1], [1], [256, 1024, 1024, 4096] ]
+          - Range: [                [1], [64, 64, 64, 7000], [1],                     [1] ]
+          - Range: [ [64, 64, 64, 7000],                [1], [1],                     [1] ]
 
   ########################################
   ########################################
@@ -1294,40 +1224,6 @@ BenchmarkProblems:
   ########################################
   # TT - Small or Skinny
   ########################################
-    - # Benchmark Group
-      InitialSolutionParameters:
-      BenchmarkCommonParameters:
-        - EdgeType: ["ShiftPtr"]
-        - LoopTail: [True]
-        - KernelLanguage: ["Source"]
-        - PrefetchGlobalRead: [True]
-        - PrefetchLocalRead: [True]
-      ForkParameters:
-        - ThreadTile:
-          - [ 2, 2 ]
-          - [ 2, 4 ]
-          - [ 4, 4 ]
-          - [ 4, 8 ]
-          - [ 8, 8 ]
-        - WorkGroup:
-          - [ 32, 4, 1 ]
-          - [ 8, 8, 1 ]
-          - [ 16, 16, 1 ]
-          - [ 16, 8, 1 ]
-          - [ 8, 16, 1 ]
-        - WorkGroupMapping: [-1, -4]
-        - GlobalSplitU: [1]
-        - DepthU: [ 8 ]
-        - VectorWidth: [-1]
-      BenchmarkForkParameters:
-      JoinParameters:
-      BenchmarkJoinParameters:
-      BenchmarkFinalParameters:
-        - ProblemSizes:
-          - Range: [ [64, 128], [64, 64, 64, 7000], [1], [128] ] # skinny-0, source code for k<=128
-          - Range: [ [64, 64, 64, 7000], [64, 128], [1], [128] ] # skinny-1, source code for k<=128
-          - Range: [ [64, 64, 64, 700], [64, 64, 64, 700], [1], [128] ] # small, source code for k<=128
-
     - # Benchmark Group
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -1362,42 +1258,13 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [64, 128], [64, 64, 64, 7000], [1], [256, 1024, 1024, 4096] ] # skinny-0
-          - Range: [ [64, 64, 64, 7000], [64, 128], [1], [256, 1024, 1024, 4096] ] # skinny-1
-          - Range: [ [64, 64, 64, 700], [64, 64, 64, 700], [1], [256, 1024, 1024, 4096] ] # small
+          - Range: [          [64, 128], [64, 64, 64, 7000], [1], [256, 1024, 1024, 4096] ] # skinny-0
+          - Range: [ [64, 64, 64, 7000],          [64, 128], [1], [256, 1024, 1024, 4096] ] # skinny-1
+          - Range: [ [64, 64, 64,  700], [64, 64, 64,  700], [1], [256, 1024, 1024, 4096] ] # small
 
   ########################################
   # TT - Large
   ########################################
-    - # Benchmark Group
-      InitialSolutionParameters:
-      BenchmarkCommonParameters:
-        - EdgeType: ["ShiftPtr"]
-        - LoopTail: [True]
-        - KernelLanguage: ["Source"]
-        - PrefetchLocalRead: [True]
-        - GlobalSplitU: [1]
-      ForkParameters:
-        - PrefetchGlobalRead: [False, True]
-        - ThreadTile:
-          - [ 4, 4 ]
-          - [ 4, 8 ]
-          - [ 6, 8 ]
-          - [ 8, 4 ]
-          - [ 8, 6 ]
-          - [ 8, 8 ]
-        - WorkGroup:
-          - [ 16, 16, 1 ]
-        - WorkGroupMapping: [-1, -4]
-        - DepthU: [ 8 ]
-        - VectorWidth: [-1]
-      BenchmarkForkParameters:
-      JoinParameters:
-      BenchmarkJoinParameters:
-      BenchmarkFinalParameters:
-        - ProblemSizes:
-          - Range: [ [64, 64, 64, 7000], [64, 64, 64, 7000], [1], [128] ] # large, source code for k<=128
-
     - # Benchmark Group
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -1439,33 +1306,6 @@ BenchmarkProblems:
       BenchmarkCommonParameters:
         - EdgeType: ["ShiftPtr"]
         - LoopTail: [True]
-        - KernelLanguage: ["Source"]
-        - PrefetchGlobalRead: [True]
-        - PrefetchLocalRead: [True]
-        - WorkGroupMapping: [-1]
-      ForkParameters:
-        - ThreadTile:
-          - [ 2, 2 ]
-          - [ 4, 4 ]
-        - WorkGroup:
-          - [ 8, 8, 1 ]
-        - GlobalSplitU: [1]
-        - DepthU: [ 8, 16, 24, 32, 64 ]
-        - VectorWidth: [-1]
-      BenchmarkForkParameters:
-      JoinParameters:
-      BenchmarkJoinParameters:
-      BenchmarkFinalParameters:
-        - ProblemSizes:
-          - Range: [ [4], [4], [1], [128] ] # corner, source code for k<=128
-          - Range: [ [4], [64, 64, 64, 7000], [1], [128] ] # skinny-0, source code for k<=128
-          - Range: [ [64, 64, 64, 7000], [4], [1], [128] ] # skinny-1, source code for k<=128
-
-    - # Benchmark Group
-      InitialSolutionParameters:
-      BenchmarkCommonParameters:
-        - EdgeType: ["ShiftPtr"]
-        - LoopTail: [True]
         - KernelLanguage: ["Assembly"]
         - PrefetchGlobalRead: [True]
         - PrefetchLocalRead: [True]
@@ -1487,9 +1327,78 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [4], [4], [1], [256, 1024, 1024, 4096] ] # corner
-          - Range: [ [4], [64, 64, 64, 7000], [1], [256, 1024, 1024, 4096] ] # skinny-0
-          - Range: [ [64, 64, 64, 7000], [4], [1], [256, 1024, 1024, 4096] ] # skinny-1
+          - Range: [               [64],               [64], [1], [256, 1024, 1024, 4096] ] # corner
+          - Range: [               [64], [64, 64, 64, 7000], [1], [256, 1024, 1024, 4096] ] # skinny-0
+          - Range: [ [64, 64, 64, 7000],               [64], [1], [256, 1024, 1024, 4096] ] # skinny-1
+
+  ########################################
+  # TT - Source kernels
+  ########################################
+    - # BenchmarkProblemSizeGroup - VW=2 for m,n,k<=4
+      InitialSolutionParameters:
+        - WorkGroupMapping: [-1]
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Source"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - VectorWidth: [2]
+        - WorkGroupMapping: [-8]
+      ForkParameters:
+        - ThreadTile:
+          - [ 8, 8 ]
+          - [ 4, 8 ]
+          - [ 4, 4 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+        - PrefetchGlobalRead: [False, True]
+        - PrefetchLocalRead: [False, True]
+        - DepthU: [ 4, 8, 16, 32 ]
+        - VectorWidth: [2]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [               [32],               [32], [1],                    [32] ]
+          - Range: [               [32], [64, 64, 64, 7000], [1], [256, 1024, 1024, 4096] ]
+          - Range: [ [64, 64, 64, 7000],               [32], [1], [256, 1024, 1024, 4096] ]
+          - Range: [ [64, 64, 64, 7000], [64, 64, 64, 7000], [1],                    [32] ]
+          - Range: [               [32],               [32], [1], [256, 1024, 1024, 4096] ]
+          - Range: [               [32], [64, 64, 64, 7000], [1],                    [32] ]
+          - Range: [ [64, 64, 64, 7000],               [32], [1],                    [32] ]
+
+    - # BenchmarkProblemSizeGroup - VW=1 for m,n,k==1
+      InitialSolutionParameters:
+        - WorkGroupMapping: [-1]
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Source"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - VectorWidth: [1]
+        - WorkGroupMapping: [-8]
+      ForkParameters:
+        - ThreadTile:
+          - [ 8, 8 ]
+          - [ 4, 8 ]
+          - [ 4, 4 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+        - PrefetchGlobalRead: [False, True]
+        - PrefetchLocalRead: [False, True]
+        - DepthU: [ 4, 8, 16, 32 ]
+        - VectorWidth: [1]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [                [1],                [1], [1],                     [1] ]
+          - Range: [                [1], [64, 64, 64, 7000], [1], [256, 1024, 1024, 4096] ]
+          - Range: [ [64, 64, 64, 7000],                [1], [1], [256, 1024, 1024, 4096] ]
+          - Range: [ [64, 64, 64, 7000], [64, 64, 64, 7000], [1],                     [1] ]
+          - Range: [                [1],                [1], [1], [256, 1024, 1024, 4096] ]
+          - Range: [                [1], [64, 64, 64, 7000], [1],                     [1] ]
+          - Range: [ [64, 64, 64, 7000],                [1], [1],                     [1] ]
 
 LibraryLogic:
     ScheduleName: "vega10"


### PR DESCRIPTION
Changes to solution selection logic to call 
- hip kernels with VW=1 if m==1||n==1||k==1
- hip kernels with VW=2 if m<=32||n<=32||k<=32