### PR TITLE
restore support of rocBLAS build without an AMD GPU

### DIFF
--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -948,6 +948,8 @@ def assignGlobalParameters( config ):
       globalParameters["AsmCaps"][v]["MaxVmcnt"] = 63
     elif tryAssembler(isaVersion, "", "s_waitcnt vmcnt(15)"):
       globalParameters["AsmCaps"][v]["MaxVmcnt"] = 15
+    else:
+      globalParameters["AsmCaps"][v]["MaxVmcnt"] = 0
 
     caps = ""
     for k in globalParameters["AsmCaps"][v]:


### PR DESCRIPTION
Make sure MaxVmcnt always has a value, to restore support of rocBLAS build without either an AMD GPU or a functional video driver (such as in a docker environment).