### PR TITLE
merge develop-gfx9 into develop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,6 @@
 *.vscode
 *~
 Tensile.egg-info
-build
+build*
 dist
 .cache

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -111,7 +111,7 @@ globalParameters["MaxLDS"] = 65536                # max LDS a kernel should atte
 globalParameters["MaxDepthU"] = 256               # max DepthU value to allow
 globalParameters["ShortNames"] = False            # on windows kernel names can get too long; =True will convert solution/kernel names to serial ids
 globalParameters["MergeFiles"] = True             # F=store every solution and kernel in separate file; T=store all solutions in single file
-globalParameters["SupportedISA"] = [(8,0,3), (9,0,0)]             # assembly kernels writer supports these architectures
+globalParameters["SupportedISA"] = [(8,0,3), (9,0,0), (9,0,6)]             # assembly kernels writer supports these architectures
 globalParameters["BenchmarkProblemsPath"] = "1_BenchmarkProblems" # subdirectory for benchmarking phases
 globalParameters["BenchmarkDataPath"] = "2_BenchmarkData"         # subdirectory for storing final benchmarking data
 globalParameters["LibraryLogicPath"] = "3_LibraryLogic"           # subdirectory for library logic produced by analysis

--- a/Tensile/Configs/rocblas_dgemm_asm_full.yaml
+++ b/Tensile/Configs/rocblas_dgemm_asm_full.yaml
@@ -1,5 +1,5 @@
 GlobalParameters:
-  MinimumRequiredVersion: 4.4.0
+  MinimumRequiredVersion: 4.3.0
   PrintLevel: 1
   ForceRedoBenchmarkProblems: True
   ForceRedoLibraryLogic: True
@@ -37,29 +37,8 @@ BenchmarkProblems:
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
       BenchmarkCommonParameters:
-        - KernelLanguage: ["Source"]
-        - EdgeType: ["ShiftPtr"]
-        - LoopTail: [True]
-        - WorkGroupMapping: [8]
-        - PrefetchLocalRead: [True]
-        - PrefetchGlobalRead: [True]
-        - VectorWidth: [-1]
-      ForkParameters:
-        - ThreadTile:
-          - [ 4, 4 ]
-        - WorkGroup:
-          - [ 16, 16,  1 ]
-        - DepthU: [ 8 ]
-      BenchmarkForkParameters:
-      JoinParameters:
-      BenchmarkJoinParameters:
-      BenchmarkFinalParameters:
-        - ProblemSizes:
-          - Range: [ [64], [64], [1], [128] ] #source for k<=128
-
-    - # BenchmarkProblemSizeGroup - Standard
-      InitialSolutionParameters:
-      BenchmarkCommonParameters:
+        - BufferLoad: [True]
+        - BufferStore: [True]
         - KernelLanguage: ["Assembly"]
         - EdgeType: ["ShiftPtr"]
         - LoopTail: [True]
@@ -79,36 +58,13 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [64], [64], [1], [256] ]
+          - Range: [ [64], [64], [1], [64] ]
 
     - # BenchmarkProblemSizeGroup - M,N < VW
       InitialSolutionParameters:
       BenchmarkCommonParameters:
-        - KernelLanguage: ["Source"]
-        - EdgeType: ["ShiftPtr"]
-        - LoopTail: [True]
-        - WorkGroupMapping: [8]
-        - PrefetchLocalRead: [True]
-        - PrefetchGlobalRead: [True]
-        - VectorWidth: [-1]
-      ForkParameters:
-        - ThreadTile:
-          - [ 4, 4 ]
-        - WorkGroup:
-          - [ 16, 16,  1 ]
-        - DepthU: [ 4 ]
-      BenchmarkForkParameters:
-      JoinParameters:
-      BenchmarkJoinParameters:
-      BenchmarkFinalParameters:
-        - ProblemSizes:
-          - Range: [ [1], [1], [1], [128] ] #source for k<=128
-          - Range: [ [1], [64], [1], [128] ] #source for k<=128
-          - Range: [ [64], [1], [1], [128] ] #source for k<=128
-
-    - # BenchmarkProblemSizeGroup - M,N < VW
-      InitialSolutionParameters:
-      BenchmarkCommonParameters:
+        - BufferLoad: [True]
+        - BufferStore: [True]
         - KernelLanguage: ["Assembly"]
         - EdgeType: ["ShiftPtr"]
         - LoopTail: [True]
