### PR TITLE
Link in email for failed/unstable jobs is updated

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ import java.nio.file.Path;
 
 tensileCI:
 {
-    def tensile = new rocProject('tensile')
+    def tensile = new rocProject('Tensile')
     tensile.paths.build_command = 'cmake -D CMAKE_BUILD_TYPE=Debug ../lib'
     // Define test architectures, optional rocm version argument is available
     def nodes = new dockerNodes(['gfx900','gfx906'], tensile)


### PR DESCRIPTION
Changed link from http://hsautil.amd.com/job/ROCmSoftwarePlatform/job/tensile fixed to http://hsautil.amd.com/job/ROCmSoftwarePlatform/job/Tensile