### PR TITLE
Changed timeout to minutes instead of hours

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,7 +67,7 @@ tensileCI:
         }
     }
 
-    tensile.timeout.test = 10
+    tensile.timeout.test = 600
 
     def test_dir = auxiliary.isJobStartedByTimer() ? "Tensile/Tests/nightly" : "Tensile/Tests/pre_checkin"
     def testCommand =


### PR DESCRIPTION
So, last night all the PRs timed out due to a change I made in rocJenkins that changed the timeout units from hours to minutes. This PR fixes this issue.