### PR TITLE
OptNLL calls functionEnd instead of just s_endpgm

### DIFF
--- a/Tensile/KernelWriter.py
+++ b/Tensile/KernelWriter.py
@@ -1290,7 +1290,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
         kl.append(self.notLocalSplitUGlobalWrite(kernel))
 
     # function suffix
-    kl.append(self.functionEnd(kernel))
+    kl.append(self.functionEnd(kernel, True))
     kl.append(self.functionSuffix(kernel))
 
     kl.append(self.closeString(kernel))
@@ -2314,7 +2314,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
   # Function End
   ##############################################################################
   @abc.abstractmethod
-  def functionEnd(self, kernel):
+  def functionEnd(self, kernel, addLabel=True):
     return ""
 
   ##############################################################################

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -4655,7 +4655,7 @@ class KernelWriterAssembly(KernelWriter):
           kStr += self.addStore(kernel, ss, addrCalc, sumIdx, tmpSgpr)
 
         kStr += "\n"
-        kStr += inst("s_endpgm", "endpgm after opt NLL")
+        kStr += str(self.functionEnd(kernel, False))
         #kStr += inst("s_branch %s"%summationEnd, "skip the OptNLL")
 
         label = self.getLabelName("OptNLL_End")
@@ -8062,7 +8062,7 @@ class KernelWriterAssembly(KernelWriter):
   ##############################################################################
   # Function End
   ##############################################################################
-  def functionEnd(self, kernel):
+  def functionEnd(self, kernel, addLabel=True):
     imod = Code.Module()
     if kernel["PersistentKernel"]:
       # Persistent may generate a SerialWorkGroupIter which is OOB, only loop back if we are in a valid WG:
@@ -8070,7 +8070,8 @@ class KernelWriterAssembly(KernelWriter):
       imod.addInst("s_mul_i32", sgpr(stmp), sgpr("NumWorkGroups0"), sgpr("NumWorkGroups1"), "Total WG")
       imod.addInst("s_cmp_ge_u32", sgpr("SerialWorkGroupIter"), sgpr(stmp), "outside legal WG?")
       imod.addInst("s_cbranch_scc0", self.getLabelTarget("PersistentLoopStart"), "persistent loop back")
-    imod.addCode(Code.Label(self.getLabelNum("KernelEnd"), "KernelEnd"))
+    if addLabel:
+      imod.addCode(Code.Label(self.getLabelNum("KernelEnd"), "KernelEnd"))
     imod.addInst("s_endpgm", "Kernel End")
     return imod
 

--- a/Tensile/KernelWriterSource.py
+++ b/Tensile/KernelWriterSource.py
@@ -2556,7 +2556,7 @@ class KernelWriterSource(KernelWriter):
   ##############################################################################
   # Function End
   ##############################################################################
-  def functionEnd(self, kernel):
+  def functionEnd(self, kernel, addLabel):
     kStr = ""
 
     if kernel["PersistentKernel"]:


### PR DESCRIPTION
For persistent, this adds the required loop-back code