### PR TITLE
Added V340L as a supported device

### DIFF
--- a/HostLibraryTests/configs/lite_configs/vega10_Cijk_Ailk_Bjlk_SB.yaml
+++ b/HostLibraryTests/configs/lite_configs/vega10_Cijk_Ailk_Bjlk_SB.yaml
@@ -2,7 +2,8 @@
 - vega10
 - gfx900
 - [Device 6863, Device 6862, Device 687f, Device 6860, Device 6861, 'Vega 10 XTX [Radeon
-    Vega Frontier Edition]', 'Vega [Radeon RX Vega]', 'Vega 10 [Radeon Instinct MI25]']
+    Vega Frontier Edition]', 'Vega [Radeon RX Vega]', 'Vega 10 [Radeon Instinct MI25]',
+  Vega, Device 6864]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false
@@ -26,8 +27,8 @@
   NumIndicesBatch: 1
   NumIndicesC: 3
   NumIndicesFree: 2
-  NumIndicesSummation: 1
   NumIndicesLD: 4
+  NumIndicesSummation: 1
   OperationType: GEMM
   SilentHighPrecisionAccumulate: false
   TLUA: true
@@ -162,8 +163,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: true
@@ -323,8 +324,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: true
@@ -484,8 +485,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: true
@@ -649,8 +650,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: true
@@ -814,8 +815,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: true
@@ -979,8 +980,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: true
@@ -1143,8 +1144,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: true

--- a/HostLibraryTests/configs/lite_configs/vega10_Cijk_Ailk_Bjlk_SB.yaml
+++ b/HostLibraryTests/configs/lite_configs/vega10_Cijk_Ailk_Bjlk_SB.yaml
@@ -3,7 +3,7 @@
 - gfx900
 - [Device 6863, Device 6862, Device 687f, Device 6860, Device 6861, 'Vega 10 XTX [Radeon
     Vega Frontier Edition]', 'Vega [Radeon RX Vega]', 'Vega 10 [Radeon Instinct MI25]',
-  Vega, Device 6864]
+    Vega, Device 6864]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/HostLibraryTests/configs/lite_configs/vega10_Cijk_Ailk_Bljk_SB.yaml
+++ b/HostLibraryTests/configs/lite_configs/vega10_Cijk_Ailk_Bljk_SB.yaml
@@ -2,7 +2,8 @@
 - vega10
 - gfx900
 - [Device 6863, Device 6862, Device 687f, Device 6860, Device 6861, 'Vega 10 XTX [Radeon
-    Vega Frontier Edition]', 'Vega [Radeon RX Vega]', 'Vega 10 [Radeon Instinct MI25]']
+    Vega Frontier Edition]', 'Vega [Radeon RX Vega]', 'Vega 10 [Radeon Instinct MI25]',
+  Vega, Device 6864]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false
@@ -26,8 +27,8 @@
   NumIndicesBatch: 1
   NumIndicesC: 3
   NumIndicesFree: 2
-  NumIndicesSummation: 1
   NumIndicesLD: 4
+  NumIndicesSummation: 1
   OperationType: GEMM
   SilentHighPrecisionAccumulate: false
   TLUA: true
@@ -162,8 +163,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: true
@@ -327,8 +328,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: true
@@ -492,8 +493,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: true
@@ -657,8 +658,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: true
@@ -822,8 +823,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: true
@@ -987,8 +988,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: true
@@ -1151,8 +1152,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: true

--- a/HostLibraryTests/configs/lite_configs/vega10_Cijk_Ailk_Bljk_SB.yaml
+++ b/HostLibraryTests/configs/lite_configs/vega10_Cijk_Ailk_Bljk_SB.yaml
@@ -3,7 +3,7 @@
 - gfx900
 - [Device 6863, Device 6862, Device 687f, Device 6860, Device 6861, 'Vega 10 XTX [Radeon
     Vega Frontier Edition]', 'Vega [Radeon RX Vega]', 'Vega 10 [Radeon Instinct MI25]',
-  Vega, Device 6864]
+    Vega, Device 6864]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/HostLibraryTests/configs/lite_configs/vega10_Cijk_Alik_Bjlk_SB.yaml
+++ b/HostLibraryTests/configs/lite_configs/vega10_Cijk_Alik_Bjlk_SB.yaml
@@ -2,7 +2,8 @@
 - vega10
 - gfx900
 - [Device 6863, Device 6862, Device 687f, Device 6860, Device 6861, 'Vega 10 XTX [Radeon
-    Vega Frontier Edition]', 'Vega [Radeon RX Vega]', 'Vega 10 [Radeon Instinct MI25]']
+    Vega Frontier Edition]', 'Vega [Radeon RX Vega]', 'Vega 10 [Radeon Instinct MI25]',
+  Vega, Device 6864]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false
@@ -26,8 +27,8 @@
   NumIndicesBatch: 1
   NumIndicesC: 3
   NumIndicesFree: 2
