### PR TITLE
Fixing contraction index ordering and kernel invocation.

### DIFF
--- a/Tensile/BenchmarkProblems.py
+++ b/Tensile/BenchmarkProblems.py
@@ -387,12 +387,12 @@ def compareResults(old, new, name):
     import math
     try:
         old = float(old)
-    except ValueError:
+    except (ValueError, TypeError):
         old = -1
 
     try:
         new = float(new)
-    except ValueError:
+    except (ValueError, TypeError):
         new = -1
 
     def isbad(x):

--- a/Tensile/ClientWriter.py
+++ b/Tensile/ClientWriter.py
@@ -308,17 +308,24 @@ def checkConstStride(constStrideMap, keyIdx):
   #print ("idx=", keyIdx, "=", finalVal)
   return finalVal
 
-
 def problemSizeParams(solution, problemSize):
     numIndices = len(solution.problemType.indices)
 
-    assert len(problemSize) == numIndices + 4
+    problemSizeArg = ('problem-size', ','.join(map(str, problemSize[:numIndices])))
 
-    return [('problem-size', ','.join(map(str, problemSize[:numIndices]))),
-            ('a-strides', problemSize[numIndices+2]),
-            ('b-strides', problemSize[numIndices+3]),
-            ('c-strides', problemSize[numIndices+0]),
-            ('d-strides', problemSize[numIndices+1])]
+    if len(problemSize) == numIndices:
+        return [problemSizeArg]
+    elif len(problemSize) == numIndices + 4:
+        return [problemSizeArg,
+                ('a-strides', problemSize[numIndices+2]),
+                ('b-strides', problemSize[numIndices+3]),
+                ('c-strides', problemSize[numIndices+0]),
+                ('d-strides', problemSize[numIndices+1])]
+
+    raise RuntimeError(
+        "Invalid number of problem type indices: {0} - Indices: {1}, problemSize: {2}".format(len(problemSize), numIndices,
+            ', '.join(map(str, problemSize))))
+
 
 def dataInitName(num):
     if num == 0: return 'Zero'

--- a/Tensile/Contractions.py
+++ b/Tensile/Contractions.py
@@ -23,8 +23,10 @@ from .DataType import DataType
 from . import Hardware
 from . import Properties
 from .SolutionStructs import Solution as OriginalSolution
-from .Utils import state
+from .Utils import state, state_key_ordering
 
+
+@state_key_ordering
 class FreeIndex:
     StateKeys = ['a', 'b', 'ca', 'cb', 'da', 'db']
 
@@ -36,6 +38,7 @@ class FreeIndex:
         self.da = da
         self.db = db
 
+@state_key_ordering
 class BatchIndex:
     StateKeys = ['a', 'b', 'c', 'd']
     def __init__(self, a=None, b=None, c=None, d=None):
@@ -44,6 +47,7 @@ class BatchIndex:
         self.c = c
         self.d = d
 
+@state_key_ordering
 class BoundIndex:
     StateKeys = ['a', 'b']
     def __init__(self, a=None, b=None):
@@ -94,9 +98,9 @@ class ProblemType:
 
         rv = cls()
         rv.indices = indices
-        rv.freeIndices = freeIndices
-        rv.batchIndices = batchIndices
-        rv.boundIndices = boundIndices
+        rv.freeIndices = sorted(freeIndices)
+        rv.batchIndices = sorted(batchIndices)
+        rv.boundIndices = sorted(boundIndices)
         rv.aDims = len(d['IndexAssignmentsA'])
         rv.bDims = len(d['IndexAssignmentsB'])
         rv.cDims = d['NumIndicesC']

--- a/Tensile/Tests/nightly/classic/test_tensor_contraction.yaml
+++ b/Tensile/Tests/nightly/classic/test_tensor_contraction.yaml
@@ -7,7 +7,7 @@ GlobalParameters:
   CMakeBuildType: Release
   EnqueuesPerSync: 1
   SyncsPerBenchmark: 1
