### PR TITLE
add 'Device 66af' for Radeon VII

### DIFF
--- a/Tensile/Configs/miopen/boiler/library_logic_hip_only.yml
+++ b/Tensile/Configs/miopen/boiler/library_logic_hip_only.yml
@@ -1,7 +1,7 @@
 
 LibraryLogic:
 #   ScheduleName: "vega20"
-#   DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7"]
+#   DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Device 66af", "Vega 20"]
 #   ArchitectureName: "gfx906"
 
 #   ScheduleName: "vega10"

--- a/Tensile/Configs/miopen/boiler/library_logic_vega20_only.yml
+++ b/Tensile/Configs/miopen/boiler/library_logic_vega20_only.yml
@@ -1,7 +1,7 @@
 
 LibraryLogic:
     ScheduleName: "vega20"
-    DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7"]
+    DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Device 66af", "Vega 20"]
     ArchitectureName: "gfx906"
 
 #   ScheduleName: "vega10"

--- a/Tensile/Configs/rocblas_dgemm_asm_lite.yaml
+++ b/Tensile/Configs/rocblas_dgemm_asm_lite.yaml
@@ -458,7 +458,7 @@ BenchmarkProblems:
 
 LibraryLogic:
 #   ScheduleName: "vega20"
-#   DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Vega 20"]
+#   DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Device 66af", "Vega 20"]
 #   ArchitectureName: "gfx906"
 
     ScheduleName: "vega10"

--- a/Tensile/Configs/rocblas_dgemm_nn_asm_full.yaml
+++ b/Tensile/Configs/rocblas_dgemm_nn_asm_full.yaml
@@ -231,7 +231,7 @@ BenchmarkProblems:
 
 LibraryLogic:
     ScheduleName: "vega20"
-    DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Vega 20"]
+    DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Device 66af", "Vega 20"]
     ArchitectureName: "gfx906"
 
 #   ScheduleName: "vega10"

--- a/Tensile/Configs/rocblas_dgemm_nn_inc0_asm_full.yaml
+++ b/Tensile/Configs/rocblas_dgemm_nn_inc0_asm_full.yaml
@@ -125,7 +125,7 @@ BenchmarkProblems:
 
 LibraryLogic:
     ScheduleName: "vega20"
-    DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Vega 20"]
+    DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Device 66af", "Vega 20"]
     ArchitectureName: "gfx906"
 
 #   ScheduleName: "vega10"

--- a/Tensile/Configs/rocblas_dgemm_nt_asm_full.yaml
+++ b/Tensile/Configs/rocblas_dgemm_nt_asm_full.yaml
@@ -179,7 +179,7 @@ BenchmarkProblems:
 
 LibraryLogic:
     ScheduleName: "vega20"
-    DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Vega 20"]
+    DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Device 66af", "Vega 20"]
     ArchitectureName: "gfx906"
 
 #   ScheduleName: "vega10"

--- a/Tensile/Configs/rocblas_dgemm_nt_inc0_asm_full.yaml
+++ b/Tensile/Configs/rocblas_dgemm_nt_inc0_asm_full.yaml
@@ -455,7 +455,7 @@ BenchmarkProblems:
 
 LibraryLogic:
     ScheduleName: "vega20"
-    DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Vega 20"]
+    DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Device 66af", "Vega 20"]
     ArchitectureName: "gfx906"
 
 #   ScheduleName: "vega10"

--- a/Tensile/Configs/rocblas_dgemm_nt_inc1_asm_full.yaml
+++ b/Tensile/Configs/rocblas_dgemm_nt_inc1_asm_full.yaml
@@ -2123,7 +2123,7 @@ BenchmarkProblems:
 
 LibraryLogic:
     ScheduleName: "vega20"
-    DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Vega 20"]
+    DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Device 66af", "Vega 20"]
     ArchitectureName: "gfx906"
 
 #   ScheduleName: "vega10"

--- a/Tensile/Configs/rocblas_dgemm_nt_inc2_asm_full.yaml
+++ b/Tensile/Configs/rocblas_dgemm_nt_inc2_asm_full.yaml
@@ -5174,7 +5174,7 @@ BenchmarkProblems:
 
 LibraryLogic:
     ScheduleName: "vega20"
-    DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Vega 20"]
+    DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Device 66af", "Vega 20"]
     ArchitectureName: "gfx906"
 
 #   ScheduleName: "vega10"

--- a/Tensile/Configs/rocblas_dgemm_nt_inc3_asm_full.yaml
+++ b/Tensile/Configs/rocblas_dgemm_nt_inc3_asm_full.yaml
@@ -5126,7 +5126,7 @@ BenchmarkProblems:
 
 LibraryLogic:
     ScheduleName: "vega20"
