### PR TITLE
add Jimmy's FP32 TN replacement kernel - take 2

### DIFF
--- a/Tensile/Configs/rocblas_sgemm_tn_inc2_asm_full.yaml
+++ b/Tensile/Configs/rocblas_sgemm_tn_inc2_asm_full.yaml
@@ -100,9 +100,9 @@ BenchmarkProblems:
       ForkParameters:
         - PrefetchGlobalRead: [True]
         - ThreadTile:
-          - [ 4, 8 ]
+          - [ 4, 4 ]
         - WorkGroup:
-          - [ 16, 16, 1 ]
+          - [ 16, 32, 1 ]
         - WorkGroupMapping: [8]
         - GlobalSplitU: [1]
         - DepthU: [32]

--- a/Tensile/ReplacementKernels-cov3/Cijk_Alik_Bljk_SB_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_4_USFGRO1_VAW1_VW4_WG16_32_1_WGM8.s.txt
+++ b/Tensile/ReplacementKernels-cov3/Cijk_Alik_Bljk_SB_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_4_USFGRO1_VAW1_VW4_WG16_32_1_WGM8.s.txt
@@ -10,216 +10,217 @@
 /* Begin Kernel                           */
 /******************************************/
 
-.hsa_code_object_version 2,0
-.hsa_code_object_isa 9, 0, 8, "AMD", "AMDGPU" 
+.amdgcn_target "amdgcn-amd-amdhsa--gfx908+sram-ecc"
 .text
-.protected Cijk_Alik_Bljk_SB_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_8_USFGRO1_VAW1_VW4_WG16_16_1_WGM8
-.globl Cijk_Alik_Bljk_SB_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_8_USFGRO1_VAW1_VW4_WG16_16_1_WGM8
+.protected Cijk_Alik_Bljk_SB_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_4_USFGRO1_VAW1_VW4_WG16_32_1_WGM8
+.globl Cijk_Alik_Bljk_SB_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_4_USFGRO1_VAW1_VW4_WG16_32_1_WGM8
 .p2align 8
-.type Cijk_Alik_Bljk_SB_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_8_USFGRO1_VAW1_VW4_WG16_16_1_WGM8,@function
-.amdgpu_hsa_kernel Cijk_Alik_Bljk_SB_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_8_USFGRO1_VAW1_VW4_WG16_16_1_WGM8
-Cijk_Alik_Bljk_SB_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_8_USFGRO1_VAW1_VW4_WG16_16_1_WGM8:
-.amd_kernel_code_t
-  is_ptr64 = 1
-  enable_sgpr_kernarg_segment_ptr = 1
-  kernarg_segment_byte_size = 148 // bytes of kern args
-  workitem_vgpr_count = 108 // vgprs
-  wavefront_sgpr_count = 98 // sgprs
-  compute_pgm_rsrc1_vgprs = 26 // floor((108-1)/4)
-  compute_pgm_rsrc1_sgprs = 12 // floor((98-1)/8)
-  compute_pgm_rsrc2_tidig_comp_cnt = 0 // 1D wg
-  compute_pgm_rsrc2_tgid_x_en = 1 // wg.x
-  compute_pgm_rsrc2_tgid_y_en = 1 // wg.y
-  compute_pgm_rsrc2_tgid_z_en = 1 // wg.z
-  workgroup_group_segment_byte_size = 60000// lds bytes
-  compute_pgm_rsrc2_user_sgpr = 2 // vcc
-  kernarg_segment_alignment = 4
-  group_segment_alignment = 4
-  private_segment_alignment = 4
-.end_amd_kernel_code_t
+.type Cijk_Alik_Bljk_SB_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_4_USFGRO1_VAW1_VW4_WG16_32_1_WGM8,@function
+.section .rodata,#alloc
+.p2align 6
+.amdhsa_kernel Cijk_Alik_Bljk_SB_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_4_USFGRO1_VAW1_VW4_WG16_32_1_WGM8
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_next_free_vgpr 108 // vgprs
+  .amdhsa_next_free_sgpr 98 // sgprs
+  .amdhsa_group_segment_fixed_size 60000 // lds bytes
+  .amdhsa_private_segment_fixed_size 0
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+.text
 
 /******************************************/
 /* Optimizations and Config:              */
 /******************************************/