-  NumIndicesSummation: 1
   NumIndicesLD: 4
+  NumIndicesSummation: 1
   OperationType: GEMM
   SilentHighPrecisionAccumulate: false
   TLUA: false
@@ -162,8 +163,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: false
@@ -327,8 +328,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: false
@@ -492,8 +493,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: false
@@ -657,8 +658,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: false
@@ -822,8 +823,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: false
@@ -986,8 +987,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: false

--- a/HostLibraryTests/configs/lite_configs/vega10_Cijk_Alik_Bjlk_SB.yaml
+++ b/HostLibraryTests/configs/lite_configs/vega10_Cijk_Alik_Bjlk_SB.yaml
@@ -3,7 +3,7 @@
 - gfx900
 - [Device 6863, Device 6862, Device 687f, Device 6860, Device 6861, 'Vega 10 XTX [Radeon
     Vega Frontier Edition]', 'Vega [Radeon RX Vega]', 'Vega 10 [Radeon Instinct MI25]',
-  Vega, Device 6864]
+    Vega, Device 6864]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/HostLibraryTests/configs/lite_configs/vega10_Cijk_Alik_Bljk_SB.yaml
+++ b/HostLibraryTests/configs/lite_configs/vega10_Cijk_Alik_Bljk_SB.yaml
@@ -2,7 +2,8 @@
 - vega10
 - gfx900
 - [Device 6863, Device 6862, Device 687f, Device 6860, Device 6861, 'Vega 10 XTX [Radeon
-    Vega Frontier Edition]', 'Vega [Radeon RX Vega]', 'Vega 10 [Radeon Instinct MI25]']
+    Vega Frontier Edition]', 'Vega [Radeon RX Vega]', 'Vega 10 [Radeon Instinct MI25]',
+  Vega, Device 6864]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false
@@ -26,8 +27,8 @@
   NumIndicesBatch: 1
   NumIndicesC: 3
   NumIndicesFree: 2
-  NumIndicesSummation: 1
   NumIndicesLD: 4
+  NumIndicesSummation: 1
   OperationType: GEMM
   SilentHighPrecisionAccumulate: false
   TLUA: false
@@ -158,8 +159,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: false
@@ -323,8 +324,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: false
@@ -488,8 +489,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: false
@@ -653,8 +654,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: false
@@ -818,8 +819,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: false
@@ -983,8 +984,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: false
@@ -1148,8 +1149,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: false
@@ -1312,8 +1313,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: false

--- a/HostLibraryTests/configs/lite_configs/vega10_Cijk_Alik_Bljk_SB.yaml
+++ b/HostLibraryTests/configs/lite_configs/vega10_Cijk_Alik_Bljk_SB.yaml
@@ -3,7 +3,7 @@
 - gfx900
 - [Device 6863, Device 6862, Device 687f, Device 6860, Device 6861, 'Vega 10 XTX [Radeon
     Vega Frontier Edition]', 'Vega [Radeon RX Vega]', 'Vega 10 [Radeon Instinct MI25]',
-  Vega, Device 6864]
+    Vega, Device 6864]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/HostLibraryTests/configs/lite_configs_mixed/vega10_Cijk_Ailk_Bjlk_SB.yaml
+++ b/HostLibraryTests/configs/lite_configs_mixed/vega10_Cijk_Ailk_Bjlk_SB.yaml
@@ -2,7 +2,8 @@
 - vega10
 - gfx900
 - [Device 6863, Device 6862, Device 687f, Device 6860, Device 6861, 'Vega 10 XTX [Radeon
-    Vega Frontier Edition]', 'Vega [Radeon RX Vega]', 'Vega 10 [Radeon Instinct MI25]']
+    Vega Frontier Edition]', 'Vega [Radeon RX Vega]', 'Vega 10 [Radeon Instinct MI25]',
+  Vega, Device 6864]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false
@@ -27,8 +28,8 @@
   NumIndicesBatch: 1
   NumIndicesC: 3
   NumIndicesFree: 2
-  NumIndicesSummation: 1
   NumIndicesLD: 4
+  NumIndicesSummation: 1
   OperationType: GEMM
   SilentHighPrecisionAccumulate: false
   TLUA: true
@@ -166,8 +167,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: true
@@ -330,8 +331,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: true
@@ -494,8 +495,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: true
@@ -662,8 +663,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: true
@@ -829,8 +830,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: true
@@ -996,8 +997,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: true
@@ -1163,8 +1164,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: true

