### PR TITLE
Include <mutex> in SolutionHelper.h

### DIFF
--- a/Tensile/Source/SolutionHelper.h
+++ b/Tensile/Source/SolutionHelper.h
@@ -27,6 +27,7 @@
 #include <unordered_map>
 #include <string>
 #include <tuple>
+#include <mutex>
 
 /*******************************************************************************
  * Kernel Cache


### PR DESCRIPTION
std::mutex is used in generated Solutions.cpp but <mutex> is not included.