### PR TITLE
Fix v20 testing

### DIFF
--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -772,8 +772,10 @@ def assignGlobalParameters( config ):
   # Determine assembler capabilities:
   # Try to assemble the new explicit co syntax:
   globalParameters["AsmCaps"] = {}
+  globalParameters["ArchCaps"] = {}
   for (v) in globalParameters["SupportedISA"]:
     globalParameters["AsmCaps"][v] = {}
+    globalParameters["ArchCaps"][v] = {}
     isaVersion = "gfx" + "".join(map(str,v))
     globalParameters["AsmCaps"][v]["SupportedIsa"] = tryAssembler(isaVersion, "")
     globalParameters["AsmCaps"][v]["HasExplicitCO"] = tryAssembler(isaVersion, "v_add_co_u32 v0,vcc,v0,v0")
@@ -785,8 +787,8 @@ def assignGlobalParameters( config ):
       caps += " %s=%u" % (k, globalParameters["AsmCaps"][v][k])
 
     print1 ("# Asm caps for %s:%s" % (isaVersion, caps))
-
-
+    globalParameters["ArchCaps"][v]["HasEccHalf"] = (v==(9,0,6))
+    print1 ("# Arch caps for %s:%s" % (isaVersion, globalParameters["ArchCaps"][v]))
 
   # For ubuntu platforms, call dpkg to grep the version of hcc.  This check is platform specific, and in the future
   # additional support for yum, dnf zypper may need to be added.  On these other platforms, the default version of

--- a/Tensile/Tests/nightly/assertions/test_hgemm_asem2_asm.yaml
+++ b/Tensile/Tests/nightly/assertions/test_hgemm_asem2_asm.yaml
@@ -37,6 +37,7 @@ BenchmarkProblems:
         - KernelLanguage: ["Assembly"]
       ForkParameters:
         - AssertSummationElementMultiple: [2]
+        - AssertFree0ElementMultiple: [1,2]
         - GlobalSplitU: [1, 3]
         - PrefetchLocalRead: [False]
         - PrefetchGlobalRead: [True]
@@ -63,6 +64,7 @@ BenchmarkProblems:
         - EdgeType: ["ShiftPtr"]
       ForkParameters:
         - AssertSummationElementMultiple: [2]
+        - AssertFree0ElementMultiple: [1,2]
         - KernelLanguage: ["Assembly"]
         - GlobalSplitU: [1, 3]
         - PrefetchLocalRead: [False]
@@ -102,6 +104,7 @@ BenchmarkProblems:
         - KernelLanguage: ["Assembly"]
       ForkParameters:
         - AssertSummationElementMultiple: [2]
+        - AssertFree0ElementMultiple: [1,2]
         - GlobalSplitU: [1, 3]
         - PrefetchLocalRead: [True]
         - PrefetchGlobalRead: [True]
@@ -128,6 +131,7 @@ BenchmarkProblems:
         - EdgeType: ["ShiftPtr"]
       ForkParameters:
         - AssertSummationElementMultiple: [2]
+        - AssertFree0ElementMultiple: [1,2]
         - KernelLanguage: ["Assembly"]
         - GlobalSplitU: [1, 3]
         - PrefetchLocalRead: [True]
@@ -166,6 +170,7 @@ BenchmarkProblems:
         - KernelLanguage: ["Assembly"]
       ForkParameters:
         - AssertSummationElementMultiple: [2]
+        - AssertFree0ElementMultiple: [1,2]
         - GlobalSplitU: [1, 3]
         - PrefetchLocalRead: [True]
         - PrefetchGlobalRead: [False]
@@ -192,6 +197,7 @@ BenchmarkProblems:
         - EdgeType: ["ShiftPtr"]
       ForkParameters:
         - AssertSummationElementMultiple: [2]
+        - AssertFree0ElementMultiple: [1,2]
         - KernelLanguage: ["Assembly"]
         - GlobalSplitU: [1, 3]
         - PrefetchLocalRead: [True]
@@ -231,6 +237,7 @@ BenchmarkProblems:
         - KernelLanguage: ["Assembly"]
       ForkParameters:
         - AssertSummationElementMultiple: [2]
+        - AssertFree0ElementMultiple: [1,2]
         - PrefetchLocalRead: [False]
         - PrefetchGlobalRead: [False]
         - ThreadTile:
@@ -256,6 +263,7 @@ BenchmarkProblems:
         - EdgeType: ["ShiftPtr"]
       ForkParameters:
         - AssertSummationElementMultiple: [2]
+        - AssertFree0ElementMultiple: [1,2]
         - KernelLanguage: ["Assembly"]
         - PrefetchLocalRead: [False]
         - PrefetchGlobalRead: [False]