-/* ThreadTile= 4 x 8 */
-/* SubGroup= 16 x 16 */
+/* ThreadTile= 4 x 4 */
+/* SubGroup= 16 x 32 */
 /* VectorWidth=4 */
 /* GlobalLoadVectorWidthA=4, GlobalLoadVectorWidthB=4 */
 /* DirectToLdsA=False */
 /* DirectToLdsB=False */
 /* UseSgprForGRO=1 */
-.amd_amdgpu_hsa_metadata
-Version: [ 1, 0 ]
-Kernels:
-  - Name: Cijk_Alik_Bljk_SB_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_8_USFGRO1_VAW1_VW4_WG16_16_1_WGM8
-    SymbolName: 'Cijk_Alik_Bljk_SB_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_8_USFGRO1_VAW1_VW4_WG16_16_1_WGM8@kd'
-    Language: OpenCL C
-    LanguageVersion: [ 2, 0 ]
-    Args:
-      - Name:            sizeC
-        Size:            8
-        Align:           8
-        ValueKind:       ByValue
-        ValueType:       I64
-      - Name:            sizeA
-        Size:            8
-        Align:           8
-        ValueKind:       ByValue
-        ValueType:       I64
-      - Name:            sizeB
-        Size:            8
-        Align:           8
-        ValueKind:       ByValue
-        ValueType:       I64
-      - Name:            D
-        Size:            8
-        Align:           8
-        ValueKind:       GlobalBuffer
-        ValueType:       F32
-        AddrSpaceQual:   Generic
-      - Name:            C
-        Size:            8
-        Align:           8
-        ValueKind:       GlobalBuffer
-        ValueType:       F32
-        AddrSpaceQual:   Generic
-      - Name:            A
-        Size:            8
-        Align:           8
-        ValueKind:       GlobalBuffer
-        ValueType:       F32
-        AddrSpaceQual:   Generic
-      - Name:            B
-        Size:            8
-        Align:           8
-        ValueKind:       GlobalBuffer
-        ValueType:       F32
-        AddrSpaceQual:   Generic
-      - Name:            alpha
-        Size:            4
-        Align:           4
-        ValueKind:       ByValue
-        ValueType:       F32
-      - Name:            beta
-        Size:            4
-        Align:           4
-        ValueKind:       ByValue
-        ValueType:       F32
-      - Name:            strideD0
-        Size:            4
-        Align:           4
-        ValueKind:       ByValue
-        ValueType:       U32
-      - Name:            strideD1
-        Size:            4
-        Align:           4
-        ValueKind:       ByValue
-        ValueType:       U32
-      - Name:            strideC0
-        Size:            4
-        Align:           4
-        ValueKind:       ByValue
-        ValueType:       U32
-      - Name:            strideC1
-        Size:            4
-        Align:           4
-        ValueKind:       ByValue
-        ValueType:       U32
-      - Name:            strideA0
-        Size:            4
-        Align:           4
-        ValueKind:       ByValue
-        ValueType:       U32
-      - Name:            strideA1
-        Size:            4
-        Align:           4
-        ValueKind:       ByValue
-        ValueType:       U32
-      - Name:            strideB0
-        Size:            4
-        Align:           4
-        ValueKind:       ByValue
-        ValueType:       U32
-      - Name:            strideB1
-        Size:            4
-        Align:           4
-        ValueKind:       ByValue
-        ValueType:       U32
-      - Name:            SizesFree0
-        Size:            4
-        Align:           4
-        ValueKind:       ByValue
-        ValueType:       U32
-      - Name:            SizesFree1
-        Size:            4
-        Align:           4
-        ValueKind:       ByValue
-        ValueType:       U32
-      - Name:            SizesFree2
-        Size:            4
-        Align:           4
-        ValueKind:       ByValue
-        ValueType:       U32
-      - Name:            SizesSum0
-        Size:            4
-        Align:           4
-        ValueKind:       ByValue
-        ValueType:       U32
-      - Name:            OrigStaggerUIter
-        Size:            4
-        Align:           4
-        ValueKind:       ByValue
-        ValueType:       I32
-      - Name:            NumWorkGroups0
-        Size:            4
-        Align:           4
-        ValueKind:       ByValue
-        ValueType:       U32
-      - Name:            NumWorkGroups1
-        Size:            4
-        Align:           4
-        ValueKind:       ByValue
-        ValueType:       U32
-      - Name:            MagicNumberProblemNumGroupTiles0
-        Size:            4
-        Align:           4
-        ValueKind:       ByValue
-        ValueType:       U32
-      - Name:            GridNumWorkGroups0
-        Size:            4
-        Align:           4
-        ValueKind:       ByValue
-        ValueType:       U32
-      - Name:            NumFullBlocks
-        Size:            4
-        Align:           4
-        ValueKind:       ByValue
-        ValueType:       U32
-      - Name:            WgmRemainder1
-        Size:            4
-        Align:           4
-        ValueKind:       ByValue
-        ValueType:       U32
-      - Name:            MagicNumberWgmRemainder1
-        Size:            4
-        Align:           4
-        ValueKind:       ByValue
-        ValueType:       U32
-      - Name:            padding
-        Size:            4
-        Align:           4
-        ValueKind:       ByValue
-        ValueType:       U32
-    CodeProps:
-      KernargSegmentSize: 148
-      GroupSegmentFixedSize: 57344
-      PrivateSegmentFixedSize: 0
-      KernargSegmentAlign:  8
-      WavefrontSize:        64
-      NumSGPRs:             98
-      NumVGPRs:             108
-      MaxFlatWorkGroupSize: 256
-.end_amd_amdgpu_hsa_metadata
+.amdgpu_metadata
+---
+amdhsa.version:
+  - 1
+  - 0
+amdhsa.kernels:
+  - .name: Cijk_Alik_Bljk_SB_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_4_USFGRO1_VAW1_VW4_WG16_32_1_WGM8
+    .symbol: 'Cijk_Alik_Bljk_SB_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_4_USFGRO1_VAW1_VW4_WG16_32_1_WGM8.kd'
+    .language:                   OpenCL C
+    .language_version:
+      - 2
+      - 0
+    .args:
+      - .name:            sizeC
+        .size:            8
+        .offset:          0
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            sizeA
+        .size:            8
+        .offset:          8
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            sizeB
+        .size:            8
+        .offset:          16
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            D
+        .size:            8
+        .offset:          24
+        .value_kind:      global_buffer
+        .value_type:      f32
+        .address_space:   generic
+      - .name:            C
+        .size:            8
+        .offset:          32
+        .value_kind:      global_buffer
+        .value_type:      f32
+        .address_space:   generic
+      - .name:            A
+        .size:            8
+        .offset:          40
+        .value_kind:      global_buffer
+        .value_type:      f32
+        .address_space:   generic
+      - .name:            B
+        .size:            8
+        .offset:          48
+        .value_kind:      global_buffer
+        .value_type:      f32
+        .address_space:   generic
+      - .name:            alpha
+        .size:            4
+        .offset:          56
+        .value_kind:      by_value
+        .value_type:      f32
+      - .name:            beta
+        .size:            4
+        .offset:          60
+        .value_kind:      by_value
+        .value_type:      f32
+      - .name:            strideD0
+        .size:            4
+        .offset:          64
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideD1
+        .size:            4
+        .offset:          68
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideC0
+        .size:            4
+        .offset:          72
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideC1
+        .size:            4
+        .offset:          76
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideA0
+        .size:            4
+        .offset:          80
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideA1
+        .size:            4
+        .offset:          84
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideB0
+        .size:            4
+        .offset:          88
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideB1
+        .size:            4
+        .offset:          92
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree0
+        .size:            4
+        .offset:          96
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree1
+        .size:            4
+        .offset:          100
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree2
+        .size:            4
+        .offset:          104
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesSum0
+        .size:            4
+        .offset:          108
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            OrigStaggerUIter
+        .size:            4
+        .offset:          112
+        .value_kind:      by_value
+        .value_type:      i32
+      - .name:            NumWorkGroups0
+        .size:            4
+        .offset:          116
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            NumWorkGroups1
+        .size:            4
+        .offset:          120
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            MagicNumberProblemNumGroupTiles0
+        .size:            4
+        .offset:          124
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            GridNumWorkGroups0
+        .size:            4
+        .offset:          128
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            NumFullBlocks
+        .size:            4
+        .offset:          132
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            WgmRemainder1
+        .size:            4
+        .offset:          136
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            MagicNumberWgmRemainder1
+        .size:            4
+        .offset:          140
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            padding
+        .size:            4
+        .offset:          144
+        .value_kind:      by_value
+        .value_type:      u32
+    .group_segment_fixed_size:   60000
+    .kernarg_segment_align:      8
+    .kernarg_segment_size:       152
+    .max_flat_workgroup_size:    512
+    .private_segment_fixed_size: 0
+    .sgpr_count:                 98
+    .sgpr_spill_count:           0
+    .vgpr_count:                 108
+    .vgpr_spill_count:           0
+    .wavefront_size:             64
+...
+.end_amdgpu_metadata
+Cijk_Alik_Bljk_SB_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_4_USFGRO1_VAW1_VW4_WG16_32_1_WGM8:
 
 /******************************************/
 /* Asm syntax workarounds                 */

