### PR TITLE
Fixing builds for old YAML files without PersistentKernel parameter.

### DIFF
--- a/Tensile/Contractions.py
+++ b/Tensile/Contractions.py
@@ -271,7 +271,7 @@ class SizeMapping:
                    depthU             = d['DepthU'],
                    globalSplitU       = d['GlobalSplitU'],
                    staggerStrideShift = d['_staggerStrideShift'] if '_staggerStrideShift' in d else 0,
-                   persistentKernel   = d['PersistentKernel'],
+                   persistentKernel   = d['PersistentKernel'] if 'PersistentKernel' in d else 0,
                    sourceKernel       = d['KernelLanguage'] == 'Source',
                    )
 


### PR DESCRIPTION
Still not sure why rocBLAS is building in CI but this will fix it.