### PR TITLE
Switch deprecated include of hip_hcc

### DIFF
--- a/Tensile/Source/lib/source/hip/HipSolutionAdapter.cpp
+++ b/Tensile/Source/lib/source/hip/HipSolutionAdapter.cpp
@@ -24,7 +24,7 @@
  *
  *******************************************************************************/
 
-#include <hip/hip_hcc.h>
+#include <hip/hip_ext.h>
 #include <hip/hip_runtime.h>
 
 #include <cstddef>

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -301,7 +301,7 @@ def writeSolutionsAndKernels(outputPath, CxxCompiler, problemTypes, solutions, k
     kernelHeaderFile.write("#pragma once\n")
     if globalParameters["RuntimeLanguage"] == "HIP":
       kernelHeaderFile.write("#include <hip/hip_runtime.h>\n")
-      kernelHeaderFile.write("#include <hip/hip_hcc.h>\n\n")
+      kernelHeaderFile.write("#include <hip/hip_ext.h>\n\n")
     kernelHeaderFile.write("#include \"KernelHeader.h\"\n\n")
   else:
     kernelSourceFile = None


### PR DESCRIPTION
fixes compile warnings in Tensile and in rocBLAS when using tensile and rocm3.0+