### PR TITLE
Add missing line break 

### DIFF
--- a/Tensile/ClientWriter.py
+++ b/Tensile/ClientWriter.py
@@ -239,6 +239,7 @@ def writeRunScript(path, libraryLogicPath, forBenchmark, enableTileSelection):
       runScriptFile.write("\n")
       runScriptFile.write("ERR1=$?\n")
     else:
+      runScriptFile.write("\n")
       runScriptFile.write("ERR1=0\n")
 
     if globalParameters["NewClient"]:


### PR DESCRIPTION
Add missing line break in run.sh with `NewClient:2` introduced in #677 

As previously in `run.sh`:
```
#!/bin/bash

set -ex
set +e
./clientERR1=0
        ^^^^^
/mnt/Tensile/build/out_zgemm_hip_cn_tt2_16_3/0_Build/client/tensile_client --config-file=/mnt/Tensile/build/out_zgemm_hip_cn_tt2_16_3/1_BenchmarkProblems/Cijk_AlikC_Bljk_ZB_00/00_Final/build/../source/ClientParameters.ini
ERR2=$?
...