### PR TITLE
Cleanup global load do

### DIFF
--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -220,8 +220,6 @@ validParameters = {
     "LocalWrite2B":               [ False, True ],
     "LocalRead2A":                [ False, True ],
     "LocalRead2B":                [ False, True ],
-    "BufferLoad":                 [ False, True],
-    "BufferStore":                [ False, True],
 
     # Attempt to load directly from global memory into LDS.
     # Assembly only
@@ -234,14 +232,15 @@ validParameters = {
     # For an 8x8 TT with PrefetchGlobalRead=1 this can save 33 VGPRs.
     "DirectToLds":                [ False, True],
 
-    # Use buffer limit field to precisely check array bounds.
-    # Requires BufferLoad.  Eliminate the shift logic and
-    # simplifies the bounds checking.  Enables
+    "BufferStore":                [ False, True],
+
+    # Use buffer loads including limit field to precisely check array bounds.
+    # Eliminate the shift logic and simplifies the bounds checking.  Enables
     # UseSgprForGRO.
-    "PreciseBoundsCheck":         [ False, True],
+    "BufferLoad":                 [ False, True],
 
     # Attempt to use SGPR for Global Read Offsets.
-    # Requires BufferLoad=1 and PreciseBoundsCheck=1
+    # Requires BufferLoad=1
     # This will convert VGPR into SGPR which is usually a win (in particular if the GlobalReadWidth is 1.)
     # However, the mode may exhaust all available SGPR, in particular for large unroll
     # -1 attempt to use a hueristic to determine when the tile size will use too many SGPR
@@ -444,7 +443,6 @@ defaultBenchmarkCommonParameters = [
     {"BufferLoad":                [ True ] },
     {"BufferStore":               [ True ] },
     {"DirectToLds":               [ True ] },
-    {"PreciseBoundsCheck":        [ True ] },
     {"UseSgprForGRO":             [ -1 ] },
     {"AssertSummationElementMultiple": [ 1 ] },
     {"AssertFree0ElementMultiple": [ 1 ] },

--- a/Tensile/KernelWriter.py
+++ b/Tensile/KernelWriter.py
@@ -122,10 +122,10 @@ class KernelWriter:
 
       # tile edges
       if kernel["EdgeType"] == "ShiftPtr":
-        if not (kernel["PreciseBoundsCheck"] and kernel["GuaranteeNoPartialA"]):
+        if not (kernel["BufferLoad"] and kernel["GuaranteeNoPartialA"]):
           kStr += self.comment("global read addresses: shift a")
           kStr += self.graShift(kernel, tensorParametersA)
-        if not (kernel["PreciseBoundsCheck"] and  kernel["GuaranteeNoPartialB"]):
+        if not (kernel["BufferLoad"] and  kernel["GuaranteeNoPartialB"]):
           kStr += self.comment("global read addresses: shift b")
           kStr += self.graShift(kernel, tensorParametersB)
       elif kernel["EdgeType"] == "Branch":

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -3928,7 +3928,7 @@ class KernelWriterAssembly(KernelWriter):
                 else:
                   destVgpr="G2L%s+%u+%u"%(tc, g2lIdx, regIdx)
 
-                if kernel["ProblemType"]["DataType"].isHalf():
+                if kernel["ProblemType"]["DataType"].isHalf() and not kernel["DirectToLds%s"%tc]:
                   hi16=loopCnt%2 if tP["glvw"]==1 else r%2
                 else:
                   hi16 = 0
@@ -3954,7 +3954,7 @@ class KernelWriterAssembly(KernelWriter):
                             addr0=vgpr(offsetVgpr), addr1=sgpr("Srd%s"%tc, 4), \
                             soffset=soffset, offset=offset, \
                             extraFields=extraFields, \
-                            hi16=kernel["ProblemType"]["DataType"].isHalf() and r%2==1, \
+                            hi16=hi16, \
                             comment="load single buffer value")
 
               else: # Not buffer load

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -3885,7 +3885,16 @@ class KernelWriterAssembly(KernelWriter):
             r = 0
             # for each component in vector
             while r < loadWidth*self.bpr/tP["bpe"]:
+              if kernel["ProblemType"]["DataType"].isHalf():
+                regIdx = r/2
+              elif kernel["ProblemType"]["DataType"].isSingle():
+                regIdx = r
+              elif kernel["ProblemType"]["DataType"].isDouble():
+                regIdx = r*2
+              else:
+                printWarning("DataType unsupported")
               kStr += self.comment1("g2l=%u, load component %u"%(g2lIdx, r))
+
               # load single element from address (except packed half case below)
               numElementsPerLoad = 1
               offset = 0
@@ -3979,18 +3988,8 @@ class KernelWriterAssembly(KernelWriter):
                     "addr < maxAddr")
 
                 # load single element from address
-                bpl = self.bpeAB
-       		if kernel["ProblemType"]["DataType"].isHalf():
-                  regIdx = r/2
-                elif kernel["ProblemType"]["DataType"].isSingle():
-                  regIdx = r
-                elif kernel["ProblemType"]["DataType"].isDouble():
-                  regIdx = r*2
-                else:
-                  printWarning("DataType unsupported")
-
                 kStr += self.chooseGlobalLoad(False, \
-                          bpl, destVgpr="G2L%s+%u+%u"%(tc, g2lIdx, regIdx), \
+                          self.bpeAB, destVgpr="G2L%s+%u+%u"%(tc, g2lIdx, regIdx), \
                           rpv=bpl/4.0, \
                           addr0=vgpr("GlobalReadAddr%s+%u"%(tc,graIdx),2), addr1="", \
                           soffset=0, offset=0, \

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -3813,7 +3813,6 @@ class KernelWriterAssembly(KernelWriter):
     graIdx = 0
     g2lIdx = 0
     loadWidth = tP["globalReadInstruction"].totalWidth
-    ldsOffset = 0
 
     ########################################
     # Calculate Max Addr

--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -1449,6 +1449,17 @@ class Solution:
           state["LocalWriteUseSgprB"] = True
 
       if 0:
+        print "DirectToLds Conditions (elementMultipleOk=", elementMultipleOk, \
+              "wavefronts=", wavefronts, ")"
+        print "  (LSCA)",state["LSCA"],"*", "(numBytes)", numBytes, "=?", "256 * (wavefronts)", wavefronts, \
+              "=>", (state["LSCA"] * numBytes == 256 * wavefronts)
+        print "  (LSCA)",state["LSCA"],"*", "(numBytes)", numBytes, "=?", state["NumThreads"], "* 4", \
+              "=>", (state["LSCA"] * numBytes == state["NumThreads"]*4)
+        print "  (LSCB)",state["LSCB"],"*", "(numBytes)", numBytes, "=?", "256 * (wavefronts)", wavefronts, \
+              "=>", (state["LSCB"] * numBytes == 256 * wavefronts)
+        print "  (LSCB)",state["LSCB"],"*", "(numBytes)", numBytes, "=?", state["NumThreads"], "* 4", \
+              "=>", (state["LSCB"] * numBytes == state["NumThreads"]*4)
+
         print "A: TLU=", state["ProblemType"]["TLUA"], " MT=", state["MacroTile0"], \
                " LSCA=", state["LSCA"], "LSPA=", state["LSPA"], "GLVB_A=", state["GlobalLoadVectorWidthA"], \
                " dataTypeNumBytes=", state["ProblemType"]["DataType"].numBytes(), \

--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -1408,7 +1408,6 @@ class Solution:
     if not state["BufferLoad"] or state["KernelLanguage"] != "Assembly":
       state["BufferLoad"] = False
       state["DirectToLds"] = False
-      state["PreciseBoundsCheck"] = False
       state["UseSgprForGRO"] = False
       state["FractionalLoad"] = False
 
@@ -1500,7 +1499,7 @@ class Solution:
 
     #--
     # ShiftPtr can't use UseSgprForGRO since it needs to modify the VGPR pointers
-    if state["PreciseBoundsCheck"] and state["UseSgprForGRO"] \
+    if state["BufferLoad"] and state["UseSgprForGRO"] \
             and state["EdgeType"]=="ShiftPtr":
       if not state["GuaranteeNoPartialA"] or not state["GuaranteeNoPartialB"]:
         state["UseSgprForGRO"] = False
@@ -1510,10 +1509,10 @@ class Solution:
     # (as opposed to using dedicated VGPR for each GRO
     # Requires preciseBounds check since we rely on the buffer bounds check, not
     # individual vector registers doing bounds compares.
-    if not state["PreciseBoundsCheck"]:
+    if not state["BufferLoad"]:
       state["UseSgprForGRO"] = 0
       if state["FractionalLoad"]:
-        reject(state, "Fractional currently requires PreciseBoundsCheck") # Move to PBC always
+        reject(state, "Fractional requires BufferLoad")
 
     if state["UseSgprForGRO"] == -1:
       # Don't use SGPR if it looks like we might not have enough - better to leave PBC enabled even if we have to use VGPR

--- a/Tensile/Tests/pre_checkin/direct_to_lds/hgemm_asm_nn.yaml
+++ b/Tensile/Tests/pre_checkin/direct_to_lds/hgemm_asm_nn.yaml
@@ -1,0 +1,43 @@
+# benchmark assembly and source kernels
+GlobalParameters:
+  MinimumRequiredVersion: 4.2.0
+  NumElementsToValidate: -1
+  KernelTime: True
+  PrintSolutionRejectionReason: True
+
+BenchmarkProblems:
+
+  - # hgemm NN
+    - # ProblemType
+      OperationType: GEMM
+      DataType: h
+      TransposeA: False
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Assembly
+      # This should enable DirectToLdsA=1 DirectToLdsB=0
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - LoopTail: [True]
+        - EdgeType: ["ShiftPtr"]
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - GlobalSplitU: [1]
+        - PrefetchLocalRead: [False]
+        - PrefetchGlobalRead: [True]
+        - ThreadTile:
+          - [ 16, 8 ]
+        - WorkGroup:
+          - [ 8,  8,  1 ]
+        - DepthU: [64]
+        - GlobalReadVectorWidth: [2]
+        - VectorWidth: [2]
+        - AssertSummationElementMultiple: [2]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [127,1,129], [127,1,129], [2], [60,2,70] ]

--- a/Tensile/Tests/pre_checkin/direct_to_lds/test_direct_to_lds.py
+++ b/Tensile/Tests/pre_checkin/direct_to_lds/test_direct_to_lds.py
@@ -1,0 +1,5 @@
+import Tensile.Tensile as Tensile
+
+def test_hgemm_asm_nn(tmpdir):
+ Tensile.Tensile([Tensile.TensileTestPath("pre_checkin/direct_to_lds/hgemm_asm_nn.yaml"), tmpdir.strpath])
+


### PR DESCRIPTION
- remove ~100 lines of twisty global load code
- add separate routine for guardK cases
- use chooseGlobalLoad function rather than inline load selection or MemoryInstruction class
- use unsigned math for edge detection (greater range of buffers)
- Remove PreciseBoundsCheck parm (now always enabled with BufferLoad=1)
- update documentation in Common.py