### PR TITLE
add client and tuning updates for tile aware selection

### DIFF
--- a/Tensile/BenchmarkStructs.py
+++ b/Tensile/BenchmarkStructs.py
@@ -26,7 +26,7 @@ from .Common import print1, print2, printWarning, defaultSolution, \
     defaultBenchmarkCommonParameters, hasParam, \
     defaultBenchmarkJoinParameters, getParamValues, defaultForkParameters, \
     defaultBenchmarkForkParameters, defaultJoinParameters, printExit, \
-    validParameters
+    validParameters, defaultSolutionSummationSizes
 from .SolutionStructs import Solution, ProblemType, ProblemSizes
 
 class BenchmarkProcess:
@@ -77,6 +77,7 @@ class BenchmarkProcess:
     self.benchmarkSteps = []
     self.hardcodedParameters = [{}]
     self.singleValueParameters = {}
+    self.solutionSummationSizes = []
 
     # (I)
     self.fillInMissingStepsWithDefaults(self.isBatched, problemSizeGroupConfig)
@@ -99,6 +100,7 @@ class BenchmarkProcess:
     print2("####################################################################")
     print2("")
 
+    self.solutionSummationSizes = defaultSolutionSummationSizes
     ############################################################################
     # (I-0) get 6 phases from config
     configBenchmarkCommonParameters = config["BenchmarkCommonParameters"] \
@@ -495,17 +497,20 @@ class BenchmarkProcess:
     print2("####################################################################")
     print1("# Benchmark Final")
     for problemSizesDict in self.benchmarkFinalParameters:
-      problemSizes = problemSizesDict["ProblemSizes"]
-      self.currentProblemSizes = ProblemSizes(self.problemType, problemSizes)
-      currentBenchmarkParameters = {}
-      benchmarkStep = BenchmarkStep(
-          self.hardcodedParameters,
-          currentBenchmarkParameters,
-          self.initialSolutionParameters,
-          self.currentProblemSizes,
-          self.benchmarkStepIdx )
-      self.benchmarkSteps.append(benchmarkStep)
-      self.benchmarkStepIdx+=1
+      if "SolutionSummationSizes" in problemSizesDict:
+        self.solutionSummationSizes = problemSizesDict["SolutionSummationSizes"]
+      else:  
+        problemSizes = problemSizesDict["ProblemSizes"]
+        self.currentProblemSizes = ProblemSizes(self.problemType, problemSizes)
+        currentBenchmarkParameters = {}
+        benchmarkStep = BenchmarkStep(
+            self.hardcodedParameters,
+            currentBenchmarkParameters,
+            self.initialSolutionParameters,
+            self.currentProblemSizes,
+            self.benchmarkStepIdx )
+        self.benchmarkSteps.append(benchmarkStep)
+        self.benchmarkStepIdx+=1
 
 
   ##############################################################################

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -653,9 +653,10 @@ validParameters = {
     "ISA":                        validISA,       # arch for assembly kernels
 
     # Replaces assembly kernels if they are found in the directory Tensile/Tensile/ReplacementKernels
-    "ReplacementKernel":          [False, True],
-
+    "ReplacementKernel":          [False, True]
     }
+
+
 # same parameter for all solution b/c depends only on compiler
 defaultBenchmarkCommonParameters = [
     {"LoopDoWhile":               [ False ] },
@@ -737,7 +738,7 @@ defaultBenchmarkCommonParameters = [
     {"NonTemporalC":              [ 0 ] },
     {"NonTemporalA":              [ 0 ] },
     {"NonTemporalB":              [ 0 ] },
-    {"ReplacementKernel":         [ False ] },
+    {"ReplacementKernel":         [ False ] }
     ]
 # benchmark these solution independently
 defaultForkParameters = []
@@ -785,14 +786,21 @@ defaultProblemType = {
 
     # for LD description
     "NumIndicesLD":            4,
-    "IndexAssignmentsLD":       [3, 4, 5, 6]      # order is LDD, LDC, LDA, LDB
+    "IndexAssignmentsLD":       [3, 4, 5, 6],      # order is LDD, LDC, LDA, LDB
+
+    # Tile aware solution selection
+    "TileAwareSelection":       False
     }
+
 defaultProblemSizes = [{"Range": [ [2880], 0, 0 ]}]
 defaultBenchmarkFinalProblemSizes = [{"Range": [
     [64, 64, 64, 512], 0, 0 ]}]
 defaultBatchedProblemSizes = [{"Range": [ [2880], 0, [1], 0 ]}]
 defaultBatchedBenchmarkFinalProblemSizes = [{"Range": [
     [64, 64, 64, 512], 0, [1], 0 ]}]
+
+
+defaultSolutionSummationSizes = [32,64,96,128,256,512,1024,2048,4096,8192,16192]
 
 
 ################################################################################

--- a/Tensile/Contractions.py
+++ b/Tensile/Contractions.py
@@ -274,12 +274,14 @@ class Solution:
                 'sizeMapping',
                 'debugKernel',
                 'info',
-                'index']
+                'index',
+                'ideals']
     HiddenKeys = ['originalSolution']
 
     @classmethod
-    def FromOriginalState(cls, d, deviceInfo):
+    def FromOriginalState(cls, d, deviceInfo, idealPerformance = None):
         rv = cls()
+
 
         if 'SolutionNameMin' in d:
             rv.name = d['SolutionNameMin']
@@ -298,6 +300,7 @@ class Solution:
         rv.info = cls.ReadOriginalInfo(d)
 
         rv.sizeMapping = SizeMapping.FromOriginalState(d)
+        rv.ideals = idealPerformance
 
         if d['KernelLanguage'] == 'Assembly':
             d['ISA'] = tuple(map(int,deviceInfo[1][3:6]))
@@ -322,6 +325,7 @@ class Solution:
         self.debugKernel = False
         self.info = {}
         self.index = None
+        self.ideals = None
 
         for key, value in kwargs:
             if key not in Solution.StateKeys and key not in Solution.HiddenKeys:

