### PR TITLE
Test configs for ZGEMM HIP generator 

### DIFF
--- a/Tensile/Tests/nightly/double_complex/test_double_complex_nightly.py
+++ b/Tensile/Tests/nightly/double_complex/test_double_complex_nightly.py
@@ -1,6 +1,32 @@
 import Tensile.Tensile as Tensile
 
+def test_zgemm_hip_source_nn(tmpdir):
+ Tensile.Tensile([Tensile.TensileTestPath("nightly/double_complex/zgemm_hip_source_nn.yaml"), tmpdir.strpath])
+
+def test_zgemm_hip_source_nt(tmpdir):
+ Tensile.Tensile([Tensile.TensileTestPath("nightly/double_complex/zgemm_hip_source_nt.yaml"), tmpdir.strpath])
+
+def test_zgemm_hip_source_nc(tmpdir):
+ Tensile.Tensile([Tensile.TensileTestPath("nightly/double_complex/zgemm_hip_source_nc.yaml"), tmpdir.strpath])
+
+def test_zgemm_hip_source_cn(tmpdir):
+ Tensile.Tensile([Tensile.TensileTestPath("nightly/double_complex/zgemm_hip_source_cn.yaml"), tmpdir.strpath])
+
+def test_zgemm_hip_source_tc(tmpdir):
+ Tensile.Tensile([Tensile.TensileTestPath("nightly/double_complex/zgemm_hip_source_tc.yaml"), tmpdir.strpath])
 
 def test_zgemm_asm(tmpdir):
  Tensile.Tensile([Tensile.TensileTestPath("nightly/double_complex/zgemm_asm.yaml"), tmpdir.strpath])
+
+def test_zgemm_hip_source_ct(tmpdir):
+ Tensile.Tensile([Tensile.TensileTestPath("nightly/double_complex/zgemm_hip_source_ct.yaml"), tmpdir.strpath])
+
+def test_zgemm_hip_source_tn(tmpdir):
+ Tensile.Tensile([Tensile.TensileTestPath("nightly/double_complex/zgemm_hip_source_tn.yaml"), tmpdir.strpath])
+
+def test_zgemm_hip_source_tt(tmpdir):
+ Tensile.Tensile([Tensile.TensileTestPath("nightly/double_complex/zgemm_hip_source_tt.yaml"), tmpdir.strpath])
+
+def test_zgemm_hip_source_cc(tmpdir):
+ Tensile.Tensile([Tensile.TensileTestPath("nightly/double_complex/zgemm_hip_source_cc.yaml"), tmpdir.strpath])
 

--- a/Tensile/Tests/nightly/double_complex/zgemm_hip_source_cc.yaml
+++ b/Tensile/Tests/nightly/double_complex/zgemm_hip_source_cc.yaml
@@ -1,0 +1,43 @@
+GlobalParameters:
+  MinimumRequiredVersion: 4.2.0
+  NumElementsToValidate: -1
+  KernelTime: True
+
+BenchmarkProblems:
+  - # zgemm CC
+    - # ProblemType
+      OperationType: GEMM
+      DataType: z
+      DestDataType: z
+      ComputeDataType: z
+      TransposeA: True
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+      ComplexConjugateA: True
+      ComplexConjugateB: True
+
+    - # BenchmarkProblemSizeGroup - Source
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - LoopTail: [True]
+        - EdgeType: ["ShiftPtr"]
+        - KernelLanguage: ["Source"]
+      ForkParameters:
+        - GlobalSplitU: [1, 3]
+        - PrefetchLocalRead: [True]
+        - PrefetchGlobalRead: [False]
+        - ThreadTile:
+          - [ 4, 2 ]
+          - [ 4, 8 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+          - [ 32,  4,  1 ]
+        - DepthU: [8]
+        - VectorWidth: [-1]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [126,1,130], 0, [2], [62,1,66] ]

--- a/Tensile/Tests/nightly/double_complex/zgemm_hip_source_cn.yaml
+++ b/Tensile/Tests/nightly/double_complex/zgemm_hip_source_cn.yaml
@@ -43,3 +43,24 @@ BenchmarkProblems:
         - ProblemSizes:
           - Range: [ [126,1,130], 0, [2], [62,1,66] ]
 