--- a/HostLibraryTests/configs/lite_configs_mixed/vega10_Cijk_Ailk_Bjlk_SB.yaml
+++ b/HostLibraryTests/configs/lite_configs_mixed/vega10_Cijk_Ailk_Bjlk_SB.yaml
@@ -3,7 +3,7 @@
 - gfx900
 - [Device 6863, Device 6862, Device 687f, Device 6860, Device 6861, 'Vega 10 XTX [Radeon
     Vega Frontier Edition]', 'Vega [Radeon RX Vega]', 'Vega 10 [Radeon Instinct MI25]',
-  Vega, Device 6864]
+    Vega, Device 6864]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/HostLibraryTests/configs/lite_configs_mixed/vega10_Cijk_Ailk_Bljk_SB.yaml
+++ b/HostLibraryTests/configs/lite_configs_mixed/vega10_Cijk_Ailk_Bljk_SB.yaml
@@ -2,7 +2,8 @@
 - vega10
 - gfx900
 - [Device 6863, Device 6862, Device 687f, Device 6860, Device 6861, 'Vega 10 XTX [Radeon
-    Vega Frontier Edition]', 'Vega [Radeon RX Vega]', 'Vega 10 [Radeon Instinct MI25]']
+    Vega Frontier Edition]', 'Vega [Radeon RX Vega]', 'Vega 10 [Radeon Instinct MI25]',
+  Vega, Device 6864]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false
@@ -27,8 +28,8 @@
   NumIndicesBatch: 1
   NumIndicesC: 3
   NumIndicesFree: 2
-  NumIndicesSummation: 1
   NumIndicesLD: 4
+  NumIndicesSummation: 1
   OperationType: GEMM
   SilentHighPrecisionAccumulate: false
   TLUA: true
@@ -166,8 +167,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: true
@@ -334,8 +335,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: true
@@ -498,8 +499,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: true
@@ -666,8 +667,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: true
@@ -834,8 +835,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: true
@@ -1001,8 +1002,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: true
@@ -1168,8 +1169,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: true
@@ -1335,8 +1336,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: true

--- a/HostLibraryTests/configs/lite_configs_mixed/vega10_Cijk_Ailk_Bljk_SB.yaml
+++ b/HostLibraryTests/configs/lite_configs_mixed/vega10_Cijk_Ailk_Bljk_SB.yaml
@@ -3,7 +3,7 @@
 - gfx900
 - [Device 6863, Device 6862, Device 687f, Device 6860, Device 6861, 'Vega 10 XTX [Radeon
     Vega Frontier Edition]', 'Vega [Radeon RX Vega]', 'Vega 10 [Radeon Instinct MI25]',
-  Vega, Device 6864]
+    Vega, Device 6864]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/HostLibraryTests/configs/lite_configs_mixed/vega10_Cijk_Alik_Bjlk_SB.yaml
+++ b/HostLibraryTests/configs/lite_configs_mixed/vega10_Cijk_Alik_Bjlk_SB.yaml
@@ -3,7 +3,7 @@
 - gfx900
 - [Device 6863, Device 6862, Device 687f, Device 6860, Device 6861, 'Vega 10 XTX [Radeon
     Vega Frontier Edition]', 'Vega [Radeon RX Vega]', 'Vega 10 [Radeon Instinct MI25]',
-  Vega, Device 6864]
+    Vega, Device 6864]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/HostLibraryTests/configs/lite_configs_mixed/vega10_Cijk_Alik_Bjlk_SB.yaml
+++ b/HostLibraryTests/configs/lite_configs_mixed/vega10_Cijk_Alik_Bjlk_SB.yaml
@@ -2,7 +2,8 @@
 - vega10
 - gfx900
 - [Device 6863, Device 6862, Device 687f, Device 6860, Device 6861, 'Vega 10 XTX [Radeon
-    Vega Frontier Edition]', 'Vega [Radeon RX Vega]', 'Vega 10 [Radeon Instinct MI25]']
+    Vega Frontier Edition]', 'Vega [Radeon RX Vega]', 'Vega 10 [Radeon Instinct MI25]',
+  Vega, Device 6864]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false
@@ -27,8 +28,8 @@
   NumIndicesBatch: 1
   NumIndicesC: 3
   NumIndicesFree: 2
-  NumIndicesSummation: 1
   NumIndicesLD: 4
+  NumIndicesSummation: 1
   OperationType: GEMM
   SilentHighPrecisionAccumulate: false
   TLUA: false
@@ -166,8 +167,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: false
@@ -330,8 +331,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: false
@@ -494,8 +495,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: false
@@ -662,8 +663,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: false
@@ -830,8 +831,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: false
@@ -997,8 +998,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: false
@@ -1164,8 +1165,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: false
@@ -1331,8 +1332,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: false

