### PR TITLE
improved HIP-Clang support

### DIFF
--- a/Tensile/Source/CMakeLists.txt
+++ b/Tensile/Source/CMakeLists.txt
@@ -133,6 +133,9 @@ else()
       # with addition of bfloat16 library requires c++14
       #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14"  )
       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wno-deprecated-declarations" )
+      if( Tensile_COMPILER MATCHES "hipcc" )
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__HIP_HCC_COMPAT_MODE__=1")
+      endif()
     endif()
 
     if(Tensile_MERGE_FILES)

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -126,7 +126,7 @@ def buildSourceCodeObjectFile(CxxCompiler, outputPath, kernelFile):
     archs = ['gfx'+''.join(map(str,arch)) for arch in globalParameters['SupportedISA'] \
              if globalParameters["AsmCaps"][arch]["SupportedISA"]]
 
-    archFlags = ['-amdgpu-target=' + arch for arch in archs]
+    archFlags = ['--amdgpu-target=' + arch for arch in archs]
 
     if (CxxCompiler == 'hcc'):
 
@@ -149,20 +149,22 @@ def buildSourceCodeObjectFile(CxxCompiler, outputPath, kernelFile):
       #print(' '.join(extractArgs))
       subprocess.check_call(extractArgs, cwd=buildPath)
 
+      coFilenames = ["{0}-000-{1}.hsaco".format(soFilename, arch) for arch in archs]
     elif (CxxCompiler == "hipcc"):
 
-      hipFlags = "--genco"
+      hipFlags = ["--genco", "-D__HIP_HCC_COMPAT_MODE__=1"]
 
       hipFlags += ['-I', outputPath]
 
-      compileArgs = [which('hipcc')] + hipFlags + archFlags + [kernelFile, '-c', '-o', soFilename]
+      compileArgs = [which('hipcc')] + hipFlags + archFlags + [kernelFile, '-c', '-o', soFilepath]
 
       #print(' '.join(compileArgs))
       subprocess.check_call(compileArgs)
+
+      coFilenames = [soFilename]
     else:
       raise RuntimeError("Unknown compiler {}".format(CxxCompiler))
 
-    coFilenames = ["{0}-000-{1}.hsaco".format(soFilename, arch) for arch in archs]
     extractedCOs = [os.path.join(buildPath, name) for name in coFilenames]
     destCOs = [os.path.join(destDir, name) for name in coFilenames]
 


### PR DESCRIPTION
+ Fixed options --amdgpu-target= missing one leading dash
+ Fixed support for HIP-Clang compiler to generate kernel code object correctly
+ Add -D__HIP_HCC_COMPAT_MODE__=1 for compilation with HIP-Clang