### PR TITLE
added hpa dot2 nightly tests

### DIFF
--- a/Tensile/Tests/nightly/dot2/hgemm_hpa_dot2_nn.yaml
+++ b/Tensile/Tests/nightly/dot2/hgemm_hpa_dot2_nn.yaml
@@ -1,0 +1,199 @@
+mnGlobalParameters:
+  MinimumRequiredVersion: 4.4.0
+  PrintLevel: 1
+  ForceRedoBenchmarkProblems: True
+  ForceRedoLibraryLogic: True
+  ForceRedoLibraryClient: True
+  CMakeBuildType: Release
+  EnqueuesPerSync: 1
+  SyncsPerBenchmark: 1
+  LibraryPrintDebug: False
+  NumElementsToValidate: 1000
+  ValidationMaxToPrint: 100
+  ValidationPrintValids: False
+  ShortNames: False
+  MergeFiles: True
+  Platform: 0
+  Device: 0
+  KernelTime: True
+  PinClocks: False
+  SleepPercent: 200
+  PrintSolutionRejectionReason: False
+  DataInitTypeA: 3           # 0=0, 1=1, 2=serial, 3=rand, 4=NaN
+  DataInitTypeB: 3           # 0=0, 1=1, 2=serial, 3=rand, 4=NaN
+  DataInitTypeBeta: 0        # 0=0, 1=1, 2=serial, 3=rand, 4=NaN
+  CpuThreads: 0
+
+BenchmarkProblems:
+
+  ########################################
+  ########################################
+  ###
+  ###   NN
+  ###
+  ########################################
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: h
+      HighPrecisionAccumulate: True
+      TransposeA: False
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+
+  ########################################
+  # NN - Small or Skinny
+  ########################################
+    - # Benchmark Group
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - EdgeType: ["ShiftPtr"]
+        - InnerUnroll: [2]
+        - LocalDotLayout: [2]
+        - LoopTail: [True]
+        - KernelLanguage: ["Assembly"]
+        - PrefetchGlobalRead: [True]
+        - PrefetchLocalRead: [True]
+      ForkParameters:
+        - ThreadTile:
+          - [ 4, 4 ]
+          - [ 4, 8 ]
+          - [ 8, 4 ]
+          - [ 8, 8 ]
+        - WorkGroup:
+          - [ 8, 8, 1 ]
+          - [ 16, 16, 1 ]
+          - [ 16, 8, 1 ]
+          - [ 32, 8, 1 ]
+          - [ 16, 4, 1 ]
+          - [ 32, 4, 1 ]
+        - WorkGroupMapping: [1, 8]
+        - GlobalSplitU: [1]
+        - DepthU: [ 8, 16, 24, 32, 64 ]
+        - VectorWidth: [4, 8]
+        - GlobalReadVectorWidth: [-1]
+        - AssertSummationElementMultiple: [2]
+        - AssertFree0ElementMultiple: [2]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [          [64, 128], [64, 64, 64, 7000], [1], [256, 1024, 1024, 4096] ] # skinny-0
+          - Range: [ [64, 64, 64,  700], [64, 64, 64,  700], [1], [256, 1024, 1024, 4096] ] # small
+
+  ########################################
+  # NN - Large
+  ########################################
+    - # Benchmark Group
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - EdgeType: ["ShiftPtr"]
+        - InnerUnroll: [2]
+        - LocalDotLayout: [2]
+        - LoopTail: [True]
+        - KernelLanguage: ["Assembly"]
+        - PrefetchLocalRead: [True]
+        - GlobalSplitU: [1]
+      ForkParameters:
+        - PrefetchGlobalRead: [True]
+        - ThreadTile:
+          - [ 4, 4 ]
+          - [ 4, 8 ]
+          - [ 8, 4 ]
+          - [ 8, 8 ]
+        - WorkGroup:
+          - [ 8, 8, 1 ]
+          - [ 16, 16, 1 ]
+        - WorkGroupMapping: [8]            # 1 removed for training performance
+        - DepthU: [ 16 ]
+        - VectorWidth: [4, 8]
+        - GlobalReadVectorWidth: [-1]
+        - AssertSummationElementMultiple: [2]
+        - AssertFree0ElementMultiple: [2]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [64, 64, 64, 7000], [64, 64, 64, 7000], [1], [256, 1024, 1024, 4096] ] # large
+
+  ########################################
+  # NN - VectorWidth Correctness
+  ########################################
+    - # Benchmark Group
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - EdgeType: ["ShiftPtr"]
+        - InnerUnroll: [2]
+        - LocalDotLayout: [2]
+        - LoopTail: [True]
+        - KernelLanguage: ["Assembly"]
+        - PrefetchGlobalRead: [True]
+        - PrefetchLocalRead: [True]
+        - WorkGroupMapping: [1]
+      ForkParameters:
+        - ThreadTile:
+          - [ 4, 4 ]
+        - WorkGroup:
+          - [ 8, 8, 1 ]
+          - [ 16, 16, 1 ]
+        - GlobalSplitU: [1]
+        - DepthU: [ 8, 16, 24, 32, 64 ]
+        #- DepthU: [ 16 ]
+        - VectorWidth: [4]
+        - GlobalReadVectorWidth: [-1]
+        - AssertSummationElementMultiple: [2]
+        - AssertFree0ElementMultiple: [2]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [               [64],               [64], [1], [256, 1024, 1024, 4096] ] # corner
+          - Range: [               [64], [64, 64, 64, 7000], [1], [256, 1024, 1024, 4096] ] # skinny-0
+          - Range: [ [64, 64, 64, 7000],               [64], [1], [256, 1024, 1024, 4096] ] # skinny-1
+
+  ########################################
+  # NN - Batch
+  ########################################
+    - # Benchmark Group - ResNet 1x1:
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - EdgeType: ["ShiftPtr"]
+        - InnerUnroll: [2]
+        - LocalDotLayout: [2]
+        - LoopTail: [True]
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - PrefetchGlobalRead: [True]
+        - PrefetchLocalRead: [ False]
+        - ThreadTile:
+          - [ 4, 4 ]
+          - [ 4, 8 ]
+          - [ 8, 4 ]
+          - [ 8, 8 ]
+        - WorkGroup:
+          - [ 8,  8, 1 ]
+          - [ 16, 8, 1 ]
+        - WorkGroupMapping: [8]
+        - DepthU: [ 8, 16, 24, 32, 64 ]
+        - VectorWidth: [4, 8]
+        - GlobalReadVectorWidth: [-1]
+        - LdsPadB: [0,1,2,4]
+        - AssertSummationElementMultiple: [2]
+        - AssertFree0ElementMultiple: [2]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [  196,  256, 64, 1024 ]
+          - Exact: [  784,  512, 64,  128 ]
+          - Exact: [ 3136,  512,  1, 2048 ]
+          - Exact: [  196, 1024, 64,  256 ]
+          - Exact: [ 3136, 2048,  1,  512 ]
+
+