--- a/HostLibraryTests/configs/lite_configs_mixed/vega10_Cijk_Alik_Bljk_SB.yaml
+++ b/HostLibraryTests/configs/lite_configs_mixed/vega10_Cijk_Alik_Bljk_SB.yaml
@@ -2,7 +2,8 @@
 - vega10
 - gfx900
 - [Device 6863, Device 6862, Device 687f, Device 6860, Device 6861, 'Vega 10 XTX [Radeon
-    Vega Frontier Edition]', 'Vega [Radeon RX Vega]', 'Vega 10 [Radeon Instinct MI25]']
+    Vega Frontier Edition]', 'Vega [Radeon RX Vega]', 'Vega 10 [Radeon Instinct MI25]',
+  Vega, Device 6864]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false
@@ -27,8 +28,8 @@
   NumIndicesBatch: 1
   NumIndicesC: 3
   NumIndicesFree: 2
-  NumIndicesSummation: 1
   NumIndicesLD: 4
+  NumIndicesSummation: 1
   OperationType: GEMM
   SilentHighPrecisionAccumulate: false
   TLUA: false
@@ -166,8 +167,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: false
@@ -330,8 +331,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: false
@@ -494,8 +495,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: false
@@ -658,8 +659,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: false
@@ -822,8 +823,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: false
@@ -990,8 +991,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: false
@@ -1157,8 +1158,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: false
@@ -1324,8 +1325,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: false
@@ -1491,8 +1492,8 @@
       NumIndicesBatch: 1
       NumIndicesC: 3
       NumIndicesFree: 2
-      NumIndicesSummation: 1
       NumIndicesLD: 4
+      NumIndicesSummation: 1
       OperationType: GEMM
       SilentHighPrecisionAccumulate: false
       TLUA: false

--- a/HostLibraryTests/configs/lite_configs_mixed/vega10_Cijk_Alik_Bljk_SB.yaml
+++ b/HostLibraryTests/configs/lite_configs_mixed/vega10_Cijk_Alik_Bljk_SB.yaml
@@ -3,7 +3,7 @@
 - gfx900
 - [Device 6863, Device 6862, Device 687f, Device 6860, Device 6861, 'Vega 10 XTX [Radeon
     Vega Frontier Edition]', 'Vega [Radeon RX Vega]', 'Vega 10 [Radeon Instinct MI25]',
-  Vega, Device 6864]
+    Vega, Device 6864]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/Tensile/Configs/miopen/Logic/deepbench_conv/vega10_Cijk_Ailk_Bljk_HB.yaml
+++ b/Tensile/Configs/miopen/Logic/deepbench_conv/vega10_Cijk_Ailk_Bljk_HB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.2.0}
 - vega10
 - gfx900
-- [Device 6863, Device 6862, Device 687f, Device 6860, Device 6861]
+- [Device 6863, Device 6862, Device 687f, Device 6860, Device 6861, Device 6864]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/Tensile/Configs/miopen/Logic/deepbench_conv/vega10_Cijk_Ailk_Bljk_SB.yaml
+++ b/Tensile/Configs/miopen/Logic/deepbench_conv/vega10_Cijk_Ailk_Bljk_SB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.2.0}
 - vega10
 - gfx900
-- [Device 6863, Device 6862, Device 687f, Device 6860, Device 6861]
+- [Device 6863, Device 6862, Device 687f, Device 6860, Device 6861, Device 6864]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/Tensile/Configs/miopen/Logic/deepbench_gemm/vega10_Cijk_Ailk_Bjlk_HB.yaml
+++ b/Tensile/Configs/miopen/Logic/deepbench_gemm/vega10_Cijk_Ailk_Bjlk_HB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.2.0}
 - vega10
 - gfx900
-- [Device 6863, Device 6862, Device 687f, Device 6860, Device 6861]
+- [Device 6863, Device 6862, Device 687f, Device 6860, Device 6861, Device 6864]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/Tensile/Configs/miopen/Logic/deepbench_gemm/vega10_Cijk_Ailk_Bjlk_SB.yaml
+++ b/Tensile/Configs/miopen/Logic/deepbench_gemm/vega10_Cijk_Ailk_Bjlk_SB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.2.0}
 - vega10
 - gfx900
-- [Device 6863, Device 6862, Device 687f, Device 6860, Device 6861]
+- [Device 6863, Device 6862, Device 687f, Device 6860, Device 6861, Device 6864]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/Tensile/Configs/miopen/Logic/deepbench_gemm/vega10_Cijk_Ailk_Bljk_HB.yaml
+++ b/Tensile/Configs/miopen/Logic/deepbench_gemm/vega10_Cijk_Ailk_Bljk_HB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.2.0}
 - vega10
 - gfx900
