### PR TITLE
bugfix for fractional-overhanging instruction

### DIFF
--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -3460,7 +3460,7 @@ class KernelWriterAssembly(KernelWriter):
       kStr += inst("v_cmp_lt_u32", \
           sgpr(mask,2),
           vgpr("Serial"), \
-          sgpr(mask,2),
+          sgpr(mask,1),
           "fractional-overhang: some wi write to harmless LDS location")
       if kernel["FractionalLoad"] == 1:
         kStr += inst("v_cndmask_b32", \


### PR DESCRIPTION
fixed instruction v_cmp_lt_u32 to use 32bit SRC1 for fractional-overhanging logic