-    DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Vega 20"]
+    DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Device 66af", "Vega 20"]
     ArchitectureName: "gfx906"
 
 #   ScheduleName: "vega10"

--- a/Tensile/Configs/rocblas_dgemm_nt_resume_train_exp.yaml
+++ b/Tensile/Configs/rocblas_dgemm_nt_resume_train_exp.yaml
@@ -5127,7 +5127,7 @@ BenchmarkProblems:
 
 LibraryLogic:
     ScheduleName: "vega20"
-    DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Vega 20"]
+    DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Device 66af", "Vega 20"]
     ArchitectureName: "gfx906"
 
 #   ScheduleName: "vega10"

--- a/Tensile/Configs/rocblas_dgemm_tn_asm_full.yaml
+++ b/Tensile/Configs/rocblas_dgemm_tn_asm_full.yaml
@@ -93,7 +93,7 @@ BenchmarkProblems:
 
 LibraryLogic:
     ScheduleName: "vega20"
-    DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Vega 20"]
+    DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Device 66af", "Vega 20"]
     ArchitectureName: "gfx906"
 
 #   ScheduleName: "vega10"

--- a/Tensile/Configs/rocblas_dgemm_tt_asm_full.yaml
+++ b/Tensile/Configs/rocblas_dgemm_tt_asm_full.yaml
@@ -93,7 +93,7 @@ BenchmarkProblems:
 
 LibraryLogic:
     ScheduleName: "vega20"
-    DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Vega 20"]
+    DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Device 66af", "Vega 20"]
     ArchitectureName: "gfx906"
 
 #   ScheduleName: "vega10"

--- a/Tensile/Configs/rocblas_hgemm_asm_full.yaml
+++ b/Tensile/Configs/rocblas_hgemm_asm_full.yaml
@@ -1402,7 +1402,7 @@ BenchmarkProblems:
 
 LibraryLogic:
 #   ScheduleName: "vega20"
-#   DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Vega 20"]
+#   DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Device 66af", "Vega 20"]
 #   ArchitectureName: "gfx906"
 
     ScheduleName: "vega10"

--- a/Tensile/Configs/rocblas_hgemm_asm_lite.yaml
+++ b/Tensile/Configs/rocblas_hgemm_asm_lite.yaml
@@ -305,7 +305,7 @@ BenchmarkProblems:
 
 LibraryLogic:
 #   ScheduleName: "vega20"
-#   DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Vega 20"]
+#   DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Device 66af", "Vega 20"]
 #   ArchitectureName: "gfx906"
 
     ScheduleName: "vega10"

--- a/Tensile/Configs/rocblas_hpa_bfloat16_hip_single_kernel.yaml
+++ b/Tensile/Configs/rocblas_hpa_bfloat16_hip_single_kernel.yaml
@@ -76,7 +76,7 @@ BenchmarkProblems:
 #  ########################################
 #LibraryLogic:
 #    ScheduleName: "vega20"
-#    DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Vega 20"]
+#   DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Device 66af", "Vega 20"]
 #    ArchitectureName: "gfx906"
 #
 ##   ScheduleName: "vega10"

--- a/Tensile/Configs/rocblas_hpa_hgemm_nn_asm_full.yaml
+++ b/Tensile/Configs/rocblas_hpa_hgemm_nn_asm_full.yaml
@@ -606,7 +606,7 @@ BenchmarkProblems:
 
 LibraryLogic:
 #   ScheduleName: "vega20"
-#   DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Vega 20"]
+#   DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Device 66af", "Vega 20"]
 #   ArchitectureName: "gfx906"
 
     ScheduleName: "vega10"

--- a/Tensile/Configs/rocblas_hpa_hgemm_nt_asm_full.yaml
+++ b/Tensile/Configs/rocblas_hpa_hgemm_nt_asm_full.yaml
@@ -230,7 +230,7 @@ BenchmarkProblems:
 
 LibraryLogic:
 #   ScheduleName: "vega20"
-#   DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Vega 20"]
+#   DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Device 66af", "Vega 20"]
 #   ArchitectureName: "gfx906"
 
     ScheduleName: "vega10"

--- a/Tensile/Configs/rocblas_hpa_hgemm_tn_asm_full.yaml
+++ b/Tensile/Configs/rocblas_hpa_hgemm_tn_asm_full.yaml
@@ -431,7 +431,7 @@ BenchmarkProblems:
 
 LibraryLogic:
 #   ScheduleName: "vega20"
-#   DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Vega 20"]
+#   DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Device 66af", "Vega 20"]
 #   ArchitectureName: "gfx906"
 
     ScheduleName: "vega10"

