### PR TITLE
allow optional definitions for lda, ldb and ldc in problem sizes

### DIFF
--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -743,6 +743,10 @@ defaultProblemType = {
     "NumIndicesC":              2,
     "UseInitialStrides":        False,
 
+    "IndexAssignmentLDC":       3,
+    "IndexAssignmentLDA":       4,
+    "IndexAssignmentLDB":       5,
+
     }
 defaultProblemSizes = [{"Range": [ [2880], 0, 0 ]}]
 defaultBenchmarkFinalProblemSizes = [{"Range": [

--- a/Tensile/LibraryLogic.py
+++ b/Tensile/LibraryLogic.py
@@ -373,7 +373,7 @@ class LogicAnalyzer:
     # column indices
     csvFile = csv.reader(dataFile)
     problemSizeStartIdx = 1
-    totalSizeIdx = problemSizeStartIdx + self.numIndices
+    totalSizeIdx = problemSizeStartIdx + self.numIndices + 3
     solutionStartIdx = totalSizeIdx + 1
     rowLength = solutionStartIdx + numSolutions
 

--- a/Tensile/Source/Client.cpp
+++ b/Tensile/Source/Client.cpp
@@ -69,25 +69,26 @@ int main( int argc, char *argv[] ) {
     float *initialB_float;
     float alpha_float;
     float beta_float;
+    float *referenceD_float;
     float *referenceC_float;
     float *deviceOnHostD_float;
     float *deviceOnHostC_float;
     initData(&initialD_float, &initialC_float, &initialA_float, &initialB_float, &alpha_float,
-        &beta_float, &referenceC_float, &deviceOnHostD_float, &deviceOnHostC_float);
+        &beta_float, &referenceD_float, &referenceC_float, &deviceOnHostD_float, &deviceOnHostC_float);
 
     for (unsigned int i = 0; i < numBenchmarks; i++) {
 #if Tensile_CLIENT_BENCHMARK
       invalids = benchmarkProblemSizes(initialD_float, initialC_float, initialA_float,
-          initialB_float, alpha_float, beta_float, referenceC_float,
+          initialB_float, alpha_float, beta_float, referenceD_float, referenceC_float,
           deviceOnHostD_float, deviceOnHostC_float);
 #else
       invalids = callLibrary(initialD_float, initialC_float, initialA_float, initialB_float,
-          alpha_float, beta_float, strideA, strideB, strideC, referenceC_float, 
+          alpha_float, beta_float, strideA, strideB, strideC, referenceD_float, referenceC_float,
           deviceOnHostD_float, deviceOnHostC_float);
 #endif
     }
     destroyData(initialD_float, initialC_float, initialA_float, initialB_float,
-        referenceC_float, deviceOnHostD_float, deviceOnHostC_float);
+        referenceD_float, referenceC_float, deviceOnHostD_float, deviceOnHostC_float);
     }
     break;
 #endif
@@ -99,24 +100,25 @@ int main( int argc, char *argv[] ) {
     double *initialB_double;
     double alpha_double;
     double beta_double;
+    double *referenceD_double;
     double *referenceC_double;
     double *deviceOnHostD_double;
     double *deviceOnHostC_double;
     initData(&initialD_double, &initialC_double, &initialA_double, &initialB_double,
-        &alpha_double, &beta_double, &referenceC_double, &deviceOnHostD_double, &deviceOnHostC_double);
+        &alpha_double, &beta_double, &referenceD_double, &referenceC_double, &deviceOnHostD_double, &deviceOnHostC_double);
     for (unsigned int i = 0; i < numBenchmarks; i++) {
 #if Tensile_CLIENT_BENCHMARK
       invalids = benchmarkProblemSizes(initialD_double, initialC_double, initialA_double,
-          initialB_double, alpha_double, beta_double, referenceC_double,
+          initialB_double, alpha_double, beta_double, referenceD_double, referenceC_double,
           deviceOnHostD_double, deviceOnHostC_double);
 #else
       invalids = callLibrary(initialD_double, initialC_double, initialA_double, initialB_double,
-          alpha_double, beta_double, strideA, strideB, strideC, referenceC_double,
+          alpha_double, beta_double, strideA, strideB, strideC, referenceD_double, referenceC_double,
           deviceOnHostD_double, deviceOnHostC_double);
 #endif
     }
     destroyData(initialD_double, initialC_double, initialA_double, initialB_double,
-        referenceC_double, deviceOnHostD_double, deviceOnHostC_double);
+        referenceD_double, referenceC_double, deviceOnHostD_double, deviceOnHostC_double);
     }
     break;
 #endif
