### PR TITLE
header guard for amd_mixed_dot should require ROCm 2.2 or later

### DIFF
--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -167,7 +167,7 @@ def writeSolutionsAndKernels(outputPath, problemTypes, solutions, kernels, kerne
       kernelHeaderFile.write("#include \"KernelHeader.h\"\n")
       kernelHeaderFile.write("\n\n")
       kernelHeaderFile.write("__device__ inline int GenDot4(int a, int b, int c) { \n")
-      kernelHeaderFile.write("#if (__hcc_workweek__ >= 19015) || __HIP_CLANG_ONLY__\n")
+      kernelHeaderFile.write("#if (__hcc_workweek__ >= 19092) || __HIP_CLANG_ONLY__\n")
       kernelHeaderFile.write("  typedef union { int32_t i; char4 z; } PkInt8x4;\n")
       kernelHeaderFile.write("#else\n")
       kernelHeaderFile.write("  typedef struct { int c0:8,c1:8,c2:8,c3:8; } C4I8;\n")
@@ -175,7 +175,7 @@ def writeSolutionsAndKernels(outputPath, problemTypes, solutions, kernels, kerne
       kernelHeaderFile.write("#endif\n")
       kernelHeaderFile.write("  PkInt8x4 va, vb; va.i = a; vb.i = b;\n")
 
-      kernelHeaderFile.write("#if (__hcc_workweek__ >= 19015) || __HIP_CLANG_ONLY__\n")
+      kernelHeaderFile.write("#if (__hcc_workweek__ >= 19092) || __HIP_CLANG_ONLY__\n")
       kernelHeaderFile.write("      return amd_mixed_dot(va.z, vb.z, c, true); }\n")
       kernelHeaderFile.write("#else\n")
       kernelHeaderFile.write("      return c + (vb.z.c3*va.z.c3 + vb.z.c2*va.z.c2 + vb.z.c1*va.z.c1 + vb.z.c0*va.z.c0); }\n")


### PR DESCRIPTION
\_\_hcc_workweek\_\_ was 19045 for ROCm 2.1; \_\_hcc_workweek\_\_ is 19092 for ROCm 2.2.  ROCm 2.1 did not support amd_mixed_dot while ROCm 2.2 does.  So we need to change the header guard to require at least ROCm 2.2.