+    - # Regression test - Source
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - LoopTail: [True]
+        - EdgeType: ["ShiftPtr"]
+        - DepthU: [16]
+        - VectorWidth: [1]
+      ForkParameters:
+        - KernelLanguage: ["Source"]
+        - PrefetchLocalRead: [True]
+        - PrefetchGlobalRead: [False]
+        - ThreadTile:
+          - [ 2, 16 ]
+        - WorkGroup:
+          - [ 8,  8, 1 ]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [ 1, 1, 1, 64 ]

--- a/Tensile/Tests/nightly/double_complex/zgemm_hip_source_cn.yaml
+++ b/Tensile/Tests/nightly/double_complex/zgemm_hip_source_cn.yaml
@@ -1,0 +1,45 @@
+# benchmark assembly and source kernels
+GlobalParameters:
+  MinimumRequiredVersion: 4.2.0
+  NumElementsToValidate: -1
+  KernelTime: True
+
+BenchmarkProblems:
+
+  - # zgemm CN
+    - # ProblemType
+      OperationType: GEMM
+      DataType: z
+      DestDataType: z
+      ComputeDataType: z
+      TransposeA: True
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+      ComplexConjugateA: True
+
+    - # BenchmarkProblemSizeGroup - Source
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - LoopTail: [True]
+        - EdgeType: ["ShiftPtr"]
+        - KernelLanguage: ["Source"]
+      ForkParameters:
+        - GlobalSplitU: [1, 3]
+        - PrefetchLocalRead: [True]
+        - PrefetchGlobalRead: [False]
+        - ThreadTile:
+          - [ 4, 2 ]
+          - [ 4, 8 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+          - [ 32,  4,  1 ]
+        - DepthU: [8]
+        - VectorWidth: [-1]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [126,1,130], 0, [2], [62,1,66] ]
+

--- a/Tensile/Tests/nightly/double_complex/zgemm_hip_source_ct.yaml
+++ b/Tensile/Tests/nightly/double_complex/zgemm_hip_source_ct.yaml
@@ -1,0 +1,43 @@
+GlobalParameters:
+  MinimumRequiredVersion: 4.2.0
+  NumElementsToValidate: -1
+  KernelTime: True
+
+BenchmarkProblems:
+  - # zgemm CT
+    - # ProblemType
+      OperationType: GEMM
+      DataType: z
+      DestDataType: z
+      ComputeDataType: z
+      TransposeA: True
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+      ComplexConjugateA: True
+
+    - # BenchmarkProblemSizeGroup - Source
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - LoopTail: [True]
+        - EdgeType: ["ShiftPtr"]
+        - KernelLanguage: ["Source"]
+      ForkParameters:
+        - GlobalSplitU: [1, 3]
+        - PrefetchLocalRead: [True]
+        - PrefetchGlobalRead: [False]
+        - ThreadTile:
+          - [ 4, 2 ]
+          - [ 4, 8 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+          - [ 32,  4,  1 ]
+        - DepthU: [8]
+        - VectorWidth: [-1]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [126,1,130], 0, [2], [62,1,66] ]
+

--- a/Tensile/Tests/nightly/double_complex/zgemm_hip_source_nc.yaml
+++ b/Tensile/Tests/nightly/double_complex/zgemm_hip_source_nc.yaml
@@ -1,0 +1,43 @@
+# benchmark assembly and source kernels
+GlobalParameters:
+  MinimumRequiredVersion: 4.2.0
+  NumElementsToValidate: -1
+  KernelTime: True
+
+BenchmarkProblems:
+  - # zgemm NC
+    - # ProblemType
+      OperationType: GEMM
+      DataType: z
+      DestDataType: z
+      ComputeDataType: z
+      TransposeA: False
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+      ComplexConjugateB: True
+
+    - # BenchmarkProblemSizeGroup - Source
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - LoopTail: [True]
+        - EdgeType: ["ShiftPtr"]
+        - KernelLanguage: ["Source"]
+      ForkParameters:
+        - GlobalSplitU: [1, 3]
+        - PrefetchLocalRead: [True]
+        - PrefetchGlobalRead: [False]
+        - ThreadTile:
+          - [ 4, 2 ]
+          - [ 4, 8 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+          - [ 32,  4,  1 ]
+        - DepthU: [8]
+        - VectorWidth: [-1]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [126,1,130], 0, [2], [62,1,66] ]