--- a/Tensile/LibraryLogic.py
+++ b/Tensile/LibraryLogic.py
@@ -22,6 +22,7 @@
 from .Common import print1, print2, HR, printExit, defaultAnalysisParameters, globalParameters, pushWorkingPath, popWorkingPath, assignParameterWithDefault, startTime, ProgressBar, printWarning
 from .SolutionStructs import Solution
 from . import YAMLIO
+from . import SolutionSelectionLibrary
 
 from copy import deepcopy
 from sys import stdout
@@ -1388,6 +1389,7 @@ def main(  config ):
           fileName))[0]
       dataFileName = fileBase + ".csv"
       solutionsFileName = fileBase + ".yaml"
+      selectionFileName = fileBase + ".gsp"
       if not os.path.exists(dataFileName):
         printExit("%s doesn't exist for %s" % (dataFileName, fileBase) )
       if not os.path.exists(solutionsFileName):
@@ -1399,13 +1401,18 @@ def main(  config ):
       if problemType not in problemTypes:
         problemTypes[problemType] = []
       problemTypes[problemType].append( (problemSizes, \
-          dataFileName, solutionsFileName) )
+          dataFileName, solutionsFileName, selectionFileName) )
       #if problemTypeTuple not in problemTypeTuples:
       #  problemTypeTuples.append(problemTypeTuple)
 
   for problemType in problemTypes:
     logicTuple = analyzeProblemType( problemType, problemTypes[problemType], \
         analysisParameters )
+    enableTileSelection = problemType["TileAwareSelection"]
+    if enableTileSelection:
+      SolutionSelectionLibrary.main( problemTypes[problemType], analysisParameters["ScheduleName"], \
+        analysisParameters["ArchitectureName"], \
+        analysisParameters["DeviceNames"], logicTuple )
     YAMLIO.writeLibraryLogicForSchedule(globalParameters["WorkingPath"], \
         analysisParameters["ScheduleName"], analysisParameters["ArchitectureName"], \
         analysisParameters["DeviceNames"], logicTuple)

--- a/Tensile/SolutionSelectionLibrary.py
+++ b/Tensile/SolutionSelectionLibrary.py
@@ -1,0 +1,180 @@
+################################################################################
+# Copyright (C) 2016-2019 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell cop-
+# ies of the Software, and to permit persons to whom the Software is furnished
+# to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM-
+# PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNE-
+# CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+################################################################################
+
+from .Common import print1, print2, HR, printExit, defaultAnalysisParameters, globalParameters, pushWorkingPath, popWorkingPath, assignParameterWithDefault, startTime, ProgressBar, printWarning
+from .SolutionStructs import Solution
+from . import SolutionLibrary
+from . import Utils
+from . import YAMLIO
+from . import __version__
+
+from copy import deepcopy
+from sys import stdout
+import array
+import csv
+import os
+import time
+
+try:
+  import yaml
+except ImportError:
+  printExit("You must install PyYAML to use Tensile (to parse config files). See http://pyyaml.org/wiki/PyYAML for installation instructions.")
+
+def getSummationKeys(header):
+  keys=[]
+  for i in range(7, len(header)):
+    keystr = header[i].split("=")[1].strip()
+    key = int(keystr)
+    keys.append(key)
+  return keys
+
+def makeKey(row):
+  key=row[3]
+  for i in range(4, 7):
+    key += "_%s" % row[i].strip()
+  return key
+
+def writeSelectionLibraryForSchedule( filePath, schedulePrefix, architectureName, deviceNames, \
+    logicTuple, solutionIdx, validSolutionsNames, solutionData):
+  problemType   = deepcopy(logicTuple[0])
+  solutions     = deepcopy(logicTuple[1])
+  indexOrder    = deepcopy(logicTuple[2])
+  exactLogic    = deepcopy(logicTuple[3])
+  rangeLogic    = deepcopy(logicTuple[4])
+
+  filename = os.path.join(filePath, "%s_%s_TensileLibrary.ylib" \
+      % (schedulePrefix, str(problemType)))
+  print2("# writeLogic( %s )" % ( filename ))
+
+  data = []
+  # Tensile version
+  data.append({"MinimumRequiredVersion":__version__})
+  # schedule name
+  data.append(schedulePrefix)     # change from Tensile to vega10
+  data.append(architectureName)
+  # schedule device names
+  data.append(deviceNames)
+  # problem type
+  problemTypeState = problemType.state
+  problemTypeState["DataType"] = \
+      problemTypeState["DataType"].value
+  problemTypeState["DestDataType"] = \
+      problemTypeState["DestDataType"].value
+  problemTypeState["ComputeDataType"] = \
+      problemTypeState["ComputeDataType"].value
+  data.append(problemTypeState)
+  # solutions
+  solutionList = []
+  for solution in solutions:
+    solutionState = solution.getAttributes()
+    solutionState["ProblemType"] = solutionState["ProblemType"].state
+    solutionState["ProblemType"]["DataType"] = \
+        solutionState["ProblemType"]["DataType"].value
+    solutionState["ProblemType"]["DestDataType"] = \
+        solutionState["ProblemType"]["DestDataType"].value
+    solutionState["ProblemType"]["ComputeDataType"] = \
+        solutionState["ProblemType"]["ComputeDataType"].value
+    solutionList.append(solutionState)
+  data.append(solutionList)
+  # index order
+  data.append(indexOrder)
+
+  # exactLogic
+  exactLogicList = []
+  for key in exactLogic:
+    exactLogicList.append([list(key), exactLogic[key]])
+  data.append(exactLogicList)
+
+  # rangeLogic
+  data.append(rangeLogic)
+
+  data.append(solutionIdx)
+  data.append(validSolutionsNames)
+  data.append(solutionData)
+
+  newLibrary = SolutionLibrary.MasterSolutionLibrary.FromOriginalState(data, libraryOrder = ['Hardware', 'OperationIdentifier', 'Predicates', 'Matching'])
+  newLibrary.applyNaming()
+  YAMLIO.write(filename, Utils.state(newLibrary))
+
+  
+################################################################################
+################################################################################
+###
+###   Main
+###
+################################################################################
+################################################################################
+def main(problemSizeGroups , schedulePrefix, architectureName, deviceNames, logicTuple ):
+
+  performanceMap = {}
+  solutionData = {}
+  solutionIdx = {}
+  for problemSizeGroup in problemSizeGroups:
+    solutionsFileName = problemSizeGroup[2]
+    selectionFileName = problemSizeGroup[3]
+
+    if not os.path.exists(solutionsFileName):
+      printExit("%s doesn't exist for %s" % (solutionsFileName, fileBase))
+
+    if not os.path.exists(selectionFileName):
+      printExit("%s doesn't exist for %s" % (selectionFileName, fileBase))
+
+    (problemSizes, solutions) = YAMLIO.readSolutions(solutionsFileName)
+
+    if len(solutions) == 0:
+      printExit("%s doesn't contains any solutions." % (solutionsFileName) )
+
+    selectionFile = open(selectionFileName, "r") 
+    selectionFileCSV = csv.reader(selectionFile)
+
+    rowIdx = 0
+    summationKeys = None 
+    for row in selectionFileCSV:
+      if rowIdx == 0:
+        summationKeys = getSummationKeys(row)
+      else:
+        if len(row) > 0:
+          keyBase = makeKey(row)
+          idx=7
+          name = row[0]
+          solutionIdx[name] = rowIdx
+          perfData = {}
+          for summationKey in summationKeys:
+            key = "%s_%s" % (keyBase,summationKey)
+            value = float(row[idx])
+            perfData[summationKey] = value
+            idx+=1
+            if key not in performanceMap:
+              performanceMap[key] = (name,value)
+            else:
+              (name1,value1) = performanceMap[key]
+              if value > value1:
+                performanceMap[key] = (name,value)
+          solutionData[name]=perfData
+      rowIdx+=1
+  validSolutionsNames = set([])
+  for key in performanceMap:
+    (name,_) = performanceMap[key]      
+    validSolutionsNames.add(name)
+  writeSelectionLibraryForSchedule(globalParameters["WorkingPath"], schedulePrefix, architectureName, \
+    deviceNames, logicTuple, solutionIdx, validSolutionsNames, solutionData)
+
+

