### PR TITLE
Use signed integer for loop counter

### DIFF
--- a/Tensile/KernelWriterSource.py
+++ b/Tensile/KernelWriterSource.py
@@ -1594,7 +1594,7 @@ class KernelWriterSource(KernelWriter):
     kStr = ""
     for loopIdx in kernel["ProblemType"]["IndicesSummation"]:
       loopChar = self.indexChars[loopIdx]
-      kStr += "%sunsigned int numIter%s;%s" \
+      kStr += "%sint numIter%s;%s" \
           % (self.indent, loopChar, self.endLine)
     return kStr
 


### PR DESCRIPTION
This works around a possible HCC compiler bug that causes the kernel to hang indefinitely under some combination of kernel parameters and problem size (refer to SWDEV-208692 for details)
