### PR TITLE
New client validation stride

### DIFF
--- a/Tensile/Source/client/include/Reference.hpp
+++ b/Tensile/Source/client/include/Reference.hpp
@@ -88,10 +88,10 @@ namespace Tensile
         template <typename Inputs, typename Accumulator = typename Inputs::DType>
         struct ReferenceSolution
         {
-            static void SolveCPU(ContractionProblem const& contraction, Inputs const& inputs);
+            static void SolveCPU(ContractionProblem const& contraction, Inputs const& inputs, size_t validationStride = 1);
         };
 
-        void SolveCPU(ContractionProblem const& contraction, ContractionInputs const& inputs);
+        void SolveCPU(ContractionProblem const& contraction, ContractionInputs const& inputs, size_t validationStride = 1);
     }
 }
 

--- a/Tensile/Source/client/include/ReferenceValidator.hpp
+++ b/Tensile/Source/client/include/ReferenceValidator.hpp
@@ -108,6 +108,7 @@ namespace Tensile
             int  m_elementsToValidate;
             bool m_printValids;
             int  m_printMax;
+            int  m_validationStride;
 
             bool m_printTensorA;
             bool m_printTensorB;

--- a/Tensile/Source/client/source/Reference.cpp
+++ b/Tensile/Source/client/source/Reference.cpp
@@ -85,18 +85,10 @@ namespace Tensile
             for(int i = 0; i < batchSize.size(); i++) batchSize[i] = problem.batchSize(i);
             for(int i = 0; i < boundSize.size(); i++) boundSize[i] = problem.boundSize(i);
 
-            //auto batchCount = CoordCount(batchSize.begin(), batchSize.end());
-            //auto freeACount = CoordCount(freeASize.begin(), freeASize.end());
-            //auto freeBCount = CoordCount(freeBSize.begin(), freeBSize.end());
             auto boundCount = CoordCount(boundSize.begin()+1, boundSize.end());
 
-            auto dCount = d.totalLogicalElements();
-            //for(size_t batchNum = 0; batchNum < batchCount; batchNum++)
-            //for(size_t freeANum = 0; freeANum < freeACount; freeANum++)
-            //for(size_t freeBNum = 0; freeBNum < freeBCount; freeBNum++)
-
 #pragma omp parallel for
-            for(size_t dNum = 0; dNum < dCount; dNum += validationStride)
+            for(size_t dNum = 0; dNum < d.totalLogicalElements(); dNum += validationStride)
             {
                 std::vector<size_t> aCoord(a.dimensions());
                 std::vector<size_t> bCoord(b.dimensions());

--- a/Tensile/Source/client/source/ReferenceValidator.cpp
+++ b/Tensile/Source/client/source/ReferenceValidator.cpp
@@ -80,7 +80,11 @@ namespace Tensile
             {
                 m_problem = problem;
                 m_referenceInputs = m_dataInit->prepareCPUInputs();
-                SolveCPU(problem, *m_referenceInputs);
+                m_validationStride = 1;
+                if(m_elementsToValidate > 0 && m_elementsToValidate < problem.d().totalLogicalElements())
+                    m_validationStride = NextPrime(problem.d().totalAllocatedElements() / m_elementsToValidate);
+
+                SolveCPU(problem, *m_referenceInputs, m_validationStride);
             }
         }
 
@@ -278,10 +282,6 @@ namespace Tensile
             using Type = typename TypedInputs::DType;
             Type const* resultBuffer = reinterpret_cast<Type const*>(m_cpuResultBuffer.data());
 
-            size_t validationStride = 1;
-            if(m_elementsToValidate > 0 && m_elementsToValidate < tensor.totalLogicalElements())
-                validationStride = NextPrime(tensor.totalAllocatedElements() / m_elementsToValidate);
-
             int printed = 0;
 
             bool doPrint = m_printMax < 0 || printed < m_printMax;
@@ -319,7 +319,7 @@ namespace Tensile
                 }
             };
 
-            if(validationStride == 1)
+            if(m_validationStride == 1)
             {
                 std::vector<size_t> coord(tensor.dimensions());
                 size_t outerCount = CoordCount(tensor.sizes().begin()+1, tensor.sizes().end());
@@ -343,7 +343,7 @@ namespace Tensile
             else
             {
                 std::vector<size_t> coord(tensor.dimensions());
-                for(size_t elemNumber = 0; elemNumber < tensor.totalLogicalElements(); elemNumber += validationStride)
+                for(size_t elemNumber = 0; elemNumber < tensor.totalLogicalElements(); elemNumber += m_validationStride)
                 {
                     CoordNumbered(elemNumber, coord.begin(), coord.end(), tensor.sizes().begin(), tensor.sizes().end());
                     size_t elemIndex = tensor.index(coord);


### PR DESCRIPTION
Only calculate the elements that will be used for validation.

Not sure why I didn't see that the old client was doing this before.  This should reduce test times and allow further reduction especially with the complex tests.