--- a/Tensile/ReplacementKernels-cov3/Cijk_Alik_Bljk_SB_MT64x128x32_SE_K1.s.txt
+++ b/Tensile/ReplacementKernels-cov3/Cijk_Alik_Bljk_SB_MT64x128x32_SE_K1.s.txt
@@ -34,8 +34,8 @@
 /******************************************/
 /* Optimizations and Config:              */
 /******************************************/
-/* ThreadTile= 4 x 8 */
-/* SubGroup= 16 x 16 */
+/* ThreadTile= 4 x 4 */
+/* SubGroup= 16 x 32 */
 /* VectorWidth=4 */
 /* GlobalLoadVectorWidthA=4, GlobalLoadVectorWidthB=4 */
 /* DirectToLdsA=False */
@@ -211,7 +211,7 @@ amdhsa.kernels:
     .group_segment_fixed_size:   60000
     .kernarg_segment_align:      8
     .kernarg_segment_size:       152
-    .max_flat_workgroup_size:    256
+    .max_flat_workgroup_size:    512
     .private_segment_fixed_size: 0
     .sgpr_count:                 98
     .sgpr_spill_count:           0

--- a/Tensile/ReplacementKernels/Cijk_Alik_Bljk_SB_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_4_USFGRO1_VAW1_VW4_WG16_32_1_WGM8.s.txt
+++ b/Tensile/ReplacementKernels/Cijk_Alik_Bljk_SB_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_4_USFGRO1_VAW1_VW4_WG16_32_1_WGM8.s.txt
@@ -10,217 +10,216 @@
 /* Begin Kernel                           */
 /******************************************/
 
