### PR TITLE
test passing code_object_version from rocBLAS to Tensile

### DIFF
--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -1863,7 +1863,8 @@ class KernelWriterAssembly(KernelWriter):
     kStr = ""
 
     # begin kernel descriptor
-    kStr += ".hsa_code_object_version 2,0%s" % self.endLine
+    kStr += ".hsa_code_object_version %s,0%s" \
+        % (globalParameters["CodeObjectVersion"][1], self.endLine)
     kStr += ".hsa_code_object_isa %u, %u, %u, \"AMD\", \"AMDGPU\" %s" \
         % (self.version[0], self.version[1], self.version[2], self.endLine)
     kStr += ".text%s" % self.endLine

--- a/Tensile/Source/CMakeLists.txt
+++ b/Tensile/Source/CMakeLists.txt
@@ -36,6 +36,8 @@ set_property( CACHE Tensile_RUNTIME_LANGUAGE PROPERTY STRINGS HIP OCL )
 set(Tensile_CODE_OBJECT_VERSION V2 CACHE STRING "Which code object version to use")
 set_property( CACHE Tensile_CODE_OBJECT_VERSION PROPERTY STRINGS V2 V3)
 
+message( STATUS "Tensile_CODE_OBJECT_VERSION from Tensile/Source/CMakeLists.txt: ${Tensile_CODE_OBJECT_VERSION}")
+
 ###############################################################################
 # Benchmark Client
 set(ClientName "client")
@@ -117,7 +119,6 @@ elseif( Tensile_RUNTIME_LANGUAGE MATCHES "HIP")
     target_compile_definitions( ${ClientName} PUBLIC  -DTensile_ENABLE_HALF )
   endif()
 endif()
-
 
 ###############################################################################
 # Create Tensile Library

--- a/Tensile/Source/TensileConfig.cmake
+++ b/Tensile/Source/TensileConfig.cmake
@@ -32,6 +32,8 @@ function(TensileCreateLibraryCmake
     Tensile_SHORT_FILE_NAMES
     Tensile_LIBRARY_PRINT_DEBUG )
 
+  message(STATUS "Tensile_CODE_OBJECT_VERSION from TensileCreateLibraryCmake : ${Tensile_CODE_OBJECT_VERSION}")
+
   # Tensile_ROOT can be specified instead of using the installed path.
   set(oneValueArgs Tensile_ROOT)
   cmake_parse_arguments(PARSE "" "${oneValueArgs}" "" ${ARGN})

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -913,6 +913,8 @@ def TensileCreateLibrary():
   arguments["EmbedLibrary"] = args.EmbedLibrary
   assignGlobalParameters(arguments)
 
+  print1("# CodeObjectVersion from TensileCreateLibrary: %s" % arguments["CodeObjectVersion"])
+
   globalParameters["BuildCodeObjects"] = True
 
   if not os.path.exists(logicPath):


### PR DESCRIPTION
- use globalParameters["codeObjectVersion"] rather than default value of 2 for hsa_code_object_version
- diagnostic print statements to track codeObjectVersion