--- a/Tensile/Tests/nightly/double_complex/zgemm_hip_source_nn.yaml
+++ b/Tensile/Tests/nightly/double_complex/zgemm_hip_source_nn.yaml
@@ -1,0 +1,43 @@
+# benchmark source kernels
+GlobalParameters:
+  MinimumRequiredVersion: 4.2.0
+  NumElementsToValidate: -1
+  KernelTime: True
+
+BenchmarkProblems:
+
+  - # zgemm NN
+    - # ProblemType
+      OperationType: GEMM
+      DataType: z
+      DestDataType: z
+      ComputeDataType: z
+      TransposeA: False
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Source
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - LoopTail: [True]
+        - EdgeType: ["ShiftPtr"]
+        - KernelLanguage: ["Source"]
+      ForkParameters:
+        - GlobalSplitU: [1, 3]
+        - PrefetchLocalRead: [True]
+        - PrefetchGlobalRead: [False]
+        - ThreadTile:
+          - [ 4, 2 ]
+          - [ 4, 8 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+          - [ 32,  4,  1 ]
+        - DepthU: [8]
+        - VectorWidth: [-1]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [126,1,130], 0, [2], [62,1,66] ]

--- a/Tensile/Tests/nightly/double_complex/zgemm_hip_source_nt.yaml
+++ b/Tensile/Tests/nightly/double_complex/zgemm_hip_source_nt.yaml
@@ -1,0 +1,42 @@
+# benchmark assembly and source kernels
+GlobalParameters:
+  MinimumRequiredVersion: 4.2.0
+  NumElementsToValidate: -1
+  KernelTime: True
+
+BenchmarkProblems:
+  - # zgemm NT
+    - # ProblemType
+      OperationType: GEMM
+      DataType: z
+      DestDataType: z
+      ComputeDataType: z
+      TransposeA: False
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Source
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - LoopTail: [True]
+        - EdgeType: ["ShiftPtr"]
+        - KernelLanguage: ["Source"]
+      ForkParameters:
+        - GlobalSplitU: [1, 3]
+        - PrefetchLocalRead: [True]
+        - PrefetchGlobalRead: [False]
+        - ThreadTile:
+          - [ 4, 2 ]
+          - [ 4, 8 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+          - [ 32,  4,  1 ]
+        - DepthU: [8]
+        - VectorWidth: [-1]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [126,1,130], 0, [2], [62,1,66] ]

--- a/Tensile/Tests/nightly/double_complex/zgemm_hip_source_tc.yaml
+++ b/Tensile/Tests/nightly/double_complex/zgemm_hip_source_tc.yaml
@@ -1,0 +1,42 @@
+GlobalParameters:
+  MinimumRequiredVersion: 4.2.0
+  NumElementsToValidate: -1
+  KernelTime: True
+
+BenchmarkProblems:
+  - # zgemm TC
+    - # ProblemType
+      OperationType: GEMM
+      DataType: z
+      DestDataType: z
+      ComputeDataType: z
+      TransposeA: True
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+      ComplexConjugateB: True
+
+    - # BenchmarkProblemSizeGroup - Source
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - LoopTail: [True]
+        - EdgeType: ["ShiftPtr"]
+        - KernelLanguage: ["Source"]
+      ForkParameters:
+        - GlobalSplitU: [1, 3]
+        - PrefetchLocalRead: [True]
+        - PrefetchGlobalRead: [False]
+        - ThreadTile:
+          - [ 4, 2 ]
+          - [ 4, 8 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+          - [ 32,  4,  1 ]
+        - DepthU: [8]
+        - VectorWidth: [-1]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [126,1,130], 0, [2], [62,1,66] ]