--- a/Tensile/Tests/nightly/dot2/hgemm_hpa_dot2_tn.yaml
+++ b/Tensile/Tests/nightly/dot2/hgemm_hpa_dot2_tn.yaml
@@ -1,0 +1,201 @@
+GlobalParameters:
+  MinimumRequiredVersion: 4.4.0
+  PrintLevel: 1
+  ForceRedoBenchmarkProblems: True
+  ForceRedoLibraryLogic: True
+  ForceRedoLibraryClient: True
+  CMakeBuildType: Release
+  EnqueuesPerSync: 1
+  SyncsPerBenchmark: 1
+  LibraryPrintDebug: False
+  NumElementsToValidate: 1000
+  ValidationMaxToPrint: 100
+  ValidationPrintValids: False
+  ShortNames: False
+  MergeFiles: True
+  Platform: 0
+  Device: 0
+  KernelTime: True
+  PinClocks: False
+  SleepPercent: 200
+  PrintSolutionRejectionReason: True
+  DataInitTypeA: 3           # 0=0, 1=1, 2=serial, 3=rand, 4=NaN
+  DataInitTypeB: 3           # 0=0, 1=1, 2=serial, 3=rand, 4=NaN
+  DataInitTypeBeta: 0        # 0=0, 1=1, 2=serial, 3=rand, 4=NaN
+  CpuThreads: 0
+
+BenchmarkProblems:
+
+  ########################################
+  ########################################
+  ###
+  ###   NN
+  ###
+  ########################################
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: h
+      HighPrecisionAccumulate: True
+      TransposeA: True
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+
+  ########################################
+  # NN - Small or Skinny
+  ########################################
+    - # Benchmark Group
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - EdgeType: ["ShiftPtr"]
+        - InnerUnroll: [2]
+        - LocalDotLayout: [2]
+        - LoopTail: [True]
+        - KernelLanguage: ["Assembly"]
+        - PrefetchGlobalRead: [True]
+        - PrefetchLocalRead: [True]
+      ForkParameters:
+        - ThreadTile:
+          - [ 4, 4 ]
+          - [ 4, 8 ]
+          - [ 8, 4 ]
+          - [ 8, 8 ]
+        - WorkGroup:
+          - [ 8, 8, 1 ]
+          - [ 16, 16, 1 ]
+          - [ 16, 8, 1 ]
+          - [ 32, 8, 1 ]
+          - [ 16, 4, 1 ]
+          - [ 32, 4, 1 ]
+        - WorkGroupMapping: [1, 8]
+        - GlobalSplitU: [1]
+        - DepthU: [ 8, 16, 24, 32, 64 ]
+        - VectorWidth: [4, 8]
+        - GlobalReadVectorWidth: [-1]
+        - AssertSummationElementMultiple: [2]
+        - AssertFree0ElementMultiple: [2]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [          [64, 128], [64, 64, 64, 7000], [1], [256, 1024, 1024, 4096] ] # skinny-0
+          - Range: [ [64, 64, 64,  700], [64, 64, 64,  700], [1], [256, 1024, 1024, 4096] ] # small
+
+  ########################################
+  # NN - Large
+  ########################################
+    - # Benchmark Group
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - EdgeType: ["ShiftPtr"]
+        - InnerUnroll: [2]
+        - LocalDotLayout: [2]
+        - LoopTail: [True]
+        - KernelLanguage: ["Assembly"]
+        - PrefetchLocalRead: [True]
+        - GlobalSplitU: [1]
+      ForkParameters:
+        - PrefetchGlobalRead: [False, True]
+        - ThreadTile:
+          - [ 4, 4 ]
+          - [ 4, 8 ]
+          - [ 8, 4 ]
+          - [ 8, 8 ]
+        - WorkGroup:
+          - [ 8, 8, 1 ]
+          - [ 16, 16, 1 ]
+        - WorkGroupMapping: [8]            # 1 removed for training performance
+        - DepthU: [ 16 ]
+        - VectorWidth: [4, 8]
+        - GlobalReadVectorWidth: [-1]
+        - AssertSummationElementMultiple: [2]
+        - AssertFree0ElementMultiple: [2]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [64, 64, 64, 7000], [64, 64, 64, 7000], [1], [256, 1024, 1024, 4096] ] # large
+
+  ########################################
+  # NN - VectorWidth Correctness
+  ########################################
+    - # Benchmark Group
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - EdgeType: ["ShiftPtr"]
+        - InnerUnroll: [2]
+        - LocalDotLayout: [2]
+        - LoopTail: [True]
+        - KernelLanguage: ["Assembly"]
+        - PrefetchGlobalRead: [True]
+        - PrefetchLocalRead: [True]
+        - WorkGroupMapping: [1]
+      ForkParameters:
+        - ThreadTile:
+          - [ 4, 4 ]
+        - WorkGroup:
+          - [ 8, 8, 1 ]
+          - [ 16, 16, 1 ]
+        - GlobalSplitU: [1]
+        - DepthU: [ 8, 16, 24, 32, 64 ]
+        - VectorWidth: [4]
+        - GlobalReadVectorWidth: [-1]
+        - AssertSummationElementMultiple: [2]
+        - AssertFree0ElementMultiple: [2]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [               [64],               [64], [1], [256, 1024, 1024, 4096] ] # corner
+          - Range: [               [64], [64, 64, 64, 7000], [1], [256, 1024, 1024, 4096] ] # skinny-0
+          - Range: [ [64, 64, 64, 7000],               [64], [1], [256, 1024, 1024, 4096] ] # skinny-1
+
+  ########################################
+  # NN - Batch
+  ########################################
+    - # Benchmark Group - ResNet 1x1:
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - EdgeType: ["ShiftPtr"]
+        - InnerUnroll: [2]
+        - LocalDotLayout: [2]
+        - LoopTail: [True]
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - PrefetchGlobalRead: [ False, True ]
+        - PrefetchLocalRead: [ False]
+        - ThreadTile:
+          - [ 4, 4 ]
+          - [ 4, 8 ]
+          - [ 8, 4 ]
+          - [ 8, 8 ]
+        - WorkGroup:
+          - [ 8,  8, 1 ]
+          - [ 16, 8, 1 ]
+          - [ 8, 32, 1 ]
+          - [ 16, 16, 1 ]
+          - [ 32,  8, 1 ]
+        - WorkGroupMapping: [8]
+        - DepthU: [ 16 ]
+        - VectorWidth: [4, 8]
+        - GlobalReadVectorWidth: [-1]
+        - LdsPadB: [0,1,2,4]
+        - AssertSummationElementMultiple: [2]
+        - AssertFree0ElementMultiple: [2]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [  196,  256, 64, 1024 ]
+          - Exact: [  784,  512, 64,  128 ]
+          - Exact: [ 3136,  512,  1, 2048 ]
+          - Exact: [  196, 1024, 64,  256 ]
+          - Exact: [ 3136, 2048,  1,  512 ]
+
+

