### PR TITLE
Small N bug fix

### DIFF
--- a/Tensile/ClientWriter.py
+++ b/Tensile/ClientWriter.py
@@ -947,7 +947,7 @@ def writeClientParameters(forBenchmark, solutions, problemSizes, stepName, \
           solution["AssertSummationElementMultiple"],
           solution["AssertFree0ElementMultiple"],
           solution["AssertFree1ElementMultiple"],
-          0,
+          solution["AssertMinApproxSize"],
           "true" if solution["LdcEqualsLdd"] else "false",
           solution["PackBatchDims"]==2, \
           solution["PackBatchDims"]==1, \

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -424,6 +424,9 @@ validParameters = {
     # 1 indicates no assertion (since all sizes are multiples of 1)
     "AssertFree1ElementMultiple" : [1,2,4,8],
 
+    # Some kernels only work for certain sizes, see ProblemProperties in TensileTypes for exact defs
+    "AssertMinApproxSize" : [0,1,2],
+
     # Generate code inside kernel to check Assertions on Tensor dimensions
     "CheckTensorDimAsserts":               [False, True],
 
@@ -719,6 +722,7 @@ defaultBenchmarkCommonParameters = [
     {"AssertSummationElementMultiple": [ 1 ] },
     {"AssertFree0ElementMultiple": [ 1 ] },
     {"AssertFree1ElementMultiple": [ 1 ] },
+    {"AssertMinApproxSize":        [ -1 ] },
     {"CheckTensorDimAsserts"      : [ False ] },
     {"CheckDimOverflow"           : [ 0 ] },
 

--- a/Tensile/Contractions.py
+++ b/Tensile/Contractions.py
@@ -240,7 +240,6 @@ class ProblemPredicate(Properties.Predicate):
         # TODO - change to use SetConstStrideB
         if key == 'PackBatchDims' and value==1:
             return cls("StrideBEqual", index=2, value=0)
-        # TODO - remove this when logic files have been updated
         if key == 'AssertMinApproxSize':
             return None
 

--- a/Tensile/Contractions.py
+++ b/Tensile/Contractions.py
@@ -240,6 +240,7 @@ class ProblemPredicate(Properties.Predicate):
         # TODO - change to use SetConstStrideB
         if key == 'PackBatchDims' and value==1:
             return cls("StrideBEqual", index=2, value=0)
+        # TODO - remove this when logic files have been updated
         if key == 'AssertMinApproxSize':
             return None
 

--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -2161,6 +2161,14 @@ class Solution:
     # these work everywhere, no special restrictions
     state["AssertMinApproxSize"] = 0
 
+    if state["KernelLanguage"] == "Assembly":
+      if state["VectorWidth"] > 1:
+        # VW>1 kernels require dims>1
+        state["AssertMinApproxSize"] = 3
+    elif state["VectorWidth"] > 1:
+      # VW>1 kernels require dims>1
+      state["AssertMinApproxSize"] = 2
+    
     # Use SGPR to store an offset from GlobalReadOffsetA+0.
     # (as opposed to using dedicated VGPR for each GRO
     # Requires preciseBounds check since we rely on the buffer bounds check, not

--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -2158,6 +2158,9 @@ class Solution:
           reject(state, "GlobalLoadVectorWidthB %u must be == VectorWidth %u or == 1" % \
                   (state["GlobalLoadVectorWidthB"], state["VectorWidth"]))
 
+    # these work everywhere, no special restrictions
+    state["AssertMinApproxSize"] = 0
+
     # Use SGPR to store an offset from GlobalReadOffsetA+0.
     # (as opposed to using dedicated VGPR for each GRO
     # Requires preciseBounds check since we rely on the buffer bounds check, not

--- a/Tensile/Source/TensileTypes.h
+++ b/Tensile/Source/TensileTypes.h
@@ -514,6 +514,7 @@ struct ProblemProperties {
 
     bool allBelow1 = true;
     bool anyBelow1 = false;
+    bool anyBelow4 = false;
     for (int si=0; si!=pdims.numSizes(); si++) {
       if (!props->isBatchIdx(si)) {
         auto size = pdims.sizes(si);
@@ -521,11 +522,13 @@ struct ProblemProperties {
           allBelow1 = false;
         if (size == 1)
           anyBelow1 = true;
+        else if(size < 4)
+          anyBelow4 = true;
       }
     }
     if (allBelow1)
       _approxSize = 1; // really small
-    else if (anyBelow1)
+    else if (anyBelow1 || anyBelow4)
       _approxSize = 2; // one dim not big enough
     else
       _approxSize = 99; // big enough

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -741,7 +741,7 @@ def writeSolutionAndExactTable(scheduleName, deviceNames, schedProbName, problem
         solution["AssertSummationElementMultiple"], \
         solution["AssertFree0ElementMultiple"], \
         solution["AssertFree1ElementMultiple"], \
-        0, \
+        solution["AssertMinApproxSize"], \
         solution["LdcEqualsLdd"], \
         solution["PackBatchDims"]==2, \
         solution["PackBatchDims"]==1, \

--- a/Tensile/Tests/nightly/vector_width/sgemm_nn_asm.yaml
+++ b/Tensile/Tests/nightly/vector_width/sgemm_nn_asm.yaml
@@ -43,3 +43,9 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Range: [ [127,1,129], 0, [4], [63,1,65] ]
+          - Exact: [1024, 2, 1, 4096]
+          - Exact: [2048, 2, 1, 4096]
+          - Exact: [1024, 1, 1, 4096]
+          - Exact: [2048, 1, 1, 4096]
+          - Exact: [1024, 2, 1, 8192]
+          - Exact: [2048, 2, 1, 4096]


### PR DESCRIPTION
SWDEV-212072

Adding AssertMinApproxSize back in to the old client and adding tests for small sizes.

- Running nightly Tensile tests locally since CI is not in a stable state
- Running rocBLAS tests locally as well