--- a/Tensile/Tests/nightly/double_complex/zgemm_hip_source_tn.yaml
+++ b/Tensile/Tests/nightly/double_complex/zgemm_hip_source_tn.yaml
@@ -1,0 +1,43 @@
+# benchmark assembly and source kernels
+GlobalParameters:
+  MinimumRequiredVersion: 4.2.0
+  NumElementsToValidate: -1
+  KernelTime: True
+
+BenchmarkProblems:
+
+  - # zgemm TN
+    - # ProblemType
+      OperationType: GEMM
+      DataType: z
+      DestDataType: z
+      ComputeDataType: z
+      TransposeA: True
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Source
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - LoopTail: [True]
+        - EdgeType: ["ShiftPtr"]
+        - KernelLanguage: ["Source"]
+      ForkParameters:
+        - GlobalSplitU: [1, 3]
+        - PrefetchLocalRead: [True]
+        - PrefetchGlobalRead: [False]
+        - ThreadTile:
+          - [ 4, 2 ]
+          - [ 4, 8 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+          - [ 32,  4,  1 ]
+        - DepthU: [8]
+        - VectorWidth: [-1]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [126,1,130], 0, [2], [62,1,66] ]

--- a/Tensile/Tests/nightly/double_complex/zgemm_hip_source_tn.yaml
+++ b/Tensile/Tests/nightly/double_complex/zgemm_hip_source_tn.yaml
@@ -41,3 +41,25 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Range: [ [126,1,130], 0, [2], [62,1,66] ]
+
+    - # Regression test - Source
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - LoopTail: [True]
+        - EdgeType: ["ShiftPtr"]
+        - DepthU: [16]
+        - VectorWidth: [1]
+      ForkParameters:
+        - KernelLanguage: ["Source"]
+        - PrefetchLocalRead: [True]
+        - PrefetchGlobalRead: [False]
+        - ThreadTile:
+          - [ 2, 16 ]
+        - WorkGroup:
+          - [ 8,  8, 1 ]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [ 1, 1, 1, 64 ]

--- a/Tensile/Tests/nightly/double_complex/zgemm_hip_source_tt.yaml
+++ b/Tensile/Tests/nightly/double_complex/zgemm_hip_source_tt.yaml
@@ -1,0 +1,41 @@
+GlobalParameters:
+  MinimumRequiredVersion: 4.2.0
+  NumElementsToValidate: -1
+  KernelTime: True
+
+BenchmarkProblems:
+  - # zgemm TT
+    - # ProblemType
+      OperationType: GEMM
+      DataType: z
+      DestDataType: z
+      ComputeDataType: z
+      TransposeA: True
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Source
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - LoopTail: [True]
+        - EdgeType: ["ShiftPtr"]
+        - KernelLanguage: ["Source"]
+      ForkParameters:
+        - GlobalSplitU: [1, 3]
+        - PrefetchLocalRead: [True]
+        - PrefetchGlobalRead: [False]
+        - ThreadTile:
+          - [ 4, 2 ]
+          - [ 4, 8 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+          - [ 32,  4,  1 ]
+        - DepthU: [8]
+        - VectorWidth: [-1]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [126,1,130], 0, [2], [62,1,66] ]

--- a/Tensile/Tests/pre_checkin/double_complex/double_complex_hip_cc.yaml
+++ b/Tensile/Tests/pre_checkin/double_complex/double_complex_hip_cc.yaml
@@ -1,0 +1,42 @@
+GlobalParameters:
+  MinimumRequiredVersion: 4.2.0
+  NumElementsToValidate: 128
+  KernelTime: True
+
+BenchmarkProblems:
+  - # zgemm CC
+    - # ProblemType
+      OperationType: GEMM
+      DataType: z
+      DestDataType: z
+      ComputeDataType: z
+      TransposeA: True
+      TransposeB: True
+      ComplexConjugateA: True
+      ComplexConjugateB: True
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Source
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - LoopTail: [True]
+        - EdgeType: ["ShiftPtr"]
+        - KernelLanguage: ["Source"]
+      ForkParameters:
+        - PrefetchLocalRead: [False]
+        - PrefetchGlobalRead: [False]
+        - ThreadTile:
+          - [ 2, 4 ]
+        - WorkGroup:
+          - [  8,  8,  1 ]
+        - DepthU: [8]
+        - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [1,2]
+        - AssertFree0ElementMultiple: [1,2]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [127,1,129], 0, [2], [63,1,65] ]

