### PR TITLE
added ubuntu labels, CI doesn't work without it

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@ tensileCI:
     def tensile = new rocProject('Tensile')
     tensile.paths.build_command = 'cmake -D CMAKE_BUILD_TYPE=Debug -D CMAKE_CXX_COMPILER=hcc -DCMAKE_CXX_FLAGS=-Werror -DTensile_ROOT=$(pwd)/../Tensile ../HostLibraryTests'
     // Define test architectures, optional rocm version argument is available
-    def nodes = new dockerNodes(['gfx900','gfx906'], tensile)
+    def nodes = new dockerNodes(['gfx900 && ubuntu','gfx906 && ubuntu'], tensile)
 
     boolean formatCheck = false
 


### PR DESCRIPTION
- Recent change in rocJenkins requires OS label: https://github.com/ROCmSoftwarePlatform/rocJenkins/commit/8b8b1cfcb95ce0265215a54f4fe530dc152b3ffd 