### PR TITLE
bfloat16 arithmetic added to source kernels

### DIFF
--- a/Tensile/ClientWriter.py
+++ b/Tensile/ClientWriter.py
@@ -998,12 +998,12 @@ def writeClientParameters(forBenchmark, solutions, problemSizes, stepName, \
           for scheduleName in schedulesForProblemType[problemType]:
             functionsForDataType.append([scheduleName, problemType])
         h += "template<>\n"
-        h += "inline %s generatedCallTo_%s<%s>(\n" \
-            % (returnName, functionName, typeName)
+        h += "inline %s generatedCallTo_%s<%s, %s, %s>(\n" \
+            % (returnName, functionName, typeName, destTypeName, computeTypeName)
         h += "    unsigned int *sizes,\n"
         h += "    unsigned int *minStrides,\n"
-        h += "    %s alpha,\n" % destTypeName
-        h += "    %s beta,\n" % destTypeName
+        h += "    %s alpha,\n" % computeTypeName
+        h += "    %s beta,\n" % computeTypeName
         h += "    unsigned int lda,\n"
         h += "    unsigned int ldb,\n"
         h += "    unsigned int ldc,\n"

--- a/Tensile/Configs/rocblas_hpa_bfloat16_hip_single_kernel.yaml
+++ b/Tensile/Configs/rocblas_hpa_bfloat16_hip_single_kernel.yaml
@@ -8,7 +8,7 @@ GlobalParameters:
   EnqueuesPerSync: 1
   SyncsPerBenchmark: 1
   LibraryPrintDebug: False
-  NumElementsToValidate: 0
+  NumElementsToValidate: 8
   ValidationMaxToPrint: 4
   ValidationPrintValids: False
   ShortNames: False
@@ -16,9 +16,18 @@ GlobalParameters:
   Platform: 0
   Device: 0
   KernelTime: True
-  PinClocks: True
+  PinClocks: False
   SleepPercent: 200
-  DataInitTypeBeta : 0
+  DataInitTypeBeta : 1
+  DataInitTypeAlpha: 1
+  DataInitTypeA: 1
+  DataInitTypeB: 1
+  DataInitTypeC: 1
+  DataInitTypeD: 1
+  PrintTensorA: 1
+  PrintTensorB: 1
+  PrintTensorC: 2
+  PrintTensorD: 2
 
 BenchmarkProblems:
   ########################################
@@ -29,6 +38,7 @@ BenchmarkProblems:
       OperationType: GEMM
       DataType: B
       DestDataType: B
+      ComputeDataType: s
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: True
@@ -61,6 +71,29 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [5760], [5760], [1], [5760] ]
+          - Range: [ [8], [8], [1], [8] ]
 
-  ########################################
+#  ########################################
+#LibraryLogic:
+#    ScheduleName: "vega20"
+#    DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Vega 20"]
+#    ArchitectureName: "gfx906"
+#
+##   ScheduleName: "vega10"
+##   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]"]
+##   ArchitectureName: "gfx900"
+#
+##   ScheduleName: "mi25"
+##   DeviceNames: ["Device 6860"]
+##   ArchitectureName: "gfx900"
+#
+##   ScheduleName: "r9nano"
+##   DeviceNames: ["Device 7300"]
+##   ArchitectureName: "gfx803"
+#
+##   ScheduleName: "hip"
+##   DeviceNames: ["Device 0000"]
+##   ArchitectureName: "fallback"
+#
+#LibraryClient:
+