@@ -128,22 +130,23 @@ int main( int argc, char *argv[] ) {
     TensileComplexFloat *initialB_TCF;
     TensileComplexFloat alpha_TCF;
     TensileComplexFloat beta_TCF;
+    TensileComplexFloat *referenceD_TCF;
     TensileComplexFloat *referenceC_TCF;
     TensileComplexFloat *deviceOnHostD_TCF;
     TensileComplexFloat *deviceOnHostC_TCF;
     initData(&initialD_TCF, &initialC_TCF, &initialA_TCF, &initialB_TCF, &alpha_TCF,
-        &beta_TCF, &referenceC_TCF, &deviceOnHostD_TCF, &deviceOnHostC_TCF);
+        &beta_TCF, &referenceD_TCF, &referenceC_TCF, &deviceOnHostD_TCF, &deviceOnHostC_TCF);
     for (unsigned int i = 0; i < numBenchmarks; i++) {
 #if Tensile_CLIENT_BENCHMARK
       invalids = benchmarkProblemSizes(initialD_TCF, initialC_TCF, initialA_TCF, initialB_TCF,
-          alpha_TCF, beta_TCF, referenceC_TCF, deviceOnHostD_TCF, deviceOnHostC_TCF);
+          alpha_TCF, beta_TCF, referenceD_TCF, referenceC_TCF, deviceOnHostD_TCF, deviceOnHostC_TCF);
 #else
       invalids = callLibrary(initialD_TCF, initialC_TCF, initialA_TCF, initialB_TCF,
-          alpha_TCF, beta_TCF, strideA, strideB, strideC, referenceC_TCF,
+          alpha_TCF, beta_TCF, strideA, strideB, strideC, referenceD_TCF, referenceC_TCF,
           deviceOnHostD_TCF, deviceOnHostC_TCF);
 #endif
     }
-    destroyData(initialD_TCF, initialC_TCF, initialA_TCF, initialB_TCF, referenceC_TCF,
+    destroyData(initialD_TCF, initialC_TCF, initialA_TCF, initialB_TCF, referenceD_TCF, referenceC_TCF,
         deviceOnHostD_TCF, deviceOnHostC_TCF);
     }
     break;
@@ -156,22 +159,23 @@ int main( int argc, char *argv[] ) {
     TensileComplexDouble *initialB_TCD;
     TensileComplexDouble alpha_TCD;
     TensileComplexDouble beta_TCD;
+    TensileComplexDouble *referenceD_TCD;
     TensileComplexDouble *referenceC_TCD;
     TensileComplexDouble *deviceOnHostD_TCD;
     TensileComplexDouble *deviceOnHostC_TCD;
     initData(&initialD_TCD, &initialC_TCD, &initialA_TCD, &initialB_TCD, &alpha_TCD,
-        &beta_TCD, &referenceC_TCD, &deviceOnHostD_TCD, &deviceOnHostC_TCD);
+        &beta_TCD, &referenceD_TCD, &referenceC_TCD, &deviceOnHostD_TCD, &deviceOnHostC_TCD);
     for (unsigned int i = 0; i < numBenchmarks; i++) {
 #if Tensile_CLIENT_BENCHMARK
       invalids = benchmarkProblemSizes(initialD_TCD, initialC_TCD, initialA_TCD, initialB_TCD,
-          alpha_TCD, beta_TCD, referenceC_TCD, deviceOnHostD_TCD, deviceOnHostC_TCD);
+          alpha_TCD, beta_TCD, referenceD_TCD, referenceC_TCD, deviceOnHostD_TCD, deviceOnHostC_TCD);
 #else
       invalids = callLibrary(initialD_TCD, initialC_TCD, initialA_TCD, initialB_TCD,
-          alpha_TCD, beta_TCD, strideA, strideB, strideC, referenceC_TCD,
+          alpha_TCD, beta_TCD, strideA, strideB, strideC, referenceD_TCD, referenceC_TCD,
           deviceOnHostD_TCD, deviceOnHostC_TCD);
 #endif
     }
