### PR TITLE
for ROCm2.3 use hipExtModuleLaunchKernel not hipHccModuleLaunchKernel

### DIFF
--- a/Tensile/SolutionWriter.py
+++ b/Tensile/SolutionWriter.py
@@ -768,7 +768,7 @@ class SolutionWriter:
             s += "%shipFunctionArgs.magicShiftSize%s = magicShiftSize%s;\n" % (t, idxChar, idxChar)
 
           s += "%skernelsLaunched++;\n" % (t)
-          s += "%shipHccModuleLaunchKernel(\n" % (t)
+          s += "%shipExtModuleLaunchKernel(\n" % (t)
           t += "  "
           s += "%shipFunction,\n" % (t)
           s += "%sglobalWorkSize[kernelIdx][0]*localWorkSize[0],\n" % (t)


### PR DESCRIPTION
**Warning: When this PR is merged Tensile (and rocBLAS) will not build on ROCm versions 2.2 and earlier. It will be necessary to upgrade to ROCm2.3 or later to build Tensile (and rocBLAS).**


- ROCm 2.3 adds hipExtModuleLaunchKernel and deprecates hipHccModuleLaunchKernel.
- There are warning messages for use of the deprecated hipHccModuleLaunchKernel. Over 3000 warning messages are avoided in rocBLAS with compile flag   -Wno-deprecated-declarations in rocBLAS PR#544. 