--- a/Tensile/Tests/pre_checkin/double_complex/double_complex_hip_cn.yaml
+++ b/Tensile/Tests/pre_checkin/double_complex/double_complex_hip_cn.yaml
@@ -1,0 +1,42 @@
+GlobalParameters:
+  MinimumRequiredVersion: 4.2.0
+  NumElementsToValidate: 128
+  KernelTime: True
+
+BenchmarkProblems:
+  - # zgemm CN
+    - # ProblemType
+      OperationType: GEMM
+      DataType: z
+      DestDataType: z
+      ComputeDataType: z
+      TransposeA: True
+      TransposeB: False
+      ComplexConjugateA: True
+      ComplexConjugateB: False
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Source
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - LoopTail: [True]
+        - EdgeType: ["ShiftPtr"]
+        - KernelLanguage: ["Source"]
+      ForkParameters:
+        - PrefetchLocalRead: [False]
+        - PrefetchGlobalRead: [False]
+        - ThreadTile:
+          - [ 2, 4 ]
+        - WorkGroup:
+          - [  8,  8,  1 ]
+        - DepthU: [8]
+        - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [1,2]
+        - AssertFree0ElementMultiple: [1,2]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [127,1,129], 0, [2], [63,1,65] ]

--- a/Tensile/Tests/pre_checkin/double_complex/double_complex_hip_ct.yaml
+++ b/Tensile/Tests/pre_checkin/double_complex/double_complex_hip_ct.yaml
@@ -1,0 +1,42 @@
+GlobalParameters:
+  MinimumRequiredVersion: 4.2.0
+  NumElementsToValidate: 128
+  KernelTime: True
+
+BenchmarkProblems:
+  - # zgemm CT
+    - # ProblemType
+      OperationType: GEMM
+      DataType: z
+      DestDataType: z
+      ComputeDataType: z
+      TransposeA: True
+      TransposeB: True
+      ComplexConjugateA: True
+      ComplexConjugateB: False
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Source
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - LoopTail: [True]
+        - EdgeType: ["ShiftPtr"]
+        - KernelLanguage: ["Source"]
+      ForkParameters:
+        - PrefetchLocalRead: [False]
+        - PrefetchGlobalRead: [False]
+        - ThreadTile:
+          - [ 2, 4 ]
+        - WorkGroup:
+          - [  8,  8,  1 ]
+        - DepthU: [8]
+        - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [1,2]
+        - AssertFree0ElementMultiple: [1,2]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [127,1,129], 0, [2], [63,1,65] ]

--- a/Tensile/Tests/pre_checkin/double_complex/double_complex_hip_nc.yaml
+++ b/Tensile/Tests/pre_checkin/double_complex/double_complex_hip_nc.yaml
@@ -1,0 +1,42 @@
+GlobalParameters:
+  MinimumRequiredVersion: 4.2.0
+  NumElementsToValidate: 128
+  KernelTime: True
+
+BenchmarkProblems:
+  - # zgemm NC
+    - # ProblemType
+      OperationType: GEMM
+      DataType: z
+      DestDataType: z
+      ComputeDataType: z
+      TransposeA: False
+      TransposeB: True
+      ComplexConjugateA: False
+      ComplexConjugateB: True
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Source
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - LoopTail: [True]
+        - EdgeType: ["ShiftPtr"]
+        - KernelLanguage: ["Source"]
+      ForkParameters:
+        - PrefetchLocalRead: [False]
+        - PrefetchGlobalRead: [False]
+        - ThreadTile:
+          - [ 2, 4 ]
+        - WorkGroup:
+          - [  8,  8,  1 ]
+        - DepthU: [8]
+        - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [1,2]
+        - AssertFree0ElementMultiple: [1,2]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [127,1,129], 0, [2], [63,1,65] ]

