### PR TITLE
enabling GSU for i8 gemm

### DIFF
--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -1141,6 +1141,7 @@ class Solution:
         return
       supported = \
         state["ProblemType"]["DataType"].isSingle() or \
+        state["ProblemType"]["DestDataType"].isInt32() or \
         (state["KernelLanguage"] == "Assembly" and \
          (state["ProblemType"]["DataType"].isHalf() and \
           not state["ProblemType"]["HighPrecisionAccumulate"]))

--- a/Tensile/Tests/pre_checkin/igemm_hpa_hip_nn.yaml
+++ b/Tensile/Tests/pre_checkin/igemm_hpa_hip_nn.yaml
@@ -24,8 +24,8 @@ BenchmarkProblems:
         - KernelLanguage: ["Source"]
       ForkParameters:
         - GlobalSplitU: [1, 3]
-        - PrefetchLocalRead: [False]
-        - PrefetchGlobalRead: [True]
+        - PrefetchLocalRead: [True]
+        - PrefetchGlobalRead: [False]
         - ThreadTile:
           - [ 2, 4 ]
           - [ 4, 8 ]


### PR DESCRIPTION
- make atomicAddType a templated function so it can be used for int as well as for float
- add macro DEST_DATA_TYPE to Kernels.cpp
- in Kernels.cpp use destination data type for alpha, beta, and registers for MACs
- change to PrefetchLocalRead=True and PrefetchGlobalRead=False for igemm_hpa_hip_nn.yaml
