### PR TITLE
fix bug in TensileCreateLibrary for --no-merge switch

### DIFF
--- a/Tensile/Contractions.py
+++ b/Tensile/Contractions.py
@@ -295,10 +295,22 @@ class ProblemPredicate(Properties.Predicate):
             raise RuntimeError("Unknown assertion key: {}".format(key))
 
     @classmethod
+    def CompoundPredicates(cls, state, problemType):
+        rv = []
+
+        if 'VectorWidth' in state and state['VectorWidth'] > 1:
+            if not problemType.aType.isInt8x4():
+                rv += [cls('LeadingFreeSizesGreaterOrEqual', value=state['VectorWidth'])]
+
+        return rv
+
+    @classmethod
     def FromOriginalState(cls, d, problemType, morePreds=[]):
         problemTypePreds = problemType.predicates(True, True, True)
+        compoundPreds = cls.CompoundPredicates(d, problemType)
+        extraPreds = problemTypePreds + compoundPreds + morePreds
 
-        return super().FromOriginalState(d, problemTypePreds + morePreds)
+        return super().FromOriginalState(d, extraPreds)
 
 class SizeMapping:
     StateKeys = ['workGroup',

--- a/Tensile/Source/lib/include/Tensile/ContractionProblemPredicates.hpp
+++ b/Tensile/Source/lib/include/Tensile/ContractionProblemPredicates.hpp
@@ -188,9 +188,6 @@ namespace Tensile
 
                 virtual bool operator()(ContractionProblem const& problem) const override
                 {
-                    // do we need this? 
-                    // this assert is not currenly used in rocblas 
-                    // enabling it is causing test failures
                     return problem.freeSizeA(0) >= value
                         && problem.freeSizeB(0) >= value;
                 }

--- a/Tensile/Source/lib/include/Tensile/ContractionProblemPredicates.hpp
+++ b/Tensile/Source/lib/include/Tensile/ContractionProblemPredicates.hpp
@@ -191,9 +191,8 @@ namespace Tensile
                     // do we need this? 
                     // this assert is not currenly used in rocblas 
                     // enabling it is causing test failures
-                    //return problem.freeSizeA(0) >= value
-                    //    && problem.freeSizeB(0) >= value;
-                    return true;
+                    return problem.freeSizeA(0) >= value
+                        && problem.freeSizeB(0) >= value;
                 }
             };
 

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -308,7 +308,7 @@ def writeSolutionsAndKernels(outputPath, CxxCompiler, problemTypes, solutions, k
     kernelHeaderFile.write("#pragma once\n")
     if globalParameters["RuntimeLanguage"] == "HIP":
       kernelHeaderFile.write("#include <hip/hip_runtime.h>\n")
-      kernelHeaderFile.write("#include <hip/hip_ext.h>\n\n")
+      kernelHeaderFile.write("#include <hip/hip_hcc.h>\n\n")
     kernelHeaderFile.write("#include \"KernelHeader.h\"\n\n")
 
   kernelsWithBuildErrs = {}

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -249,26 +249,26 @@ def buildKernelSourceAndHeaderFiles(results, outputPath, kernelsWithBuildErrs, \
       kernelsWithBuildErrs[kernelName] = err
       #print "*** warning: invalid kernel#%s"%kernelName
 
-    if kernelSourceFile:
+    #if kernelSourceFile:
       # write kernel.cpp
-      if not globalParameters["MergeFiles"]:
-        filename = os.path.join(outputPath, "Kernels", kernelName+".cpp")
-        sourceFilenames.append(filename)
-        kernelSourceFile = open(filename, "w")
-        kernelSourceFile.write(CHeader)
+    if not globalParameters["MergeFiles"]:
+      filename = os.path.join(outputPath, "Kernels", kernelName+".cpp")
+      sourceFilenames.append(filename)
+      kernelSourceFile = open(filename, "w")
+      kernelSourceFile.write(CHeader)
 
-      kernelSourceFile.write(src)
+    kernelSourceFile.write(src)
 
-      if not globalParameters["MergeFiles"]:
-        kernelSourceFile.close()
+    if not globalParameters["MergeFiles"]:
+      kernelSourceFile.close()
         # write kernel.h
-        kernelHeaderFile = open(os.path.join(outputPath, "Kernels", kernelName+".h"), "w")
-        kernelHeaderFile.write(CHeader)
+      kernelHeaderFile = open(os.path.join(outputPath, "Kernels", kernelName+".h"), "w")
+      kernelHeaderFile.write(CHeader)
 
-      kernelHeaderFile.write(header)
+    kernelHeaderFile.write(header)
 
-      if not globalParameters["MergeFiles"]:
-        kernelHeaderFile.close()
+    if not globalParameters["MergeFiles"]:
+      kernelHeaderFile.close()
 
   return sourceFilenames
 
@@ -308,7 +308,7 @@ def writeSolutionsAndKernels(outputPath, CxxCompiler, problemTypes, solutions, k
     kernelHeaderFile.write("#pragma once\n")
     if globalParameters["RuntimeLanguage"] == "HIP":
       kernelHeaderFile.write("#include <hip/hip_runtime.h>\n")
-      kernelHeaderFile.write("#include <hip/hip_hcc.h>\n\n")
+      kernelHeaderFile.write("#include <hip/hip_ext.h>\n\n")
     kernelHeaderFile.write("#include \"KernelHeader.h\"\n\n")
 
   kernelsWithBuildErrs = {}


### PR DESCRIPTION

This fixes a bug introduced in the last merge where the source kernels were not getting merged in when the --no-merge-files was enabled in TensileCreateLibrary 