### PR TITLE
fix merge tensile script to handle duplicate solution configurations

### DIFF
--- a/Tensile/Utilities/merge_rocblas_yaml_files.py
+++ b/Tensile/Utilities/merge_rocblas_yaml_files.py
@@ -214,6 +214,10 @@ def MergeTensileLogicFiles(origionalLibraryLogic, exactLibraryLogic):
   idx = 0
   idxMapping = newSolutionOffset
 
+  mergedSolutionList = []
+  for solution in solutionList:
+    mergedSolutionList.append(solution)
+
   # construct the mappings from the old exact kernal configurations
   # to their definitions in the merged files
   for solution in solutionListExact:
@@ -223,21 +227,16 @@ def MergeTensileLogicFiles(origionalLibraryLogic, exactLibraryLogic):
       # gets mapped to the pre-existing configuration
       idxOrg = solutionList.index(solution)
       replicationMapping[idx] = idxOrg
+
     else:
       filterdSolutionExactList.append(solution)
       # if the solution does not exist in the origional configurations
       # it gets mapped to the new offset
       replicationMapping[idx] = idxMapping
+      mergedSolutionList.append(solution)
       idxMapping += 1
 
     idx += 1
-
-  mergedSolutionList = []
-  for solution in solutionList:
-    mergedSolutionList.append(solution)
-  
-  for solution in solutionListExact:
-    mergedSolutionList.append(solution)
 
   exactLogic = origionalLibraryLogic.exactLogic
   exactLogicExact = exactLibraryLogic.exactLogic
@@ -257,15 +256,15 @@ def MergeTensileLogicFiles(origionalLibraryLogic, exactLibraryLogic):
     
     filteredExactLogicExact.append(exact)
 
-
-  sizeList, _ = zip(*exactLogicExact)
+  #sizeList, _ = zip(*exactLogicExact)
+  sizeList, _ = zip(*filteredExactLogicExact)
 
   mergedExactLogic = []
   for logicMapping in exactLogic:
     if logicMapping[0] not in sizeList:
       mergedExactLogic.append(logicMapping)
 
-  for logicMapping in exactLogicExact:
+  for logicMapping in filteredExactLogicExact:
     mergedExactLogic.append(logicMapping)
 
   mergedLibraryLogic.versionString = origionalLibraryLogic.versionString


### PR DESCRIPTION

updated the merge_rocblas_yaml_files.py in Utilities to fix a bug in this script.

It was not handling the cases when the exact file had solutions which were duplicates in the original logic file.