### PR TITLE
Adding a pre-commit hook which must be manually added

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,120 @@
+# Style file for MLSE Libraries based on the modified rocBLAS style
+
+# Common settings
+BasedOnStyle:  WebKit
+TabWidth:        4
+IndentWidth:     4
+UseTab:          Never
+ColumnLimit: 100
+
+# Other languages JavaScript, Proto
+
+---
+Language: Cpp
+
+# http://releases.llvm.org/6.0.1/tools/clang/docs/ClangFormatStyleOptions.html#disabling-formatting-on-a-piece-of-code
+# int formatted_code;
+# // clang-format off
+#     void    unformatted_code  ;
+# // clang-format on
+# void formatted_code_again;
+
+DisableFormat:   false
+Standard: Cpp11
+
+AccessModifierOffset: -4
+AlignAfterOpenBracket: true
+AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: true
+AlignEscapedNewlinesLeft: true
+AlignOperands:   true
+AlignTrailingComments: false
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: false
+BinPackParameters: false
+
+# Configure each individual brace in BraceWrapping
+BreakBeforeBraces: Custom
+# Control of individual brace wrapping cases
+BraceWrapping: {
+    AfterClass: 'true'
+    AfterControlStatement: 'true'
+    AfterEnum : 'true'
+    AfterFunction : 'true'
+    AfterNamespace : 'true'
+    AfterStruct : 'true'
+    AfterUnion : 'true'
+    BeforeCatch : 'true'
+    BeforeElse : 'true'
+    IndentBraces : 'false'
+#    AfterExternBlock : 'true'
+}
+
+#BreakAfterJavaFieldAnnotations: true
+#BreakBeforeInheritanceComma: false
+#BreakBeforeBinaryOperators: None
+#BreakBeforeTernaryOperators: true
+#BreakConstructorInitializersBeforeComma: true
+#BreakStringLiterals: true
+
+CommentPragmas:  '^ IWYU pragma:'
+#CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+#SpaceBeforeCpp11BracedList: false
+DerivePointerAlignment: false
+ExperimentalAutoDetectBinPacking: false
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IndentCaseLabels: false
+#FixNamespaceComments: true
+IndentWrappedFunctionNames: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+#JavaScriptQuotes: Double
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: All
+ObjCBlockIndentWidth: 4
+#ObjCSpaceAfterProperty: true
+#ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: Never
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+#SpaceAfterTemplateKeyword: true
+#SpaceBeforeInheritanceColon: true
+
+#SortUsingDeclarations: true
+SortIncludes: true
+
+# Comments are for developers, they should arrange them
+ReflowComments: false
+
+#IncludeBlocks: Preserve
+#IndentPPDirectives: AfterHash
+---

--- a/.githooks/install
+++ b/.githooks/install
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+cd $(git rev-parse --git-dir)
+cd hooks
+
+echo "Installing hooks..." 
+ln -s ../../.githooks/pre-commit pre-commit
+echo "Done!"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,97 @@
+#!/bin/sh
+#
+# This pre-commit hook checks if any versions of clang-format
+# are installed, and if so, uses the installed version to format
+# the staged changes.
+
+base=clang-format-3.8
+formatClang=""
+
+# Redirect output to stderr.
+exec 1>&2
+
+ # check if clang-format is installed
+type "$base" >/dev/null 2>&1 && formatClang="$base"
+
+
+# no versions of clang-format are installed
+if [ -z "$formatClang" ]
+then
+    echo "$base is not installed. Commit is cancelled. Delete the hook to force commit."
+    exit 1
+fi
+
+
+basePython=yapf
+formatPython=""
+
+# Redirect output to stderr.
+exec 1>&2
+
+ # check if clang-format is installed
+type "$basePython" >/dev/null 2>&1 && formatPython="$basePython"
+
+
+# no versions of clang-format are installed
+if [ -z "$formatPython" ]
+then
+    echo "$base is not installed. Commit is cancelled. Delete the hook to force commit."
+    exit 1
+fi
+
+
+
+
+
+
+# Do everything from top - level
+cd $(git rev-parse --show-toplevel)
+
+if git rev-parse --verify HEAD >/dev/null 2>&1
+then
+    against=HEAD
+else
+    # Initial commit: diff against an empty tree object
+    against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
+fi
+
+exitCode=0
+
+# do the formatting
+for file in $(git diff-index --cached --name-only $against | grep -E '\.h$|\.hpp$|\.cpp$|\.cl$|\.h\.in$|\.hpp\.in$|\.cpp\.in$')
+do
+    if [ -e "$file" ]
+    then
+       	"$formatClang" -style=file -output-replacements-xml "$file" | grep "\<replacement\>" >/dev/null
+	if [ $? -ne 1 ]; then
+            echo "$format" -i -style=file "$file"
+	    exitCode=1
+	fi
+	
+    fi
+done
+
+# do the formatting
+for file in $(git diff-index --cached --name-only $against | grep -E '\.py$')
+do
+    if [ -e "$file" ]
+    then
+       	"$formatPython" --diff "$file" | grep "+" >/dev/null
+	if [ $? -ne 1 ]; then
+            echo "$formatPython" -i "$file"
+	    exitCode=1
+	fi
+	
+    fi
+done
+
+
+
+if [ $exitCode -eq 1 ]; then
+    echo "Please fix the errors by running the commands listed above."
+    echo "Commit is cancelled. You may force by deleting the hook in .githook"
+else
+    echo "Format checks passed"
+fi
+
+exit $exitCode

--- a/.style.yapf
+++ b/.style.yapf
@@ -1,0 +1,4 @@
+[style]
+based_on_style: pep8
+use_tabs: false
+column_limit: 50


### PR DESCRIPTION
pre-commit hook based on the style from rocBLAS. Jenkins will eventually check for style. A PR with the entire repo formatted to pass checks will be added soon.

Install the pre-commit hook by running ./githooks/install

- clang format based on rocBLAS with feedback from Scott. A sample C++ file attached
[sample.cpp.txt](https://github.com/ROCmSoftwarePlatform/Tensile/files/2886888/sample.cpp.txt)


- python format checks via yapf (https://github.com/google/yapf). Python style follow https://www.python.org/dev/peps/pep-0008/#tabs-or-spaces