--- a/Tensile/Tests/pre_checkin/double_complex/double_complex_hip_nn.yaml
+++ b/Tensile/Tests/pre_checkin/double_complex/double_complex_hip_nn.yaml
@@ -1,0 +1,40 @@
+GlobalParameters:
+  MinimumRequiredVersion: 4.2.0
+  NumElementsToValidate: 128
+  KernelTime: True
+
+BenchmarkProblems:
+  - # zgemm NN
+    - # ProblemType
+      OperationType: GEMM
+      DataType: z
+      DestDataType: z
+      ComputeDataType: z
+      TransposeA: False
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Source
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - LoopTail: [True]
+        - EdgeType: ["ShiftPtr"]
+        - KernelLanguage: ["Source"]
+      ForkParameters:
+        - PrefetchLocalRead: [False]
+        - PrefetchGlobalRead: [False]
+        - ThreadTile:
+          - [ 2, 4 ]
+        - WorkGroup:
+          - [  8,  8,  1 ]
+        - DepthU: [8]
+        - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [1,2]
+        - AssertFree0ElementMultiple: [1,2]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [127,1,129], 0, [2], [63,1,65] ]

--- a/Tensile/Tests/pre_checkin/double_complex/double_complex_hip_nt.yaml
+++ b/Tensile/Tests/pre_checkin/double_complex/double_complex_hip_nt.yaml
@@ -1,0 +1,40 @@
+GlobalParameters:
+  MinimumRequiredVersion: 4.2.0
+  NumElementsToValidate: 128
+  KernelTime: True
+
+BenchmarkProblems:
+  - # zgemm TN
+    - # ProblemType
+      OperationType: GEMM
+      DataType: z
+      DestDataType: z
+      ComputeDataType: z
+      TransposeA: False
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Source
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - LoopTail: [True]
+        - EdgeType: ["ShiftPtr"]
+        - KernelLanguage: ["Source"]
+      ForkParameters:
+        - PrefetchLocalRead: [False]
+        - PrefetchGlobalRead: [False]
+        - ThreadTile:
+          - [ 2, 4 ]
+        - WorkGroup:
+          - [  8,  8,  1 ]
+        - DepthU: [8]
+        - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [1,2]
+        - AssertFree0ElementMultiple: [1,2]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [127,1,129], 0, [2], [63,1,65] ]

--- a/Tensile/Tests/pre_checkin/double_complex/double_complex_hip_tc.yaml
+++ b/Tensile/Tests/pre_checkin/double_complex/double_complex_hip_tc.yaml
@@ -1,0 +1,42 @@
+GlobalParameters:
+  MinimumRequiredVersion: 4.2.0
+  NumElementsToValidate: 128
+  KernelTime: True
+
+BenchmarkProblems:
+  - # zgemm TC
+    - # ProblemType
+      OperationType: GEMM
+      DataType: z
+      DestDataType: z
+      ComputeDataType: z
+      TransposeA: True
+      TransposeB: True
+      ComplexConjugateA: False
+      ComplexConjugateB: True
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Source
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - LoopTail: [True]
+        - EdgeType: ["ShiftPtr"]
+        - KernelLanguage: ["Source"]
+      ForkParameters:
+        - PrefetchLocalRead: [False]
+        - PrefetchGlobalRead: [False]
+        - ThreadTile:
+          - [ 2, 4 ]
+        - WorkGroup:
+          - [  8,  8,  1 ]
+        - DepthU: [8]
+        - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [1,2]
+        - AssertFree0ElementMultiple: [1,2]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [127,1,129], 0, [2], [63,1,65] ]