-.amdgcn_target "amdgcn-amd-amdhsa--gfx908+sram-ecc"
+.hsa_code_object_version 2,0
+.hsa_code_object_isa 9, 0, 8, "AMD", "AMDGPU" 
 .text
-.protected Cijk_Alik_Bljk_SB_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_8_USFGRO1_VAW1_VW4_WG16_16_1_WGM8
-.globl Cijk_Alik_Bljk_SB_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_8_USFGRO1_VAW1_VW4_WG16_16_1_WGM8
+.protected Cijk_Alik_Bljk_SB_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_4_USFGRO1_VAW1_VW4_WG16_32_1_WGM8
+.globl Cijk_Alik_Bljk_SB_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_4_USFGRO1_VAW1_VW4_WG16_32_1_WGM8
 .p2align 8
-.type Cijk_Alik_Bljk_SB_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_8_USFGRO1_VAW1_VW4_WG16_16_1_WGM8,@function
-.section .rodata,#alloc
-.p2align 6
-.amdhsa_kernel Cijk_Alik_Bljk_SB_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_8_USFGRO1_VAW1_VW4_WG16_16_1_WGM8
-  .amdhsa_user_sgpr_kernarg_segment_ptr 1
-  .amdhsa_next_free_vgpr 108 // vgprs
-  .amdhsa_next_free_sgpr 98 // sgprs
-  .amdhsa_group_segment_fixed_size 60000 // lds bytes
-  .amdhsa_private_segment_fixed_size 0
-  .amdhsa_system_sgpr_workgroup_id_x 1
-  .amdhsa_system_sgpr_workgroup_id_y 1
-  .amdhsa_system_sgpr_workgroup_id_z 1
-  .amdhsa_system_vgpr_workitem_id 0
-.end_amdhsa_kernel
-.text
+.type Cijk_Alik_Bljk_SB_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_4_USFGRO1_VAW1_VW4_WG16_32_1_WGM8,@function
+.amdgpu_hsa_kernel Cijk_Alik_Bljk_SB_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_4_USFGRO1_VAW1_VW4_WG16_32_1_WGM8
+Cijk_Alik_Bljk_SB_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_4_USFGRO1_VAW1_VW4_WG16_32_1_WGM8:
+.amd_kernel_code_t
+  is_ptr64 = 1
+  enable_sgpr_kernarg_segment_ptr = 1
+  kernarg_segment_byte_size = 148 // bytes of kern args
+  workitem_vgpr_count = 108 // vgprs
+  wavefront_sgpr_count = 98 // sgprs
+  compute_pgm_rsrc1_vgprs = 26 // floor((108-1)/4)
+  compute_pgm_rsrc1_sgprs = 12 // floor((98-1)/8)
+  compute_pgm_rsrc2_tidig_comp_cnt = 0 // 1D wg
+  compute_pgm_rsrc2_tgid_x_en = 1 // wg.x
+  compute_pgm_rsrc2_tgid_y_en = 1 // wg.y
+  compute_pgm_rsrc2_tgid_z_en = 1 // wg.z
+  workgroup_group_segment_byte_size = 60000// lds bytes
+  compute_pgm_rsrc2_user_sgpr = 2 // vcc
+  kernarg_segment_alignment = 4
+  group_segment_alignment = 4
+  private_segment_alignment = 4
+.end_amd_kernel_code_t
 
 /******************************************/
 /* Optimizations and Config:              */
 /******************************************/
