### PR TITLE
Include atomic for usage with _hipFunctions

### DIFF
--- a/Tensile/Source/SolutionHelper.h
+++ b/Tensile/Source/SolutionHelper.h
@@ -28,6 +28,7 @@
 #include <string>
 #include <tuple>
 #include <mutex>
+#include <atomic>
 
 /*******************************************************************************
  * Kernel Cache


### PR DESCRIPTION
Fixes an error for implicit instantiation of undefined std::atomic<hipFunction_t*> _hipFunctions. We need to include this library if we want to use std::atomic .

We see this bug in compiling rocBLAS with latest HIP-Clang. I've tested this on Ubuntu 16.04, on Vega10 card with HIP-Clang, latest llvm/clang and ROCm-Device-Libraries. 