--- a/Tensile/Tests/pre_checkin/double_complex/double_complex_hip_tn.yaml
+++ b/Tensile/Tests/pre_checkin/double_complex/double_complex_hip_tn.yaml
@@ -1,0 +1,40 @@
+GlobalParameters:
+  MinimumRequiredVersion: 4.2.0
+  NumElementsToValidate: 128
+  KernelTime: True
+
+BenchmarkProblems:
+  - # zgemm TN
+    - # ProblemType
+      OperationType: GEMM
+      DataType: z
+      DestDataType: z
+      ComputeDataType: z
+      TransposeA: True
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Source
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - LoopTail: [True]
+        - EdgeType: ["ShiftPtr"]
+        - KernelLanguage: ["Source"]
+      ForkParameters:
+        - PrefetchLocalRead: [False]
+        - PrefetchGlobalRead: [False]
+        - ThreadTile:
+          - [ 2, 4 ]
+        - WorkGroup:
+          - [  8,  8,  1 ]
+        - DepthU: [8]
+        - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [1,2]
+        - AssertFree0ElementMultiple: [1,2]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [127,1,129], 0, [2], [63,1,65] ]

--- a/Tensile/Tests/pre_checkin/double_complex/double_complex_hip_tt.yaml
+++ b/Tensile/Tests/pre_checkin/double_complex/double_complex_hip_tt.yaml
@@ -1,0 +1,40 @@
+GlobalParameters:
+  MinimumRequiredVersion: 4.2.0
+  NumElementsToValidate: 128
+  KernelTime: True
+
+BenchmarkProblems:
+  - # zgemm TT
+    - # ProblemType
+      OperationType: GEMM
+      DataType: z
+      DestDataType: z
+      ComputeDataType: z
+      TransposeA: True
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Source
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - LoopTail: [True]
+        - EdgeType: ["ShiftPtr"]
+        - KernelLanguage: ["Source"]
+      ForkParameters:
+        - PrefetchLocalRead: [False]
+        - PrefetchGlobalRead: [False]
+        - ThreadTile:
+          - [ 2, 4 ]
+        - WorkGroup:
+          - [  8,  8,  1 ]
+        - DepthU: [8]
+        - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [1,2]
+        - AssertFree0ElementMultiple: [1,2]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [127,1,129], 0, [2], [63,1,65] ]

--- a/Tensile/Tests/pre_checkin/double_complex/test_double_complex.py
+++ b/Tensile/Tests/pre_checkin/double_complex/test_double_complex.py
@@ -1,29 +1,56 @@
 import Tensile.Tensile as Tensile
- 
-def test_double_complex_asm_nt(tmpdir):
- Tensile.Tensile([Tensile.TensileTestPath("pre_checkin/double_complex/double_complex_asm_nt.yaml"), tmpdir.strpath])
+
+def test_double_complex_asm_tt(tmpdir):
+ Tensile.Tensile([Tensile.TensileTestPath("pre_checkin/double_complex/double_complex_asm_tt.yaml"), tmpdir.strpath])
+
+def test_double_complex_hip_cc(tmpdir):
+ Tensile.Tensile([Tensile.TensileTestPath("pre_checkin/double_complex/double_complex_hip_cc.yaml"), tmpdir.strpath])
+
+def test_double_complex_hip_tc(tmpdir):
+ Tensile.Tensile([Tensile.TensileTestPath("pre_checkin/double_complex/double_complex_hip_tc.yaml"), tmpdir.strpath])
+
+def test_double_complex_hip_cn(tmpdir):
+ Tensile.Tensile([Tensile.TensileTestPath("pre_checkin/double_complex/double_complex_hip_cn.yaml"), tmpdir.strpath])
 
 def test_double_complex_asm_tn(tmpdir):
  Tensile.Tensile([Tensile.TensileTestPath("pre_checkin/double_complex/double_complex_asm_tn.yaml"), tmpdir.strpath])
 