-/* ThreadTile= 4 x 8 */
-/* SubGroup= 16 x 16 */
+/* ThreadTile= 4 x 4 */
+/* SubGroup= 16 x 32 */
 /* VectorWidth=4 */
 /* GlobalLoadVectorWidthA=4, GlobalLoadVectorWidthB=4 */
 /* DirectToLdsA=False */
 /* DirectToLdsB=False */
 /* UseSgprForGRO=1 */
-.amdgpu_metadata
----
-amdhsa.version:
-  - 1
-  - 0
-amdhsa.kernels:
-  - .name: Cijk_Alik_Bljk_SB_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_8_USFGRO1_VAW1_VW4_WG16_16_1_WGM8
-    .symbol: 'Cijk_Alik_Bljk_SB_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_8_USFGRO1_VAW1_VW4_WG16_16_1_WGM8.kd'
-    .language:                   OpenCL C
-    .language_version:
-      - 2
-      - 0
-    .args:
-      - .name:            sizeC
-        .size:            8
-        .offset:          0
-        .value_kind:      by_value
-        .value_type:      u64
-      - .name:            sizeA
-        .size:            8
-        .offset:          8
-        .value_kind:      by_value
-        .value_type:      u64
-      - .name:            sizeB
-        .size:            8
-        .offset:          16
-        .value_kind:      by_value
-        .value_type:      u64
-      - .name:            D
-        .size:            8
-        .offset:          24
-        .value_kind:      global_buffer
-        .value_type:      f32
-        .address_space:   generic
-      - .name:            C
-        .size:            8
-        .offset:          32
-        .value_kind:      global_buffer
-        .value_type:      f32
-        .address_space:   generic
-      - .name:            A
-        .size:            8
-        .offset:          40
-        .value_kind:      global_buffer
-        .value_type:      f32
-        .address_space:   generic
-      - .name:            B
-        .size:            8
-        .offset:          48
-        .value_kind:      global_buffer
-        .value_type:      f32
-        .address_space:   generic
-      - .name:            alpha
-        .size:            4
-        .offset:          56
-        .value_kind:      by_value
-        .value_type:      f32
-      - .name:            beta
-        .size:            4
-        .offset:          60
-        .value_kind:      by_value
-        .value_type:      f32
-      - .name:            strideD0
-        .size:            4
-        .offset:          64
-        .value_kind:      by_value
-        .value_type:      u32
-      - .name:            strideD1
-        .size:            4
-        .offset:          68
-        .value_kind:      by_value
-        .value_type:      u32
-      - .name:            strideC0
-        .size:            4
-        .offset:          72
-        .value_kind:      by_value
-        .value_type:      u32
-      - .name:            strideC1
-        .size:            4
-        .offset:          76
-        .value_kind:      by_value
-        .value_type:      u32
-      - .name:            strideA0
-        .size:            4
-        .offset:          80
-        .value_kind:      by_value
-        .value_type:      u32
-      - .name:            strideA1
-        .size:            4
-        .offset:          84
-        .value_kind:      by_value
-        .value_type:      u32
-      - .name:            strideB0
-        .size:            4
-        .offset:          88
-        .value_kind:      by_value
-        .value_type:      u32
-      - .name:            strideB1
-        .size:            4
-        .offset:          92
-        .value_kind:      by_value
-        .value_type:      u32
-      - .name:            SizesFree0
-        .size:            4
-        .offset:          96
-        .value_kind:      by_value
-        .value_type:      u32
-      - .name:            SizesFree1
-        .size:            4
-        .offset:          100
-        .value_kind:      by_value
-        .value_type:      u32
-      - .name:            SizesFree2
-        .size:            4
-        .offset:          104
-        .value_kind:      by_value
-        .value_type:      u32
-      - .name:            SizesSum0
-        .size:            4
-        .offset:          108
-        .value_kind:      by_value
-        .value_type:      u32
-      - .name:            OrigStaggerUIter
-        .size:            4
-        .offset:          112
-        .value_kind:      by_value
-        .value_type:      i32
-      - .name:            NumWorkGroups0
-        .size:            4
-        .offset:          116
-        .value_kind:      by_value
-        .value_type:      u32
-      - .name:            NumWorkGroups1
-        .size:            4
-        .offset:          120
-        .value_kind:      by_value
-        .value_type:      u32
-      - .name:            MagicNumberProblemNumGroupTiles0
-        .size:            4
-        .offset:          124
-        .value_kind:      by_value
-        .value_type:      u32
-      - .name:            GridNumWorkGroups0
-        .size:            4
-        .offset:          128
-        .value_kind:      by_value
-        .value_type:      u32
-      - .name:            NumFullBlocks
-        .size:            4
-        .offset:          132
-        .value_kind:      by_value
-        .value_type:      u32
-      - .name:            WgmRemainder1
-        .size:            4
-        .offset:          136
-        .value_kind:      by_value
-        .value_type:      u32
-      - .name:            MagicNumberWgmRemainder1
-        .size:            4
-        .offset:          140
-        .value_kind:      by_value
-        .value_type:      u32
-      - .name:            padding
-        .size:            4
-        .offset:          144
-        .value_kind:      by_value
-        .value_type:      u32
-    .group_segment_fixed_size:   60000
-    .kernarg_segment_align:      8
-    .kernarg_segment_size:       152
-    .max_flat_workgroup_size:    256
-    .private_segment_fixed_size: 0
-    .sgpr_count:                 98
-    .sgpr_spill_count:           0
-    .vgpr_count:                 108
-    .vgpr_spill_count:           0
-    .wavefront_size:             64
-...
-.end_amdgpu_metadata
-Cijk_Alik_Bljk_SB_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_8_USFGRO1_VAW1_VW4_WG16_16_1_WGM8:
+.amd_amdgpu_hsa_metadata
+Version: [ 1, 0 ]
+Kernels:
+  - Name: Cijk_Alik_Bljk_SB_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_4_USFGRO1_VAW1_VW4_WG16_32_1_WGM8
+    SymbolName: 'Cijk_Alik_Bljk_SB_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_4_USFGRO1_VAW1_VW4_WG16_32_1_WGM8@kd'
+    Language: OpenCL C
+    LanguageVersion: [ 2, 0 ]
+    Args:
+      - Name:            sizeC
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            sizeA
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            sizeB
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            D
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       F32
+        AddrSpaceQual:   Generic
+      - Name:            C
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       F32
+        AddrSpaceQual:   Generic
+      - Name:            A
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       F32
+        AddrSpaceQual:   Generic
+      - Name:            B
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       F32
+        AddrSpaceQual:   Generic
+      - Name:            alpha
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       F32
+      - Name:            beta
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       F32
+      - Name:            strideD0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideD1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideC0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideC1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideA0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideA1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideB0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideB1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree2
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesSum0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            OrigStaggerUIter
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       I32
+      - Name:            NumWorkGroups0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            NumWorkGroups1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            MagicNumberProblemNumGroupTiles0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            GridNumWorkGroups0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            NumFullBlocks
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            WgmRemainder1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            MagicNumberWgmRemainder1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            padding
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+    CodeProps:
+      KernargSegmentSize: 148
+      GroupSegmentFixedSize: 60000
+      PrivateSegmentFixedSize: 0
+      KernargSegmentAlign:  8
+      WavefrontSize:        64
+      NumSGPRs:             98
+      NumVGPRs:             108
+      MaxFlatWorkGroupSize: 512
+.end_amd_amdgpu_hsa_metadata
 
 /******************************************/
 /* Asm syntax workarounds                 */

