### PR TITLE
disable PreciseBoundsCheck for all {s,d}gemm assembly kernels; add hgemm_asm_single_kernel YAML

### DIFF
--- a/Tensile/Configs/rocblas_dgemm_asm_lite.yaml
+++ b/Tensile/Configs/rocblas_dgemm_asm_lite.yaml
@@ -66,6 +66,7 @@ BenchmarkProblems:
         - WorkGroupMapping: [8]
         - PrefetchLocalRead: [True]
         - PrefetchGlobalRead: [True]
+        - PreciseBoundsCheck: [False]
         - VectorWidth: [-1]
       ForkParameters:
         - ThreadTile:
@@ -114,6 +115,7 @@ BenchmarkProblems:
         - WorkGroupMapping: [8]
         - PrefetchLocalRead: [True]
         - PrefetchGlobalRead: [True]
+        - PreciseBoundsCheck: [False]
         - VectorWidth: [-1]
       ForkParameters:
         - ThreadTile:
@@ -174,6 +176,7 @@ BenchmarkProblems:
         - WorkGroupMapping: [8]
         - PrefetchLocalRead: [True]
         - PrefetchGlobalRead: [True]
+        - PreciseBoundsCheck: [False]
         - VectorWidth: [-1]
       ForkParameters:
         - ThreadTile:
@@ -222,6 +225,7 @@ BenchmarkProblems:
         - WorkGroupMapping: [8]
         - PrefetchLocalRead: [True]
         - PrefetchGlobalRead: [True]
+        - PreciseBoundsCheck: [False]
         - VectorWidth: [-1]
       ForkParameters:
         - ThreadTile:
@@ -283,6 +287,7 @@ BenchmarkProblems:
         - WorkGroupMapping: [8]
         - PrefetchLocalRead: [True]
         - PrefetchGlobalRead: [True]
+        - PreciseBoundsCheck: [False]
         - VectorWidth: [-1]
       ForkParameters:
         - ThreadTile:
@@ -331,6 +336,7 @@ BenchmarkProblems:
         - WorkGroupMapping: [8]
         - PrefetchLocalRead: [True]
         - PrefetchGlobalRead: [True]
+        - PreciseBoundsCheck: [False]
         - VectorWidth: [-1]
       ForkParameters:
         - ThreadTile:
@@ -391,6 +397,7 @@ BenchmarkProblems:
         - WorkGroupMapping: [8]
         - PrefetchLocalRead: [True]
         - PrefetchGlobalRead: [True]
+        - PreciseBoundsCheck: [False]
         - VectorWidth: [-1]
       ForkParameters:
         - ThreadTile:
@@ -439,6 +446,7 @@ BenchmarkProblems:
         - WorkGroupMapping: [8]
         - PrefetchLocalRead: [True]
         - PrefetchGlobalRead: [True]
+        - PreciseBoundsCheck: [False]
         - VectorWidth: [-1]
       ForkParameters:
         - ThreadTile:

--- a/Tensile/Configs/rocblas_hgemm_asm_single_kernel.yaml
+++ b/Tensile/Configs/rocblas_hgemm_asm_single_kernel.yaml
@@ -1,0 +1,64 @@
+GlobalParameters:
+  MinimumRequiredVersion: 4.3.0
+  PrintLevel: 1
+  ForceRedoBenchmarkProblems: True
+  ForceRedoLibraryLogic: True
+  ForceRedoLibraryClient: True
+  CMakeBuildType: Release
+  EnqueuesPerSync: 1
+  SyncsPerBenchmark: 1
+  LibraryPrintDebug: False
+  NumElementsToValidate: 0
+  ValidationMaxToPrint: 4
+  ValidationPrintValids: False
+  ShortNames: False
+  MergeFiles: True
+  Platform: 0
+  Device: 0
+  KernelTime: True
+  PinClocks: True
+  SleepPercent: 200
+  DataInitTypeBeta : 0
+
+BenchmarkProblems:
+  ########################################
+  # NT - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: h
+      TransposeA: False
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - PrefetchLocalRead: [True]
+      ForkParameters:
+        - PrefetchGlobalRead: [True]
+        - ThreadTile:
+          - [ 8, 8 ]
+        - WorkGroup:
+          - [ 8, 8, 1 ]
+        - WorkGroupMapping: [8]
+        - GlobalSplitU: [1]
+        - DepthU: [8]
+        - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [8]
+        - AssertFree0ElementMultiple: [8]
+      BenchmarkForkParameters:
+      JoinParameters:
+        - MacroTile
+        - GlobalSplitU
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [5760], [5760], [1], [5760] ]
+
+  ########################################

--- a/Tensile/Configs/rocblas_sgemm_asm_full.yaml
+++ b/Tensile/Configs/rocblas_sgemm_asm_full.yaml
@@ -45,6 +45,7 @@ BenchmarkProblems:
         - LoopTail: [True]
         - KernelLanguage: ["Assembly"]
         - PrefetchLocalRead: [True]
+        - PreciseBoundsCheck: [False]
         - WorkGroupMapping: [1]
       ForkParameters:
         - PrefetchGlobalRead: [False, True]
@@ -128,6 +129,7 @@ BenchmarkProblems:
         - KernelLanguage: ["Assembly"]
         - PrefetchGlobalRead: [True]
         - PrefetchLocalRead: [True]
+        - PreciseBoundsCheck: [False]
         - WorkGroupMapping: [1]
       ForkParameters:
         - ThreadTile:
