### PR TITLE
add python2.7-dev to install packages

### DIFF
--- a/docker/dockerfile-build-hip-hcc-ctu-ubuntu-16.04
+++ b/docker/dockerfile-build-hip-hcc-ctu-ubuntu-16.04
@@ -22,6 +22,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     git \
     pkg-config \
     python2.7 \
+    python2.7-dev \
     python-pip \
     python-pytest \
     python-setuptools \

--- a/docker/dockerfile-build-nvidia-cuda-8
+++ b/docker/dockerfile-build-nvidia-cuda-8
@@ -25,6 +25,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     git \
     pkg-config \
     python2.7 \
+    python2.7-dev \
     python-pip \
     python-pytest \
     python-setuptools \

--- a/docker/dockerfile-build-rocm-terminal
+++ b/docker/dockerfile-build-rocm-terminal
@@ -21,6 +21,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     git \
     pkg-config \
     python2.7 \
+    python2.7-dev \
     python-pip \
     python-pytest \
     python-setuptools \


### PR DESCRIPTION
aim to fix 

fatal error: Python.h: No such file or directory 

by adding python2.7-dev to list of packages to install in docker container