### PR TITLE
hipExtModuleLaunchKernel;  <hip/hip_hcc.h>

### DIFF
--- a/Tensile/SolutionWriter.py
+++ b/Tensile/SolutionWriter.py
@@ -800,7 +800,7 @@ class SolutionWriter:
             """
 
           s += "%skernelsLaunched++;\n" % (t)
-          s += "%shipHccModuleLaunchKernel(\n" % (t)
+          s += "%shipExtModuleLaunchKernel(\n" % (t)
           t += "  "
           s += "%shipFunction,\n" % (t)
           s += "%sglobalWorkSize[kernelIdx][0]*localWorkSize[0],\n" % (t)

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -125,6 +125,9 @@ def buildSourceCodeObjectFile(CxxCompiler, outputPath, kernelFile):
     if (CxxCompiler == 'hcc'):
 
       hipFlags = subprocess.check_output([which('hcc-config'), '--cxxflags', '--shared']).decode().split(' ')
+      # when HCC_HOME is defined -I/opt/rocm/include is *not* part of
+      # hcc-config --cxxflags; so we need hipconfig -C to be safe
+      hipFlags += subprocess.check_output([which('hipconfig'), '-C']).decode().split(' ')
       hipLinkFlags = subprocess.check_output([which('hcc-config'), '--ldflags', '--shared']).decode().split(' ')
 
       hipFlags += ['-I', outputPath]
@@ -270,7 +273,8 @@ def writeSolutionsAndKernels(outputPath, CxxCompiler, problemTypes, solutions, k
     kernelSourceFile.write("#include \"Kernels.h\"\n")
     kernelHeaderFile.write("#pragma once\n")
     if globalParameters["RuntimeLanguage"] == "HIP":
-      kernelHeaderFile.write("#include <hip/hip_runtime.h>\n\n")
+      kernelHeaderFile.write("#include <hip/hip_runtime.h>\n")
+      kernelHeaderFile.write("#include <hip/hip_hcc.h>\n\n")
     kernelHeaderFile.write("#include \"KernelHeader.h\"\n\n")
   else:
     kernelSourceFile = None


### PR DESCRIPTION
+ replace hipHccModuleLaunchKernel by hipExtModuleLaunchKernel
+ \#include <hip/hip_hcc.h> for hipExtModuleLaunchKernel
+ get -I/opt/rocm/include from $(hipconfig -C) in case HCC_HOME is set, causing $(hcc-config --cxxflags) to not have -I/opt/rocm/include