--- a/Tensile/Tests/nightly/global_split_u/hgemm_gsu.yaml
+++ b/Tensile/Tests/nightly/global_split_u/hgemm_gsu.yaml
@@ -70,6 +70,7 @@ BenchmarkProblems:
         - GlobalReadVectorWidth: [2,4,8]
         - VectorAtomicWidth: [-1]
         - AssertFree0ElementMultiple: [8]  # so we can test GRVW sweep
+        - AssertSummationElementMultiple: [1,2]  # so we can test GRVW sweep
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:

--- a/Tensile/Tests/nightly/local_split_u/hgemm_lsu.yaml
+++ b/Tensile/Tests/nightly/local_split_u/hgemm_lsu.yaml
@@ -70,6 +70,7 @@ BenchmarkProblems:
         - VectorWidth: [2,4,8]
         - GlobalReadVectorWidth: [2,4,8]
         - AssertFree0ElementMultiple: [8]  # so we can test GRVW sweep
+        - AssertSummationElementMultiple: [1,2]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:

--- a/Tensile/Tests/nightly/local_split_u/hgemm_lsu_grvw2.yaml
+++ b/Tensile/Tests/nightly/local_split_u/hgemm_lsu_grvw2.yaml
@@ -1,4 +1,4 @@
-# no GRVW assertions
+# no GRVW assertions (added 1,2 for V20)
 
 GlobalParameters:
   MinimumRequiredVersion: 4.2.0
@@ -71,6 +71,8 @@ BenchmarkProblems:
         - DepthU: [ 8,16,32 ]
         - VectorWidth: [2,4,8]
         - GlobalReadVectorWidth: [2]
+        - AssertSummationElementMultiple: [1,2]
+        - AssertFree0ElementMultiple: [1,2]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:

--- a/Tensile/Tests/nightly/vector_width/hgemm_nn_asm.yaml
+++ b/Tensile/Tests/nightly/vector_width/hgemm_nn_asm.yaml
@@ -37,9 +37,11 @@ BenchmarkProblems:
         - DepthU: [32]
         - VectorWidth: [1,2,4,8]
         - GlobalReadVectorWidth: [1,2,4,8]
+        - AssertSummationElementMultiple: [1,2]
+        - AssertFree0ElementMultiple: [1,2]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [4], [63,1,65] ]
+          - Range: [ [126,1,130], 0, [2], [62,1,66] ]

--- a/Tensile/Tests/pre_checkin/direct_to_lds/hgemm_asm_nn.yaml
+++ b/Tensile/Tests/pre_checkin/direct_to_lds/hgemm_asm_nn.yaml
@@ -35,9 +35,10 @@ BenchmarkProblems:
         - GlobalReadVectorWidth: [2]
         - VectorWidth: [2]
         - AssertSummationElementMultiple: [2]
+        - AssertFree0ElementMultiple: [1,2]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], [127,1,129], [2], [60,2,70] ]
+          - Range: [ [126,1,130], 0, [2], [62,1,66] ]

--- a/Tensile/Tests/pre_checkin/hgemm_asm_nn.yaml
+++ b/Tensile/Tests/pre_checkin/hgemm_asm_nn.yaml
@@ -3,6 +3,7 @@ GlobalParameters:
   MinimumRequiredVersion: 4.2.0
   NumElementsToValidate: -1
   KernelTime: True
+  PrintSolutionRejectionReason: 1
 
 BenchmarkProblems:
 
@@ -35,12 +36,14 @@ BenchmarkProblems:
           - [  8,  8,  1 ]
         - DepthU: [8]
         - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [1,2]
+        - AssertFree0ElementMultiple: [1,2]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [126,1,130], 0, [2], [62,1,66] ]
 
     - # BenchmarkProblemSizeGroup - Assembly
       InitialSolutionParameters:
@@ -62,71 +65,11 @@ BenchmarkProblems:
           - [  8,  8,  1 ]
         - DepthU: [16]
         - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [1,2]
