### PR TITLE
Add VectorWidth=1 for small bfloat16 to YAML file

### DIFF
--- a/Tensile/Configs/rocblas_hpa_bfloat16_hip_lite.yaml
+++ b/Tensile/Configs/rocblas_hpa_bfloat16_hip_lite.yaml
@@ -63,62 +63,62 @@ BenchmarkProblems:
         - ProblemSizes:
           - Range: [ [127,1,129], 0, [2], [63,1,65] ]
 
-#   - # BenchmarkProblemSizeGroup - Source
-#     InitialSolutionParameters:
-#     BenchmarkCommonParameters:
-#       - LoopTail: [True]
-#       - EdgeType: ["ShiftPtr"]
-#     ForkParameters:
-#       - KernelLanguage: ["Source"]
-#       - GlobalSplitU: [1, 3]
-#       - PrefetchLocalRead: [True]
-#       - PrefetchGlobalRead: [False]
-#       - ThreadTile:
-#         - [ 8, 2 ]
-#         - [ 2, 8 ]
-#         - [ 16, 2 ]
-#         - [ 2, 16 ]
-#       - WorkGroup:
-#         - [ 16, 16,  1 ]
-#         - [  8,  8,  1 ]
-#       - DepthU: [16]
-#       - VectorWidth: [-1]
-#     BenchmarkForkParameters:
-#     JoinParameters:
-#     BenchmarkJoinParameters:
-#     BenchmarkFinalParameters:
-#       - ProblemSizes:
-#         - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+    - # BenchmarkProblemSizeGroup - Source
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - LoopTail: [True]
+        - EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - KernelLanguage: ["Source"]
+        - GlobalSplitU: [1, 3]
+        - PrefetchLocalRead: [True]
+        - PrefetchGlobalRead: [False]
+        - ThreadTile:
+          - [ 8, 2 ]
+          - [ 2, 8 ]
+          - [ 16, 2 ]
+          - [ 2, 16 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+          - [  8,  8,  1 ]
+        - DepthU: [16]
+        - VectorWidth: [-1]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
 
-#   - # BenchmarkProblemSizeGroup - Source
-#     InitialSolutionParameters:
-#     BenchmarkCommonParameters:
-#       - LoopTail: [True]
-#       - EdgeType: ["ShiftPtr"]
-#     ForkParameters:
-#       - KernelLanguage: ["Source"]
-#       - GlobalSplitU: [1, 3]
-#       - PrefetchLocalRead: [True]
-#       - PrefetchGlobalRead: [False]
-#       - ThreadTile:
-#         - [ 8, 2 ]
-#         - [ 2, 8 ]
-#         - [ 16, 2 ]
-#         - [ 2, 16 ]
-#       - WorkGroup:
-#         - [ 16, 16,  1 ]
-#         - [  8,  8,  1 ]
-#       - DepthU: [16]
-#       - VectorWidth: [1]
-#     BenchmarkForkParameters:
-#     JoinParameters:
-#     BenchmarkJoinParameters:
-#     BenchmarkFinalParameters:
-#       - ProblemSizes:
-#         - Range: [ [1], [1], [2], [1] ]
-#         - Range: [ [        1], [127,1,129], [2], [63,1,65] ]
-#         - Range: [ [127,1,129], [        1], [2], [63,1,65] ]
-#         - Range: [ [127,1,129], [127,1,129], [2], [      1] ]
+    - # BenchmarkProblemSizeGroup - Source
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - LoopTail: [True]
+        - EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - KernelLanguage: ["Source"]
+        - GlobalSplitU: [1, 3]
+        - PrefetchLocalRead: [True]
+        - PrefetchGlobalRead: [False]
+        - ThreadTile:
+          - [ 8, 2 ]
+          - [ 2, 8 ]
+          - [ 16, 2 ]
+          - [ 2, 16 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+          - [  8,  8,  1 ]
+        - DepthU: [16]
+        - VectorWidth: [1]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [1], [1], [2], [1] ]
+          - Range: [ [        1], [127,1,129], [2], [63,1,65] ]
+          - Range: [ [127,1,129], [        1], [2], [63,1,65] ]
+          - Range: [ [127,1,129], [127,1,129], [2], [      1] ]
 
 # ########################################
 # # NT
@@ -161,62 +161,62 @@ BenchmarkProblems:
         - ProblemSizes:
           - Range: [ [127,1,129], 0, [2], [63,1,65] ]
 
-#   - # BenchmarkProblemSizeGroup - Source
-#     InitialSolutionParameters:
-#     BenchmarkCommonParameters:
-#       - LoopTail: [True]
-#       - EdgeType: ["ShiftPtr"]
-#     ForkParameters:
-#       - KernelLanguage: ["Source"]
-#       - GlobalSplitU: [1, 3]
-#       - PrefetchLocalRead: [True]
-#       - PrefetchGlobalRead: [False]
-#       - ThreadTile:
-#         - [ 8, 2 ]
-#         - [ 2, 8 ]
-#         - [ 16, 2 ]
-#         - [ 2, 16 ]
-#       - WorkGroup:
-#         - [ 16, 16,  1 ]
-#         - [  8,  8,  1 ]
-#       - DepthU: [16]
-#       - VectorWidth: [-1]
-#     BenchmarkForkParameters:
-#     JoinParameters:
-#     BenchmarkJoinParameters:
-#     BenchmarkFinalParameters:
-#       - ProblemSizes:
-#         - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+    - # BenchmarkProblemSizeGroup - Source
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - LoopTail: [True]
+        - EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - KernelLanguage: ["Source"]
+        - GlobalSplitU: [1, 3]
+        - PrefetchLocalRead: [True]
+        - PrefetchGlobalRead: [False]
+        - ThreadTile:
+          - [ 8, 2 ]
+          - [ 2, 8 ]
+          - [ 16, 2 ]
+          - [ 2, 16 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+          - [  8,  8,  1 ]
+        - DepthU: [16]
+        - VectorWidth: [-1]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
 
-#   - # BenchmarkProblemSizeGroup - Source
-#     InitialSolutionParameters:
-#     BenchmarkCommonParameters:
-#       - LoopTail: [True]
-#       - EdgeType: ["ShiftPtr"]
-#     ForkParameters:
-#       - KernelLanguage: ["Source"]
-#       - GlobalSplitU: [1, 3]
-#       - PrefetchLocalRead: [True]
-#       - PrefetchGlobalRead: [False]
-#       - ThreadTile:
-#         - [ 8, 2 ]
-#         - [ 2, 8 ]
-#         - [ 16, 2 ]
-#         - [ 2, 16 ]
-#       - WorkGroup:
-#         - [ 16, 16,  1 ]
-#         - [  8,  8,  1 ]
-#       - DepthU: [16]
-#       - VectorWidth: [1]
-#     BenchmarkForkParameters:
-#     JoinParameters:
-#     BenchmarkJoinParameters:
-#     BenchmarkFinalParameters:
-#       - ProblemSizes:
-#         - Range: [ [1], [1], [2], [1] ]
-#         - Range: [ [        1], [127,1,129], [2], [63,1,65] ]
-#         - Range: [ [127,1,129], [        1], [2], [63,1,65] ]
-#         - Range: [ [127,1,129], [127,1,129], [2], [      1] ]
+    - # BenchmarkProblemSizeGroup - Source
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - LoopTail: [True]
+        - EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - KernelLanguage: ["Source"]
+        - GlobalSplitU: [1, 3]
+        - PrefetchLocalRead: [True]
+        - PrefetchGlobalRead: [False]
+        - ThreadTile:
+          - [ 8, 2 ]
+          - [ 2, 8 ]
+          - [ 16, 2 ]
+          - [ 2, 16 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+          - [  8,  8,  1 ]
+        - DepthU: [16]
+        - VectorWidth: [1]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [1], [1], [2], [1] ]
+          - Range: [ [        1], [127,1,129], [2], [63,1,65] ]
+          - Range: [ [127,1,129], [        1], [2], [63,1,65] ]
+          - Range: [ [127,1,129], [127,1,129], [2], [      1] ]
 
 # ########################################
 # # TN
@@ -259,62 +259,62 @@ BenchmarkProblems:
         - ProblemSizes:
           - Range: [ [127,1,129], 0, [2], [63,1,65] ]
 
-#   - # BenchmarkProblemSizeGroup - Source
-#     InitialSolutionParameters:
-#     BenchmarkCommonParameters:
-#       - LoopTail: [True]
-#       - EdgeType: ["ShiftPtr"]
-#     ForkParameters:
-#       - KernelLanguage: ["Source"]
-#       - GlobalSplitU: [1, 3]
-#       - PrefetchLocalRead: [True]
-#       - PrefetchGlobalRead: [False]
-#       - ThreadTile:
-#         - [ 8, 2 ]
-#         - [ 2, 8 ]
-#         - [ 16, 2 ]
-#         - [ 2, 16 ]
-#       - WorkGroup:
-#         - [ 16, 16,  1 ]
-#         - [  8,  8,  1 ]
-#       - DepthU: [16]
-#       - VectorWidth: [-1]
-#     BenchmarkForkParameters:
-#     JoinParameters:
-#     BenchmarkJoinParameters:
-#     BenchmarkFinalParameters:
-#       - ProblemSizes:
-#         - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+    - # BenchmarkProblemSizeGroup - Source
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - LoopTail: [True]
+        - EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - KernelLanguage: ["Source"]
+        - GlobalSplitU: [1, 3]
+        - PrefetchLocalRead: [True]
+        - PrefetchGlobalRead: [False]
+        - ThreadTile:
+          - [ 8, 2 ]
+          - [ 2, 8 ]
+          - [ 16, 2 ]
+          - [ 2, 16 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+          - [  8,  8,  1 ]
+        - DepthU: [16]
+        - VectorWidth: [-1]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
 
-#   - # BenchmarkProblemSizeGroup - Source
-#     InitialSolutionParameters:
-#     BenchmarkCommonParameters:
-#       - LoopTail: [True]
-#       - EdgeType: ["ShiftPtr"]
-#     ForkParameters:
-#       - KernelLanguage: ["Source"]
-#       - GlobalSplitU: [1, 3]
-#       - PrefetchLocalRead: [True]
-#       - PrefetchGlobalRead: [False]
-#       - ThreadTile:
-#         - [ 8, 2 ]
-#         - [ 2, 8 ]
-#         - [ 16, 2 ]
-#         - [ 2, 16 ]
-#       - WorkGroup:
-#         - [ 16, 16,  1 ]
-#         - [  8,  8,  1 ]
-#       - DepthU: [16]
-#       - VectorWidth: [1]
-#     BenchmarkForkParameters:
-#     JoinParameters:
-#     BenchmarkJoinParameters:
-#     BenchmarkFinalParameters:
-#       - ProblemSizes:
-#         - Range: [ [1], [1], [2], [1] ]
-#         - Range: [ [        1], [127,1,129], [2], [63,1,65] ]
-#         - Range: [ [127,1,129], [        1], [2], [63,1,65] ]
-#         - Range: [ [127,1,129], [127,1,129], [2], [      1] ]
+    - # BenchmarkProblemSizeGroup - Source
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - LoopTail: [True]
+        - EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - KernelLanguage: ["Source"]
+        - GlobalSplitU: [1, 3]
+        - PrefetchLocalRead: [True]
+        - PrefetchGlobalRead: [False]
+        - ThreadTile:
+          - [ 8, 2 ]
+          - [ 2, 8 ]
+          - [ 16, 2 ]
+          - [ 2, 16 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+          - [  8,  8,  1 ]
+        - DepthU: [16]
+        - VectorWidth: [1]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [1], [1], [2], [1] ]
+          - Range: [ [        1], [127,1,129], [2], [63,1,65] ]
+          - Range: [ [127,1,129], [        1], [2], [63,1,65] ]
+          - Range: [ [127,1,129], [127,1,129], [2], [      1] ]
 
 # ########################################
 # # TT - standard
@@ -356,60 +356,60 @@ BenchmarkProblems:
         - ProblemSizes:
           - Range: [ [127,1,129], 0, [2], [63,1,65] ]
 
-#   - # BenchmarkProblemSizeGroup - Source
-#     InitialSolutionParameters:
-#     BenchmarkCommonParameters:
-#       - LoopTail: [True]
-#       - EdgeType: ["ShiftPtr"]
-#     ForkParameters:
-#       - KernelLanguage: ["Source"]
-#       - PrefetchLocalRead: [False]
-#       - PrefetchGlobalRead: [False]
-#       - ThreadTile:
-#         - [ 8, 2 ]
-#         - [ 2, 2 ]
-#         - [ 4, 2 ]
-#         - [ 8, 4 ]
-#       - WorkGroup:
-#         - [ 16, 16,  1 ]
-#         - [  8,  8,  1 ]
-#       - DepthU: [16]
-#       - VectorWidth: [-1]
-#     BenchmarkForkParameters:
-#     JoinParameters:
-#     BenchmarkJoinParameters:
-#     BenchmarkFinalParameters:
-#       - ProblemSizes:
-#         - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+    - # BenchmarkProblemSizeGroup - Source
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - LoopTail: [True]
+        - EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - KernelLanguage: ["Source"]
+        - PrefetchLocalRead: [False]
+        - PrefetchGlobalRead: [False]
+        - ThreadTile:
+          - [ 8, 2 ]
+          - [ 2, 2 ]
+          - [ 4, 2 ]
+          - [ 8, 4 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+          - [  8,  8,  1 ]
+        - DepthU: [16]
+        - VectorWidth: [-1]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
 
-#   - # BenchmarkProblemSizeGroup - Source
-#     InitialSolutionParameters:
-#     BenchmarkCommonParameters:
-#       - LoopTail: [True]
-#       - EdgeType: ["ShiftPtr"]
-#     ForkParameters:
-#       - KernelLanguage: ["Source"]
-#       - PrefetchLocalRead: [False]
-#       - PrefetchGlobalRead: [False]
-#       - ThreadTile:
-#         - [ 8, 2 ]
-#         - [ 2, 2 ]
-#         - [ 4, 2 ]
-#         - [ 8, 4 ]
-#       - WorkGroup:
-#         - [ 16, 16,  1 ]
-#         - [  8,  8,  1 ]
-#       - DepthU: [16]
-#       - VectorWidth: [1]
-#     BenchmarkForkParameters:
-#     JoinParameters:
-#     BenchmarkJoinParameters:
-#     BenchmarkFinalParameters:
-#       - ProblemSizes:
-#         - Range: [ [1], [1], [2], [1] ]
-#         - Range: [ [        1], [127,1,129], [2], [63,1,65] ]
-#         - Range: [ [127,1,129], [        1], [2], [63,1,65] ]
-#         - Range: [ [127,1,129], [127,1,129], [2], [      1] ]
+    - # BenchmarkProblemSizeGroup - Source
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - LoopTail: [True]
+        - EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - KernelLanguage: ["Source"]
+        - PrefetchLocalRead: [False]
+        - PrefetchGlobalRead: [False]
+        - ThreadTile:
+          - [ 8, 2 ]
+          - [ 2, 2 ]
+          - [ 4, 2 ]
+          - [ 8, 4 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+          - [  8,  8,  1 ]
+        - DepthU: [16]
+        - VectorWidth: [1]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [1], [1], [2], [1] ]
+          - Range: [ [        1], [127,1,129], [2], [63,1,65] ]
+          - Range: [ [127,1,129], [        1], [2], [63,1,65] ]
+          - Range: [ [127,1,129], [127,1,129], [2], [      1] ]
 
 LibraryLogic:
 #   ScheduleName: "vega10"


### PR DESCRIPTION
- bfloat16 tests in rocBLAS were failing for small size
- This PR sets VectorWidth=1 for small size
- The rocBLAS YAML files generated with this change pass all rocBLAS gemm_ex bfoat16 tests