### PR TITLE
correct *C datatype for Beta only kernel

### DIFF
--- a/Tensile/KernelWriterSource.py
+++ b/Tensile/KernelWriterSource.py
@@ -2228,7 +2228,7 @@ class KernelWriterSource(KernelWriter):
     #restrictStr = "restrict"
     #if self.language == "HIP":
     #  restrictStr = "__restrict__"
-    ptrStr = kernel["ProblemType"]["DataType"].toDevice(self.language)
+    ptrStr = kernel["ProblemType"]["DestDataType"].toDevice(self.language)
     kStr += "  " + globalStr + ptrStr \
         + " *C,"
     kStr += self.endLine


### PR DESCRIPTION
- Corrects *C datatype for Beta only kernel. Need to set it to int32_t not uint32_t
- This is related to SWDEV-169708