### PR TITLE
fix the merge script to work with ldd sizes

### DIFF
--- a/Tensile/Utilities/merge_rocblas_yaml_files.py
+++ b/Tensile/Utilities/merge_rocblas_yaml_files.py
@@ -84,7 +84,16 @@ class LibraryLogic:
           self.__set_indexOrder(None)
 
         if (length > 7):
-          self.__set_exactLogic(data[7])
+          exactData = data[7]
+          exactList = list()
+          for exact in exactData:
+            size = exact[0]
+            if (len(size) > 4):
+              exactOut = [size[:4],exact[1]]
+              exactList.append(exactOut)
+            else:
+              exactList.append(exact)
+          self.__set_exactLogic(exactList)
         else:
           self.__set_exactLogic(None)
 


### PR DESCRIPTION

This enables merging scripts which includes ldd dimensions in the sizes.

This implementations strips off the ldd dimentions