### PR TITLE
Allow override assembler path with env var TENSILE_ROCM_ASSEMBLER_PATH

### DIFF
--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -760,7 +760,9 @@ def assignGlobalParameters( config ):
 
   # ROCm Agent Enumerator Path
   globalParameters["ROCmAgentEnumeratorPath"] = locateExe("/opt/rocm/bin", "rocm_agent_enumerator")
-  globalParameters["AssemblerPath"] = locateExe("/opt/rocm/bin", "hcc")
+  globalParameters["AssemblerPath"] = os.environ.get("TENSILE_ROCM_ASSEMBLER_PATH");
+  if globalParameters["AssemblerPath"] is None:
+    globalParameters["AssemblerPath"] = locateExe("/opt/rocm/bin", "hcc");
   globalParameters["ROCmSMIPath"] = locateExe("/opt/rocm/bin", "rocm-smi")
 
   # read current gfx version


### PR DESCRIPTION
hcc may not be available or installed to a different path. This patch allows override assembler path
by env var.

This is to facilitate development of HIP/VDI where hcc is not installed.