### PR TITLE
add CxxCompiler to TensileCreateLibrary to specify hcc or hip-clang

### DIFF
--- a/Tensile/BenchmarkProblems.py
+++ b/Tensile/BenchmarkProblems.py
@@ -479,7 +479,7 @@ def writeBenchmarkFiles(stepBaseDir, solutions, problemSizes, stepName, filesToC
   # write solution, kernels and CMake
   problemType = solutions[0]["ProblemType"]
   writeSolutionsAndKernels( \
-      globalParameters["WorkingPath"], [problemType], solutions, kernels, kernelsBetaOnly, \
+      globalParameters["WorkingPath"], globalParameters["CxxCompiler"], [problemType], solutions, kernels, kernelsBetaOnly, \
       solutionWriter, kernelWriterSource, kernelWriterAssembly )
 
   if len(solutions) == 0:

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -159,6 +159,7 @@ else:
   globalParameters["RuntimeLanguage"] = "HIP"
 
 globalParameters["CodeObjectVersion"] = "V2"
+globalParameters["CxxCompiler"] = "hcc"
 
 # might be deprecated
 globalParameters["EnableHalf"] = False

--- a/Tensile/Source/CMakeLists.txt
+++ b/Tensile/Source/CMakeLists.txt
@@ -35,8 +35,11 @@ set(Tensile_RUNTIME_LANGUAGE HIP CACHE STRING "Which runtime language to use")
 set_property( CACHE Tensile_RUNTIME_LANGUAGE PROPERTY STRINGS HIP OCL )
 set(Tensile_CODE_OBJECT_VERSION V2 CACHE STRING "Which code object version to use")
 set_property( CACHE Tensile_CODE_OBJECT_VERSION PROPERTY STRINGS V2 V3)
+set(Tensile_COMPILER hcc CACHE STRING "Which compiler to use")
+set_property( CACHE Tensile_COMPILER PROPERTY STRINGS hcc hipcc)
 
 message( STATUS "Tensile_CODE_OBJECT_VERSION from Tensile/Source/CMakeLists.txt: ${Tensile_CODE_OBJECT_VERSION}")
+message( STATUS "Tensile_COMPILER            from Tensile/Source/CMakeLists.txt: ${Tensile_COMPILER}")
 
 ###############################################################################
 # Benchmark Client
@@ -128,6 +131,7 @@ if(NOT Tensile_CLIENT_BENCHMARK)
     ${Tensile_LOGIC_PATH}           # path
     ${Tensile_RUNTIME_LANGUAGE}     # OCL or HIP
     ${Tensile_CODE_OBJECT_VERSION}  # V2 or V3
+    ${Tensile_COMPILER}             # hcc or hipcc
     ${Tensile_MERGE_FILES}          # ON or OFF
     ${Tensile_SHORT_FILE_NAMES}     # ON or OFF
     ${Tensile_LIBRARY_PRINT_DEBUG}  # ON or OFF

--- a/Tensile/Source/TensileConfig.cmake
+++ b/Tensile/Source/TensileConfig.cmake
@@ -27,12 +27,14 @@ include(CMakeParseArguments)
 function(TensileCreateLibraryCmake
     Tensile_LOGIC_PATH
     Tensile_RUNTIME_LANGUAGE
+    Tensile_COMPILER
     Tensile_CODE_OBJECT_VERSION
     Tensile_MERGE_FILES
     Tensile_SHORT_FILE_NAMES
     Tensile_LIBRARY_PRINT_DEBUG )
 
   message(STATUS "Tensile_CODE_OBJECT_VERSION from TensileCreateLibraryCmake : ${Tensile_CODE_OBJECT_VERSION}")
+  message(STATUS "Tensile_COMPILER            from TensileCreateLibraryCmake : ${Tensile_COMPILER}")
 
   # Tensile_ROOT can be specified instead of using the installed path.
   set(oneValueArgs Tensile_ROOT)
@@ -69,6 +71,7 @@ function(TensileCreateLibraryCmake
   endif()
 
   set(Tensile_CREATE_COMMAND ${Tensile_CREATE_COMMAND} "--code-object-version=${Tensile_CODE_OBJECT_VERSION}")
+  set(Tensile_CREATE_COMMAND ${Tensile_CREATE_COMMAND} "--cxx-compiler=${Tensile_COMPILER}")
 
   # TensileLibraryWriter positional arguments
   set(Tensile_CREATE_COMMAND ${Tensile_CREATE_COMMAND}

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -131,27 +131,28 @@ def buildSourceCodeObjectFile(CxxCompiler, outputPath, kernelFile):
 
       compileArgs = [which('hcc')] + hipFlags + archFlags + [kernelFile, '-c', '-o', objectFilepath]
 
+      linkArgs = [globalParameters['AssemblerPath']] + hipLinkFlags + archFlags + [objectFilepath, '-shared', '-o', soFilepath]
+      extractArgs = [globalParameters['ExtractKernelPath'], '-i', soFilename]
+
+      #print(' '.join(compileArgs))
+      subprocess.check_call(compileArgs)
+
+      #print(' '.join(linkArgs))
+      subprocess.check_call(linkArgs)
+
+      #print(' '.join(extractArgs))
+      subprocess.check_call(extractArgs, cwd=buildPath)
+
     elif (CxxCompiler == "hipcc"):
 
       hipFlags = "--genco"
-      hipLinkFlags = ""
 
       hipFlags += ['-I', outputPath]
 
-      compileArgs = [which('hipcc')] + hipFlags + archFlags + [kernelFile, '-c', '-o', objectFilepath]
+      compileArgs = [which('hipcc')] + hipFlags + archFlags + [kernelFile, '-c', '-o', soFilename]
 
-
-    linkArgs = [globalParameters['AssemblerPath']] + hipLinkFlags + archFlags + [objectFilepath, '-shared', '-o', soFilepath]
-    extractArgs = [globalParameters['ExtractKernelPath'], '-i', soFilename]
-
-    #print(' '.join(compileArgs))
-    subprocess.check_call(compileArgs)
-
-    #print(' '.join(linkArgs))
-    subprocess.check_call(linkArgs)
-
-    #print(' '.join(extractArgs))
-    subprocess.check_call(extractArgs, cwd=buildPath)
+      #print(' '.join(compileArgs))
+      subprocess.check_call(compileArgs)
 
     return ["{0}-000-{1}.hsaco".format(soFilepath,arch) for arch in archs]
 

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -159,7 +159,7 @@ def buildSourceCodeObjectFile(CxxCompiler, outputPath, kernelFile):
 def buildSourceCodeObjectFiles(CxxCompiler, kernelFiles, kernels, outputPath):
     sourceKernelFiles = [f for (f,k) in zip(kernelFiles, kernels) if 'KernelLanguage' not in k or k["KernelLanguage"] == "Source"]
 
-    sourceKernelFiles = zip(CxxCompiler, itertools.repeat(outputPath), sourceKernelFiles)
+    sourceKernelFiles = zip(itertools.repeat(CxxCompiler), itertools.repeat(outputPath), sourceKernelFiles)
 
     coFiles = Common.ParallelMap(buildSourceCodeObjectFile, sourceKernelFiles, "Compiling source kernels",
                                  method=lambda x: x.starmap)


### PR DESCRIPTION
- add optional argument CxxCompiler to TensileCreateLibrary, it has default hcc, and other option hipcc. This enables changing the compiler used for Tensile from the script install.sh in rocBLAS
- Use this argument CxxCompiler to select compiler to create Tensile library
- Also add globalParameters["CxxCompiler"] = hcc so that Tensile can use the globalParemeter CxxCompiler defined in Tensile/Common.py to change the compiler
- Tested with hcc, not tested with hipcc
- Additional changes are in a rocBLAS PR