### PR TITLE
provide for replacement kernel

### DIFF
--- a/ReplacementKernels/README
+++ b/ReplacementKernels/README
@@ -1,0 +1,20 @@
+This directory is for replacement assembly kernels.
+
+If Tensile is generating a kernel Cijk_Ailk_Bjlk_DB_MT096x128x08_K1.s, and you want to edit
+the file Cijk_Ailk_Bjlk_DB_MT096x128x08_K1.s by hand and have Tensile use the kernel from
+the edited file then:
+
+- Add a .txt to the filename, for example Cijk_Ailk_Bjlk_DB_MT096x128x08_K1.s.txt
+- Add Cijk_Ailk_Bjlk_DB_MT096x128x08_K1.s.txt to this directory
+
+If you set PrintLevel >= 1 in Common.py the following diagnostic print lines will be output:
+- replacement_assemblyFilename : when the replacement file is used
+- write_assemblyFilename : when the Tensile generated file is used
+
+Note that the file name may be different in the Tensile procedure 1_BenchmarkProblems and 
+3_LibraryLogic, so if you want the file to be replaced in both procedures, you will need to add
+it with both filenames, for example, you may need to add both the files below, where the two 
+files have the same contents:
+
+Cijk_Ailk_Bjlk_DB_MT096x128x08_K1.s.txt
+Cijk_Ailk_Bjlk_DB_MT096x128x08_AF0EM01_AF1EM01_ASEM01_FL1_K1_NLCA01_TT06_04_USFGRO0_WG16_32_01.s.txt

--- a/Tensile/KernelWriter.py
+++ b/Tensile/KernelWriter.py
@@ -23,6 +23,7 @@ from SolutionStructs import Solution
 from Common import globalParameters, CHeader
 import abc
 import os
+import shutil
 from os import path, chmod
 from os import name as osname
 from subprocess import Popen
@@ -1749,9 +1750,25 @@ class KernelWriter:
       asmPath = os.path.join(globalParameters["WorkingPath"], "assembly")
       # write assembly file to assembly directory
       kernelName = self.getKernelName(kernel)
+      kernelFileName = "%s.s" % kernelName
+      kernelFileName_txt = "%s.s.txt" % kernelName
       fileBase = path.join(asmPath, kernelName )
       assemblyFileName = "%s.s" % fileBase
+      SCRIPT_ROOT = os.path.dirname(os.path.realpath(__file__))
+      REPLACEMENT_KERNEL_ROOT = SCRIPT_ROOT + "/ReplacementKernels"
+      REPLACEMENT_KERNEL_PATH = os.path.join(REPLACEMENT_KERNEL_ROOT, kernelFileName_txt)
       codeObjectFileName = "%s.co" % fileBase
+      if os.path.isfile(REPLACEMENT_KERNEL_PATH):
+        shutil.copyfile(REPLACEMENT_KERNEL_PATH, assemblyFileName)
+        if globalParameters["PrintLevel"] >= 1:
+          print "replacement_assemblyFilename %s" % assemblyFileName
+      else:
+        if globalParameters["PrintLevel"] >= 1:
+          print "write_assemblyFilename %s" % assemblyFileName
+        assemblyFile = open(assemblyFileName, "w")
+        assemblyFile.write(fileString)
+        assemblyFile.close()
+
       assemblyFile = open(assemblyFileName, "w")
       assemblyFile.write(fileString)
       assemblyFile.close()


### PR DESCRIPTION
These are the same as the changes in the develop branch.

If Tensile is generating a kernel Cijk_Ailk_Bjlk_DB_MT096x128x08_K1.s, and you want to edit
the file Cijk_Ailk_Bjlk_DB_MT096x128x08_K1.s by hand and have Tensile use the kernel from
the edited file then:

- Add a .txt to the filename, for example Cijk_Ailk_Bjlk_DB_MT096x128x08_K1.s.txt
- Add Cijk_Ailk_Bjlk_DB_MT096x128x08_K1.s.txt to this directory

If you set PrintLevel >= 1 in Common.py the following diagnostic print lines will be output:
- replacement_assemblyFilename : when the replacement file is used
- write_assemblyFilename : when the Tensile generated file is used

Note that the file name may be different in the Tensile procedure 1_BenchmarkProblems and 
3_LibraryLogic, so if you want the file to be replaced in both procedures, you will need to add
it with both filenames, for example, you may need to add both the files below, where the two 
files have the same contents:

Cijk_Ailk_Bjlk_DB_MT096x128x08_K1.s.txt
Cijk_Ailk_Bjlk_DB_MT096x128x08_AF0EM01_AF1EM01_ASEM01_FL1_K1_NLCA01_TT06_04_USFGRO0_WG16_32_01.s.txt