### PR TITLE
fixed matrix D indexing bug in LocalSplitU path

### DIFF
--- a/Tensile/KernelWriterSource.py
+++ b/Tensile/KernelWriterSource.py
@@ -2308,9 +2308,9 @@ class KernelWriterSource(KernelWriter):
           for i in range(0, kernel["ProblemType"]["NumIndicesC"]):
             kStr += " globalC%s" % self.indexChars[i]
             if i == kernel["ProblemType"]["Index0"] and kernel["GlobalWriteVectorWidth"]>1:
-              kStr += " + %u" %s
+              kStr += " + %s" % (loadOffset0)
             if i == kernel["ProblemType"]["Index1"]:
-              kStr += " + %u*CPSV" %b
+              kStr += " + %s" % (loadOffset1)
             if i < kernel["ProblemType"]["NumIndicesC"]-1:
               kStr += ", (%s)" % self.uint64Str
           kStr += ") ]"


### PR DESCRIPTION
fixed matrix D indexing bug in LocalSplitU path, index changes from PR 412 did not fully integrate with PR 413