### PR TITLE
code_object_version switch V2 or V3

### DIFF
--- a/Tensile/Source/CMakeLists.txt
+++ b/Tensile/Source/CMakeLists.txt
@@ -32,6 +32,8 @@ option( Tensile_CLIENT_BENCMARK "ON=BenchmarkClient; OFF=LibraryClient" ON)
 option( Tensile_MERGE_FILES "Merge kernels and solutions files" OFF)
 set(Tensile_RUNTIME_LANGUAGE HIP CACHE STRING "Which runtime language to use")
 set_property( CACHE Tensile_RUNTIME_LANGUAGE PROPERTY STRINGS HIP OCL )
+set(Tensile_CODE_OBJECT_VERSION V2 CACHE STRING "Which code object version to use")
+set_property( CACHE Tensile_CODE_OBJECT_VERSION PROPERTY STRINGS V2 V3)
 
 ###############################################################################
 # Benchmark Client
@@ -116,9 +118,10 @@ endif()
 # Create Tensile Library
 if(NOT Tensile_CLIENT_BENCHMARK)
   include(${CMAKE_SOURCE_DIR}/TensileConfig.cmake)
-  TensileCreateLibrary(
+  TensileCreateLibraryCmake(
     ${Tensile_LOGIC_PATH}           # path
     ${Tensile_RUNTIME_LANGUAGE}     # OCL or HIP
+    ${Tensile_CODE_OBJECT_VERSION}  # V2 or V3
     ${Tensile_MERGE_FILES}          # ON or OFF
     ${Tensile_SHORT_FILE_NAMES}     # ON or OFF
     ${Tensile_LIBRARY_PRINT_DEBUG}  # ON or OFF

--- a/Tensile/Source/TensileConfig.cmake
+++ b/Tensile/Source/TensileConfig.cmake
@@ -24,9 +24,10 @@ include(CMakeParseArguments)
 ################################################################################
 # Create A Tensile Library from LibraryLogic.yaml files
 ################################################################################
-function(TensileCreateLibrary
+function(TensileCreateLibraryCmake
     Tensile_LOGIC_PATH
     Tensile_RUNTIME_LANGUAGE
+    Tensile_CODE_OBJECT_VERSION
     Tensile_MERGE_FILES
     Tensile_SHORT_FILE_NAMES
     Tensile_LIBRARY_PRINT_DEBUG )
@@ -64,6 +65,8 @@ function(TensileCreateLibrary
   else()
     set(Tensile_CREATE_COMMAND ${Tensile_CREATE_COMMAND} "--no-library-print-debug")
   endif()
+
+  set(Tensile_CREATE_COMMAND ${Tensile_CREATE_COMMAND} "--code-object-version=${Tensile_CODE_OBJECT_VERSION}")
 
   # TensileLibraryWriter positional arguments
   set(Tensile_CREATE_COMMAND ${Tensile_CREATE_COMMAND}

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -885,6 +885,7 @@ def TensileCreateLibrary():
   argParser.add_argument("LogicPath",       help="Path to LibraryLogic.yaml files.")
   argParser.add_argument("OutputPath",      help="Where to write library files?")
   argParser.add_argument("RuntimeLanguage", help="Which runtime language?", choices=["OCL", "HIP", "HSA"])
+  argParser.add_argument("--code-object-version",    dest="CodeObjectVersion", action="store", default="V2")
   argParser.add_argument("--merge-files",            dest="MergeFiles",        action="store_true")
   argParser.add_argument("--no-merge-files",         dest="MergeFiles",        action="store_false")
   argParser.add_argument("--short-file-names",       dest="ShortNames",        action="store_true")
@@ -904,6 +905,7 @@ def TensileCreateLibrary():
   ensurePath(outputPath)
   arguments = {}
   arguments["RuntimeLanguage"] = args.RuntimeLanguage
+  arguments["CodeObjectVersion"] = args.CodeObjectVersion
   arguments["MergeFiles"] = args.MergeFiles
   arguments["ShortNames"] = args.ShortNames
   arguments["LibraryPrintDebug"] = args.LibraryPrintDebug


### PR DESCRIPTION
- set Tensile_CODE_OBJECT_VERSION to default V2 in Tensile/Source/CMakeLists.txt
- Pass argument Tensile_CODE_OBJECT_VERSION  to TensileCreateLibraryCmake
- TensileCreateLibraryCmake calls TensileCreateLibrary in TensileCreateLibrary.py, with optional argument --code-object-version set to V2 or V3, the default is V2.
- rocBLAS PR to call TensileCreateLibraryCmake with Tensile_CODE_OBJECT_VERSION must follow this PR. 