--- a/Tensile/Configs/rocblas_hpa_hgemm_tt_asm_full.yaml
+++ b/Tensile/Configs/rocblas_hpa_hgemm_tt_asm_full.yaml
@@ -223,7 +223,7 @@ BenchmarkProblems:
 
 LibraryLogic:
 #   ScheduleName: "vega20"
-#   DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Vega 20"]
+#   DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Device 66af", "Vega 20"]
 #   ArchitectureName: "gfx906"
 
     ScheduleName: "vega10"

--- a/Tensile/Configs/rocblas_igemm_asm_full_nn.yaml
+++ b/Tensile/Configs/rocblas_igemm_asm_full_nn.yaml
@@ -608,7 +608,7 @@ BenchmarkProblems:
 
 LibraryLogic:
     ScheduleName: "vega20"
-    DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Vega 20"]
+    DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Device 66af", "Vega 20"]
     ArchitectureName: "gfx906"
 
 #   ScheduleName: "vega10"

--- a/Tensile/Configs/rocblas_igemm_asm_full_nt.yaml
+++ b/Tensile/Configs/rocblas_igemm_asm_full_nt.yaml
@@ -242,7 +242,7 @@ BenchmarkProblems:
 
 LibraryLogic:
     ScheduleName: "vega20"
-    DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Vega 20"]
+    DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Device 66af", "Vega 20"]
     ArchitectureName: "gfx906"
 
 #   ScheduleName: "vega10"

--- a/Tensile/Configs/rocblas_igemm_asm_full_tn.yaml
+++ b/Tensile/Configs/rocblas_igemm_asm_full_tn.yaml
@@ -488,7 +488,7 @@ BenchmarkProblems:
 
 LibraryLogic:
     ScheduleName: "vega20"
-    DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Vega 20"]
+    DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Device 66af", "Vega 20"]
     ArchitectureName: "gfx906"
 
 #   ScheduleName: "vega10"

--- a/Tensile/Configs/rocblas_igemm_asm_full_tt.yaml
+++ b/Tensile/Configs/rocblas_igemm_asm_full_tt.yaml
@@ -232,7 +232,7 @@ BenchmarkProblems:
 
 LibraryLogic:
     ScheduleName: "vega20"
-    DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Vega 20"]
+    DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Device 66af", "Vega 20"]
     ArchitectureName: "gfx906"
 
 #   ScheduleName: "vega10"

--- a/Tensile/Configs/rocblas_igemm_hip_single_kernel.yaml
+++ b/Tensile/Configs/rocblas_igemm_hip_single_kernel.yaml
@@ -71,7 +71,7 @@ BenchmarkProblems:
 
 LibraryLogic:
 #   ScheduleName: "vega20"
-#   DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Vega 20"]
+#   DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Device 66af", "Vega 20"]
 #   ArchitectureName: "gfx906"
 #
 #   ScheduleName: "vega10"

--- a/Tensile/Configs/rocblas_sgemm_asm_full.yaml
+++ b/Tensile/Configs/rocblas_sgemm_asm_full.yaml
@@ -1443,7 +1443,7 @@ BenchmarkProblems:
 
 LibraryLogic:
 #   ScheduleName: "vega20"
-#   DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Vega 20"]
+#   DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Device 66af", "Vega 20"]
 #   ArchitectureName: "gfx906"
 
     ScheduleName: "vega10"

--- a/Tensile/Configs/rocblas_sgemm_asm_lite.yaml
+++ b/Tensile/Configs/rocblas_sgemm_asm_lite.yaml
@@ -553,7 +553,7 @@ BenchmarkProblems:
 
 LibraryLogic:
 #   ScheduleName: "vega20"
-#   DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Vega 20"]
+#   DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Device 66af", "Vega 20"]
 #   ArchitectureName: "gfx906"
 
     ScheduleName: "vega10"

--- a/Tensile/Configs/rocblas_sgemm_asm_only.yaml
+++ b/Tensile/Configs/rocblas_sgemm_asm_only.yaml
@@ -325,7 +325,7 @@ BenchmarkProblems:
 
 LibraryLogic:
 #   ScheduleName: "vega20"
-#   DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Vega 20"]
+#   DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Device 66af", "Vega 20"]
 #   ArchitectureName: "gfx906"
 
     ScheduleName: "vega10"


### PR DESCRIPTION
Resolves SWDEV-190051 along with rocBLAS PR#595
- when /usr/share/misc/pci.ids is missing on the system, Radeon VII presents itself as 'Device 66af', not 'Vega 20'. This fix brings 'Device 66af' into the 'Vega 20' fold.