### PR TITLE
Revert "quick fix for not selecting kernels with VW2 when size is 1"

### DIFF
--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -1685,9 +1685,6 @@ class Solution:
     if state["KernelLanguage"] == "Assembly":
       # Asm kernels only work if all dims are > 32
       state["AssertMinApproxSize"] = 1
-      if state["VectorWidth"] > 1:
-        # VW>1 kernels require dims>1
-        state["AssertMinApproxSize"] = 3
     elif state["VectorWidth"] > 1:
       # VW>1 kernels require dims>1
       state["AssertMinApproxSize"] = 2

--- a/Tensile/Source/TensileTypes.h
+++ b/Tensile/Source/TensileTypes.h
@@ -375,7 +375,6 @@ struct ProblemProperties {
 
     bool allBelow1 = true;
     bool allBelow32 = true;
-    bool anyBelow1 = false;
     for (int si=0; si!=pdims.numSizes(); si++) {
       if (!props->isBatchIdx(si)) {
         auto size = pdims.sizes(si);
@@ -383,16 +382,12 @@ struct ProblemProperties {
           allBelow32 = false;
         if (size > 1)
           allBelow1 = false;
-        if (size == 1)
-          anyBelow1 = true;
       }
     }
     if (allBelow1)
       _approxSize = 1; // really small
     else if (allBelow32)
       _approxSize = 2; // still small
-    else if (anyBelow1)
-      _approxSize = 2; // one dim not big enough
     else
       _approxSize = 99; // big enough
 


### PR DESCRIPTION
Reverts ROCmSoftwarePlatform/Tensile#522
 - fails nightly trsv tests due to no fallback kernel when fix in place