@@ -128,9 +84,54 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [1], [1], [1], [256] ]
-          - Range: [ [1], [64], [1], [256] ]
-          - Range: [ [64], [1], [1], [256] ]
+          - Range: [ [1], [1], [1], [64] ]
+          - Range: [ [1], [64], [1], [64] ]
+          - Range: [ [64], [1], [1], [64] ]
+
+    - # BenchmarkProblemSizeGroup - M*384 384*N (small)
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - BufferLoad: [True]
+        - BufferStore: [True]
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - WorkGroupMapping: [8]
+        - PrefetchLocalRead: [True]
+        - PrefetchGlobalRead: [True]
+        - PreciseBoundsCheck: [False]
+        - VectorWidth: [-1]
+      ForkParameters:
+        - ThreadTile:
+          - [ 4, 4 ]
+          - [ 6, 4 ]
+          - [ 4, 6 ]
+        - WorkGroup:
+          - [ 16,  8,  1 ]
+          - [  8, 16,  1 ]
+          - [ 16, 16,  1 ]
+        - DepthU: [ 2, 4, 8, 12 ]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [ 15396, 15396, 1, 384 ]
+          - Exact: [ 14372, 14372, 1, 384 ]
+          - Exact: [ 13348, 13348, 1, 384 ]
+          - Exact: [ 12324, 12324, 1, 384 ]
+          - Exact: [ 11300, 11300, 1, 384 ]
+          - Exact: [ 10276, 10276, 1, 384 ]
+          - Exact: [  9252,  9252, 1, 384 ]
+          - Exact: [  8228,  8228, 1, 384 ]
+          - Exact: [  7204,  7204, 1, 384 ]
+          - Exact: [  6180,  6180, 1, 384 ]
+          - Exact: [  5156,  5156, 1, 384 ]
+          - Exact: [  4132,  4132, 1, 384 ]
+          - Exact: [  3108,  3108, 1, 384 ]
+          - Exact: [  2084,  2084, 1, 384 ]
+          - Exact: [  1060,  1060, 1, 384 ]
+          - Exact: [    36,    36, 1, 384 ]
 
   ########################################
   # NT
@@ -147,29 +148,8 @@ BenchmarkProblems:
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
       BenchmarkCommonParameters:
-        - KernelLanguage: ["Source"]
-        - EdgeType: ["ShiftPtr"]
-        - LoopTail: [True]
-        - WorkGroupMapping: [8]
-        - PrefetchLocalRead: [True]
-        - PrefetchGlobalRead: [True]
-        - VectorWidth: [-1]
-      ForkParameters:
-        - ThreadTile:
-          - [ 4, 4 ]
-        - WorkGroup:
-          - [ 16, 16,  1 ]
-        - DepthU: [ 8 ]
-      BenchmarkForkParameters:
-      JoinParameters:
-      BenchmarkJoinParameters:
-      BenchmarkFinalParameters:
-        - ProblemSizes:
-          - Range: [ [64], [64], [1], [128] ] # source for k<=128
-
-    - # BenchmarkProblemSizeGroup - Standard
-      InitialSolutionParameters:
-      BenchmarkCommonParameters:
+        - BufferLoad: [True]
+        - BufferStore: [True]
         - KernelLanguage: ["Assembly"]
         - EdgeType: ["ShiftPtr"]
         - LoopTail: [True]
@@ -189,36 +169,43 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [64], [64], [1], [256] ]
+          - Range: [ [64], [64], [1], [64] ]
 
-    - # BenchmarkProblemSizeGroup - M,N < VW
+    - # BenchmarkProblemSizeGroup - Demo
       InitialSolutionParameters:
       BenchmarkCommonParameters:
-        - KernelLanguage: ["Source"]
+        - BufferLoad: [True]
+        - BufferStore: [True]
+        - KernelLanguage: ["Assembly"]
         - EdgeType: ["ShiftPtr"]
         - LoopTail: [True]
-        - WorkGroupMapping: [8]
         - PrefetchLocalRead: [True]
-        - PrefetchGlobalRead: [True]
-        - VectorWidth: [-1]
+        - PreciseBoundsCheck: [False]
       ForkParameters:
+        - PrefetchGlobalRead: [True]
         - ThreadTile:
           - [ 4, 4 ]
         - WorkGroup:
           - [ 16, 16,  1 ]
-        - DepthU: [ 4 ]
+        - WorkGroupMapping: [8]
+        - GlobalSplitU: [1]
+        - DepthU: [ 8 ]
+        - VectorWidth: [-1]
       BenchmarkForkParameters:
       JoinParameters:
+        - MacroTile
+        - GlobalSplitU
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [1], [1], [1], [128] ] # source for k<=128
-          - Range: [ [1], [64], [1], [128] ] # source for k<=128
-          - Range: [ [64], [1], [1], [128] ] # source for k<=128
+          - Exact: [ 5760, 5760, 1, 5760 ]
+          - Exact: [ 7744, 7744, 1, 7744 ]
 
     - # BenchmarkProblemSizeGroup - M,N < VW
       InitialSolutionParameters:
       BenchmarkCommonParameters:
+        - BufferLoad: [True]
+        - BufferStore: [True]
         - KernelLanguage: ["Assembly"]
         - EdgeType: ["ShiftPtr"]
         - LoopTail: [True]
@@ -238,10 +225,54 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [1], [1], [1], [256] ]
-          - Range: [ [1], [64], [1], [256] ]
-          - Range: [ [64], [1], [1], [256] ]
+          - Range: [ [1], [1], [1], [64] ]
+          - Range: [ [1], [64], [1], [64] ]
+          - Range: [ [64], [1], [1], [64] ]
 
+    - # BenchmarkProblemSizeGroup - M*384 384*N (small)
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - BufferLoad: [True]
+        - BufferStore: [True]
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - WorkGroupMapping: [8]
+        - PrefetchLocalRead: [True]
+        - PrefetchGlobalRead: [True]
+        - PreciseBoundsCheck: [False]
+        - VectorWidth: [-1]
+      ForkParameters:
+        - ThreadTile:
+          - [ 4, 4 ]
+          - [ 6, 4 ]
+          - [ 4, 6 ]
+        - WorkGroup:
+          - [ 16,  8,  1 ]
+          - [  8, 16,  1 ]
+          - [ 16, 16,  1 ]
+        - DepthU: [ 2, 4, 8, 12 ]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [  4132,  4132, 1, 400 ]
+          - Exact: [  3108,  3108, 1, 400 ]
+          - Exact: [  2084,  2084, 1, 400 ]
+          - Exact: [  1060,  1060, 1, 400 ]
+          - Exact: [    36,    36, 1, 400 ]
+          - Exact: [   384,   384, 1, 384 ]
+          - Exact: [   768,   768, 1, 384 ]
+          - Exact: [  1152,  1152, 1, 384 ]
+          - Exact: [  1536,  1536, 1, 384 ]
+          - Exact: [  1920,  1920, 1, 384 ]
+          - Exact: [  2304,  2304, 1, 384 ]
+          - Exact: [  2688,  2688, 1, 384 ]
+          - Exact: [  3072,  3072, 1, 384 ]
+          - Exact: [  3456,  3456, 1, 384 ]
+          - Exact: [  3840,  3840, 1, 384 ]
+          - Exact: [  4224,  4224, 1, 384 ]
 
   ########################################
   # TN
@@ -258,29 +289,8 @@ BenchmarkProblems:
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
       BenchmarkCommonParameters:
-        - KernelLanguage: ["Source"]
-        - EdgeType: ["ShiftPtr"]
-        - LoopTail: [True]
-        - WorkGroupMapping: [8]
-        - PrefetchLocalRead: [True]
-        - PrefetchGlobalRead: [True]
-        - VectorWidth: [-1]
-      ForkParameters:
-        - ThreadTile:
-          - [ 4, 4 ]
-        - WorkGroup:
-          - [ 16, 16,  1 ]
-        - DepthU: [ 8 ]
-      BenchmarkForkParameters:
-      JoinParameters:
-      BenchmarkJoinParameters:
-      BenchmarkFinalParameters:
-        - ProblemSizes:
-          - Range: [ [64], [64], [1], [128] ] # source for k<=128
-
-    - # BenchmarkProblemSizeGroup - Standard
-      InitialSolutionParameters:
-      BenchmarkCommonParameters:
+        - BufferLoad: [True]
+        - BufferStore: [True]
         - KernelLanguage: ["Assembly"]
         - EdgeType: ["ShiftPtr"]
         - LoopTail: [True]
@@ -300,36 +310,13 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [64], [64], [1], [256] ]
+          - Range: [ [64], [64], [1], [64] ]
 
     - # BenchmarkProblemSizeGroup - M,N < VW
       InitialSolutionParameters:
       BenchmarkCommonParameters:
-        - KernelLanguage: ["Source"]
-        - EdgeType: ["ShiftPtr"]
-        - LoopTail: [True]
-        - WorkGroupMapping: [8]
-        - PrefetchLocalRead: [True]
-        - PrefetchGlobalRead: [True]
-        - VectorWidth: [-1]
-      ForkParameters:
-        - ThreadTile:
-          - [ 4, 4 ]
-        - WorkGroup:
-          - [ 16, 16,  1 ]
-        - DepthU: [ 4 ]
-      BenchmarkForkParameters:
-      JoinParameters:
-      BenchmarkJoinParameters:
-      BenchmarkFinalParameters:
-        - ProblemSizes:
-          - Range: [ [1], [1], [1], [128] ] # source for k<=128
-          - Range: [ [1], [64], [1], [128] ] # source for k<=128
-          - Range: [ [64], [1], [1], [128] ] # source for k<=128
-
-    - # BenchmarkProblemSizeGroup - M,N < VW
-      InitialSolutionParameters:
-      BenchmarkCommonParameters:
+        - BufferLoad: [True]
+        - BufferStore: [True]
         - KernelLanguage: ["Assembly"]
         - EdgeType: ["ShiftPtr"]
         - LoopTail: [True]
@@ -349,9 +336,9 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [1], [1], [1], [256] ]
-          - Range: [ [1], [64], [1], [256] ]
-          - Range: [ [64], [1], [1], [256] ]
+          - Range: [ [1], [1], [1], [64] ]
+          - Range: [ [1], [64], [1], [64] ]
+          - Range: [ [64], [1], [1], [64] ]
 
   ########################################
   # TT
@@ -368,29 +355,8 @@ BenchmarkProblems:
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
       BenchmarkCommonParameters:
-        - KernelLanguage: ["Source"]
-        - EdgeType: ["ShiftPtr"]
-        - LoopTail: [True]
-        - WorkGroupMapping: [8]
-        - PrefetchLocalRead: [True]
-        - PrefetchGlobalRead: [True]
-        - VectorWidth: [-1]
-      ForkParameters:
-        - ThreadTile:
-          - [ 4, 4 ]
-        - WorkGroup:
-          - [ 16, 16,  1 ]
-        - DepthU: [ 8 ]
-      BenchmarkForkParameters:
-      JoinParameters:
-      BenchmarkJoinParameters:
-      BenchmarkFinalParameters:
-        - ProblemSizes:
-          - Range: [ [64], [64], [1], [128] ] # source for k<=128
-
-    - # BenchmarkProblemSizeGroup - Standard
-      InitialSolutionParameters:
-      BenchmarkCommonParameters:
+        - BufferLoad: [True]
+        - BufferStore: [True]
         - KernelLanguage: ["Assembly"]
         - EdgeType: ["ShiftPtr"]
         - LoopTail: [True]
@@ -410,36 +376,13 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [64], [64], [1], [256] ]
+          - Range: [ [64], [64], [1], [64] ]
 
     - # BenchmarkProblemSizeGroup - M,N < VW
       InitialSolutionParameters:
       BenchmarkCommonParameters:
-        - KernelLanguage: ["Source"]
-        - EdgeType: ["ShiftPtr"]
-        - LoopTail: [True]
-        - WorkGroupMapping: [8]
-        - PrefetchLocalRead: [True]
-        - PrefetchGlobalRead: [True]
-        - VectorWidth: [-1]
-      ForkParameters:
-        - ThreadTile:
-          - [ 4, 4 ]
-        - WorkGroup:
-          - [ 16, 16,  1 ]
-        - DepthU: [ 4 ]
-      BenchmarkForkParameters:
-      JoinParameters:
-      BenchmarkJoinParameters:
-      BenchmarkFinalParameters:
-        - ProblemSizes:
-          - Range: [ [1], [1], [1], [128] ] # source for k<=128
-          - Range: [ [1], [64], [1], [128] ] # source for k<=128
-          - Range: [ [64], [1], [1], [128] ] # source for k<=128
-
-    - # BenchmarkProblemSizeGroup - M,N < VW
-      InitialSolutionParameters:
-      BenchmarkCommonParameters:
+        - BufferLoad: [True]
+        - BufferStore: [True]
         - KernelLanguage: ["Assembly"]
         - EdgeType: ["ShiftPtr"]
         - LoopTail: [True]
@@ -459,10 +402,9 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [1], [1], [1], [256] ]
-          - Range: [ [1], [64], [1], [256] ]
-          - Range: [ [64], [1], [1], [256] ]
-
+          - Range: [ [1], [1], [1], [64] ]
+          - Range: [ [1], [64], [1], [64] ]
+          - Range: [ [64], [1], [1], [64] ]
 
 LibraryLogic:
 #   ScheduleName: "vega20"

--- a/Tensile/Configs/rocblas_hgemm_asm_lite.yaml
+++ b/Tensile/Configs/rocblas_hgemm_asm_lite.yaml
@@ -304,6 +304,10 @@ BenchmarkProblems:
 
 
 LibraryLogic:
+#   ScheduleName: "vega20"
+#   DeviceNames: ["Device 66a0", "Device 66a7"]
+#   ArchitectureName: "gfx906"
+
     ScheduleName: "vega10"
     DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]"]
     ArchitectureName: "gfx900"

--- a/Tensile/Configs/rocblas_sgemm_asm_full.yaml
+++ b/Tensile/Configs/rocblas_sgemm_asm_full.yaml
@@ -1460,6 +1460,10 @@ BenchmarkProblems:
           - Range: [ [64, 64, 64, 7000], [4], [1], [256, 1024, 1024, 4096] ] # skinny-1
 
 LibraryLogic:
+#   ScheduleName: "vega20"
+#   DeviceNames: ["Device 66a0", "Device 66a7"]
+#   ArchitectureName: "gfx906"
+
     ScheduleName: "vega10"
     DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]"]
     ArchitectureName: "gfx900"

--- a/Tensile/Configs/rocblas_sgemm_asm_lite.yaml
+++ b/Tensile/Configs/rocblas_sgemm_asm_lite.yaml
@@ -551,6 +551,10 @@ BenchmarkProblems:
 
 
 LibraryLogic:
+#   ScheduleName: "vega20"
+#   DeviceNames: ["Device 66a0", "Device 66a7"]
+#   ArchitectureName: "gfx906"
+
     ScheduleName: "vega10"
     DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]"]
     ArchitectureName: "gfx900"

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -662,7 +662,17 @@ class KernelWriterAssembly(KernelWriter):
             ds_read_b64, ds_read2_b32, ds_read_b32 ],
           "LocalWrite": [ ds_write_b128, ds_write2_b64,
             ds_write_b64, ds_write2_b32, ds_write_b32, ds_write_b16 ]
-          } # 900
+          }, # 900
+        (9,0,6): {
+          "GlobalRead": [ chosen_load_dwordx4, chosen_load_dwordx2,
+            chosen_load_dword ],
+          "GlobalWrite": [ chosen_store_dwordx4, chosen_store_dwordx2,
+            chosen_store_dword ],
+          "LocalRead": [ ds_read_b128, ds_read2_b64,
+            ds_read_b64, ds_read2_b32, ds_read_b32 ],
+          "LocalWrite": [ ds_write_b128, ds_write2_b64,
+            ds_write_b64, ds_write2_b32, ds_write_b32, ds_write_b16 ]
+          } # 906
         }
 
 

--- a/Tensile/Source/Client.h
+++ b/Tensile/Source/Client.h
@@ -632,7 +632,7 @@ bool callLibrary(
 
   float perfScaling = 1.f;
 #if Tensile_RUNTIME_LANGUAGE_HIP
-  perfScaling = 1.f * expectedClockRate / avgCoreClock; // if clock speeds drop
+//  perfScaling = 1.f * expectedClockRate / avgCoreClock; // if clock speeds drop
 #endif
   double gflops = solutionIsValid ? perfScaling * totalFlops / timeNs : 0;
 
@@ -1054,7 +1054,7 @@ bool benchmarkAllSolutionsForSize(
 
     float perfScaling = 1.f;
 #if Tensile_RUNTIME_LANGUAGE_HIP
-    perfScaling = 1.f * expectedClockRate / avgCoreClock; // if clock speeds drop
+//    perfScaling = 1.f * expectedClockRate / avgCoreClock; // if clock speeds drop
 #endif
     double gflops = solutionIsValid ? perfScaling * totalFlops / timeNs : 0;
     //std::cout << gflops << " gflops = " << totalFlops << " flops / " << timeNs << " ns" << std::endl;

--- a/Tensile/Source/TensileConfig.cmake
+++ b/Tensile/Source/TensileConfig.cmake
@@ -103,7 +103,7 @@ function(TensileCreateLibrary
   set(options)
   add_library(Tensile ${options} ${Tensile_SOURCE_FILES})
   # specify gpu targets
-  set(Tensile_HIP_ISA "gfx803" "gfx900")
+  set(Tensile_HIP_ISA "gfx803" "gfx900" "gfx906")
   foreach( target ${Tensile_HIP_ISA} )
     target_link_libraries( Tensile PRIVATE --amdgpu-target=${target} )
   endforeach()


### PR DESCRIPTION
Impacts of this merge:

-  pre-ROCm 1.9 compiler/assembler will issue a warning stating that gfx906 is not supported, fallback to gfx803 when building the develop branch of rocBLAS.  The warning is benign and can be safely ignored.
-  perfScaling in Tensile/Source/Client.h is disabled even for Power Play enabled GPUs, i.e. always 1.