### PR TITLE
extend Jenkins timeout to 3 hr from 2 hr

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -188,7 +188,7 @@ def docker_build_inside_image( def build_image, compiler_data compiler_args, doc
     def tox_file = isJobStartedByTimer() ? "Tensile/Tests/nightly" : "Tensile/Tests/pre_checkin";
     stage( "Test ${compiler_args.compiler_name} ${compiler_args.build_config}" )
     {
-      timeout(time: 2, unit: 'HOURS') {
+      timeout(time: 3, unit: 'HOURS') {
         sh """#!/usr/bin/env bash
           set -x
           cd ${paths.project_src_prefix}


### PR DESCRIPTION
- Nightly tests on jenkins-ubuntu-0 take 2 hr + 17 min, and all tests pass. 
- The nightly tests may be failing due to 2 hr timeout
- Extend timeout to 3 hr