### PR TITLE
add DestDataType in client API

### DIFF
--- a/Tensile/ClientWriter.py
+++ b/Tensile/ClientWriter.py
@@ -853,8 +853,9 @@ def writeClientParameters(forBenchmark, solutions, problemSizes, stepName, \
       h += "  return f( static_cast<cl_mem>(deviceC), static_cast<cl_mem>(deviceA), static_cast<cl_mem>(deviceB),\n"
     else:
       typeName = dataTypes[0].toCpp()
+      destTypeName = destDataTypes[dataType].toCpp()
       h += "  return f( static_cast<%s *>(deviceC), static_cast<%s *>(deviceA), static_cast<%s *>(deviceB),\n" \
-          % (typeName, typeName, typeName)
+          % (destTypeName, typeName, typeName)
     h += "      alpha,\n"
     if problemType["UseBeta"]:
       h += "      beta,\n"
@@ -992,7 +993,7 @@ def writeClientParameters(forBenchmark, solutions, problemSizes, stepName, \
               h += "        static_cast<cl_mem>(deviceA),\n"
               h += "        static_cast<cl_mem>(deviceB),\n"
             else:
-              h += "        static_cast<%s *>(deviceC),\n" % typeName
+              h += "        static_cast<%s *>(deviceC),\n" % destTypeName
               h += "        static_cast<%s *>(deviceA),\n" % typeName
               h += "        static_cast<%s *>(deviceB),\n" % typeName
             h += "        alpha,\n"

--- a/Tensile/Configs/rocblas_igemm_hip_single_kernel.yaml
+++ b/Tensile/Configs/rocblas_igemm_hip_single_kernel.yaml
@@ -20,9 +20,6 @@ GlobalParameters:
   SleepPercent: 200
   DataInitTypeBeta : 1
   DataInitTypeAlpha : 2
-  PrintTensorA: 3
-  PrintTensorB: 3
-  PrintTensorC: 3
   DataInitTypeA: 3
   DataInitTypeB: 3
   DataInitTypeC: 3
@@ -77,9 +74,9 @@ LibraryLogic:
 #   DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7"]
 #   ArchitectureName: "gfx906"
 #
-    ScheduleName: "vega10"
-    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]"]
-    ArchitectureName: "gfx900"
+#   ScheduleName: "vega10"
+#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]"]
+#   ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"
 #   DeviceNames: ["Device 6860"]
@@ -89,8 +86,8 @@ LibraryLogic:
 #   DeviceNames: ["Device 7300"]
 #   ArchitectureName: "gfx803"
 
-#   ScheduleName: "hip"
-#   DeviceNames: ["Device 0000"]
-#   ArchitectureName: "fallback"
+    ScheduleName: "hip"
+    DeviceNames: ["Device 0000"]
+    ArchitectureName: "fallback"
 
 LibraryClient:

--- a/Tensile/SolutionWriter.py
+++ b/Tensile/SolutionWriter.py
@@ -780,17 +780,18 @@ class SolutionWriter:
     # data ptrs
     if includeData:
       typeName = problemType["DataType"].toCpp()
+      destTypeName = problemType["DestDataType"].toCpp()
       if self.language == "HIP":
-        argList.append(("%s *"%typeName, "dataC"))
+        argList.append(("%s *"%destTypeName, "dataC"))
         argList.append(("const %s *"%typeName, "dataA"))
         argList.append(("const %s *"%typeName, "dataB"))
       else:
         argList.append(("cl_mem", "dataC"))
         argList.append(("cl_mem", "dataA"))
         argList.append(("cl_mem", "dataB"))
-      argList.append((typeName, "alpha"))
+      argList.append((destTypeName, "alpha"))
       if problemType["UseBeta"]:
-        argList.append((typeName, "beta"))
+        argList.append((destTypeName, "beta"))
       argList.append(("unsigned int", "offsetC"))
       argList.append(("unsigned int", "offsetA"))
       argList.append(("unsigned int", "offsetB"))


### PR DESCRIPTION
- Add DestDataType to client API for matrix c and scalars alpha and beta. 
- This will make matrix c and scalars alpha and beta TensileInt32 data type, not TensileInt8x4 data type.
- remove PrintTensorA, PrintTensorB, PrintTensorC from rocblas_igemm_hip_single_kernel.yaml because it is not necessary to print out the three tensors. 