### PR TITLE
Allow tuning scripts to work in python2 and python3

### DIFF
--- a/Tensile/Utilities/merge_rocblas_yaml_files.py
+++ b/Tensile/Utilities/merge_rocblas_yaml_files.py
@@ -284,7 +284,7 @@ def MergeTensileLogicFiles(origionalLibraryLogic, exactLibraryLogic):
     # kernel configuration
     kernelIndex = exact[1][0]
     
-    if replicationMapping.has_key(kernelIndex):
+    if kernelIndex in replicationMapping:
       exact[1][0] = replicationMapping[kernelIndex]
     
     filteredExactLogicExact.append(exact)

--- a/tuning/automation/ExtractSizes.py
+++ b/tuning/automation/ExtractSizes.py
@@ -831,7 +831,7 @@ def RunMain():
 
     problemMapper = ProcessFile(inputFileName)
 
-    keys = problemMapper.keys()
+    keys = list(problemMapper.keys())
 
     for key in keys:
         lineDefinitions = problemMapper[key]

--- a/tuning/automation/GenerateTuningConfigurations.py
+++ b/tuning/automation/GenerateTuningConfigurations.py
@@ -261,7 +261,7 @@ def updateProblemGroupFromKey(problemKey, sizeKey,problemGroup,sizeList):
 
 def OutputConfigs(problemMapper, configPath, outputName, library):
 
-    keys = problemMapper.keys()
+    keys = list(problemMapper.keys())
 
     configDefs = {}
 
@@ -353,7 +353,7 @@ done
 
 def OutputScript(problemMapper, scriptPath, namePart):
 
-    keys = problemMapper.keys()
+    keys = list(problemMapper.keys())
 
     scriptFileNames = []
     for key in keys:
@@ -373,7 +373,7 @@ def OutputScript(problemMapper, scriptPath, namePart):
 
 def OutputProblemDefinitions(problemMapper, sizePath, namePart):
 
-    keys = problemMapper.keys()
+    keys = list(problemMapper.keys())
 
     for key in keys:
         lineDefinitions = problemMapper[key]

--- a/tuning/automation/GenerateTuningConfigurations.py
+++ b/tuning/automation/GenerateTuningConfigurations.py
@@ -218,7 +218,7 @@ def updateProblemGroupFromKey(problemKey, sizeKey,problemGroup,sizeList):
         scheme["LdsPadA"] = [0, -1]
         scheme["LdsPadB"] = [0, -1]
         benchmarkGroup = generateBenchmarkGroupFromScheme(scheme) 
-    appendThreadTiles(benchmarkGroup, [[2,2],[4,2],[2,4]])
+        appendThreadTiles(benchmarkGroup, [[2,2],[4,2],[2,4]])
         appendWorkGroups(benchmarkGroup, [[16,16,1],[8,16,2],[16,8,2],[4,16,4],[16,4,4],[32,8,4],[8,32,4]])
         #appendWorkGroups(benchmarkGroup, [[16,16,1],[8,16,2],[8,16,4],[16,8,2],[16,8,4],[8,8,1],
         #    [8,8,2],[8,8,4],[4,16,4],[16,4,4],[4,8,8],[8,4,8],[4,4,4],[4,4,8]])

--- a/tuning/automation/GenerateTuningConfigurations.py
+++ b/tuning/automation/GenerateTuningConfigurations.py
@@ -218,7 +218,7 @@ def updateProblemGroupFromKey(problemKey, sizeKey,problemGroup,sizeList):
         scheme["LdsPadA"] = [0, -1]
         scheme["LdsPadB"] = [0, -1]
         benchmarkGroup = generateBenchmarkGroupFromScheme(scheme) 
-	appendThreadTiles(benchmarkGroup, [[2,2],[4,2],[2,4]])
+    appendThreadTiles(benchmarkGroup, [[2,2],[4,2],[2,4]])
         appendWorkGroups(benchmarkGroup, [[16,16,1],[8,16,2],[16,8,2],[4,16,4],[16,4,4],[32,8,4],[8,32,4]])
         #appendWorkGroups(benchmarkGroup, [[16,16,1],[8,16,2],[8,16,4],[16,8,2],[16,8,4],[8,8,1],
         #    [8,8,2],[8,8,4],[4,16,4],[16,4,4],[4,8,8],[8,4,8],[4,4,4],[4,4,8]])
@@ -332,7 +332,7 @@ def generateRunScript(fileNames, outputPath):
     scriptNames = ""
 
     for fileName in fileNames:
-    	fileBaseName = os.path.basename(fileName)
+        fileBaseName = os.path.basename(fileName)
         namePart, _ = os.path.splitext(fileBaseName)
         scriptNames = "%s %s" % (scriptNames, namePart)
 

--- a/tuning/automation/TuningConfiguration.py
+++ b/tuning/automation/TuningConfiguration.py
@@ -19,14 +19,14 @@
 # CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ################################################################################
 
-
+from __future__ import print_function
 import os
 import sys
 import argparse
 
 
 def printExit(message):
-  print "Tensile::FATAL: %s" % message
+  print ("Tensile::FATAL: %s" % message)
   sys.stdout.flush()
   sys.exit(-1)
 
@@ -110,7 +110,7 @@ class TuningConfiguration(object):
         self.__libraryClient = None
 
         if fileName is not None:
-            print "reading configuration: %s" % fileName
+            print("reading configuration: %s" % fileName)
             try:
                 stream = open(fileName, "r")
             except IOError:
@@ -219,7 +219,7 @@ def generateProblemType(initialParams):
     }
 
     if initialParams:
-        keys = initialParams.keys()
+        keys = list(initialParams.keys())
         for key in keys:
             problemType[key] = initialParams[key]
 


### PR DESCRIPTION
- Currently, the scripts require the user to use python2 as there are a few loops that do not work properly in python3 due to lack of using a list, and has_key is deprecated in python3. This PR allows users to run tuning scripts with any python version that is 2.3 or newer