### PR TITLE
HotFix Fixed Wrong indention for s_setprio in DGEMM cases

### DIFF
--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -1813,8 +1813,8 @@ class KernelWriterAssembly(KernelWriter):
             if beAggressive and not doOnce:
               kStr += "s_setprio 1 // Raise priority while processing macs%s" % self.endLine
               doOnce = True
-        if beAggressive:
-          kStr += "s_setprio 0 // Reset priority after macs %s" % self.endLine
+      if beAggressive:
+        kStr += "s_setprio 0 // Reset priority after macs %s" % self.endLine
       # other precision
     else:
       printExit("Assembly doesn't support %s" % kernel["ProblemType"]["DataType"])


### PR DESCRIPTION
HotFix fro DGEMM performance drop due to wrong indention of s_setprio code