--- a/Tensile/Source/Client.cpp
+++ b/Tensile/Source/Client.cpp
@@ -78,6 +78,17 @@ int main( int argc, char *argv[] ) {
           deviceOnHostD, deviceOnHostC);
 #endif
 
+#if Tensile_CLIENT_BENCHMARK
+#define TENSILE_CLIENT_CALL_BENCHMARK_SOLUTIONS                         \
+    if (runBenchmarkSolutions != 0) {                                   \
+        benchmarkSolutions(initialD, initialC, initialA,                \
+              initialB, alpha, beta, referenceD, referenceC,            \
+              deviceOnHostD, deviceOnHostC);                            \
+    }
+#else
+#define TENSILE_CLIENT_CALL_BENCHMARK_SOLUTIONS
+#endif
+
 #define TENSILE_CLIENT_CALL_SETUP(Ti, To, Tc)                           \
     To *initialD;                                                       \
     To *initialC;                                                       \
@@ -91,6 +102,9 @@ int main( int argc, char *argv[] ) {
     To *deviceOnHostC;                                                  \
     initData(&initialD, &initialC, &initialA, &initialB, &alpha, &beta, \
         &referenceD, &referenceC, &deviceOnHostD, &deviceOnHostC);      \
+                                                                        \
+    TENSILE_CLIENT_CALL_BENCHMARK_SOLUTIONS                             \
+                                                                        \
     for (unsigned int i = 0; i < numBenchmarks; i++) {                  \
       TENSILE_CLIENT_CALL_PROBLEM                                       \
     }                                                                   \
@@ -173,7 +187,6 @@ int main( int argc, char *argv[] ) {
   if (invalids) {
 #if Tensile_CLIENT_BENCHMARK
     printf("\nInvalid Solutions: %u/%u\n", static_cast<unsigned int>(invalidSolutions.size()), numSolutions);
-    // for (unsigned int i = 0; i < numInvalidSolutions; i++) {
     for (std::set<unsigned int>::iterator i = invalidSolutions.begin(); i != invalidSolutions.end(); i++) {
       unsigned int invalidSolutionIdx = *i;
       printf("[%2u] %s\n", invalidSolutionIdx, solutions[invalidSolutionIdx]._name);

--- a/Tensile/Source/Client.h
+++ b/Tensile/Source/Client.h
@@ -63,6 +63,7 @@ unsigned int sleepPercent;
 #if Tensile_CLIENT_BENCHMARK
 unsigned int solutionStartIdx;
 unsigned int numSolutions;
+unsigned int runBenchmarkSolutions = 0;
 #endif
 
 // benchmark parameters commandline strings
@@ -96,6 +97,7 @@ const std::string keyStrideD = "--stride_d";
 #if Tensile_CLIENT_BENCHMARK
 const std::string keySolutionStartIdx = "--solution-start-idx";
 const std::string keyNumSolutions = "--num-solutions";
+const std::string keyBenchmarkSolutions = "--benchmark-solutions";
 #endif
 
 // benchmark parameters default values
@@ -127,6 +129,7 @@ unsigned int strideD = std::numeric_limits<unsigned int>::max();
 #if Tensile_CLIENT_BENCHMARK
 const unsigned int defaultSolutionStartIdx = 0;
 const unsigned int defaultNumSolutions = maxNumSolutions;
+const unsigned int defaultBenchmarkSolutions = 0;
 #endif
 
 // benchmark parameters for library client
@@ -138,7 +141,10 @@ const unsigned int defaultSize = 128;
 #endif
 
 #if Tensile_CLIENT_BENCHMARK
+const size_t solutionKeySize = 4;
 std::set<unsigned int> invalidSolutions;
+std::map<std::vector<unsigned int>, std::set<std::pair<unsigned int,double>>> solutionBenchmarks;
+std::map<std::vector<unsigned int>, std::pair<unsigned int,double>> solutionMaxPeformance;
 #endif
 
 int expectedClockRate; // MHz
@@ -213,6 +219,30 @@ void copyData(
 #endif
 }
 
+#if Tensile_CLIENT_BENCHMARK
+std::vector<unsigned int> makeKeyForSolution(unsigned int solutionIdx, unsigned int summationSize) {
+    const unsigned int *metaData = solutionMetaData[solutionIdx];
+    unsigned int transformA = metaData[6];
+    unsigned int transformB = metaData[7];
+    unsigned int mt0 = metaData[0];
+    unsigned int mt1 = metaData[1];
+    unsigned int gsu = metaData[8];
+    unsigned int lsu = metaData[9];
+
+    size_t key_size = 7;    
+    std::vector<unsigned int> key = std::vector<unsigned int>(key_size);
+    key[0] = mt0;
+    key[1] = mt1;
+    key[2] = gsu;
+    key[3] = lsu;
+    key[4] = transformA;
+    key[5] = transformB; 
+    key[6] = summationSize;
+
+    return key;
+}
+#endif
+
 // Specialize the AB data for the problem size.
 // This is used with the SerialInK data init type - each matrix needs different data.
 // Since this takes extra time, it is recommended to use this data init mode only
@@ -236,7 +266,6 @@ void specializeData(
   if (db & 0x1) {
     td.print();
   }
-
 
 
   // Bucketize the sizes for the free and bound (summation) indices:
@@ -798,6 +827,379 @@ bool callLibrary(
 } // callLibrary
 #endif
 
+
+#if Tensile_CLIENT_BENCHMARK
+template<typename DataType, typename DestDataType, typename ComputeDataType>
+bool benchmarkAllSolutions(
+    DestDataType *initialD,
+    DestDataType *initialC,
+    DataType *initialA,
+    DataType *initialB,
+    ComputeDataType alpha,
+    ComputeDataType beta,
+    DestDataType *referenceD,
+    DestDataType *referenceC,
+    DestDataType *deviceOnHostD,
+    DestDataType *deviceOnHostC,
+    double *problem_gpu_time_ms) {
+
+  bool returnInvalids = false;
+
+#if Tensile_RUNTIME_LANGUAGE_OCL
+    cl_event l_outputEvent[numSyncsPerBenchmark][numEnqueuesPerSync];
+#else
+    hipEvent_t l_eventStart[numSyncsPerBenchmark][numEnqueuesPerSync];
+    hipEvent_t l_eventStop[numSyncsPerBenchmark][numEnqueuesPerSync];
+    for (unsigned int syncIdx = 0; syncIdx < numSyncsPerBenchmark; syncIdx++) {
+      for (unsigned int enqIdx = 0; enqIdx < numEnqueuesPerSync; enqIdx++) {
+        hipEventCreateWithFlags( &l_eventStart[syncIdx][enqIdx],
+            hipEventDefault );
+        hipEventCreateWithFlags( &l_eventStop[syncIdx][enqIdx],
+            hipEventDefault );
+      }
+    }
+#endif
+
+
+  fastestGFlops = 0;
+  *problem_gpu_time_ms = 0;
+
+  std::ofstream gFile;
+
+  gFile.open(granularityFileName);
+  gFile << "Solution, M, N, MT0, MT1, LSU, GSU";
+  for (unsigned int summationIdx = 0; summationIdx < numSummations; summationIdx ++) {
+    gFile << ", K=" << summations[summationIdx];
+  }
+  gFile << std::endl;
+
+  unsigned int sizes[8];
+
+  for (unsigned int solutionIdx = 0; solutionIdx < numSolutions; solutionIdx ++) {
+
+    const unsigned int *metaData = solutionMetaData[solutionIdx];
+    unsigned int transformA = metaData[6];
+    unsigned int transformB = metaData[7];
+    unsigned int mt0 = metaData[0];
+    unsigned int mt1 = metaData[1];
+    unsigned int m = 36*mt0;
+    unsigned int n = 36*mt1;
+    unsigned int gsu = metaData[8];
+    unsigned int lsu = metaData[9];
+
+    gFile << solutions[solutionIdx]._name;
+    gFile << ", " << m;
+    gFile << ", " << n;
+    gFile << ", " << mt0;
+    gFile << ", " << mt1;
+    gFile << ", " << lsu;
+    gFile << ", " << gsu;
+
+    std::cout << "Performace for solution: " << solutions[solutionIdx]._name << std::endl;
+    for (unsigned int summationIdx = 0; summationIdx < numSummations; summationIdx ++) {
+
+      unsigned int sizes[8];
+      unsigned int k = summations[summationIdx];
+
+      sizes[0] = m;
+      sizes[1] = n;
+      sizes[2] = 1;
+      sizes[3] = k;
+      sizes[indexAssignmentsLD[0]] = m;
+      sizes[indexAssignmentsLD[1]] = m; 
+
+      
+      if (transformA == 0) {
+        sizes[indexAssignmentsLD[2]] = m;
+      } else {
+        sizes[indexAssignmentsLD[2]] = k;
+      }
+
+      if (transformB == 0) {
+        sizes[indexAssignmentsLD[3]] = k;
+      } else {
+        sizes[indexAssignmentsLD[3]] = n;
+      }
+
+      if (numIndicesLD == 4)
+      {
+        ldd = sizes[indexAssignmentsLD[0]];
+        ldc = sizes[indexAssignmentsLD[1]];
+        lda = sizes[indexAssignmentsLD[2]];
+        ldb = sizes[indexAssignmentsLD[3]];
+      }
+
+      // Compute stridesC for validation
+      // strideC accounts for memory strides (ie ldc)
+      // while elementStride is a pure element space
+      std::vector<unsigned int> strides(totalIndices[problemTypeIdx]);
+      std::vector<unsigned int> stridesD(numIndicesC[problemTypeIdx]);
+      std::vector<unsigned int> stridesC(numIndicesC[problemTypeIdx]);
+      std::vector<unsigned int> elementStrides(numIndicesC[problemTypeIdx]);
+
+      for (unsigned int i = 0; i < totalIndices[problemTypeIdx]; i++) {
+        strides[i] = std::max(minStrides[i], sizes[i]);
+      }
+      elementStrides[0] = 1;
+      stridesD[0] = 1;
+      stridesC[0] = 1;
+
+      elementStrides[1] = sizes[0];
+      stridesD[1] = (ldd != std::numeric_limits<unsigned int>::max()) ? ldd : strides[0];
+      stridesC[1] = (ldc != std::numeric_limits<unsigned int>::max()) ? ldc : strides[0];
+
+      for (unsigned int i = 2; i < numIndicesC[problemTypeIdx]; i++) {
+        elementStrides[i] = elementStrides[i-1] * sizes[i-1];
+        stridesD[i] = stridesD[i-1] * strides[i-1];
+        stridesC[i] = stridesC[i-1] * strides[i-1];
+      }
+
+      bool returnInvalids = false;
+      size_t currentElementSizeC = elementStrides[numIndicesC[problemTypeIdx]-1];
+      size_t currentMemorySizeD = stridesD[numIndicesC[problemTypeIdx]-1];
+      size_t currentMemorySizeC = stridesC[numIndicesC[problemTypeIdx]-1];
+
+      size_t sizeToCopyD = currentMemorySizeD*bytesPerElement[dataTypeIdx];
+      size_t sizeToCopyC = currentMemorySizeC*bytesPerElement[dataTypeIdx];
+
+      size_t totalFlops = numFlopsPerMac[0];
+      for (unsigned int i = 0; i < totalIndices[0]; i++) {
+        totalFlops *= sizes[i]; }
+
+      bool solutionIsValid = true;
+
+      // validate solution
+      size_t numInvalids = 0;
+      size_t numChecked = 0;
+      TensileStatus callStatus = tensileStatusSuccess;
+
+      // time solution
+      timer.start();
+        // device stats
+      unsigned long long avgCoreClock = 0;
+      unsigned long long avgMemClock = 0;
+      double avgTemp = 0;
+      unsigned long long avgFanSpeed = 0;
+      for (unsigned int syncIdx = 0; syncIdx < numSyncsPerBenchmark; syncIdx++) {
+        unsigned long long syncCoreClock = 0;
+        unsigned long long syncMemClock = 0;
+        double syncTemp = 0;
+        unsigned long long syncFanSpeed = 0;
+        for (unsigned int enqIdx = 0; enqIdx < numEnqueuesPerSync; enqIdx++) {
+#if Tensile_RUNTIME_LANGUAGE_OCL
+          TensileStatus status = generatedCallToSolution( solutions[solutionIdx], &solutionLocks[solutionIdx],
+              sizes, minStrides, lda, ldb, ldc, ldd, strideA, strideB, strideC, strideD, alpha, beta,
+              0, NULL, &l_outputEvent[syncIdx][enqIdx] );
+#else
+          TensileStatus status = generatedCallToSolution( solutions[solutionIdx], &solutionLocks[solutionIdx],
+              sizes, minStrides, lda, ldb, ldc, ldd, strideA, strideB, strideC, strideD, alpha, beta,
+              numEnqueuesPerSync, &l_eventStart[syncIdx][enqIdx],
+              &l_eventStop[syncIdx][enqIdx] );
+
+          if(status == hipErrorFileNotFound)
+          {
+              printf("Kernel file not found; exiting.\n");
+              exit(1);
+          }
+#endif
+          if (status != tensileStatusSuccess) {
+            solutionIsValid = false;
+          }
+
+        }
+        // sync
+#if Tensile_RUNTIME_LANGUAGE_OCL
+        status = clFinish(stream);
+#else
+        unsigned int numDeviceStatsQueries = 0;
+        do { // device stats
+          int currentCoreClock = tensileGetDeviceCoreClock(0);
+          int currentMemClock = tensileGetDeviceMemClock(0);
+          float currentTemp = tensileGetDeviceTemp(0);
+          int currentFanSpeed = tensileGetDeviceFanSpeed(0);
+          //std::cout << "clock: " << currentCoreClock << " Mhz" << std::endl;
+          syncCoreClock += currentCoreClock;
+          syncMemClock += currentMemClock;
+          syncTemp += currentTemp;
+          syncFanSpeed += currentFanSpeed;
+          numDeviceStatsQueries++;
+        } while (hipEventQuery(l_eventStop[syncIdx][numEnqueuesPerSync-1]) != hipSuccess);
+        syncCoreClock /= numDeviceStatsQueries;
+        syncMemClock /= numDeviceStatsQueries;
+        syncTemp /= numDeviceStatsQueries;
+        syncFanSpeed /= numDeviceStatsQueries;
+
+        avgCoreClock += syncCoreClock;
+        avgMemClock += syncMemClock;
+        avgTemp += syncTemp;
+        avgFanSpeed += syncFanSpeed;
+#endif
+        tensileStatusCheck(status);
+      } // sync loop
+
+      double timeNs = 0.0;
+#if Tensile_RUNTIME_LANGUAGE_OCL
+      if (useGPUTimer) {
+        // Loop through the multi-dimensional event array and collect kernel performance data
+        // Release events when done with them
+        cl_ulong kernel_time_sum = 0;
+        for (auto& event_array : l_outputEvent) {
+          for (auto event : event_array) {
+            // getEventDeltaTime returns unsigned long in nano-seconds on opencl
+            kernel_time_sum += getEventDeltaTime(event);
+          }
+        }
+        timeNs = static_cast<double>(kernel_time_sum);
+      } else {
+        timeNs = timer.elapsed_ns();
+      }
+#else
+      if (useGPUTimer) {
+        // Loop through the event array and collect kernel performance data
+        // Release events when done with them
+        float kernel_time_sum = 0;
+        for (unsigned int syncIdx = 0; syncIdx < numSyncsPerBenchmark; syncIdx++){
+          for (unsigned int enqIdx = 0; enqIdx < numEnqueuesPerSync; enqIdx++) {
+            // getEventDeltaTime returns unsigned long in milli-seconds on hip
+            float kernel_time = getEventDeltaTime(l_eventStart[syncIdx][enqIdx],
+                l_eventStop[syncIdx][enqIdx] );
+            kernel_time_sum += kernel_time;
+          }
+        }
+        timeNs = static_cast<double>(kernel_time_sum)
+          * TensileTimer::million;  // convert to nano-seconds
+      } else {
+        timeNs = timer.elapsed_ns();
+      }
+
+#endif
+      if (sleepPercent) {
+        unsigned int sleepMicroSeconds = (timeNs*10*sleepPercent)/1e6;
+        usleep(sleepMicroSeconds);
+      }
+
+      *problem_gpu_time_ms += timeNs/1e6;
+
+      timeNs /= (numSyncsPerBenchmark * numEnqueuesPerSync);
+      // device status
+      avgCoreClock /= numSyncsPerBenchmark;
+      avgMemClock /= numSyncsPerBenchmark;
+      avgTemp /= numSyncsPerBenchmark;
+      avgFanSpeed /= numSyncsPerBenchmark;
+
+      float perfScaling = 1.f;
+      double gflops = solutionIsValid ? perfScaling * totalFlops / timeNs : 0;
+      bool newFastest = false;
+      if (gflops > fastestGFlops) {
+        fastestGFlops = gflops;
+        fastestIdx = solutionIdx;
+        newFastest = true;
+      }
+
+      std::cout << "Solution Size: " << sizes[0];
+      for (unsigned int i = 1; i < totalIndices[problemTypeIdx]+numIndicesLD; i++) {
+        std::cout << ", " << sizes[i];
+      }
+      std::cout << std::endl;
+
+      {
+        std::cout << std::setw(10) << std::fixed << std::setprecision(3)
+            << gflops*perfScaling << ", "
+            << std::setw(10) << std::fixed << std::setprecision(3)
+            << gflops << ", "
+            << std::setw(9) << std::fixed << std::setprecision(3)
+            << timeNs * TensileTimer::reciprical_million << ", ";
+
+        if (callStatus == tensileStatusSuccess) {
+          if (numElementsToValidate) {
+            std::cout << (numInvalids ? "FAILED" : "PASSED")
+              << ": " << (numChecked-numInvalids) << "/" << numChecked << ", ";
+          } else {
+            std::cout << "NO_CHECK, "; // did not validate any results, may work or maybe not
+          }
+        } else if (callStatus == tensileStatusAssertFailure) {
+          std::cout << "DID_NOT_SATISFY_ASSERTS, ";
+        } else {
+          std::cout << "INVALID_KERNEL, "; // launch function returned error?
+        }
+
+        // device stats
+        std::cout << avgCoreClock << ", ";
+        std::cout << avgMemClock << ", ";
+        std::cout << avgTemp << ", ";
+        std::cout << avgFanSpeed << ", ";
+
+        std::cout << solutionIdx << "/" << numSolutions << ", ";
+
+        struct timeval tmnow;
+        struct tm *tm;
+        gettimeofday(&tmnow, NULL); // microsecond resolution
+        tm = localtime(&tmnow.tv_sec);
+        char prev_fill = std::cout.fill('0');
+        std::cout << (tm->tm_year + 1900) << "-"
+          << std::setw(2) << (tm->tm_mon + 1) << "-"
+          << std::setw(2) << tm->tm_mday << " "
+          << std::setw(2) << tm->tm_hour << ":"
+          << std::setw(2) << tm->tm_min << ":"
+          << std::setw(2) << tm->tm_sec << "."
+          << std::setw(6) << static_cast<int>(tmnow.tv_usec) << ", ";
+        (void) std::cout.fill(prev_fill);
+
+        std::cout << std::endl;
+      }
+
+      // write results to file
+      if ((numInvalids > 0) || (callStatus != tensileStatusSuccess)) {
+        gflops = -1.0;
+        invalidSolutions.insert(solutionIdx);
+      }
+
+      gFile << ", " << gflops;
+      float granularityPerf = static_cast<float>(gflops);
+   
+      std::vector<unsigned int> key = makeKeyForSolution(solutionIdx, k);
+      std::map<std::vector<unsigned int>, std::set<std::pair<unsigned int,double>>>::iterator found;      
+      found = solutionBenchmarks.find(key);
+
+      std::pair<unsigned int,double> value = std::make_pair(solutionIdx, granularityPerf);
+      
+      if (found == solutionBenchmarks.end()) {
+          std::set<std::pair<unsigned int,double>> valueSet; 
+          valueSet.insert(value);
+          solutionBenchmarks[key] = valueSet;           
+      } else {
+          (*found).second.insert(value);
+      }
+    }
+    gFile << std::endl;
+  } // solution loop
+
+  if (useGPUTimer) {
+#if Tensile_RUNTIME_LANGUAGE_OCL
+    for (auto& event_array : l_outputEvent) {
+      for (auto event : event_array) {
+        ::clReleaseEvent(event);
+      }
+    }
+#else
+    for (unsigned int syncIdx = 0; syncIdx < numSyncsPerBenchmark; syncIdx++){
+      for (unsigned int enqIdx = 0; enqIdx < numEnqueuesPerSync; enqIdx++) {
+        ::hipEventDestroy( l_eventStart[syncIdx][enqIdx] );
+        ::hipEventDestroy( l_eventStop[syncIdx][enqIdx] );
+      }
+    }
+#endif
+
+    gFile << std::endl;
+  }
+  file << std::endl;
+
+  gFile.close();
+
+  return returnInvalids;
+} // benchmark solutions
+#endif // benchmark client
+
 /*******************************************************************************
  * benchmark all solutions for problem size
  * return true if error/invalids
@@ -977,6 +1379,8 @@ bool benchmarkAllSolutionsForSize(
   fastestGFlops = 0;
   *problem_gpu_time_ms = 0;
   for (unsigned int solutionIdx = solutionStartIdx; solutionIdx < solutionStartIdx + numSolutions; solutionIdx ++) {
+//  for (std::set<unsigned int>::iterator it=validSolutions.begin(); it!=validSolutions.end(); ++it) {
+//    unsigned int solutionIdx = *it;
     bool solutionIsValid = true;
 
     // validate solution
@@ -1312,12 +1716,9 @@ bool benchmarkAllSolutionsForSize(
 } // benchmark solutions
 #endif // benchmark client
 
-/*******************************************************************************
- * Benchmark Problem Sizes
- ******************************************************************************/
 #if Tensile_CLIENT_BENCHMARK
 template<typename DataType, typename DestDataType, typename ComputeDataType>
-bool benchmarkProblemSizes(
+bool benchmarkSolutions(
     DestDataType *initialD,
     DestDataType *initialC,
     DataType *initialA,
@@ -1331,37 +1732,21 @@ bool benchmarkProblemSizes(
   bool returnInvalids = false;
 
   // write benchmark data column headers
-  std::cout << std::endl;
-  std::cout << "Solutions: " << std::endl;
-  for (unsigned int sIdx = 0; sIdx < numSolutions; sIdx++) {
-    std::cout << "(" << sIdx << ") " << solutions[sIdx]._name << std::endl;
-  }
-  //std::cout << "ResultsFileName: " << resultsFileName << std::endl;
-  unsigned int problemIdx = 0;
-#ifdef Tensile_RESUME_BENCHMARK
-  unsigned int resultsFileLines = countFileLines(resultsFileName);
-  if(resultsFileLines < 2){
-#endif
-    file.open(resultsFileName, std::ios::trunc);
-    file << "GFlops";
-    for ( unsigned int i = 0; i < totalIndices[problemTypeIdx]; i++) {
-      file << ", Size" << indexChars[i];
-    }
-    file << ", LDD, LDC, LDA, LDB, TotalFlops";
-    for ( unsigned int s = 0; s < numSolutions; s++) {
-      file << ", " << solutions[s]._name;
-    }
-    file << std::endl;
-
-#ifdef Tensile_RESUME_BENCHMARK
-    std::cout << "Generate a new [ " << resultsFileName << " ], problemIdx start from " << problemIdx << std::endl; 
-  }
-  else{
-    problemIdx = resultsFileLines - 1;
-    file.open(resultsFileName, std::ios::app);
-    std::cout << "The file [ " << resultsFileName << " ] has already exists, problemIdx start from " << problemIdx << std::endl;
-  }
-#endif
+  //std::cout << std::endl;
+  //std::cout << "Solutions: " << std::endl;
+  //for (unsigned int sIdx = 0; sIdx < numSolutions; sIdx++) {
+  //  std::cout << "(" << sIdx << ") " << solutions[sIdx]._name << std::endl;
+  //}
+  //file.open(resultsFileName);
+  //file << "GFlops";
+  //for ( unsigned int i = 0; i < totalIndices[problemTypeIdx]; i++) {
+  //  file << ", Size" << indexChars[i];
+  //}
+  //file << ", LDD, LDC, LDA, LDB, TotalFlops";
+  //for ( unsigned int s = 0; s < numSolutions; s++) {
+  //  file << ", " << solutions[s]._name;
+  //}
+  //file << std::endl;
 
 #if Tensile_RUNTIME_LANGUAGE_OCL
   if (!numElementsToValidate) {
@@ -1382,8 +1767,133 @@ bool benchmarkProblemSizes(
   totalKernelTimer.start();
   // iterate over all problem sizes
   double gpu_time_ms = 0;
-  for (; problemIdx < numProblems; problemIdx++ ) {
 
+  {
+
+    // benchmark all solutions 
+    double problem_gpu_time_ms;
+    bool invalids = benchmarkAllSolutions( initialD, initialC,
+        initialA, initialB, alpha, beta, referenceD, referenceC, deviceOnHostD, deviceOnHostC,
+        &problem_gpu_time_ms);
+    if (invalids) returnInvalids = true;
+    gpu_time_ms += problem_gpu_time_ms;
+    //printf ("gpu_time: %6.2f ms+ %6.2fns\n", gpu_time_ms, problem_gpu_time_ms);
+
+    //std::map<std::vector<unsigned int>, std::set<std::pair<unsigned int,double>>>::iterator benchmarkIter = solutionBenchmarks.begin();
+    std::map<std::vector<unsigned int>, std::set<std::pair<unsigned int,double>>>::iterator iter;   
+
+    for (iter = solutionBenchmarks.begin(); iter != solutionBenchmarks.end(); iter++)
+    {  
+        //std::cout << "****** size ****** -> " << (*(*it).second.begin()).second << std::endl;
+
+
+        std::vector<unsigned int> key = (*iter).first;
+
+        double maxPerf = -1.0;
+        std::pair<unsigned int,double> maxPair;
+
+        std::set<std::pair<unsigned int,double>>::iterator benchmarksIter;
+        for(benchmarksIter = (*iter).second.begin(); benchmarksIter != (*iter).second.end(); benchmarksIter++) 
+        {
+            //std::cout << "*** final perf **** -> " << (*benchmarksIter).second << std::endl;
+            std::pair<unsigned int,double> myPerf = *benchmarksIter;
+            if (myPerf.second > maxPerf)
+            {
+               maxPerf = myPerf.second;
+               maxPair = myPerf;
+            }
+        }
+        solutionMaxPeformance[key] = maxPair;
+    }
+
+    //std::map<std::vector<unsigned int>, std::pair<unsigned int,double>>::iterator piter;
+    //for (piter = solutionMaxPeformance.begin(); piter != solutionMaxPeformance.end(); piter++)
+    //{
+    //   //std::vector<unsigned int> key = (*piter).first;
+    //   std::pair<unsigned int,double> value = (*piter).second;
+    //   std::cout << "**** max for key  *** -> (" << value.first << "," << value.second << ")" << std::endl; 
+    //}
+
+
+  } // for problemIdx
+  auto timeK = totalKernelTimer.elapsed_sec();
+  std::cout <<  "\nRun kernels elapsed gpu_time:" << gpu_time_ms/1000.0
+            << " secs  total_time:" << timeK << " secs "
+            << std::setprecision(2) << gpu_time_ms/timeK*(100.0/1000)
+            << "% gpu utilization\n";
+
+  //file.close();
+
+  return returnInvalids;
+} // benchmarkSolutions
+#endif // benchmark
+
+/*******************************************************************************
+ * Benchmark Problem Sizes
+ ******************************************************************************/
+#if Tensile_CLIENT_BENCHMARK
+template<typename DataType, typename DestDataType, typename ComputeDataType>
+bool benchmarkProblemSizes(
+    DestDataType *initialD,
+    DestDataType *initialC,
+    DataType *initialA,
+    DataType *initialB,
+    ComputeDataType alpha,
+    ComputeDataType beta,
+    DestDataType *referenceD,
+    DestDataType *referenceC,
+    DestDataType *deviceOnHostD,
+    DestDataType *deviceOnHostC) {
+  bool returnInvalids = false;
+
+  // write benchmark data column headers
+  std::cout << std::endl;
+  //std::cout << "Solutions: " << std::endl;
+  //for (unsigned int sIdx = 0; sIdx < numSolutions; sIdx++) {
+  //  std::cout << "(" << sIdx << ") " << solutions[sIdx]._name << std::endl;
+  //}
+
+  //std::cout << "Valid Solutions: " << std::endl;
+  //for (std::set<unsigned int>::iterator it=validSolutions.begin(); it!=validSolutions.end(); ++it) {
+  //  unsigned int sIdx = *it;
+  //  std::cout << "(" << sIdx << ") " << solutions[sIdx]._name << std::endl;
+  //}
+  //std::cout << "ResultsFileName: " << resultsFileName << std::endl;
+  file.open(resultsFileName);
+  file << "GFlops";
+  for ( unsigned int i = 0; i < totalIndices[problemTypeIdx]; i++) {
+    file << ", Size" << indexChars[i];
+  }
+  file << ", LDD, LDC, LDA, LDB, TotalFlops";
+  for ( unsigned int s = 0; s < numSolutions; s++) {
+    file << ", " << solutions[s]._name;
+  }
+  file << std::endl;
+
+//#if Tensile_RUNTIME_LANGUAGE_OCL
+  //if (!numElementsToValidate) {
+  //  std::cout << "Pre-compiling " << numSolutions << " OpenCL kernels";
+    //for (unsigned int sIdx = 0; sIdx < numSolutions; sIdx++) {
+  //  for (std::set<unsigned int>::iterator it=validSolutions.begin(); it!=validSolutions.end(); ++it) {
+  //    unsigned int sIdx = *it;
+  //    generatedCallToSolution( solutions[sIdx], &solutionLocks[sIdx], problemSizes[0], minStrides,
+  //        lda, ldb, ldc, ldd, strideA, strideB, strideC, strideD, alpha, beta );
+  //    status = clFinish(stream); tensileStatusCheck(status);
+  //    tensileStatusCheck(status);
+  //    std::cout << ".";
+  //  }
+ //   std::cout << std::endl;
+ // }
+//#endif // opencl
+  std::cout << std::endl;
+
+	TensileTimer totalKernelTimer;
+  totalKernelTimer.start();
+  // iterate over all problem sizes
+  double gpu_time_ms = 0;
+
+  for (unsigned int problemIdx = 0; problemIdx < numProblems; problemIdx++ ) {
+ 
     // print size
     std::cout << "Problem[" << problemIdx << "/" << numProblems << "]: " << problemSizes[problemIdx][0];
     for (unsigned int i = 1; i < totalIndices[problemTypeIdx]+numIndicesLD; i++) {
@@ -1393,12 +1903,12 @@ bool benchmarkProblemSizes(
 
     // benchmark all solutions for this problem size
     double problem_gpu_time_ms;
-    bool invalids = benchmarkAllSolutionsForSize( problemIdx, initialD, initialC,
+    bool invalids = benchmarkAllSolutionsForSize(problemIdx, initialD, initialC,
         initialA, initialB, alpha, beta, referenceD, referenceC, deviceOnHostD, deviceOnHostC,
         &problem_gpu_time_ms);
     if (invalids) returnInvalids = true;
     gpu_time_ms += problem_gpu_time_ms;
-    //printf ("gpu_time: %6.2f ms+ %6.2fns\n", gpu_time_ms, problem_gpu_time_ms);
+    printf ("gpu_time: %6.2f ms+ %6.2fns\n", gpu_time_ms, problem_gpu_time_ms);
 
   } // for problemIdx
 	auto timeK = totalKernelTimer.elapsed_sec();
@@ -1695,6 +2205,7 @@ void printClientUsage(std::string executableName) {
 #else
   std::cout << "  " << keySolutionStartIdx << " [" << defaultSolutionStartIdx << "]" << std::endl;  
   std::cout << "  " << keyNumSolutions << " [" << defaultNumSolutions << "]" << std::endl;  
+  std::cout << "  " << keyBenchmarkSolutions << " [" << defaultBenchmarkSolutions << "]" << std::endl;
 #endif
 }
 
@@ -1734,6 +2245,7 @@ void parseCommandLineParameters( int argc, char *argv[] ) {
 #else
   solutionStartIdx = defaultSolutionStartIdx;
   numSolutions = defaultNumSolutions;
+  runBenchmarkSolutions = defaultBenchmarkSolutions;
 #endif
 
   try {
@@ -1916,6 +2428,9 @@ void parseCommandLineParameters( int argc, char *argv[] ) {
           std::cout << "Tensile::FATAL: " << keyNumSolutions << " " << numSolutions << " must be less than maxNumSolutions " << maxNumSolutions  << std::endl;
           throw -1;
         }
+      } else if (keyBenchmarkSolutions == argv[argIdx]) {
+        argIdx++;
+        runBenchmarkSolutions = static_cast<unsigned int>(atoi(argv[argIdx]));
       }
 #endif
       // unrecognized


### PR DESCRIPTION

implements changes to the client code as well as the python code to tune for the tile aware selection. (determines the ideal performance for the given kernel and summation index)

This will get enabled by adding TileAwareSelection: true to the benchmark parameters for the group. (the default is false)

The will generated the measurement of the ideal performance for the kernels using (default) k = [32,64,96,128,256,512,1024,2048,4096,8192,16192]

This can be overridden with - SolutionSummationSizes: [32,64,96,128,256,512,1024,2048,4096,8192,16192] 

added to the BenchmarkFinalParameters

When enabled this will produce the TensileLibrary.yaml for the solution selection which gets added to the  3_LibraryLogic subdirectory as part of the tensile tuning.