+def test_double_complex_asm_nc(tmpdir):
+ Tensile.Tensile([Tensile.TensileTestPath("pre_checkin/double_complex/double_complex_asm_nc.yaml"), tmpdir.strpath])
+
+def test_double_complex_asm_ct(tmpdir):
+ Tensile.Tensile([Tensile.TensileTestPath("pre_checkin/double_complex/double_complex_asm_ct.yaml"), tmpdir.strpath])
+
+def test_double_complex_asm_tc(tmpdir):
+ Tensile.Tensile([Tensile.TensileTestPath("pre_checkin/double_complex/double_complex_asm_tc.yaml"), tmpdir.strpath])
+
+def test_double_complex_hip_nt(tmpdir):
+ Tensile.Tensile([Tensile.TensileTestPath("pre_checkin/double_complex/double_complex_hip_nt.yaml"), tmpdir.strpath])
+
+def test_double_complex_asm_cn(tmpdir):
+ Tensile.Tensile([Tensile.TensileTestPath("pre_checkin/double_complex/double_complex_asm_cn.yaml"), tmpdir.strpath])
+
+def test_double_complex_asm_cc(tmpdir):
+ Tensile.Tensile([Tensile.TensileTestPath("pre_checkin/double_complex/double_complex_asm_cc.yaml"), tmpdir.strpath])
+
+def test_double_complex_hip_nc(tmpdir):
+ Tensile.Tensile([Tensile.TensileTestPath("pre_checkin/double_complex/double_complex_hip_nc.yaml"), tmpdir.strpath])
+
+def test_double_complex_asm_nt(tmpdir):
+ Tensile.Tensile([Tensile.TensileTestPath("pre_checkin/double_complex/double_complex_asm_nt.yaml"), tmpdir.strpath])
+
+def test_double_complex_hip_tt(tmpdir):
+ Tensile.Tensile([Tensile.TensileTestPath("pre_checkin/double_complex/double_complex_hip_tt.yaml"), tmpdir.strpath])
+
+def test_double_complex_hip_ct(tmpdir):
+ Tensile.Tensile([Tensile.TensileTestPath("pre_checkin/double_complex/double_complex_hip_ct.yaml"), tmpdir.strpath])
+
 def test_double_complex_asm_nn(tmpdir):
  Tensile.Tensile([Tensile.TensileTestPath("pre_checkin/double_complex/double_complex_asm_nn.yaml"), tmpdir.strpath])
 
-def test_double_complex_asm_tt(tmpdir):
- Tensile.Tensile([Tensile.TensileTestPath("pre_checkin/double_complex/double_complex_asm_tt.yaml"), tmpdir.strpath])
- 
-def test_double_complex_asm_nc(tmpdir):
- Tensile.Tensile([Tensile.TensileTestPath("pre_checkin/double_complex/double_complex_asm_nc.yaml"), tmpdir.strpath])
- 
-def test_double_complex_asm_cn(tmpdir):
- Tensile.Tensile([Tensile.TensileTestPath("pre_checkin/double_complex/double_complex_asm_cn.yaml"), tmpdir.strpath])
- 
-def test_double_complex_asm_ct(tmpdir):
- Tensile.Tensile([Tensile.TensileTestPath("pre_checkin/double_complex/double_complex_asm_ct.yaml"), tmpdir.strpath])
- 
-def test_double_complex_asm_tc(tmpdir):
- Tensile.Tensile([Tensile.TensileTestPath("pre_checkin/double_complex/double_complex_asm_tc.yaml"), tmpdir.strpath])
- 
-def test_double_complex_asm_cc(tmpdir):
- Tensile.Tensile([Tensile.TensileTestPath("pre_checkin/double_complex/double_complex_asm_cc.yaml"), tmpdir.strpath])
+def test_double_complex_hip_tn(tmpdir):
+ Tensile.Tensile([Tensile.TensileTestPath("pre_checkin/double_complex/double_complex_hip_tn.yaml"), tmpdir.strpath])
+
+def test_double_complex_hip_nn(tmpdir):
+ Tensile.Tensile([Tensile.TensileTestPath("pre_checkin/double_complex/double_complex_hip_nn.yaml"), tmpdir.strpath])
 


### PR DESCRIPTION
This PR adds test configs for ZGEMM HIP generator because the issues we're seeing so far are either resolved or circumvented. 

| | Time (Original) | Time (This PR) |
|---|---|---|
| `pre_checkin/double_complex` | 6m09s | 11m33s
| `nightly/double_complex` | 10m28s | ~54m27s~ **32m13s**

run with Xeon Silver 4110 & Radeon Vega20