-- [Device 6863, Device 6862, Device 687f, Device 6860, Device 6861]
+- [Device 6863, Device 6862, Device 687f, Device 6860, Device 6861, Device 6864]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/Tensile/Configs/miopen/Logic/deepbench_gemm/vega10_Cijk_Ailk_Bljk_SB.yaml
+++ b/Tensile/Configs/miopen/Logic/deepbench_gemm/vega10_Cijk_Ailk_Bljk_SB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.2.0}
 - vega10
 - gfx900
-- [Device 6863, Device 6862, Device 687f, Device 6860, Device 6861]
+- [Device 6863, Device 6862, Device 687f, Device 6860, Device 6861, Device 6864]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/Tensile/Configs/miopen/Logic/deepbench_gemm/vega10_Cijk_Alik_Bljk_HB.yaml
+++ b/Tensile/Configs/miopen/Logic/deepbench_gemm/vega10_Cijk_Alik_Bljk_HB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.2.0}
 - vega10
 - gfx900
-- [Device 6863, Device 6862, Device 687f, Device 6860, Device 6861]
+- [Device 6863, Device 6862, Device 687f, Device 6860, Device 6861, Device 6864]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/Tensile/Configs/miopen/Logic/deepbench_gemm/vega10_Cijk_Alik_Bljk_SB.yaml
+++ b/Tensile/Configs/miopen/Logic/deepbench_gemm/vega10_Cijk_Alik_Bljk_SB.yaml
@@ -1,7 +1,7 @@
 - {MinimumRequiredVersion: 4.2.0}
 - vega10
 - gfx900
-- [Device 6863, Device 6862, Device 687f, Device 6860, Device 6861]
+- [Device 6863, Device 6862, Device 687f, Device 6860, Device 6861, Device 6864]
 - AssignedDerivedParameters: true
   Batched: true
   ComplexConjugateA: false

--- a/Tensile/Configs/rocblas_cgemm.yaml
+++ b/Tensile/Configs/rocblas_cgemm.yaml
@@ -178,7 +178,8 @@ BenchmarkProblems:
 
 LibraryLogic:
     ScheduleName: "vega10"
-    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]"]
+    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]",
+        Vega, Device 6864]
     ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/rocblas_cgemm_asm_lite.yaml
+++ b/Tensile/Configs/rocblas_cgemm_asm_lite.yaml
@@ -588,7 +588,8 @@ LibraryLogic:
     ArchitectureName: "gfx906"
 
 #   ScheduleName: "vega10"
-#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]"]
+#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]",
+#       Vega, Device 6864]
 #   ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/rocblas_cgemm_hip_lite.yaml
+++ b/Tensile/Configs/rocblas_cgemm_hip_lite.yaml
@@ -346,7 +346,8 @@ BenchmarkProblems:
 
 LibraryLogic:
 #   ScheduleName: "vega10"
-    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]"]
+    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]",
+        Vega, Device 6864]
 #   ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/rocblas_dgemm_asm_lite.yaml
+++ b/Tensile/Configs/rocblas_dgemm_asm_lite.yaml
@@ -462,7 +462,8 @@ LibraryLogic:
 #   ArchitectureName: "gfx906"
 
     ScheduleName: "vega10"
-    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]"]
+    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]",
+        Vega, Device 6864]
     ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/rocblas_dgemm_hip_lite.yaml
+++ b/Tensile/Configs/rocblas_dgemm_hip_lite.yaml
@@ -164,7 +164,8 @@ BenchmarkProblems:
 
 LibraryLogic:
 #   ScheduleName: "vega10"
-    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]"]
+    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]",
+        Vega, Device 6864]
 #   ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/rocblas_dgemm_nn_asm_full.yaml
+++ b/Tensile/Configs/rocblas_dgemm_nn_asm_full.yaml
@@ -235,7 +235,8 @@ LibraryLogic:
     ArchitectureName: "gfx906"
 
 #   ScheduleName: "vega10"
-#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]"]
+#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]",
+#       Vega, Device 6864]
 #   ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/rocblas_dgemm_nn_inc0_asm_full.yaml
+++ b/Tensile/Configs/rocblas_dgemm_nn_inc0_asm_full.yaml
@@ -129,7 +129,8 @@ LibraryLogic:
     ArchitectureName: "gfx906"
 
 #   ScheduleName: "vega10"
-#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]"]
+#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]",
+#       Vega, Device 6864]
 #   ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/rocblas_dgemm_nt_asm_full.yaml
+++ b/Tensile/Configs/rocblas_dgemm_nt_asm_full.yaml
@@ -183,7 +183,8 @@ LibraryLogic:
     ArchitectureName: "gfx906"
 
 #   ScheduleName: "vega10"
