### PR TITLE
Reject invalid StaggerUStride cases

### DIFF
--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -1678,6 +1678,10 @@ class Solution:
                 (state["DepthU"] * bpeAB), 2)))
     except ValueError:
         staggerStrideShift = 0
+    if staggerStrideShift < 0:
+      reject(state, "StaggerUStride=%u is less than size of DepthU=%u * BytesPerElement=%u" \
+        % (state["StaggerUStride"], state["DepthU"], bpeAB))
+      return 
     #print "staggerStrideShift=", staggerStrideShift, "depthu=", state["DepthU"]
     state["_staggerStrideShift"] = staggerStrideShift
     if state["StaggerU"] == 0:


### PR DESCRIPTION
Prevent some combinations of `StaggerUStride`/ `DepthU`/`MatrixElementSize` which would have resulted in negative bit shift along with a rejection message when `PrintSolutionRejectionReason` is enabled 

Example for `StaggerUStride=32`, `DepthU=8`, `bpeAB(BytesPerElement)=16` :

```python
solution["_staggerStrideShift"])= (int)(math.ceil(math.log(state["StaggerUStride"] / \
                (state["DepthU"] * bpeAB), 2))) # evaluates to -2

(1 << solution["_staggerStrideShift"]) # illegal negative bit shift
```