### PR TITLE
Set GuaranteeNoPartial[AB] more aggressively for TLU=0 path

### DIFF
--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -1513,12 +1513,12 @@ class Solution:
     if state["ProblemType"]["TLUA"]:
       state["GuaranteeNoPartialA"] = state["AssertFree0ElementMultiple"]%state["GlobalLoadVectorWidthA"]==0
     else:
-      state["GuaranteeNoPartialA"] = state["AssertSummationElementMultiple"]%state["GlobalLoadVectorWidthA"]==0
+      state["GuaranteeNoPartialA"] = True
 
     if state["ProblemType"]["TLUB"]:
       state["GuaranteeNoPartialB"] = state["AssertFree1ElementMultiple"]%state["GlobalLoadVectorWidthB"]==0
     else:
-      state["GuaranteeNoPartialB"] = state["AssertSummationElementMultiple"]%state["GlobalLoadVectorWidthB"]==0
+      state["GuaranteeNoPartialB"] = True
 
     #--
     # ShiftPtr can't use UseSgprForGRO since it needs to modify the VGPR pointers


### PR DESCRIPTION
May expand search options:

rocblas testing:
[----------] Global test environment tear-down
[==========] 644002 tests from 51 test cases ran. (13550891 ms total)
[  PASSED  ] 644002 tests.