### PR TITLE
quick fix for not selecting kernels with VW2 when size is 1

### DIFF
--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -1685,6 +1685,9 @@ class Solution:
     if state["KernelLanguage"] == "Assembly":
       # Asm kernels only work if all dims are > 32
       state["AssertMinApproxSize"] = 1
+      if state["VectorWidth"] > 1:
+        # VW>1 kernels require dims>1
+        state["AssertMinApproxSize"] = 3
     elif state["VectorWidth"] > 1:
       # VW>1 kernels require dims>1
       state["AssertMinApproxSize"] = 2

--- a/Tensile/Source/TensileTypes.h
+++ b/Tensile/Source/TensileTypes.h
@@ -375,6 +375,7 @@ struct ProblemProperties {
 
     bool allBelow1 = true;
     bool allBelow32 = true;
+    bool anyBelow1 = false;
     for (int si=0; si!=pdims.numSizes(); si++) {
       if (!props->isBatchIdx(si)) {
         auto size = pdims.sizes(si);
@@ -382,12 +383,16 @@ struct ProblemProperties {
           allBelow32 = false;
         if (size > 1)
           allBelow1 = false;
+        if (size == 1)
+          anyBelow1 = true;
       }
     }
     if (allBelow1)
       _approxSize = 1; // really small
     else if (allBelow32)
       _approxSize = 2; // still small
+    else if (anyBelow1)
+      _approxSize = 2; // one dim not big enough
     else
       _approxSize = 99; // big enough
 


### PR DESCRIPTION
Tested with current tuned files in rocBLAS, as well as tuning new files. When used against current tuned files, falls back to a ~30% slower kernel, but prevents it from picking the faster but out of bounds reading kernel.