### PR TITLE
Fix run.sh script when old client is disabled

### DIFF
--- a/Tensile/ClientWriter.py
+++ b/Tensile/ClientWriter.py
@@ -204,14 +204,13 @@ def writeRunScript(path, libraryLogicPath, forBenchmark, enableTileSelection):
 
       runScriptFile.write("set +e\n")
 
-      runScriptFile.write("./client")
-
     if globalParameters["DataInitTypeA"] == -1 :
         globalParameters["DataInitTypeA"] = globalParameters["DataInitTypeAB"]
     if globalParameters["DataInitTypeB"] == -1 :
         globalParameters["DataInitTypeB"] = globalParameters["DataInitTypeAB"]
 
     if globalParameters["NewClient"] < 2:
+      runScriptFile.write("./client")
       clp = ""
       clp += " --platform-idx %u" % globalParameters["Platform"]
       clp += " --device-idx %u" % globalParameters["Device"]


### PR DESCRIPTION
run.sh should not execute old client when NewClient:2 (an option introduced in #677)

Previously:
```
#!/bin/bash

set -ex
set +e

./clientERR1=0
^^^^^^^^
"./client" will be gone if NewClient:2

/mnt/Tensile/build/out_zgemm_hip_cn_tt2_16_3/0_Build/client/tensile_client --config-file=/mnt/Tensile/build/out_zgemm_hip_cn_tt2_16_3/1_BenchmarkProblems/Cijk_AlikC_Bljk_ZB_00/00_Final/build/../source/ClientParameters.ini
ERR2=$?
...
```