--- a/Tensile/Tests/nightly/dot2/test_dot2.py
+++ b/Tensile/Tests/nightly/dot2/test_dot2.py
@@ -1,0 +1,8 @@
+import Tensile.Tensile as Tensile
+
+def test_hgemm_hpa_dot2_nn(tmpdir):
+ Tensile.Tensile([Tensile.TensileTestPath("nightly/dot2/hgemm_hpa_dot2_nn.yaml"), tmpdir.strpath])
+
+def test_hgemm_hpa_dot2_tn(tmpdir):
+ Tensile.Tensile([Tensile.TensileTestPath("nightly/dot2/hgemm_hpa_dot2_tn.yaml"), tmpdir.strpath])
+

--- a/Tensile/Tests/pre_checkin/hgemm_hpa_iu2_asm_nn.yaml
+++ b/Tensile/Tests/pre_checkin/hgemm_hpa_iu2_asm_nn.yaml
@@ -24,6 +24,7 @@ BenchmarkProblems:
         - EdgeType: ["ShiftPtr"]
         - KernelLanguage: ["Assembly"]
         - InnerUnroll: [2]
+        - LocalDotLayout: [2]
       ForkParameters:
         - GlobalSplitU: [1, 3]
         - PrefetchLocalRead: [False]
@@ -52,6 +53,7 @@ BenchmarkProblems:
         - LoopTail: [True]
         - EdgeType: ["ShiftPtr"]
         - InnerUnroll: [2]
