### PR TITLE
Improve runtime for Tensile by caching solution names

### DIFF
--- a/Tensile/LibraryLogic.py
+++ b/Tensile/LibraryLogic.py
@@ -106,8 +106,8 @@ def analyzeProblemType( problemType, problemSizeGroups, inputParameters ):
   print1("# Solutions Used:")
   for i in range(0, len(logicAnalyzer.solutions)):
     s = logicAnalyzer.solutions[i]
-    s.state["SolutionIndex"] = i
-    s.state["SolutionNameMin"] = Solution.getNameMin(s, solutionMinNaming)
+    s["SolutionIndex"] = i
+    s["SolutionNameMin"] = Solution.getNameMin(s, solutionMinNaming)
     print1("(%2u) %s : %s" % (i, \
         Solution.getNameMin(s, solutionMinNaming), \
         Solution.getNameFull(s)))  # this is the right name

--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -1818,7 +1818,7 @@ class Solution:
   def __repr__(self):
     return self.__str__()
   def getAttributes(self):
-    return self._state
+    return deepcopy(self._state)
   def __hash__(self):
     return hash(str(self))
     #return hash(self.getAttributes())

--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -635,7 +635,10 @@ class Solution:
 
   ########################################
   def __init__(self, config):
-    self.state = {}
+    self._name = None
+    config = deepcopy(config)
+
+    self._state = {}
     # problem type
     if "ProblemType" in config:
       self["ProblemType"] = ProblemType(config["ProblemType"])
@@ -644,21 +647,22 @@ class Solution:
 
     # assign parameters with defaults
     for key in defaultSolution:
-      assignParameterWithDefault(self.state, key, config, defaultSolution)
+      assignParameterWithDefault(self._state, key, config, defaultSolution)
 
     # assign parameters without defaults
     for key in config:
-      if key != "ProblemType" and key not in self.state:
-        self.state[key] = config[key]
+      if key != "ProblemType" and key not in self._state:
+        self._state[key] = config[key]
     self["Valid"] = True
     self["AssignedProblemIndependentDerivedParameters"] = False
     self["AssignedDerivedParameters"] = False
-    Solution.assignDerivedParameters(self.state)
+    Solution.assignDerivedParameters(self._state)
+    self._name = None
 
   ########################################
   # get a list of kernel parameters for this solution
   def getKernels(self):
-    kernel = deepcopy(self.state)
+    kernel = deepcopy(self._state)
     kernel.update({"Kernel": True})
     kernels = []
     kernels.append(kernel)
@@ -1642,7 +1646,7 @@ class Solution:
     # determine keys
     requiredParameters = {}
     if isinstance(objs[0], Solution):
-      keys = list(objs[0].state.keys())
+      keys = list(objs[0]._state.keys())
     else:
       keys = list(objs[0].keys())
     # only 1, rather than name being nothing, it'll be everything
@@ -1796,22 +1800,25 @@ class Solution:
 
   # make class look like dict
   def keys(self):
-    return self.state.keys()
+    return self._state.keys()
   def __len__(self):
-    return len(self.state)
+    return len(self._state)
   def __iter__(self):
-    return iter(self.state)
+    return iter(self._state)
 
   def __getitem__(self, key):
-    return self.state[key]
+    return self._state[key]
   def __setitem__(self, key, value):
-    self.state[key] = value
+    self._name = None
+    self._state[key] = value
   def __str__(self):
-    return Solution.getNameFull(self.state)
+    if self._name is None:
+      self._name = Solution.getNameFull(self._state)
+    return self._name
   def __repr__(self):
     return self.__str__()
   def getAttributes(self):
-    return self.state
+    return self._state
   def __hash__(self):
     return hash(str(self))
     #return hash(self.getAttributes())

--- a/Tensile/SolutionWriter.py
+++ b/Tensile/SolutionWriter.py
@@ -775,7 +775,7 @@ class SolutionWriter:
     s += "}\n"
     s += "\n"
     s += "/* Solution Parameters\n"
-    s += Solution.getParametersIndented(solution.state, "  ")
+    s += Solution.getParametersIndented(solution.getAttributes(), "  ")
     s += "*/\n"
     s += "\n"
 

--- a/Tensile/YAMLIO.py
+++ b/Tensile/YAMLIO.py
@@ -50,7 +50,7 @@ def writeSolutions( filename, problemSizes, solutions ):
   solutionStates = []
   for hardcoded in solutions:
     for solution in hardcoded:
-      solutionState = solution.state
+      solutionState = solution.getAttributes()
       solutionState["ProblemType"] = solutionState["ProblemType"].state
       solutionState["ProblemType"]["DataType"] = \
           solutionState["ProblemType"]["DataType"].value
@@ -140,7 +140,7 @@ def writeLibraryLogicForSchedule( filePath, schedulePrefix, architectureName, de
   # solutions
   solutionList = []
   for solution in solutions:
-    solutionState = solution.state
+    solutionState = solution.getAttributes()
     solutionState["ProblemType"] = solutionState["ProblemType"].state
     solutionState["ProblemType"]["DataType"] = \
         solutionState["ProblemType"]["DataType"].value


### PR DESCRIPTION
I first tried this in October but couldn't get things exactly working before I got pulled off the project.  Found some time yesterday to give this another shot.

Basically a lot of time is spent right now in a few loops where we are doing something like

    for solution in solutionsForSchedule:
      if solution not in solutions:
        solutions.append(solution)

in a few places.  This is inefficient because Solution uses the `__str__` operator to do equality comparison which is inefficient, and this is done n^2 times in this loop.

By lazily caching the result of the `__str__` operator we can dramatically improve performance.

Without this change, rocBLAS compiles in 21 minutes, with this change, 8:42.

This is based on a bit of profiling I did using py-spy.   I think there is more room for improvement, but that would be a bigger task.  Our current method of building a string using repeated `+=` operations is inefficient because Python strings are immutable, meaning that it has to copy the entire string for every `+=` operation.  It would be much faster to use a `cStringIO` object, or Python template strings, or something else, but that's a much bigger can of worms.