-  LibraryPrintDebug: False
+  LibraryPrintDebug: True
   NumElementsToValidate: -1
   ValidationMaxToPrint: 4
   ValidationPrintValids: False
@@ -93,9 +93,9 @@ BenchmarkProblems:
       DestDataType: s
       UseBeta: True
       NumIndicesC: 2
-      IndexAssignmentsA: [4, 3, 0, 2]
-      IndexAssignmentsB: [4, 3, 2, 1]
-      # C[ij] = Sum[klm] A[mlik] * B[mlkj]
+      IndexAssignmentsA: [2, 3, 0, 4]
+      IndexAssignmentsB: [2, 3, 4, 1]
+      # C[ij] = Sum[klm] A[klim] * B[klmj]
       # Free Indices: [i, j]
       # Batch Indices:
       # Sum Indices: k, l, m
@@ -122,7 +122,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [63,1,65], [63,1,65], [2,1,3], [2,1,3], [15,1,17] ]
+          - Range: [ [63,1,65], [63,1,65], [15,1,17], [2,1,3], [2,1,3] ]
 
   - # 6-D Image Convolution
     - # ProblemType
@@ -131,14 +131,14 @@ BenchmarkProblems:
       DestDataType: s
       UseBeta: True
       NumIndicesC: 3
-      IndexAssignmentsA: [5, 4, 0, 1, 3]  # n(s), m(s), i(f), j(b), l(s)
-      IndexAssignmentsB: [5, 4, 1, 3, 2]  # n(s), m(s), j(b), l(s), k(f)
-      # C[ijk] = Sum[lmn] A[nmijl] * B[nmjlk]
+      IndexAssignmentsA: [3, 4, 0, 1, 5]  # n(s), m(s), i(f), j(b), l(s)
+      IndexAssignmentsB: [3, 4, 1, 5, 2]  # n(s), m(s), j(b), l(s), k(f)
+      # C[ijk] = Sum[lmn] A[lmijn] * B[lmjnk]
       # Free Indices: [i, k]
       # Batch Indices: j
       # Sum Indices: l, m, n
       # Translate to traditional conv notation:
-      # i=H*W, j=N, k=Cout, l=Cin, m=R, n=S
+      # i=H*W, j=N, k=Cout, l=S, m=R, n=Cin
       # Need one more free dimension to decouple H,W.
 
     - # BenchmarkProblemSizeGroup - Standard
@@ -163,4 +163,4 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [63,1,65], [2,1,3], [63,1,65], [2,1,3], [2,1,3], [15,1,17] ]
+          - Range: [ [63,1,65], [2,1,3], [63,1,65], [15,1,17], [2,1,3], [2,1,3] ]

--- a/Tensile/Utils.py
+++ b/Tensile/Utils.py
@@ -20,6 +20,8 @@
 ################################################################################
 
 from .Common import ProgressBar
+
+import functools
 import sys
 
 class SpinnyThing:
@@ -77,6 +79,20 @@ def state(obj):
         pass
 
     return obj
+
+def state_key_ordering(cls):
+    def tup(obj):
+        return tuple([getattr(obj, k) for k in cls.StateKeys])
+
+    def lt(a, b):
+        return tup(a) < tup(b)
+    def eq(a, b):
+        return tup(a) == tup(b)
+
+    cls.__lt__ = lt
+    cls.__eq__ = eq
+
+    return functools.total_ordering(cls)
 
 def hash_combine(*objs, **kwargs):
     shift = 1


### PR DESCRIPTION
This should fix the contraction tests.  There are still problems with that test but it's consistent between the old and new clients.

I had to fix the config file since the new client normalizes the order of the indices:

`Cijk_Almijn_Blmjnk` and `Cijk_Anmijl_Bnmjlk` are really the same operation, but since the old client doesn't realize this, the sizes are not set up correctly.