### PR TITLE
Dot2 remove constraints

### DIFF
--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -1270,12 +1270,6 @@ class Solution:
               < state["GlobalReadVectorWidth"]:
             validDepthU = False
 
-      if validDepthU and state["LocalDotLayout"] > 1:
-        if state["GlobalLoadVectorWidthA"] < 4 or \
-           state["GlobalLoadVectorWidthB"] < 4:
-          reject(state, "GlobalLoadVectorWidth for A or B too small")
-          return
-
       if not state["ProblemType"]["TLUA"]:
         if depthU < state["GlobalLoadVectorWidthA"]:
           validDepthU = False


### PR DESCRIPTION
Hopefully the last dot2 fixes. I don't see any problems with any vector sizes now. I did extensive testing for a couple of days (!) straight. I changed my YAML to test every entry so it takes quite a while.

This PR also fixes an issue with InitLds. InitLds needs a barrier *after* writing all the LDS data to make sure some threads don't start writing real matrix data while other threads are still writing InitLds data. This will resolve random failures I was seeing with InitLds turned on.