+        - LocalDotLayout: [2]
       ForkParameters:
         - KernelLanguage: ["Assembly"]
         - GlobalSplitU: [1, 3]

--- a/Tensile/Tests/pre_checkin/hgemm_hpa_iu2_asm_nn.yaml
+++ b/Tensile/Tests/pre_checkin/hgemm_hpa_iu2_asm_nn.yaml
@@ -24,8 +24,8 @@ BenchmarkProblems:
         - EdgeType: ["ShiftPtr"]
         - KernelLanguage: ["Assembly"]
         - InnerUnroll: [2]
-        - LocalDotLayout: [2]
       ForkParameters:
+        - LocalDotLayout: [1, 2]
         - GlobalSplitU: [1, 3]
         - PrefetchLocalRead: [False]
         - PrefetchGlobalRead: [True]
@@ -53,8 +53,8 @@ BenchmarkProblems:
         - LoopTail: [True]
         - EdgeType: ["ShiftPtr"]
         - InnerUnroll: [2]
-        - LocalDotLayout: [2]
       ForkParameters:
+        - LocalDotLayout: [1, 2]
         - KernelLanguage: ["Assembly"]
         - GlobalSplitU: [1, 3]
         - PrefetchLocalRead: [False]

--- a/Tensile/Tests/pre_checkin/hgemm_hpa_iu2_asm_nt.yaml
+++ b/Tensile/Tests/pre_checkin/hgemm_hpa_iu2_asm_nt.yaml
@@ -23,8 +23,8 @@ BenchmarkProblems:
         - EdgeType: ["ShiftPtr"]
         - KernelLanguage: ["Assembly"]
         - InnerUnroll: [2]
