### PR TITLE
hot_fix ROCm2.8: LoopCounter and TensileCreateLibraryCmake arg order

### DIFF
--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -5573,7 +5573,7 @@ class KernelWriterAssembly(KernelWriter):
       if mode==1 and tP["isA"]:
         imod.header.addInst("s_cmp_eq_i32", \
               sgpr("LoopCounters+%u"%loopIdx), \
-              "%u"%-1, \
+              "%u"% 1, \
               "%s"%"is this the last iteration")
         imod.header.addInst("s_cmov_b32", \
               sgpr("SrdA+2"), \

--- a/Tensile/Source/CMakeLists.txt
+++ b/Tensile/Source/CMakeLists.txt
@@ -130,8 +130,8 @@ if(NOT Tensile_CLIENT_BENCHMARK)
   TensileCreateLibraryCmake(
     ${Tensile_LOGIC_PATH}           # path
     ${Tensile_RUNTIME_LANGUAGE}     # OCL or HIP
-    ${Tensile_CODE_OBJECT_VERSION}  # V2 or V3
     ${Tensile_COMPILER}             # hcc or hipcc
+    ${Tensile_CODE_OBJECT_VERSION}  # V2 or V3
     ${Tensile_MERGE_FILES}          # ON or OFF
     ${Tensile_SHORT_FILE_NAMES}     # ON or OFF
     ${Tensile_LIBRARY_PRINT_DEBUG}  # ON or OFF

--- a/Tensile/__init__.py
+++ b/Tensile/__init__.py
@@ -20,4 +20,4 @@
 ################################################################################
 
 # hardcoded tensile version; also in Tensile/Source/TensileConfigVersion.cmake
-__version__ = "4.11.0"
+__version__ = "4.11.1"


### PR DESCRIPTION
- Fix loop compare against 1 for SuppressNoLoadLoop mode
- Correct argument order in call to TensileCreateLibraryCmake
- bump patch field in version