### PR TITLE
Replace call once with local static

### DIFF
--- a/Tensile/Source/lib/include/Tensile/DataTypes.hpp
+++ b/Tensile/Source/lib/include/Tensile/DataTypes.hpp
@@ -78,6 +78,7 @@ namespace Tensile
 
     private:
         static void registerAllTypeInfo();
+        static void registerAllTypeInfoOnce();
 
         template <typename T>
         static void registerTypeInfo();
@@ -171,4 +172,3 @@ namespace Tensile
     };
 #endif
 }
-

--- a/Tensile/Source/lib/source/ContractionProblem.cpp
+++ b/Tensile/Source/lib/source/ContractionProblem.cpp
@@ -449,7 +449,7 @@ namespace Tensile
         for(auto const& bound: boundIndices)
         {
             size_t indexSize = indexSizes.at(indexIdx);
-            
+
             aSizes[bound.a] = indexSize;
             bSizes[bound.b] = indexSize;
 
@@ -894,7 +894,7 @@ namespace Tensile
     TypedContractionInputs<A, B, C, D, Alpha, Beta>::TypedContractionInputs() = default;
 
     template <typename A, typename B, typename C, typename D, typename Alpha, typename Beta>
-    TypedContractionInputs<A, B, C, D, Alpha, Beta>::~TypedContractionInputs() = default; 
+    TypedContractionInputs<A, B, C, D, Alpha, Beta>::~TypedContractionInputs() = default;
 
     template <typename A, typename B, typename C, typename D, typename Alpha, typename Beta>
     TypedContractionInputs<A, B, C, D, Alpha, Beta>::TypedContractionInputs(
@@ -913,9 +913,9 @@ namespace Tensile
 
 #ifdef TENSILE_USE_HALF
     template struct TypedContractionInputs<Half>;
+    template struct TypedContractionInputs<Half, Half, Half, Half, float, float>;
 #endif
 #ifdef TENSILE_USE_BF16
     template struct TypedContractionInputs<BFloat16, BFloat16, BFloat16, BFloat16, float, float>;
 #endif
 }
-

--- a/Tensile/Source/lib/source/DataTypes.cpp
+++ b/Tensile/Source/lib/source/DataTypes.cpp
@@ -28,7 +28,6 @@
 #include <Tensile/Utils.hpp>
 
 #include <algorithm>
-#include <mutex>
 
 namespace Tensile
 {
@@ -92,7 +91,6 @@ namespace Tensile
         addInfoObject(info);
     }
 
-
     void DataTypeInfo::registerAllTypeInfo()
     {
         registerTypeInfo<float>();
@@ -105,7 +103,10 @@ namespace Tensile
         registerTypeInfo<BFloat16>();
     }
 
-    std::once_flag typeInfoFlag;
+    void DataTypeInfo::registerAllTypeInfoOnce()
+    {
+        static int call_once = (registerAllTypeInfo(), 0);
+    }
 
     void DataTypeInfo::addInfoObject(DataTypeInfo const& info)
     {
@@ -120,7 +121,7 @@ namespace Tensile
 
     DataTypeInfo const& DataTypeInfo::Get(DataType t)
     {
-        std::call_once(typeInfoFlag, registerAllTypeInfo);
+        registerAllTypeInfoOnce();
 
         auto iter = data.find(t);
         if(iter == data.end())
@@ -131,7 +132,7 @@ namespace Tensile
 
     DataTypeInfo const& DataTypeInfo::Get(std::string const& str)
     {
-        std::call_once(typeInfoFlag, registerAllTypeInfo);
+        registerAllTypeInfoOnce();
 
         auto iter = typeNames.find(str);
         if(iter == typeNames.end())
@@ -179,4 +180,3 @@ namespace Tensile
         return stream;
     }
 }
-

--- a/Tensile/Source/lib/source/TensorOps.cpp
+++ b/Tensile/Source/lib/source/TensorOps.cpp
@@ -19,8 +19,6 @@
  * CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#include <mutex>
-
 #include <Tensile/TensorOps.hpp>
 #include <Tensile/Utils.hpp>
 
@@ -59,11 +57,9 @@ namespace Tensile
         return "Invalid";
     }
 
-    std::once_flag opTypeNameFlag;
-
     TensorOp::Type TensorOp::GetType(std::string const& name)
     {
-        std::call_once(opTypeNameFlag, InitTypeNames);
+        static int call_once = (InitTypeNames(), 0);
 
         auto iter = typeNames.find(name);
         if(iter == typeNames.end())
@@ -117,4 +113,3 @@ namespace Tensile
         return stream;
     }
 }
-


### PR DESCRIPTION
The addition of a new template data type instantiation should not affect the behavior of libraries which do not call it.

It will not cause a compilation error.

It simply instantiates a necessary data structure, without regard to kernels.

rocBLAS uses data structures independent of the kernels which get called.

The replacement of `call_once` with `static` initialization does not change the behavior. It's just faster.

This PR needs to be recommitted. It is unrelated to any failures.