--- a/Tensile/Source/Client.h
+++ b/Tensile/Source/Client.h
@@ -1655,7 +1655,7 @@ void printClientUsage(std::string executableName) {
   std::cout << "  " << keyStrideD << " [defaut is size of array D]" << std::endl;
 #if Tensile_CLIENT_LIBRARY
   std::cout << "  " << keyFunctionIdx << " [" << defaultFunctionIdx << "]" << std::endl;
-  std::cout << "  " << keySizes << " [" << defaultSize << " " << defaultSize << " " << defaultSize << "]" << std::endl;
+  std::cout << "  " << keySizes << " [" << defaultSize << " " << defaultSize << " 1 " << defaultSize << "]" << std::endl;
   std::cout << "FunctionIdx:" << std::endl;
   for (unsigned int i = 0; i < numFunctions; i++) {
     std::cout << "  (" << i << ") " << functionNames[i] << std::endl;

--- a/Tensile/Source/ReferenceCPU.h
+++ b/Tensile/Source/ReferenceCPU.h
@@ -275,7 +275,6 @@ TensileStatus tensileReferenceCPU(
       sumC = tensileMultiply<Type>(alpha,sumC);
     }
     if (!tensileIsZero(beta)) {
-      Type tmp = tensileMultiply<Type>(beta, dataC[serialIdxC]);
       if(std::is_same<Type, tensile_bfloat16>() && std::is_same<DestType, tensile_bfloat16>()) {
         float tmp = tensileMultiply<float>(beta, static_cast<float>(dataC[serialIdxC]));
         sumCfloat = tensileAdd<float>((float)tmp,sumCfloat);
@@ -290,7 +289,7 @@ TensileStatus tensileReferenceCPU(
     }
 
     if(std::is_same<Type, tensile_bfloat16>() && std::is_same<DestType, tensile_bfloat16>()) {
-      dataD[serialIdxD] = static_cast<tensile_bfloat16>(sumCfloat);
+      dataD[serialIdxD] = static_cast<ComputeType>(sumCfloat);
     }
     else if (localUseHighPrecisionAccumulate) {
       dataD[serialIdxD] = (Type)sumCfloat;

--- a/Tensile/Source/ReferenceCPU.h
+++ b/Tensile/Source/ReferenceCPU.h
@@ -224,6 +224,11 @@ TensileStatus tensileReferenceCPU(
          unpack_int8x4(valueB, b_0, b_1, b_2, b_3);
          sumC = sumC + (a_0 * b_0) + (a_1 * b_1) + (a_2 * b_2) + (a_3 * b_3);
       }
+      else if(std::is_same<Type, tensile_bfloat16>() && std::is_same<DestType, tensile_bfloat16>())
+      {
+        float product = static_cast<float>(valueA) * static_cast<float>(valueB);
+        sumCfloat = tensileAdd<float>(sumCfloat, product);
+      }
       else
       {
         Type product = tensileMultiply<Type>( valueA, valueB );
@@ -257,22 +262,42 @@ TensileStatus tensileReferenceCPU(
       serialIdxD += freeCoord[i]*stridesD[i];
       serialIdxC += freeCoord[i]*stridesC[i];
     }
-    if (localUseHighPrecisionAccumulate)
+    if(std::is_same<Type, tensile_bfloat16>() && std::is_same<DestType, tensile_bfloat16>())
+    {
+      sumCfloat = static_cast<float>(alpha) * sumCfloat;
+    }
+    else if (localUseHighPrecisionAccumulate)
+    {
       sumCfloat = tensileMultiply<float>((float)alpha,sumCfloat);
+    }
     else
+    {
       sumC = tensileMultiply<Type>(alpha,sumC);
+    }
     if (!tensileIsZero(beta)) {
       Type tmp = tensileMultiply<Type>(beta, dataC[serialIdxC]);
-      if (localUseHighPrecisionAccumulate)
+      if(std::is_same<Type, tensile_bfloat16>() && std::is_same<DestType, tensile_bfloat16>()) {
+        float tmp = tensileMultiply<float>(beta, static_cast<float>(dataC[serialIdxC]));
         sumCfloat = tensileAdd<float>((float)tmp,sumCfloat);
-      else
-        sumC = tensileAdd<Type>(tmp,sumC);
+      }
+      else {
+        Type tmp = tensileMultiply<Type>(beta, dataC[serialIdxC]);
+        if (localUseHighPrecisionAccumulate)
+          sumCfloat = tensileAdd<float>((float)tmp,sumCfloat);
+        else
+          sumC = tensileAdd<Type>(tmp,sumC);
+      }
     }
 
-    if (localUseHighPrecisionAccumulate)
+    if(std::is_same<Type, tensile_bfloat16>() && std::is_same<DestType, tensile_bfloat16>()) {
+      dataD[serialIdxD] = static_cast<tensile_bfloat16>(sumCfloat);
+    }
+    else if (localUseHighPrecisionAccumulate) {
       dataD[serialIdxD] = (Type)sumCfloat;
-    else
+    }
+    else {
       dataD[serialIdxD] = sumC;
+    }
 
     // increment free coord
     // skip = 1, validate everything


### PR DESCRIPTION
- Testing gives correct answer for 8x8 gemm with A=B=C=D=1.
- This is an initial checkin for bfloat16 arithmetic. 
- Additional testing and development will follow. 
- The ReferenceCPU.h file will be refactored in a subsequent PR to use templated Type, DestType, and ComputeType in place of std::is_same<Type, tensile_bfloat16>().