### PR TITLE
__fp16->_Float16

### DIFF
--- a/Tensile/Source/KernelHeader.h
+++ b/Tensile/Source/KernelHeader.h
@@ -22,9 +22,9 @@
 #ifndef KERNEL_HEADER
 #define KERNEL_HEADER
 
-typedef __fp16 half2 __attribute__((ext_vector_type(2)));
-typedef __fp16 half;
-typedef __fp16 __half;
+typedef _Float16 half2 __attribute__((ext_vector_type(2)));
+typedef _Float16 half;
+typedef _Float16 __half;
 
 extern "C" half2 llvm_fma_v2f16(half2, half2, half2) __asm("llvm.fma.v2f16");
 

--- a/Tensile/Source/TensileTypes.h
+++ b/Tensile/Source/TensileTypes.h
@@ -43,9 +43,9 @@
 #define tensileStatusAssertFailure hipErrorUnknown
 #define TensileComplexFloat float2
 #define TensileComplexDouble double2
-#define TensileHalf __fp16
+#define TensileHalf _Float16
 
-inline std::ostream& operator<<(std::ostream& os, const __fp16& dt)  
+inline std::ostream& operator<<(std::ostream& os, const _Float16& dt)  
 {  
    os << (float)(dt);
    return os;  


### PR DESCRIPTION
Note that even though the simple changes from __fp16 to _Float16 won't break Tensile testing, as soon as it is merged, before the same set of changes are merged into rocBLAS's develop branch, all on-going rocBLAS testing will fail.  In order to minimize the period of rocBLAS breakage, we'll have to merge the same set of changes into rocBLAS's develop branch soon after this PR is merged.