-        #- LocalDotLayout: [2]
       ForkParameters:
+        #- LocalDotLayout: [1, 2]
         - GlobalSplitU: [1, 3]
         - PrefetchLocalRead: [True]
         - PrefetchGlobalRead: [False]
@@ -52,8 +52,8 @@ BenchmarkProblems:
         - LoopTail: [True]
         - EdgeType: ["ShiftPtr"]
         - InnerUnroll: [2]
-        #- LocalDotLayout: [2]
       ForkParameters:
+        #- LocalDotLayout: [1, 2]
         - KernelLanguage: ["Assembly"]
         - GlobalSplitU: [1, 3]
         - PrefetchLocalRead: [True]

--- a/Tensile/Tests/pre_checkin/hgemm_hpa_iu2_asm_nt.yaml
+++ b/Tensile/Tests/pre_checkin/hgemm_hpa_iu2_asm_nt.yaml
@@ -23,6 +23,7 @@ BenchmarkProblems:
         - EdgeType: ["ShiftPtr"]
         - KernelLanguage: ["Assembly"]
         - InnerUnroll: [2]
+        #- LocalDotLayout: [2]
       ForkParameters:
         - GlobalSplitU: [1, 3]
         - PrefetchLocalRead: [True]
@@ -51,6 +52,7 @@ BenchmarkProblems:
         - LoopTail: [True]
         - EdgeType: ["ShiftPtr"]
         - InnerUnroll: [2]
+        #- LocalDotLayout: [2]
       ForkParameters:
         - KernelLanguage: ["Assembly"]
         - GlobalSplitU: [1, 3]

--- a/Tensile/Tests/pre_checkin/hgemm_hpa_iu2_asm_tn.yaml
+++ b/Tensile/Tests/pre_checkin/hgemm_hpa_iu2_asm_tn.yaml
@@ -25,7 +25,7 @@ BenchmarkProblems:
         - KernelLanguage: ["Assembly"]
         - InnerUnroll: [2]
       ForkParameters:
-        - LocalDotLayout: [1, 2]
+        #- LocalDotLayout: [1, 2]
         - GlobalSplitU: [1, 3]
         - PrefetchLocalRead: [True]
         - PrefetchGlobalRead: [False]
@@ -54,7 +54,7 @@ BenchmarkProblems:
         - EdgeType: ["ShiftPtr"]
         - InnerUnroll: [2]
       ForkParameters:
-        - LocalDotLayout: [1, 2]
+        #- LocalDotLayout: [1, 2]
         - KernelLanguage: ["Assembly"]
         - GlobalSplitU: [1, 3]
         - PrefetchLocalRead: [True]

--- a/Tensile/Tests/pre_checkin/hgemm_hpa_iu2_asm_tn.yaml
+++ b/Tensile/Tests/pre_checkin/hgemm_hpa_iu2_asm_tn.yaml
@@ -24,8 +24,8 @@ BenchmarkProblems:
         - EdgeType: ["ShiftPtr"]
         - KernelLanguage: ["Assembly"]
         - InnerUnroll: [2]