-#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]"]
+#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]",
+#       Vega, Device 6864]
 #   ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/rocblas_dgemm_nt_inc0_asm_full.yaml
+++ b/Tensile/Configs/rocblas_dgemm_nt_inc0_asm_full.yaml
@@ -459,7 +459,8 @@ LibraryLogic:
     ArchitectureName: "gfx906"
 
 #   ScheduleName: "vega10"
-#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]"]
+#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]",
+#       Vega, Device 6864]
 #   ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/rocblas_dgemm_nt_inc1_asm_full.yaml
+++ b/Tensile/Configs/rocblas_dgemm_nt_inc1_asm_full.yaml
@@ -2127,7 +2127,8 @@ LibraryLogic:
     ArchitectureName: "gfx906"
 
 #   ScheduleName: "vega10"
-#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]"]
+#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]",
+#       Vega, Device 6864]
 #   ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/rocblas_dgemm_nt_inc2_asm_full.yaml
+++ b/Tensile/Configs/rocblas_dgemm_nt_inc2_asm_full.yaml
@@ -5178,7 +5178,8 @@ LibraryLogic:
     ArchitectureName: "gfx906"
 
 #   ScheduleName: "vega10"
-#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]"]
+#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]",
+#       Vega, Device 6864]
 #   ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/rocblas_dgemm_nt_inc3_asm_full.yaml
+++ b/Tensile/Configs/rocblas_dgemm_nt_inc3_asm_full.yaml
@@ -5130,7 +5130,8 @@ LibraryLogic:
     ArchitectureName: "gfx906"
 
 #   ScheduleName: "vega10"
-#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]"]
+#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]",
+#       Vega, Device 6864]
 #   ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/rocblas_dgemm_nt_resume_train_exp.yaml
+++ b/Tensile/Configs/rocblas_dgemm_nt_resume_train_exp.yaml
@@ -5131,7 +5131,8 @@ LibraryLogic:
     ArchitectureName: "gfx906"
 
 #   ScheduleName: "vega10"
-#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]"]
+#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]",
+#       Vega, Device 6864]
 #   ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/rocblas_dgemm_tn_asm_full.yaml
+++ b/Tensile/Configs/rocblas_dgemm_tn_asm_full.yaml
@@ -97,7 +97,8 @@ LibraryLogic:
     ArchitectureName: "gfx906"
 
 #   ScheduleName: "vega10"
-#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]"]
+#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]",
+#       Vega, Device 6864]
 #   ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/rocblas_dgemm_tt_asm_full.yaml
+++ b/Tensile/Configs/rocblas_dgemm_tt_asm_full.yaml
@@ -97,7 +97,8 @@ LibraryLogic:
     ArchitectureName: "gfx906"
 
 #   ScheduleName: "vega10"
-#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]"]
+#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]",
+#       Vega, Device 6864]
 #   ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/rocblas_hgemm_asm_full.yaml
+++ b/Tensile/Configs/rocblas_hgemm_asm_full.yaml
@@ -1406,7 +1406,8 @@ LibraryLogic:
 #   ArchitectureName: "gfx906"
 
     ScheduleName: "vega10"
-    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]"]
+    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]",
+        Vega, Device 6864]
     ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/rocblas_hgemm_asm_lite.yaml
+++ b/Tensile/Configs/rocblas_hgemm_asm_lite.yaml
@@ -309,7 +309,8 @@ LibraryLogic:
 #   ArchitectureName: "gfx906"
 
     ScheduleName: "vega10"
-    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]"]
+    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]",
+        Vega, Device 6864]
     ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/rocblas_hgemm_hip_lite.yaml
+++ b/Tensile/Configs/rocblas_hgemm_hip_lite.yaml
@@ -275,7 +275,8 @@ BenchmarkProblems:
 
 LibraryLogic:
 #   ScheduleName: "vega10"
-    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]"]
+    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]",
+        Vega, Device 6864]
 #   ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/rocblas_hgemm_hip_lite.yaml
+++ b/Tensile/Configs/rocblas_hgemm_hip_lite.yaml
@@ -275,8 +275,8 @@ BenchmarkProblems:
 
 LibraryLogic:
 #   ScheduleName: "vega10"
-    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]",
-        Vega, Device 6864]
+#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]",
+#       Vega, Device 6864]
 #   ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/rocblas_hpa_bfloat16_asm_single_kernel.yaml
+++ b/Tensile/Configs/rocblas_hpa_bfloat16_asm_single_kernel.yaml
@@ -81,7 +81,8 @@ BenchmarkProblems:
 #    ArchitectureName: "gfx906"
 #
 ##   ScheduleName: "vega10"
-##   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]"]
+##   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]",
+##      Vega, Device 6864]
 ##   ArchitectureName: "gfx900"
 #
 ##   ScheduleName: "mi25"

