### PR TITLE
Hot fix: Set -ex flag to fail test stage if host tests fail

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,7 +76,7 @@ tensileCI:
         try
         {
             def command = """#!/usr/bin/env bash
-                    set -x
+                    set -ex
 
                     hostname
 


### PR DESCRIPTION
This change should result in the Test stage being marked as a failure if host tests fail, but unit tests pass. If any host tests fail, an error code will be returned and unit tests will not run.