+        - AssertFree0ElementMultiple: [1,2]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
-
-  - # hgemm NT
-    - # ProblemType
-      OperationType: GEMM
-      DataType: h
-      DestDataType: h
-      TransposeA: False
-      TransposeB: True
-      UseBeta: True
-      Batched: True
-
-    - # BenchmarkProblemSizeGroup - Assembly
-      InitialSolutionParameters:
-      BenchmarkCommonParameters:
-        - LoopTail: [True]
-        - EdgeType: ["ShiftPtr"]
-        - KernelLanguage: ["Assembly"]
-      ForkParameters:
-        - GlobalSplitU: [1, 3]
-        - PrefetchLocalRead: [True]
-        - PrefetchGlobalRead: [True]
-        - ThreadTile:
-          - [ 2, 2 ]
-          - [ 4, 4 ]
-          - [ 8, 16 ]
-        - WorkGroup:
-          - [ 16, 16,  1 ]
-          - [  8, 16,  1 ]
-        - DepthU: [32]
-        - VectorWidth: [-1]
-      BenchmarkForkParameters:
-      JoinParameters:
-      BenchmarkJoinParameters:
-      BenchmarkFinalParameters:
-        - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
-
-    - # BenchmarkProblemSizeGroup - Assembly
-      InitialSolutionParameters:
-      BenchmarkCommonParameters:
-        - LoopTail: [True]
-        - EdgeType: ["ShiftPtr"]
-      ForkParameters:
-        - KernelLanguage: ["Assembly"]
-        - GlobalSplitU: [1, 3]
-        - PrefetchLocalRead: [True]
-        - PrefetchGlobalRead: [True]
-        - ThreadTile:
-          - [ 4, 2 ]
-          - [ 8, 8 ]
-          - [ 8, 4 ]
-        - WorkGroup:
-          - [ 16, 16,  1 ]
-          - [ 16,  8,  1 ]
-        - DepthU: [16]
-        - VectorWidth: [-1]
-      BenchmarkForkParameters:
-      JoinParameters:
-      BenchmarkJoinParameters:
-      BenchmarkFinalParameters:
-        - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [126,1,130], 0, [2], [62,1,66] ]

--- a/Tensile/Tests/pre_checkin/hgemm_asm_nt.yaml
+++ b/Tensile/Tests/pre_checkin/hgemm_asm_nt.yaml
@@ -34,12 +34,14 @@ BenchmarkProblems:
           - [ 32,  4,  1 ]
         - DepthU: [8]
         - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [1,2]
+        - AssertFree0ElementMultiple: [1,2]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [126,1,130], 0, [2], [62,1,66] ]
 
     - # BenchmarkProblemSizeGroup - Assembly
       InitialSolutionParameters:
@@ -61,9 +63,11 @@ BenchmarkProblems:
           - [  8,  8,  1 ]
         - DepthU: [16]
         - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [1,2]
+        - AssertFree0ElementMultiple: [1,2]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [126,1,130], 0, [2], [62,1,66] ]

--- a/Tensile/Tests/pre_checkin/hgemm_asm_tn.yaml
+++ b/Tensile/Tests/pre_checkin/hgemm_asm_tn.yaml
@@ -35,12 +35,14 @@ BenchmarkProblems:
           - [ 32,  4,  1 ]
         - DepthU: [8]
         - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [1,2]
+        - AssertFree0ElementMultiple: [1,2]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [126,1,130], 0, [2], [62,1,66] ]
 
     - # BenchmarkProblemSizeGroup - Assembly
       InitialSolutionParameters:
@@ -62,12 +64,14 @@ BenchmarkProblems:
           - [  8,  8,  1 ]
         - DepthU: [16]
         - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [1,2]
+        - AssertFree0ElementMultiple: [1,2]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [126,1,130], 0, [2], [62,1,66] ]
 
     - # BenchmarkProblemSizeGroup - Assembly
       InitialSolutionParameters:
@@ -86,7 +90,7 @@ BenchmarkProblems:
         - GlobalSplitU: [1]
         - DepthU: [8]
         - VectorWidth: [2]
-        - AssertSummationElementMultiple: [2]
+        - AssertSummationElementMultiple: [1,2]
         - AssertFree0ElementMultiple: [2]
       BenchmarkForkParameters:
       JoinParameters:

--- a/Tensile/Tests/pre_checkin/hgemm_asm_tt.yaml
+++ b/Tensile/Tests/pre_checkin/hgemm_asm_tt.yaml
@@ -32,12 +32,14 @@ BenchmarkProblems:
           - [  8,  8,  1 ]
         - DepthU: [32]
         - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [1,2]
+        - AssertFree0ElementMultiple: [1,2]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [126,1,130], 0, [2], [62,1,66] ]
 
     - # BenchmarkProblemSizeGroup - Assembly
       InitialSolutionParameters:
@@ -58,9 +60,11 @@ BenchmarkProblems:
           - [  8,  8,  1 ]
         - DepthU: [16]
         - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [1,2]
+        - AssertFree0ElementMultiple: [1,2]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [126,1,130], 0, [2], [62,1,66] ]