-    destroyData(initialD_TCD, initialC_TCD, initialA_TCD, initialB_TCD, referenceC_TCD,
+    destroyData(initialD_TCD, initialC_TCD, initialA_TCD, initialB_TCD, referenceD_TCD, referenceC_TCD,
         deviceOnHostD_TCD, deviceOnHostC_TCD);
     }
     break;
@@ -184,22 +188,23 @@ int main( int argc, char *argv[] ) {
     TensileHalf *initialB_TH;
     TensileHalf alpha_TH;
     TensileHalf beta_TH;
+    TensileHalf *referenceD_TH;
     TensileHalf *referenceC_TH;
     TensileHalf *deviceOnHostD_TH;
     TensileHalf *deviceOnHostC_TH;
     initData(&initialD_TH, &initialC_TH, &initialA_TH, &initialB_TH, &alpha_TH,
-        &beta_TH, &referenceC_TH, &deviceOnHostD_TH, &deviceOnHostC_TH);
+        &beta_TH, &referenceD_TH, &referenceC_TH, &deviceOnHostD_TH, &deviceOnHostC_TH);
     for (unsigned int i = 0; i < numBenchmarks; i++) {
 #if Tensile_CLIENT_BENCHMARK
       invalids = benchmarkProblemSizes(initialD_TH, initialC_TH, initialA_TH, initialB_TH,
-          alpha_TH, beta_TH, referenceC_TH, deviceOnHostD_TH, deviceOnHostC_TH);
+          alpha_TH, beta_TH, referenceD_TH, referenceC_TH, deviceOnHostD_TH, deviceOnHostC_TH);
 #else
       invalids = callLibrary(initialD_TH, initialC_TH, initialA_TH, initialB_TH,
-          alpha_TH, beta_TH, strideA, strideB, strideC, referenceC_TH,
+          alpha_TH, beta_TH, strideA, strideB, strideC, referenceD_TH, referenceC_TH,
           deviceOnHostD_TH, deviceOnHostC_TH);
 #endif
     }
-    destroyData(initialD_TH, initialC_TH, initialA_TH, initialB_TH, referenceC_TH,
+    destroyData(initialD_TH, initialC_TH, initialA_TH, initialB_TH, referenceD_TH, referenceC_TH,
         deviceOnHostD_TH, deviceOnHostC_TH);
     }
     break;
@@ -215,22 +220,23 @@ int main( int argc, char *argv[] ) {
     TensileInt8x4 *initialB_TI;
     TensileInt32 alpha_TI;
     TensileInt32 beta_TI;
+    TensileInt32 *referenceD_TI;
     TensileInt32 *referenceC_TI;
     TensileInt32 *deviceOnHostD_TI;
     TensileInt32 *deviceOnHostC_TI;
     initData(&initialD_TI, &initialC_TI, &initialA_TI, &initialB_TI, &alpha_TI,
-        &beta_TI, &referenceC_TI, &deviceOnHostD_TI, &deviceOnHostC_TI);
+        &beta_TI, &referenceD_TI, &referenceC_TI, &deviceOnHostD_TI, &deviceOnHostC_TI);
     for (unsigned int i = 0; i < numBenchmarks; i++) {
 #if Tensile_CLIENT_BENCHMARK
       invalids = benchmarkProblemSizes(initialD_TI, initialC_TI, initialA_TI, initialB_TI,
-          alpha_TI, beta_TI, referenceC_TI, deviceOnHostD_TI, deviceOnHostC_TI);
+          alpha_TI, beta_TI, referenceD_TI, referenceC_TI, deviceOnHostD_TI, deviceOnHostC_TI);
 #else
       invalids = callLibrary(initialD_TI, initialC_TI, initialA_TI, initialB_TI,
-          alpha_TI, beta_TI, strideA, strideB, strideC, referenceC_TI,
+          alpha_TI, beta_TI, strideA, strideB, strideC, referenceD_TI, referenceC_TI,
           deviceOnHostD_TI, deviceOnHostC_TI);
 #endif
     }
-    destroyData(initialD_TI, initialC_TI, initialA_TI, initialB_TI, referenceC_TI,
+    destroyData(initialD_TI, initialC_TI, initialA_TI, initialB_TI, referenceD_TI, referenceC_TI,
         deviceOnHostD_TI, deviceOnHostC_TI);
     }
     break;

