### PR TITLE
include hip_runtime_api.h in place of hip_runtime.h

### DIFF
--- a/Tensile/Source/tensile_bfloat16.h
+++ b/Tensile/Source/tensile_bfloat16.h
@@ -188,8 +188,8 @@ inline __host__ __device__ tensile_bfloat16 abs(tensile_bfloat16 a)
     a.data &= 0x7fff;
     return a;
 }
-inline __host__ __device__ tensile_bfloat16 sin(tensile_bfloat16 a) { return tensile_bfloat16(sinf(float(a))); }
-inline __host__ __device__ tensile_bfloat16 cos(tensile_bfloat16 a) { return tensile_bfloat16(cosf(float(a))); }
+inline tensile_bfloat16 sin(tensile_bfloat16 a) { return tensile_bfloat16(sinf(float(a))); }
+inline tensile_bfloat16 cos(tensile_bfloat16 a) { return tensile_bfloat16(cosf(float(a))); }
 
 #endif // __cplusplus
 

--- a/Tensile/Source/tensile_bfloat16.h
+++ b/Tensile/Source/tensile_bfloat16.h
@@ -41,7 +41,7 @@ typedef struct
 
 #else // __cplusplus
 
-#include <hip/hip_runtime.h>
+#include <hip/hip_runtime_api.h>
 
 #include <cinttypes>
 #include <cmath>


### PR DESCRIPTION
- in tensile_bfloat16.h include hip/hip_runtime_api.h in place of hip/hip_runtime.h
- this makes tensile_bfloat16.h similar to rocblas_bfloat16.h
- rocblas_bfloat16.h is an external header, and this change enables compiling with gcc