--- a/Tensile/ReplacementKernels/Cijk_Alik_Bljk_SB_MT64x128x32_SE_K1.s.txt
+++ b/Tensile/ReplacementKernels/Cijk_Alik_Bljk_SB_MT64x128x32_SE_K1.s.txt
@@ -41,8 +41,8 @@ Cijk_Alik_Bljk_SB_MT64x128x32_SE_K1:
 /******************************************/
 /* Optimizations and Config:              */
 /******************************************/
-/* ThreadTile= 4 x 8 */
-/* SubGroup= 16 x 16 */
+/* ThreadTile= 4 x 4 */
+/* SubGroup= 16 x 32 */
 /* VectorWidth=4 */
 /* GlobalLoadVectorWidthA=4, GlobalLoadVectorWidthB=4 */
 /* DirectToLdsA=False */
@@ -212,13 +212,13 @@ Kernels:
         ValueType:       U32
     CodeProps:
       KernargSegmentSize: 148
-      GroupSegmentFixedSize: 57344
+      GroupSegmentFixedSize: 60000
       PrivateSegmentFixedSize: 0
       KernargSegmentAlign:  8
       WavefrontSize:        64
       NumSGPRs:             98
       NumVGPRs:             108
-      MaxFlatWorkGroupSize: 256
+      MaxFlatWorkGroupSize: 512
 .end_amd_amdgpu_hsa_metadata
 
 /******************************************/


### PR DESCRIPTION
Incorrect ThreadTile and WorkGroup values were used when generating the incremental logic files.  Oops.  They are now corrected and full validation for the 5 sizes passed at Tensile level.

This PR has no impact on Tensile CI testing.