### PR TITLE
Support complex gemm including cgemm and zgemm by hip solutions  [don't merge due to issue SWDEV-194263]

### DIFF
--- a/Tensile/Configs/rocblas_cgemm_hip_lite.yaml
+++ b/Tensile/Configs/rocblas_cgemm_hip_lite.yaml
@@ -1,0 +1,364 @@
+GlobalParameters:
+  MinimumRequiredVersion: 4.4.0
+  PrintLevel: 1
+  ForceRedoBenchmarkProblems: True
+  ForceRedoLibraryLogic: True
+  ForceRedoLibraryClient: True
+  CMakeBuildType: Release
+  EnqueuesPerSync: 1
+  SyncsPerBenchmark: 2
+  LibraryPrintDebug: False
+  NumElementsToValidate: 128
+  ValidationMaxToPrint: 4
+  ValidationPrintValids: False
+  ShortNames: False
+  MergeFiles: True
+  Platform: 0
+  Device: 0
+  KernelTime: True
+  PinClocks: True
+  SleepPercent: 200
+  DataInitTypeBeta : 0
+
+BenchmarkProblems:
+
+  ########################################
+  # NN
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: c
+      TransposeA: False
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Source"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - WorkGroupMapping: [8]
+        - PrefetchLocalRead: [True]
+        - PrefetchGlobalRead: [True]
+        - VectorWidth: [1]
+      ForkParameters:
+        - ThreadTile:
+          - [ 2, 2 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+        - DepthU: [ -2 ]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [64], [64], [2], [64] ]
+
+  ########################################
+  # NT
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: c
+      TransposeA: False
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Source"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - WorkGroupMapping: [8]
+        - PrefetchLocalRead: [True]
+        - PrefetchGlobalRead: [True]
+        - VectorWidth: [1]
+      ForkParameters:
+        - ThreadTile:
+          - [ 2, 2 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+        - DepthU: [ -2 ]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [64], [64], [2], [64] ]
+
+  ########################################
+  # TN
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: c
+      TransposeA: True
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Source"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - WorkGroupMapping: [8]
+        - PrefetchLocalRead: [True]
+        - PrefetchGlobalRead: [True]
+        - VectorWidth: [1]
+      ForkParameters:
+        - ThreadTile:
+          - [ 2, 2 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+        - DepthU: [ -2 ]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [64], [64], [2], [64] ]
+
+  ########################################
+  # TT
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: c
+      TransposeA: True
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Source"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - WorkGroupMapping: [8]
+        - PrefetchLocalRead: [True]
+        - PrefetchGlobalRead: [True]
+        - VectorWidth: [1]
+      ForkParameters:
+        - ThreadTile:
+          - [ 2, 2 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+        - DepthU: [ -2 ]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [64], [64], [2], [64] ]
+
+  ########################################
+  # NC
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: c
+      TransposeA: False
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+      ComplexConjugateB: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Source"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - WorkGroupMapping: [8]
+        - PrefetchLocalRead: [True]
+        - PrefetchGlobalRead: [True]
+        - VectorWidth: [1]
+      ForkParameters:
+        - ThreadTile:
+          - [ 2, 2 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+        - DepthU: [ -2 ]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [64], [64], [2], [64] ]
+
+  ########################################
+  # CN
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: c
+      TransposeA: True
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+      ComplexConjugateA: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Source"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - WorkGroupMapping: [8]
+        - PrefetchLocalRead: [True]
+        - PrefetchGlobalRead: [True]
+        - VectorWidth: [1]
+      ForkParameters:
+        - ThreadTile:
+          - [ 2, 2 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+        - DepthU: [ -2 ]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [64], [64], [2], [64] ]
+
+  ########################################
+  # CT
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: c
+      TransposeA: True
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+      ComplexConjugateA: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Source"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - WorkGroupMapping: [8]
+        - PrefetchLocalRead: [True]
+        - PrefetchGlobalRead: [True]
+        - VectorWidth: [1]
+      ForkParameters:
+        - ThreadTile:
+          - [ 2, 2 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+        - DepthU: [ -2 ]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [64], [64], [2], [64] ]
+
+  ########################################
+  # TC
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: c
+      TransposeA: True
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+      ComplexConjugateB: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Source"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - WorkGroupMapping: [8]
+        - PrefetchLocalRead: [True]
+        - PrefetchGlobalRead: [True]
+        - VectorWidth: [1]
+      ForkParameters:
+        - ThreadTile:
+          - [ 2, 2 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+        - DepthU: [ -2 ]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [64], [64], [2], [64] ]
+
+  ########################################
+  # CC
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: c
+      TransposeA: True
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+      ComplexConjugateA: True
+      ComplexConjugateB: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Source"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - WorkGroupMapping: [8]
+        - PrefetchLocalRead: [True]
+        - PrefetchGlobalRead: [True]
+        - VectorWidth: [1]
+      ForkParameters:
+        - ThreadTile:
+          - [ 2, 2 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+        - DepthU: [ -2 ]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [64], [64], [2], [64] ]
+
+
+LibraryLogic:
+#   ScheduleName: "vega10"
+    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]"]
+#   ArchitectureName: "gfx900"
+
+#   ScheduleName: "mi25"
+#   DeviceNames: ["Device 6860"]
+#   ArchitectureName: "gfx900"
+
+#   ScheduleName: "r9nano"
+#   DeviceNames: ["Device 7300"]
+#   ArchitectureName: "gfx803"
+
+    ScheduleName: "hip"
+    DeviceNames: ["Device 0000"]
+    ArchitectureName: "fallback"
+
+LibraryClient:

--- a/Tensile/Configs/rocblas_zgemm_hip_lite.yaml
+++ b/Tensile/Configs/rocblas_zgemm_hip_lite.yaml
@@ -1,0 +1,364 @@
+GlobalParameters:
+  MinimumRequiredVersion: 4.4.0
+  PrintLevel: 1
+  ForceRedoBenchmarkProblems: True
+  ForceRedoLibraryLogic: True
+  ForceRedoLibraryClient: True
+  CMakeBuildType: Release
+  EnqueuesPerSync: 1
+  SyncsPerBenchmark: 2
+  LibraryPrintDebug: False
+  NumElementsToValidate: 128
+  ValidationMaxToPrint: 4
+  ValidationPrintValids: False
+  ShortNames: False
+  MergeFiles: True
+  Platform: 0
+  Device: 0
+  KernelTime: True
+  PinClocks: True
+  SleepPercent: 200
+  DataInitTypeBeta : 0
+
+BenchmarkProblems:
+
+  ########################################
+  # NN
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: z
+      TransposeA: False
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Source"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - WorkGroupMapping: [8]
+        - PrefetchLocalRead: [True]
+        - PrefetchGlobalRead: [True]
+        - VectorWidth: [1]
+      ForkParameters:
+        - ThreadTile:
+          - [ 2, 2 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+        - DepthU: [ -2 ]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [64], [64], [2], [64] ]
+
+  ########################################
+  # NT
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: z
+      TransposeA: False
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Source"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - WorkGroupMapping: [8]
+        - PrefetchLocalRead: [True]
+        - PrefetchGlobalRead: [True]
+        - VectorWidth: [1]
+      ForkParameters:
+        - ThreadTile:
+          - [ 2, 2 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+        - DepthU: [ -2 ]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [64], [64], [2], [64] ]
+
+  ########################################
+  # TN
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: z
+      TransposeA: True
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Source"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - WorkGroupMapping: [8]
+        - PrefetchLocalRead: [True]
+        - PrefetchGlobalRead: [True]
+        - VectorWidth: [1]
+      ForkParameters:
+        - ThreadTile:
+          - [ 2, 2 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+        - DepthU: [ -2 ]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [64], [64], [2], [64] ]
+
+  ########################################
+  # TT
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: z
+      TransposeA: True
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Source"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - WorkGroupMapping: [8]
+        - PrefetchLocalRead: [True]
+        - PrefetchGlobalRead: [True]
+        - VectorWidth: [1]
+      ForkParameters:
+        - ThreadTile:
+          - [ 2, 2 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+        - DepthU: [ -2 ]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [64], [64], [2], [64] ]
+
+  ########################################
+  # NC
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: z
+      TransposeA: False
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+      ComplexConjugateB: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Source"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - WorkGroupMapping: [8]
+        - PrefetchLocalRead: [True]
+        - PrefetchGlobalRead: [True]
+        - VectorWidth: [1]
+      ForkParameters:
+        - ThreadTile:
+          - [ 2, 2 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+        - DepthU: [ -2 ]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [64], [64], [2], [64] ]
+
+  ########################################
+  # CN
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: z
+      TransposeA: True
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+      ComplexConjugateA: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Source"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - WorkGroupMapping: [8]
+        - PrefetchLocalRead: [True]
+        - PrefetchGlobalRead: [True]
+        - VectorWidth: [1]
+      ForkParameters:
+        - ThreadTile:
+          - [ 2, 2 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+        - DepthU: [ -2 ]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [64], [64], [2], [64] ]
+
+  ########################################
+  # CT
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: z
+      TransposeA: True
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+      ComplexConjugateA: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Source"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - WorkGroupMapping: [8]
+        - PrefetchLocalRead: [True]
+        - PrefetchGlobalRead: [True]
+        - VectorWidth: [1]
+      ForkParameters:
+        - ThreadTile:
+          - [ 2, 2 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+        - DepthU: [ -2 ]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [64], [64], [2], [64] ]
+
+  ########################################
+  # TC
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: z
+      TransposeA: True
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+      ComplexConjugateB: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Source"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - WorkGroupMapping: [8]
+        - PrefetchLocalRead: [True]
+        - PrefetchGlobalRead: [True]
+        - VectorWidth: [1]
+      ForkParameters:
+        - ThreadTile:
+          - [ 2, 2 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+        - DepthU: [ -2 ]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [64], [64], [2], [64] ]
+
+  ########################################
+  # CC
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: z
+      TransposeA: True
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+      ComplexConjugateA: True
+      ComplexConjugateB: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Source"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - WorkGroupMapping: [8]
+        - PrefetchLocalRead: [True]
+        - PrefetchGlobalRead: [True]
+        - VectorWidth: [1]
+      ForkParameters:
+        - ThreadTile:
+          - [ 2, 2 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+        - DepthU: [ -2 ]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [64], [64], [2], [64] ]
+
+
+LibraryLogic:
+#   ScheduleName: "vega10"
+    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]"]
+#   ArchitectureName: "gfx900"
+
+#   ScheduleName: "mi25"
+#   DeviceNames: ["Device 6860"]
+#   ArchitectureName: "gfx900"
+
+#   ScheduleName: "r9nano"
+#   DeviceNames: ["Device 7300"]
+#   ArchitectureName: "gfx803"
+
+    ScheduleName: "hip"
+    DeviceNames: ["Device 0000"]
+    ArchitectureName: "fallback"
+
+LibraryClient:

--- a/Tensile/Source/Client.h
+++ b/Tensile/Source/Client.h
@@ -1414,7 +1414,9 @@ bool benchmarkProblemSizes(
 #endif // benchmark
 
 enum InitOp {None, Abs, AltSign};
-template<typename DataType>
+template<typename DataType,
+typename std::enable_if<!(std::is_same<DataType, TensileComplexFloat>{} ||
+                          std::is_same<DataType, TensileComplexDouble>{})>::type* = nullptr >
 void initInput(
     const std::string &tag,
     unsigned dataInitType,
@@ -1467,7 +1469,54 @@ void initInput(
   }
 }
 
-
+// complex number doesn't have positive and negative.
+// Not support Abs and AltSign
+template<typename DataType,
+typename std::enable_if<std::is_same<DataType, TensileComplexFloat>{} ||
+                        std::is_same<DataType, TensileComplexDouble>{}>::type* = nullptr >
+void initInput(
+    const std::string &tag,
+    unsigned dataInitType,
+    DataType **initial,
+    size_t     maxSize,
+    InitOp     initOp)
+{
+  if (dataInitType == 0) {
+    for (size_t i = 0; i < maxSize; i++) {
+      (*initial)[i] = tensileGetZero<DataType>(); }
+    std::cout << ".";
+  } else if (dataInitType == 1) {
+    for (size_t i = 0; i < maxSize; i++) {
+      (*initial)[i] = tensileGetOne<DataType>(); }
+    std::cout << ".";
+  } else if (dataInitType == 2) {
+    for (size_t i = 0; i < maxSize; i++) {
+      (*initial)[i] = tensileGetTypeForInt<DataType>(i); }
+    std::cout << ".";
+  } else if (dataInitType == 3) {
+    for (size_t i = 0; i < maxSize; i++) {
+      DataType v = tensileGetRandom<DataType>();
+      (*initial)[i] = v;
+    }
+    std::cout << ".";
+  } else if (dataInitType == 4) {
+    for (size_t i = 0; i < maxSize; i++) {
+      (*initial)[i] = tensileGetNaN<DataType>(); }
+    std::cout << ".";
+  } else if (dataInitType == 5) {
+    // Will initialize later for each matrix dim:
+    specializeAB = true;
+  } else if (dataInitType == 6) {
+    for (size_t i = 0; i < maxSize; i++) {
+      DataType v = tensileGetTrig<DataType>(i);   // initialize with sin to get value between -1 and 1.
+      (*initial)[i] = v;
+    }
+    std::cout << ".";
+  } else {
+    std::cout << "FATAL ERROR: Bad " << tag << " = " << dataInitType << "\n";
+    exit(0);
+  }
+}
 /*******************************************************************************
  * initialize data
  ******************************************************************************/

--- a/Tensile/Source/MathTemplates.cpp
+++ b/Tensile/Source/MathTemplates.cpp
@@ -204,6 +204,14 @@ template< >
 TensileHalf tensileMultiply( TensileHalf a, TensileHalf b ) {
   return a*b;
 }
+template< >
+float tensileMultiply( TensileHalf a, TensileHalf b ) {
+  return a*b;
+}
+template< >
+float tensileMultiply( TensileHalf a, float b ) {
+  return ((float)a) * b;
+}
 #endif
 // single
 template< >
@@ -256,6 +264,14 @@ float tensileMultiply( tensile_bfloat16 a, float b ) {
 
 // complex single
 template< >
+float tensileMultiply( TensileComplexFloat a, TensileComplexFloat b ) {
+  return 0.0f;
+}
+template< >
+float tensileMultiply( TensileComplexFloat a, float b ) {
+  return 0.0f;
+}
+template< >
 TensileComplexFloat tensileMultiply( TensileComplexFloat a, TensileComplexFloat b ) {
   TensileComplexFloat c;
   TENSILEREAL(c) = TENSILEREAL(a)*TENSILEREAL(b) - TENSILECOMP(a)*TENSILECOMP(b);
@@ -263,6 +279,14 @@ TensileComplexFloat tensileMultiply( TensileComplexFloat a, TensileComplexFloat 
   return c;
 }
 // complex double
+template< >
+float tensileMultiply( TensileComplexDouble a, TensileComplexDouble b ) {
+  return 0.0f;
+}
+template< >
+float tensileMultiply( TensileComplexDouble a, float b ) {
+  return 0.0f;
+}
 template< >
 TensileComplexDouble tensileMultiply( TensileComplexDouble a, TensileComplexDouble b ) {
   TensileComplexDouble c;
@@ -281,6 +305,10 @@ TensileComplexDouble tensileMultiply( TensileComplexDouble a, TensileComplexDoub
 template< >
 TensileHalf tensileAdd( TensileHalf a, TensileHalf b ) {
   return a+b;
+}
+template< >
+float tensileAdd( TensileHalf a, float b ) {
+  return (float)a+b;
 }
 #endif
 template< >
@@ -315,6 +343,11 @@ TensileComplexFloat tensileAdd( TensileComplexFloat a, TensileComplexFloat b ) {
   TENSILECOMP(c) = TENSILECOMP(a)+TENSILECOMP(b);
   return c;
 }
+template< >
+float tensileAdd( TensileComplexFloat a, float b ) {
+  return 0.0f;
+}
+
 // complex double
 template< >
 TensileComplexDouble tensileAdd( TensileComplexDouble a, TensileComplexDouble b ) {
@@ -322,6 +355,10 @@ TensileComplexDouble tensileAdd( TensileComplexDouble a, TensileComplexDouble b 
   TENSILEREAL(c) = TENSILEREAL(a)+TENSILEREAL(b);
   TENSILECOMP(c) = TENSILECOMP(a)+TENSILECOMP(b);
   return c;
+}
+template< >
+float tensileAdd( TensileComplexDouble a, float b ) {
+  return 0.0f;
 }
 
 /*******************************************************************************

--- a/Tensile/Source/MathTemplates.h
+++ b/Tensile/Source/MathTemplates.h
@@ -81,8 +81,8 @@ Type_return tensileMultiply( Type_a a, Type_b b );
 /*******************************************************************************
  * Add Templates
  ******************************************************************************/
-template< typename Type >
-Type tensileAdd( Type a, Type b );
+template< typename Type_return, typename Type_a, typename Type_b >
+Type_return tensileAdd( Type_a a, Type_b b );
 
 
 /*******************************************************************************

--- a/Tensile/Source/TensileTypes.h
+++ b/Tensile/Source/TensileTypes.h
@@ -50,6 +50,23 @@
 #define TensileComplexFloat float2
 #define TensileComplexDouble double2
 #define TensileHalf _Float16
+
+inline std::ostream& operator<<(std::ostream& os, const TensileComplexFloat& dt)
+{
+   if(dt.y >= 0)
+       os << dt.x << "+"<< dt.y << "i";
+   else
+       os << dt.x << dt.y << "i";
+   return os;
+}
+inline std::ostream& operator<<(std::ostream& os, const TensileComplexDouble& dt)
+{
+   if(dt.y >= 0)
+       os << dt.x << "+"<< dt.y << "i";
+   else
+       os << dt.x << dt.y << "i";
+   return os;
+}
 inline std::ostream& operator<<(std::ostream& os, const _Float16& dt)
 {
    os << (float)(dt);


### PR DESCRIPTION
This PR complete the cgemm and zgemm by hip solutions. 

Due to compile issue on HIP header, we can't compile pass with ROCm 2.5 (ROCm 2.4 is fine).
There has JIRA ticket (http://ontrack-internal.amd.com/browse/SWDEV-194263) for it. 
We hope that we can go thought code review before compile issue is fixed.