--- a/Tensile/Configs/rocblas_hpa_bfloat16_hip_lite.yaml
+++ b/Tensile/Configs/rocblas_hpa_bfloat16_hip_lite.yaml
@@ -413,7 +413,8 @@ BenchmarkProblems:
 
 LibraryLogic:
 #   ScheduleName: "vega10"
-#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]"]
+#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]",
+#       Vega, Device 6864]
 #   ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/rocblas_hpa_bfloat16_hip_single_kernel.yaml
+++ b/Tensile/Configs/rocblas_hpa_bfloat16_hip_single_kernel.yaml
@@ -76,11 +76,12 @@ BenchmarkProblems:
 #  ########################################
 #LibraryLogic:
 #    ScheduleName: "vega20"
-#   DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Device 66af", "Vega 20"]
+#    DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Device 66af", "Vega 20"]
 #    ArchitectureName: "gfx906"
 #
 ##   ScheduleName: "vega10"
-##   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]"]
+##   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]",
+##      Vega, Device 6864]
 ##   ArchitectureName: "gfx900"
 #
 ##   ScheduleName: "mi25"

--- a/Tensile/Configs/rocblas_hpa_hgemm_asm_lite.yaml
+++ b/Tensile/Configs/rocblas_hpa_hgemm_asm_lite.yaml
@@ -286,7 +286,8 @@ BenchmarkProblems:
 
 LibraryLogic:
     ScheduleName: "vega10"
-    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]"]
+    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]",
+        Vega, Device 6864]
     ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/rocblas_hpa_hgemm_hip_lite.yaml
+++ b/Tensile/Configs/rocblas_hpa_hgemm_hip_lite.yaml
@@ -405,7 +405,8 @@ BenchmarkProblems:
 
 LibraryLogic:
 #   ScheduleName: "vega10"
-#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]"]
+#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]",
+#       Vega, Device 6864]
 #   ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/rocblas_hpa_hgemm_nn_asm_full.yaml
+++ b/Tensile/Configs/rocblas_hpa_hgemm_nn_asm_full.yaml
@@ -610,7 +610,8 @@ LibraryLogic:
 #   ArchitectureName: "gfx906"
 
     ScheduleName: "vega10"
-    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]"]
+    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]",
+        Vega, Device 6864]
     ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/rocblas_hpa_hgemm_nt_asm_full.yaml
+++ b/Tensile/Configs/rocblas_hpa_hgemm_nt_asm_full.yaml
@@ -234,7 +234,8 @@ LibraryLogic:
 #   ArchitectureName: "gfx906"
 
     ScheduleName: "vega10"
-    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]"]
+    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]",
+        Vega, Device 6864]
     ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/rocblas_hpa_hgemm_tn_asm_full.yaml
+++ b/Tensile/Configs/rocblas_hpa_hgemm_tn_asm_full.yaml
@@ -435,7 +435,8 @@ LibraryLogic:
 #   ArchitectureName: "gfx906"
 
     ScheduleName: "vega10"
-    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]"]
+    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]",
+        Vega, Device 6864]
     ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/rocblas_hpa_hgemm_tt_asm_full.yaml
+++ b/Tensile/Configs/rocblas_hpa_hgemm_tt_asm_full.yaml
@@ -227,7 +227,8 @@ LibraryLogic:
 #   ArchitectureName: "gfx906"
 
     ScheduleName: "vega10"
-    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]"]
+    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]",
+        Vega, Device 6864]
     ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/rocblas_hpa_igemm_nn_hip.yaml
+++ b/Tensile/Configs/rocblas_hpa_igemm_nn_hip.yaml
@@ -122,7 +122,8 @@ BenchmarkProblems:
 
 LibraryLogic:
 #   ScheduleName: "vega10"
-#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]"]
+#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]",
+#       Vega, Device 6864]
 #   ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/rocblas_hpa_igemm_nt_hip.yaml
+++ b/Tensile/Configs/rocblas_hpa_igemm_nt_hip.yaml
@@ -122,7 +122,8 @@ BenchmarkProblems:
 
 LibraryLogic:
 #   ScheduleName: "vega10"
-#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]"]
+#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]",
+#       Vega, Device 6864]
 #   ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/rocblas_hpa_igemm_tn_hip.yaml
+++ b/Tensile/Configs/rocblas_hpa_igemm_tn_hip.yaml
@@ -121,7 +121,8 @@ BenchmarkProblems:
 
 LibraryLogic:
 #   ScheduleName: "vega10"
-#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]"]
+#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]",
+#       Vega, Device 6864]
 #   ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/rocblas_hpa_igemm_tt_hip.yaml