--- a/Tensile/Tests/pre_checkin/hgemm_hpa_asm_nn.yaml
+++ b/Tensile/Tests/pre_checkin/hgemm_hpa_asm_nn.yaml
@@ -36,12 +36,14 @@ BenchmarkProblems:
           - [  8,  8,  1 ]
         - DepthU: [8]
         - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [1,2]
+        - AssertFree0ElementMultiple: [1,2]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [126,1,130], 0, [2], [62,1,66] ]
 
     - # BenchmarkProblemSizeGroup - Assembly
       InitialSolutionParameters:
@@ -63,72 +65,11 @@ BenchmarkProblems:
           - [  8,  8,  1 ]
         - DepthU: [16]
         - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [1,2]
+        - AssertFree0ElementMultiple: [1,2]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
-
-  - # hgemm NT
-    - # ProblemType
-      OperationType: GEMM
-      DataType: h
-      DestDataType: h
-      HighPrecisionAccumulate: True
-      TransposeA: False
-      TransposeB: True
-      UseBeta: True
-      Batched: True
-
-    - # BenchmarkProblemSizeGroup - Assembly
-      InitialSolutionParameters:
-      BenchmarkCommonParameters:
-        - LoopTail: [True]
-        - EdgeType: ["ShiftPtr"]
-        - KernelLanguage: ["Assembly"]
-      ForkParameters:
-        - GlobalSplitU: [1, 3]
-        - PrefetchLocalRead: [True]
-        - PrefetchGlobalRead: [True]
-        - ThreadTile:
-          - [ 2, 2 ]
-          - [ 4, 4 ]
-          - [ 8, 16 ]
-        - WorkGroup:
-          - [ 16, 16,  1 ]
-          - [  8, 16,  1 ]
-        - DepthU: [32]
-        - VectorWidth: [-1]
-      BenchmarkForkParameters:
-      JoinParameters:
-      BenchmarkJoinParameters:
-      BenchmarkFinalParameters:
-        - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
-
-    - # BenchmarkProblemSizeGroup - Assembly
-      InitialSolutionParameters:
-      BenchmarkCommonParameters:
-        - LoopTail: [True]
-        - EdgeType: ["ShiftPtr"]
-      ForkParameters:
-        - KernelLanguage: ["Assembly"]
-        - GlobalSplitU: [1, 3]
-        - PrefetchLocalRead: [True]
-        - PrefetchGlobalRead: [True]
-        - ThreadTile:
-          - [ 4, 2 ]
-          - [ 8, 8 ]
-          - [ 8, 4 ]
-        - WorkGroup:
-          - [ 16, 16,  1 ]
-          - [ 16,  8,  1 ]
-        - DepthU: [16]
-        - VectorWidth: [-1]
-      BenchmarkForkParameters:
-      JoinParameters:
-      BenchmarkJoinParameters:
-      BenchmarkFinalParameters:
-        - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [126,1,130], 0, [2], [62,1,66] ]

--- a/Tensile/Tests/pre_checkin/hgemm_hpa_asm_nt.yaml
+++ b/Tensile/Tests/pre_checkin/hgemm_hpa_asm_nt.yaml
@@ -35,12 +35,14 @@ BenchmarkProblems:
           - [ 32,  4,  1 ]
         - DepthU: [8]
         - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [1,2]
+        - AssertFree0ElementMultiple: [1,2]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [126,1,130], 0, [2], [62,1,66] ]
 
     - # BenchmarkProblemSizeGroup - Assembly
       InitialSolutionParameters:
@@ -62,9 +64,11 @@ BenchmarkProblems:
           - [  8,  8,  1 ]
         - DepthU: [16]
         - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [1,2]
+        - AssertFree0ElementMultiple: [1,2]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [126,1,130], 0, [2], [62,1,66] ]

--- a/Tensile/Tests/pre_checkin/hgemm_hpa_asm_tn.yaml
+++ b/Tensile/Tests/pre_checkin/hgemm_hpa_asm_tn.yaml
@@ -36,12 +36,14 @@ BenchmarkProblems:
           - [ 32,  4,  1 ]
         - DepthU: [8]
         - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [1,2]
+        - AssertFree0ElementMultiple: [1,2]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [126,1,130], 0, [2], [62,1,66] ]
 
     - # BenchmarkProblemSizeGroup - Assembly
       InitialSolutionParameters:
@@ -63,10 +65,12 @@ BenchmarkProblems:
           - [  8,  8,  1 ]
         - DepthU: [16]
         - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [1,2]
+        - AssertFree0ElementMultiple: [1,2]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [126,1,130], 0, [2], [62,1,66] ]
 