-        - LocalDotLayout: [2]
       ForkParameters:
+        - LocalDotLayout: [1, 2]
         - GlobalSplitU: [1, 3]
         - PrefetchLocalRead: [True]
         - PrefetchGlobalRead: [False]
@@ -53,8 +53,8 @@ BenchmarkProblems:
         - LoopTail: [True]
         - EdgeType: ["ShiftPtr"]
         - InnerUnroll: [2]
-        - LocalDotLayout: [2]
       ForkParameters:
+        - LocalDotLayout: [1, 2]
         - KernelLanguage: ["Assembly"]
         - GlobalSplitU: [1, 3]
         - PrefetchLocalRead: [True]

--- a/Tensile/Tests/pre_checkin/hgemm_hpa_iu2_asm_tn.yaml
+++ b/Tensile/Tests/pre_checkin/hgemm_hpa_iu2_asm_tn.yaml
@@ -24,6 +24,7 @@ BenchmarkProblems:
         - EdgeType: ["ShiftPtr"]
         - KernelLanguage: ["Assembly"]
         - InnerUnroll: [2]
+        - LocalDotLayout: [2]
       ForkParameters:
         - GlobalSplitU: [1, 3]
         - PrefetchLocalRead: [True]
@@ -52,6 +53,7 @@ BenchmarkProblems:
         - LoopTail: [True]
         - EdgeType: ["ShiftPtr"]
         - InnerUnroll: [2]
+        - LocalDotLayout: [2]
       ForkParameters:
         - KernelLanguage: ["Assembly"]
         - GlobalSplitU: [1, 3]

--- a/Tensile/Tests/pre_checkin/hgemm_hpa_iu2_asm_tt.yaml
+++ b/Tensile/Tests/pre_checkin/hgemm_hpa_iu2_asm_tt.yaml
@@ -22,8 +22,8 @@ BenchmarkProblems:
         - EdgeType: ["ShiftPtr"]
         - KernelLanguage: ["Assembly"]
         - InnerUnroll: [2]
-        #- LocalDotLayout: [2]
       ForkParameters:
+        - LocalDotLayout: [1, 2]
         - PrefetchLocalRead: [False]
         - PrefetchGlobalRead: [False]
         - ThreadTile:
@@ -49,8 +49,8 @@ BenchmarkProblems:
         - LoopTail: [True]
         - EdgeType: ["ShiftPtr"]
         - InnerUnroll: [2]
-        #- LocalDotLayout: [2]
       ForkParameters:
+        - LocalDotLayout: [1, 2]
         - KernelLanguage: ["Assembly"]
         - PrefetchLocalRead: [False]
         - PrefetchGlobalRead: [False]

--- a/Tensile/Tests/pre_checkin/hgemm_hpa_iu2_asm_tt.yaml
+++ b/Tensile/Tests/pre_checkin/hgemm_hpa_iu2_asm_tt.yaml
@@ -22,6 +22,7 @@ BenchmarkProblems:
         - EdgeType: ["ShiftPtr"]
         - KernelLanguage: ["Assembly"]
         - InnerUnroll: [2]
+        #- LocalDotLayout: [2]
       ForkParameters:
         - PrefetchLocalRead: [False]
         - PrefetchGlobalRead: [False]
@@ -48,6 +49,7 @@ BenchmarkProblems:
         - LoopTail: [True]
         - EdgeType: ["ShiftPtr"]
         - InnerUnroll: [2]
+        #- LocalDotLayout: [2]
       ForkParameters:
         - KernelLanguage: ["Assembly"]
         - PrefetchLocalRead: [False]


### PR DESCRIPTION


Added nightly tests for hpa dot2 coverage. This covers the NN and TN cases.

hgemm_hpa_dot2_nn.yaml and  hgemm_hpa_dot2_tn.yaml each run in about 6 - 7 minuts.

also updated hgemm_hpa_iu2_asm_??.yaml enabling the dot2 functionality with the - LocalDotLayout: [2] switch.

however the nt case fails so I commented this switch out (used as a placeholder)

 