### PR TITLE
fix RuntimeLanguage with OCL issue

### DIFF
--- a/Tensile/SolutionWriter.py
+++ b/Tensile/SolutionWriter.py
@@ -138,8 +138,10 @@ class SolutionWriter:
     s += "\n%s/* kernels */\n" % (t)
     s += "%sconst unsigned int numKernels = %u; // 1 or 4\n" % (t, len(kernels))
 
-    s += "%sint deviceId;\n" % (t)
-    s += "%shipGetDevice(&deviceId);\n" % (t)
+    if globalParameters["RuntimeLanguage"] == "HIP":
+      s += "%sint deviceId;\n" % (t)
+      s += "%shipGetDevice(&deviceId);\n" % (t)
+
     if solution["KernelLanguage"] == "Source" and globalParameters["RuntimeLanguage"] == "OCL":
       s += "%sconst char *kernelSources[numKernels] = {\n" % (t)
       t += "  "
@@ -543,6 +545,7 @@ class SolutionWriter:
           s += "%sinputEvents,\n" % (t)
         s += "%soutputEvent );\n" % (t)
         s += "%stensileStatusCheck(status);\n" % (t)
+        s += "%s}\n" % (t)
 
       ########################################
       # HIP Runtime


### PR DESCRIPTION
test in KernelLanguage with Source case, the Assembly case not support.
test by rocblas_sgemm_asm_single_kernel.yaml with modification
1. RuntimeLanguage : OCL
2. KernelLanguage = ["Source"]