### PR TITLE
PrintLevel 2 for write_assemblyFilename

### DIFF
--- a/Tensile/KernelWriter.py
+++ b/Tensile/KernelWriter.py
@@ -1800,7 +1800,7 @@ class KernelWriter:
         if globalParameters["PrintLevel"] >= 1:
           print "replacement_assemblyFilename %s" % assemblyFileName
       else:
-        if globalParameters["PrintLevel"] >= 1:
+        if globalParameters["PrintLevel"] >= 2:
           print "write_assemblyFilename %s" % assemblyFileName
         assemblyFile = open(assemblyFileName, "w")
         assemblyFile.write(fileString)


### PR DESCRIPTION
- increase PrintLevel to 2 for write_assemblyFilename to reduce redundant logging information