@@ -208,6 +210,7 @@ BenchmarkProblems:
         - KernelLanguage: ["Assembly"]
         - PrefetchGlobalRead: [True]
         - PrefetchLocalRead: [True]
+        - PreciseBoundsCheck: [False]
       ForkParameters:
         - ThreadTile:
           - [ 2, 2 ]
@@ -345,6 +348,7 @@ BenchmarkProblems:
         - LoopTail: [True]
         - KernelLanguage: ["Assembly"]
         - PrefetchLocalRead: [True]
+        - PreciseBoundsCheck: [False]
         - GlobalSplitU: [1]
       ForkParameters:
         - PrefetchGlobalRead: [False, True]
@@ -493,6 +497,7 @@ BenchmarkProblems:
         - KernelLanguage: ["Assembly"]
         - PrefetchGlobalRead: [True]
         - PrefetchLocalRead: [True]
+        - PreciseBoundsCheck: [False]
         - WorkGroupMapping: [1]
       ForkParameters:
         - ThreadTile:
@@ -526,6 +531,7 @@ BenchmarkProblems:
         - KernelLanguage: ["Assembly"]
         - PrefetchGlobalRead: [ True ]
         - PrefetchLocalRead: [ True ]
+        - PreciseBoundsCheck: [False]
       ForkParameters:
         - ThreadTile:
           - [ 2, 2 ]
@@ -570,6 +576,7 @@ BenchmarkProblems:
         - EdgeType: ["ShiftPtr"]
         - LoopTail: [True]
         - KernelLanguage: ["Assembly"]
+        - PreciseBoundsCheck: [False]
       ForkParameters:
         - PrefetchGlobalRead: [ False, True ]
         - PrefetchLocalRead: [ False]
@@ -628,6 +635,7 @@ BenchmarkProblems:
         - LoopTail: [True]
         - KernelLanguage: ["Assembly"]
         - PrefetchLocalRead: [True]
+        - PreciseBoundsCheck: [False]
         - WorkGroupMapping: [1]
       ForkParameters:
         - PrefetchGlobalRead: [False, True]
@@ -675,6 +683,7 @@ BenchmarkProblems:
         - KernelLanguage: ["Assembly"]
         - PrefetchGlobalRead: [True]
         - PrefetchLocalRead: [True]
+        - PreciseBoundsCheck: [False]
         - WorkGroupMapping: [1]
       ForkParameters:
         - ThreadTile:
@@ -751,6 +760,7 @@ BenchmarkProblems:
         - KernelLanguage: ["Assembly"]
         - PrefetchGlobalRead: [True]
         - PrefetchLocalRead: [True]
+        - PreciseBoundsCheck: [False]
       ForkParameters:
         - ThreadTile:
           - [ 2, 2 ]
@@ -851,6 +861,7 @@ BenchmarkProblems:
         - KernelLanguage: ["Assembly"]
         - PrefetchGlobalRead: [True]
         - PrefetchLocalRead: [True]
+        - PreciseBoundsCheck: [False]
         - GlobalSplitU: [1]
       ForkParameters:
         - ThreadTile:
@@ -992,6 +1003,7 @@ BenchmarkProblems:
         - KernelLanguage: ["Assembly"]
         - PrefetchGlobalRead: [True]
         - PrefetchLocalRead: [True]
+        - PreciseBoundsCheck: [False]
         - WorkGroupMapping: [1]
       ForkParameters:
         - ThreadTile:
@@ -1074,6 +1086,7 @@ BenchmarkProblems:
         - KernelLanguage: ["Assembly"]
         - PrefetchGlobalRead: [True]
         - PrefetchLocalRead: [True]
+        - PreciseBoundsCheck: [False]
       ForkParameters:
         - ThreadTile:
           - [ 2, 2 ]
@@ -1144,6 +1157,7 @@ BenchmarkProblems:
         - KernelLanguage: ["Assembly"]
         - PrefetchGlobalRead: [True]
         - PrefetchLocalRead: [True]
+        - PreciseBoundsCheck: [False]
         - GlobalSplitU: [1]
       ForkParameters:
         - ThreadTile:
@@ -1210,6 +1224,7 @@ BenchmarkProblems:
         - KernelLanguage: ["Assembly"]
         - PrefetchGlobalRead: [True]
         - PrefetchLocalRead: [True]
+        - PreciseBoundsCheck: [False]
         - WorkGroupMapping: [1]
       ForkParameters:
         - ThreadTile:
@@ -1293,6 +1308,7 @@ BenchmarkProblems:
         - KernelLanguage: ["Assembly"]
         - PrefetchGlobalRead: [True]
         - PrefetchLocalRead: [True]
+        - PreciseBoundsCheck: [False]
       ForkParameters:
         - ThreadTile:
           - [ 2, 2 ]
@@ -1358,6 +1374,7 @@ BenchmarkProblems:
         - LoopTail: [True]
         - KernelLanguage: ["Assembly"]
         - PrefetchLocalRead: [True]
+        - PreciseBoundsCheck: [False]
         - GlobalSplitU: [1]
       ForkParameters:
         - PrefetchGlobalRead: [False, True]
@@ -1419,6 +1436,7 @@ BenchmarkProblems:
         - KernelLanguage: ["Assembly"]
         - PrefetchGlobalRead: [True]
         - PrefetchLocalRead: [True]
+        - PreciseBoundsCheck: [False]
         - WorkGroupMapping: [-1]
       ForkParameters:
         - ThreadTile:


### PR DESCRIPTION
-  disable PreciseBoundsCheck for all sgemm_asm_full and dgemm_asm_lite assembly kernels
-  add hgemm_asm_single_kernel YAML file