+++ b/Tensile/Configs/rocblas_hpa_igemm_tt_hip.yaml
@@ -121,7 +121,8 @@ BenchmarkProblems:
 
 LibraryLogic:
 #   ScheduleName: "vega10"
-#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]"]
+#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]",
+#       Vega, Device 6864]
 #   ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/rocblas_igemm_asm_full_nn.yaml
+++ b/Tensile/Configs/rocblas_igemm_asm_full_nn.yaml
@@ -612,7 +612,8 @@ LibraryLogic:
     ArchitectureName: "gfx906"
 
 #   ScheduleName: "vega10"
-#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]"]
+#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]",
+#       Vega, Device 6864]
 #   ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/rocblas_igemm_asm_full_nt.yaml
+++ b/Tensile/Configs/rocblas_igemm_asm_full_nt.yaml
@@ -246,7 +246,8 @@ LibraryLogic:
     ArchitectureName: "gfx906"
 
 #   ScheduleName: "vega10"
-#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]"]
+#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]",
+#       Vega, Device 6864]
 #   ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/rocblas_igemm_asm_full_tn.yaml
+++ b/Tensile/Configs/rocblas_igemm_asm_full_tn.yaml
@@ -492,7 +492,8 @@ LibraryLogic:
     ArchitectureName: "gfx906"
 
 #   ScheduleName: "vega10"
-#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]"]
+#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]",
+#       Vega, Device 6864]
 #   ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/rocblas_igemm_asm_full_tt.yaml
+++ b/Tensile/Configs/rocblas_igemm_asm_full_tt.yaml
@@ -236,7 +236,8 @@ LibraryLogic:
     ArchitectureName: "gfx906"
 
 #   ScheduleName: "vega10"
-#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]"]
+#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]",
+#       Vega, Device 6864]
 #   ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/rocblas_igemm_hip_single_kernel.yaml
+++ b/Tensile/Configs/rocblas_igemm_hip_single_kernel.yaml
@@ -75,7 +75,8 @@ LibraryLogic:
 #   ArchitectureName: "gfx906"
 #
 #   ScheduleName: "vega10"
-#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]"]
+#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]",
+#       Vega, Device 6864]
 #   ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/rocblas_sgemm_asm_full.yaml
+++ b/Tensile/Configs/rocblas_sgemm_asm_full.yaml
@@ -1447,7 +1447,8 @@ LibraryLogic:
 #   ArchitectureName: "gfx906"
 
     ScheduleName: "vega10"
-    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]"]
+    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]",
+        Vega, Device 6864]
     ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/rocblas_sgemm_asm_lite.yaml
+++ b/Tensile/Configs/rocblas_sgemm_asm_lite.yaml
@@ -557,7 +557,8 @@ LibraryLogic:
 #   ArchitectureName: "gfx906"
 
     ScheduleName: "vega10"
-    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]", "Vega 10 [Radeon Instinct MI25]"]
+    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]", 
+        "Vega 10 [Radeon Instinct MI25]", Vega, Device 6864]
     ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/rocblas_sgemm_asm_only.yaml
+++ b/Tensile/Configs/rocblas_sgemm_asm_only.yaml
@@ -329,7 +329,8 @@ LibraryLogic:
 #   ArchitectureName: "gfx906"
 
     ScheduleName: "vega10"
-    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]", "Vega 10 [Radeon Instinct MI25]"]
+    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]", 
+        "Vega 10 [Radeon Instinct MI25]", Vega, Device 6864]
     ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/rocblas_sgemm_hip_lite.yaml
+++ b/Tensile/Configs/rocblas_sgemm_hip_lite.yaml
@@ -183,7 +183,8 @@ BenchmarkProblems:
 
 LibraryLogic:
 #   ScheduleName: "vega10"
-    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]"]
+    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]",
+        Vega, Device 6864]
 #   ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/rocblas_zgemm.yaml
+++ b/Tensile/Configs/rocblas_zgemm.yaml
@@ -178,7 +178,8 @@ BenchmarkProblems:
 
 LibraryLogic:
     ScheduleName: "vega10"
-    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]"]
+    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]",
+        Vega, Device 6864]
     ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"

--- a/Tensile/Configs/rocblas_zgemm_asm_lite.yaml
+++ b/Tensile/Configs/rocblas_zgemm_asm_lite.yaml
@@ -425,7 +425,8 @@ LibraryLogic:
     ArchitectureName: "gfx906"
 
 #   ScheduleName: "vega10"
-#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]"]
+#   DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]", "Vega [Radeon RX Vega]",
+#       Vega, Device 6864]
 #   ArchitectureName: "gfx900"
 
 #   ScheduleName: "mi25"


### PR DESCRIPTION
Similar to rocBLAS PR #763, which added Vega and Device 6864 to the Vega 10 configs