### PR TITLE
Use the faster solution selection algorithm by default

### DIFF
--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -68,7 +68,7 @@ globalParameters["ForceRedoBenchmarkProblems"] = True # if False and benchmarkin
 globalParameters["ForceRedoLibraryLogic"] = True      # if False and library logic already analyzed, then library logic will be skipped when tensile is re-run
 globalParameters["ForceRedoLibraryClient"] = True     # if False and library client already built, then building library client will be skipped when tensile is re-run
 globalParameters["ShowProgressBar"] = True     # if False and library client already built, then building library client will be skipped when tensile is re-run
-globalParameters["SolutionSelectionAlg"] = 0          # algorithm to detetermine which solutions to keep. 0=removeLeastImportantSolutions, 1=keepWinnerSolutions (faster)
+globalParameters["SolutionSelectionAlg"] = 1          # algorithm to detetermine which solutions to keep. 0=removeLeastImportantSolutions, 1=keepWinnerSolutions (faster)
 globalParameters["ExpandRanges"] = True          # expand ranges into exact configs before writing logic file.  False ignores ranges.
 globalParameters["ExitAfterKernelGen"] = False     # Exit after generating kernels
 globalParameters["ShowProgressBar"] = True     # if False and library client already built, then building library client will be skipped when tensile is re-run


### PR DESCRIPTION
At present, the variable ExpandRanges is set to True by default (and, to be honest, I don't see the point of allowing it to go to False).

When ExpandRanges is True, SolutionSelectionAlg 0 and 1 result in identical output, the only difference being that SolutionSelectionAlg 0 runs in cubic time in the number of solutions. I've seen the solution selection stage take 45+ minutes. 