### PR TITLE
hgemm only hip fallback for stride_a==0||stride_b==0

### DIFF
--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -538,21 +538,22 @@ def writeLogic(outputPath, logicData, solutionWriter ):
           s += "    hipGetDeviceProperties(&deviceProperties, deviceId);\n"
           s += "    std::string name = deviceProperties.name;\n"
 
-        s += "\n"
-        s += "//  intercept schedule selection and call HIP (source) kernel\n"
-        s += "    if((strideA2K == 0) || (strideB2K == 0))\n"
-        s += "    {\n"
-        numSchedules = len(schedules)
-        schedule = reordered_schedules[numSchedules-1]
-        scheduleName  = schedule[0]
-        s += "        return tensileGetSolution%s_%s_%s(" \
-              % ( returnType, scheduleName, problemType)
-        for i in range(0, len(argListSizes)):
-          s += "%s%s" \
-              % (argListSizes[i][1],
-                  ", " if i < len(argListSizes)-1 else ");\n")
-        s += "    }\n"
-        s += "\n"
+        if problemType["DataType"].isHalf() :
+          s += "\n"
+          s += "//  intercept schedule selection and call HIP (source) kernel\n"
+          s += "    if((strideA2K == 0) || (strideB2K == 0))\n"
+          s += "    {\n"
+          numSchedules = len(schedules)
+          schedule = reordered_schedules[numSchedules-1]
+          scheduleName  = schedule[0]
+          s += "        return tensileGetSolution%s_%s_%s(" \
+                % ( returnType, scheduleName, problemType)
+          for i in range(0, len(argListSizes)):
+            s += "%s%s" \
+                % (argListSizes[i][1],
+                    ", " if i < len(argListSizes)-1 else ");\n")
+          s += "    }\n"
+          s += "\n"
 
         if problemType["DataType"].isHalf() :
           # "first" free index, usually the letter "I"


### PR DESCRIPTION
Fallback to HIP kernels for hgemm only, not for sgemm and dgemm.

Disabling PreciseBoundsCheck for all Assembly kernels has corrected errors for sgemm and dgemm.