--- a/Tensile/Source/Client.h
+++ b/Tensile/Source/Client.h
@@ -832,7 +832,7 @@ bool benchmarkAllSolutionsForSize(
   size_t sizeToCopy = currentMemorySizeC*bytesPerElement[dataTypeIdx];
 
   file << problemIdx << ", " << sizes[0];
-  for (unsigned int i = 1; i < totalIndices[problemTypeIdx]; i++) {
+  for (unsigned int i = 1; i < totalIndices[problemTypeIdx]+3; i++) {
     file << ", " << sizes[i];
   }
   size_t totalFlops = numFlopsPerMac[dataTypeIdx];
@@ -1276,7 +1276,7 @@ bool benchmarkProblemSizes(
   for ( unsigned int i = 0; i < totalIndices[problemTypeIdx]; i++) {
     file << ", Size" << indexChars[i];
   }
-  file << ", TotalFlops";
+  file << ", LDC, LDA, LDB, TotalFlops";
   for ( unsigned int s = 0; s < numSolutions; s++) {
     file << ", " << solutions[s]._name;
   }
@@ -1304,7 +1304,7 @@ bool benchmarkProblemSizes(
 
     // print size
     std::cout << "Problem[" << problemIdx << "/" << numProblems << "]: " << problemSizes[problemIdx][0];
-    for (unsigned int i = 1; i < totalIndices[problemTypeIdx]; i++) {
+    for (unsigned int i = 1; i < totalIndices[problemTypeIdx]+3; i++) {
       std::cout << ", " << problemSizes[problemIdx][i];
     }
     std::cout << std::endl;

--- a/Tensile/Source/ReferenceCPU.h
+++ b/Tensile/Source/ReferenceCPU.h
@@ -48,9 +48,13 @@ void unpack_int8x4(uint32_t in, int32_t &out_0, int32_t &out_1, int32_t &out_2, 
 
 template< typename Type, typename DestType >
 TensileStatus tensileReferenceCPU(
-    DestType *dataC,
+    DestType *dataD,
+    const DestType *dataC,
     const Type *dataA,
     const Type *dataB,
+    const unsigned int lda,
+    const unsigned int ldb,
+    const unsigned int ldc,
     const unsigned int stride_a,
     const unsigned int stride_b,
     const unsigned int stride_c,
@@ -101,6 +105,11 @@ TensileStatus tensileReferenceCPU(
   for (unsigned int i = 1; i < numIndicesC; i++) {
     stridesC[i] = stridesC[i-1] * strides[i-1];
   }
+
+  stridesA[1] = std::max(stridesA[1], lda);
+  stridesB[1] = std::max(stridesB[1], ldb);
+  stridesC[1] = std::max(stridesC[1], ldc);
+
   if (stride_a != std::numeric_limits<unsigned int>::max())  stridesA[2] = stride_a;
   if (stride_b != std::numeric_limits<unsigned int>::max())  stridesB[2] = stride_b;
   if (stride_c != std::numeric_limits<unsigned int>::max())  stridesC[2] = stride_c;
@@ -238,9 +247,9 @@ TensileStatus tensileReferenceCPU(
     }
 
     if (localUseHighPrecisionAccumulate)
-      dataC[serialIdxC] = (Type)sumCfloat;
+      dataD[serialIdxC] = (Type)sumCfloat;
     else
-      dataC[serialIdxC] = sumC;
+      dataD[serialIdxC] = sumC;
 
     // increment free coord
     // skip = 1, validate everything

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -410,8 +410,7 @@ def writeLogic(outputPath, logicData, solutionWriter ):
           % (argListData[i][0], argListData[i][1], \
           ",\n" if i < len(argListData)-1 else ");\n\n")
 
-
-    numSizes = problemType["TotalIndices"];
+    numSizes = problemType["TotalIndices"] + 3
     firstStride = 0 if problemType["UseInitialStrides"] else 1
     lastStrideA = len(problemType["IndexAssignmentsA"])
     lastStrideB = len(problemType["IndexAssignmentsB"])


### PR DESCRIPTION
Adds support for adding LDA, LDB and LDC in problem sizes. Can be added using:
Range: [ [i], [j], [k], [l], [ldc], [lda], [ldb] ]
Exact: [ i, j, k, l, ldc, lda, ldb ]

Tested for a fixed size ldc, lda, and ldb. If ranges supplied will expand to all possible combinations.