--- a/Tensile/Tests/pre_checkin/hgemm_hpa_asm_tt.yaml
+++ b/Tensile/Tests/pre_checkin/hgemm_hpa_asm_tt.yaml
@@ -33,12 +33,14 @@ BenchmarkProblems:
           - [  8,  8,  1 ]
         - DepthU: [32]
         - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [1,2]
+        - AssertFree0ElementMultiple: [1,2]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [126,1,130], 0, [2], [62,1,66] ]
 
     - # BenchmarkProblemSizeGroup - Assembly
       InitialSolutionParameters:
@@ -59,9 +61,11 @@ BenchmarkProblems:
           - [  8,  8,  1 ]
         - DepthU: [16]
         - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [1,2]
+        - AssertFree0ElementMultiple: [1,2]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [126,1,130], 0, [2], [62,1,66] ]

--- a/Tensile/Tests/pre_checkin/hgemm_hpa_iu2_asm_nn.yaml
+++ b/Tensile/Tests/pre_checkin/hgemm_hpa_iu2_asm_nn.yaml
@@ -37,12 +37,14 @@ BenchmarkProblems:
           - [  8,  8,  1 ]
         - DepthU: [8]
         - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [1,2]
+        - AssertFree0ElementMultiple: [1,2]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [62,2,66] ]
+          - Range: [ [126,1,130], 0, [2], [62,1,66] ]
 
     - # BenchmarkProblemSizeGroup - Assembly
       InitialSolutionParameters:
@@ -65,10 +67,12 @@ BenchmarkProblems:
           - [  8,  8,  1 ]
         - DepthU: [16]
         - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [1,2]
+        - AssertFree0ElementMultiple: [1,2]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [62,2,66] ]
+          - Range: [ [126,1,130], 0, [2], [62,1,66] ]
 

--- a/Tensile/Tests/pre_checkin/hgemm_hpa_iu2_asm_nt.yaml
+++ b/Tensile/Tests/pre_checkin/hgemm_hpa_iu2_asm_nt.yaml
@@ -36,12 +36,14 @@ BenchmarkProblems:
           - [ 32,  4,  1 ]
         - DepthU: [8]
         - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [1,2]
+        - AssertFree0ElementMultiple: [1,2]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [62,2,66] ]
+          - Range: [ [126,1,130], 0, [2], [62,1,66] ]
 
     - # BenchmarkProblemSizeGroup - Assembly
       InitialSolutionParameters:
@@ -64,9 +66,11 @@ BenchmarkProblems:
           - [  8,  8,  1 ]
         - DepthU: [16]
         - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [1,2]
+        - AssertFree0ElementMultiple: [1,2]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [62,2,66] ]
+          - Range: [ [126,1,130], 0, [2], [62,1,66] ]

--- a/Tensile/Tests/pre_checkin/hgemm_hpa_iu2_asm_tn.yaml
+++ b/Tensile/Tests/pre_checkin/hgemm_hpa_iu2_asm_tn.yaml
@@ -37,12 +37,14 @@ BenchmarkProblems:
           - [ 32,  4,  1 ]
         - DepthU: [8]
         - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [1,2]
+        - AssertFree0ElementMultiple: [1,2]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [62,2,66] ]
+          - Range: [ [126,1,130], 0, [2], [62,1,66] ]
 
     - # BenchmarkProblemSizeGroup - Assembly
       InitialSolutionParameters:
@@ -65,10 +67,12 @@ BenchmarkProblems:
           - [  8,  8,  1 ]
         - DepthU: [16]
         - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [1,2]
+        - AssertFree0ElementMultiple: [1,2]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [62,2,66] ]
+          - Range: [ [126,1,130], 0, [2], [62,1,66] ]
 

--- a/Tensile/Tests/pre_checkin/hgemm_hpa_iu2_asm_tt.yaml
+++ b/Tensile/Tests/pre_checkin/hgemm_hpa_iu2_asm_tt.yaml
@@ -34,13 +34,14 @@ BenchmarkProblems:
           - [  8,  8,  1 ]
         - DepthU: [32]
         - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [1,2]
+        - AssertFree0ElementMultiple: [1,2]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [62,2,66] ]
-
+          - Range: [ [126,1,130], 0, [2], [62,1,66] ]
     - # BenchmarkProblemSizeGroup - Assembly
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -61,9 +62,11 @@ BenchmarkProblems:
           - [  8,  8,  1 ]
         - DepthU: [16]
         - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [1,2]
+        - AssertFree0ElementMultiple: [1,2]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [62,2,66] ]
+          - Range: [ [126,1,130], 0, [2], [62,1,66] ]


### PR DESCRIPTION
Modify half tests to generate kernels with assertions [0,1] and use broader range [126,1,130] to test cases on V20