### PR TITLE
arcturus HPA HGEMM (FP16) TN replacement kernels

### DIFF
--- a/Tensile/Configs/rocblas_hpa_hgemm_tn_inc1_asm_full.yaml
+++ b/Tensile/Configs/rocblas_hpa_hgemm_tn_inc1_asm_full.yaml
@@ -1,0 +1,190 @@
+GlobalParameters:
+  MinimumRequiredVersion: 4.14.0
+  PrintLevel: 1
+  ForceRedoBenchmarkProblems: True
+  ForceRedoLibraryLogic: True
+  ForceRedoLibraryClient: True
+  CMakeBuildType: Release
+  EnqueuesPerSync: 1
+  SyncsPerBenchmark: 1
+  LibraryPrintDebug: False
+  NumElementsToValidate: 0
+  ValidationMaxToPrint: 4
+  ValidationPrintValids: False
+  ShortNames: False
+  MergeFiles: True
+  Platform: 0
+  Device: 0
+  KernelTime: True
+  PinClocks: False
+  SleepPercent: 200
+  DataInitTypeBeta : 0
+  DataInitTypeAlpha: 1
+  DataInitTypeA: 3
+  DataInitTypeB: 3
+  DataInitTypeC: 3
+  DataInitTypeD: 3
+  PrintTensorA: 0
+  PrintTensorB: 0
+  PrintTensorC: 0
+  PrintTensorD: 0
+  NewClient: 0
+
+BenchmarkProblems:
+  ########################################
+  # TN - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: h
+      HighPrecisionAccumulate: True
+      TransposeA: True
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Source
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - LoopTail: [True]
+        - EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - KernelLanguage: ["Source"]
+        - GlobalSplitU: [1, 3]
+        - PrefetchLocalRead: [True]
+        - PrefetchGlobalRead: [False]
+        - ThreadTile:
+          - [ 8, 2 ]
+          - [ 8, 4 ]
+          - [ 2, 8 ]
+          - [ 4, 8 ]
+          - [ 16, 2 ]
+          - [ 16, 4 ]
+          - [ 16, 8 ]
+          - [ 2, 16 ]
+          - [ 4, 16 ]
+          - [ 8, 16 ]
+        - WorkGroup:
+          - [ 16, 16,  1 ]
+          - [  8,  8,  1 ]
+        - DepthU: [16]
+        - VectorWidth: [1]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [959,2,961],[1024],[1],[1024] ] #
+          - Range: [ [960],[1023,2,1025],[1],[1024] ]  #
+          - Range: [ [960],[1024],[1],[1023,2,1025] ]  #
+          - Range: [ [1919,2,1921],[2048],[1],[2048] ]
+          - Range: [ [1920],[2047,2,2049],[1],[2048] ]
+          - Range: [ [1920],[2048],[1],[2047,2,2049] ]
+          - Range: [ [2879,2,2881],[3072],[1],[3072] ]
+          - Range: [ [2880],[3071,2,3073],[1],[3072] ]
+          - Range: [ [2880],[3072],[1],[3071,2,3073] ]
+          - Range: [ [3839,2,3841],[4096],[1],[4096] ] #
+          - Range: [ [3840],[4095,2,4097],[1],[4096] ] #
+          - Range: [ [3840],[4096],[1],[4095,2,4097] ] #
+          - Range: [ [7679,2,7681],[8192],[1],[8192] ] #
+          - Range: [ [7680],[8191,2,8193],[1],[8192] ] #
+          - Range: [ [7680],[8192],[1],[8191,2,8193] ] #
+          - Range: [ [511,2,513],[512],[1],[512] ] #
+          - Range: [ [512],[511,2,513],[1],[512] ]  #
+          - Range: [ [512],[512],[1],[511,2,513] ]  #
+          - Range: [ [1023,2,1025],[1024],[1],[1024] ] #
+          - Range: [ [1024],[1023,2,1025],[1],[1024] ] #
+          - Range: [ [1024],[1024],[1],[1023,2,1025] ] #
+          - Range: [ [2047,2,2049],[2048],[1],[2048] ]
+          - Range: [ [2048],[2047,2,2049],[1],[2048] ]
+          - Range: [ [2048],[2048],[1],[2047,2,2049] ]
+          - Range: [ [3071,2,3073],[3072],[1],[3072] ]
+          - Range: [ [3072],[3071,2,3073],[1],[3072] ]
+          - Range: [ [3072],[3072],[1],[3071,2,3073] ]
+          - Range: [ [4095,2,4097],[4096],[1],[4096] ] #
+          - Range: [ [4096],[4095,2,4097],[1],[4096] ] #
+          - Range: [ [4096],[4096],[1],[4095,2,4097] ] #
+          - Range: [ [8191,2,8193],[8192],[1],[8192] ] #
+          - Range: [ [8192],[8191,2,8193],[1],[8192] ] #
+          - Range: [ [8192],[8192],[1],[8191,2,8193] ] #
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - PrefetchLocalRead: [True]
+      ForkParameters:
+        - PrefetchGlobalRead: [True]
+        - ThreadTile:
+          - [ 4, 4 ]
+        - WorkGroup:
+          - [ 16, 32, 1 ]
+        - WorkGroupMapping: [8]
+        - GlobalSplitU: [1]
+        - DepthU: [32]
+        - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [8]
+        - AssertFree0ElementMultiple: [8]
+        - ReplacementKernel: [True]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [ 960,1024,1,1024,992,992,1056,1056 ]
+          #- Exact: [ 1920,2048,1,2048,1952,1952,2080,2080 ]
+          - Exact: [ 2880,3072,1,3072,2912,2912,3104,3104 ]
+          #- Exact: [ 3840,4096,1,4096,3872,3872,4128,4128 ]
+          #- Exact: [ 7680,8192,1,8192,7712,7712,8224,8224 ]
+          #- Exact: [ 512,512,1,512,544,544,544,544 ]  #
+          #- Exact: [ 1024,1024,1,1024,1056,1056,1056,1056 ] #
+          #- Exact: [ 2048,2048,1,2048,2080,2080,2080,2080 ]
+          #- Exact: [ 3072,3072,1,3072,3104,3104,3104,3104 ]
+          #- Exact: [ 4096,4096,1,4096,4128,4128,4128,4128 ] #
+          #- Exact: [ 8192,8192,1,8192,8224,8224,8224,8224 ] #
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - PrefetchLocalRead: [True]
+      ForkParameters:
+        - PrefetchGlobalRead: [True]
+        - ThreadTile:
+          - [ 8, 8 ]
+        - WorkGroup:
+          - [ 16, 32, 1 ]
+        - WorkGroupMapping: [8]
+        - GlobalSplitU: [1]
+        - DepthU: [32]
+        - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [8]
+        - AssertFree0ElementMultiple: [8]
+        - ReplacementKernel: [True]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          #- Exact: [ 960,1024,1,1024,992,992,1056,1056 ]
+          - Exact: [ 1920,2048,1,2048,1952,1952,2080,2080 ]
+          #- Exact: [ 2880,3072,1,3072,2912,2912,3104,3104 ]
+          - Exact: [ 3840,4096,1,4096,3872,3872,4128,4128 ]
+          - Exact: [ 7680,8192,1,8192,7712,7712,8224,8224 ]
+          - Exact: [ 512,512,1,512,544,544,544,544 ]  #
+          - Exact: [ 1024,1024,1,1024,1056,1056,1056,1056 ] #
+          - Exact: [ 2048,2048,1,2048,2080,2080,2080,2080 ]
+          - Exact: [ 3072,3072,1,3072,3104,3104,3104,3104 ]
+          - Exact: [ 4096,4096,1,4096,4128,4128,4128,4128 ] #
+          - Exact: [ 8192,8192,1,8192,8224,8224,8224,8224 ] #
+
+#########################################
+LibraryLogic:
+    ScheduleName: "arcturus"
+    DeviceNames: ["Device 7380", "Device 7388", "Device 738c", "Device 7390"]
+    ArchitectureName: "gfx908"

--- a/Tensile/ReplacementKernels-cov3/Cijk_Alik_Bljk_HBH_MT128x256x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW8_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT8_8_USFGRO1_VAW2_VW8_WG16_32_1_WGM8.s.txt
+++ b/Tensile/ReplacementKernels-cov3/Cijk_Alik_Bljk_HBH_MT128x256x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW8_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT8_8_USFGRO1_VAW2_VW8_WG16_32_1_WGM8.s.txt
@@ -1,0 +1,1716 @@
+
+
+/******************************************/
+/* Function Prefix                        */
+/******************************************/
+
+
+
+/******************************************/
+/* Begin Kernel                           */
+/******************************************/
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx908+sram-ecc"
+.text
+.protected Cijk_Alik_Bljk_HBH_MT128x256x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW8_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT8_8_USFGRO1_VAW2_VW8_WG16_32_1_WGM8
+.globl Cijk_Alik_Bljk_HBH_MT128x256x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW8_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT8_8_USFGRO1_VAW2_VW8_WG16_32_1_WGM8
+.p2align 8
+.type Cijk_Alik_Bljk_HBH_MT128x256x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW8_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT8_8_USFGRO1_VAW2_VW8_WG16_32_1_WGM8,@function
+.section .rodata,#alloc
+.p2align 6
+.amdhsa_kernel Cijk_Alik_Bljk_HBH_MT128x256x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW8_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT8_8_USFGRO1_VAW2_VW8_WG16_32_1_WGM8
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_next_free_vgpr 128 // vgprs
+  .amdhsa_next_free_sgpr 98 // sgprs
+  .amdhsa_group_segment_fixed_size 57344 // lds bytes
+  .amdhsa_private_segment_fixed_size 0
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+.text
+
+/******************************************/
+/* Optimizations and Config:              */
+/******************************************/
+/* ThreadTile= 8 x 8 */
+/* SubGroup= 16 x 32 */
+/* VectorWidth=8 */
+/* GlobalLoadVectorWidthA=8, GlobalLoadVectorWidthB=8 */
+/* DirectToLdsA=False */
+/* DirectToLdsB=False */
+/* UseSgprForGRO=1 */
+.amdgpu_metadata
+---
+amdhsa.version:
+  - 1
+  - 0
+amdhsa.kernels:
+  - .name: Cijk_Alik_Bljk_HBH_MT128x256x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW8_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT8_8_USFGRO1_VAW2_VW8_WG16_32_1_WGM8
+    .symbol: 'Cijk_Alik_Bljk_HBH_MT128x256x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW8_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT8_8_USFGRO1_VAW2_VW8_WG16_32_1_WGM8.kd'
+    .language:                   OpenCL C
+    .language_version:
+      - 2
+      - 0
+    .args:
+      - .name:            sizeC
+        .size:            8
+        .offset:          0
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            sizeA
+        .size:            8
+        .offset:          8
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            sizeB
+        .size:            8
+        .offset:          16
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            D
+        .size:            8
+        .offset:          24
+        .value_kind:      global_buffer
+        .value_type:      struct
+        .address_space:   generic
+      - .name:            C
+        .size:            8
+        .offset:          32
+        .value_kind:      global_buffer
+        .value_type:      struct
+        .address_space:   generic
+      - .name:            A
+        .size:            8
+        .offset:          40
+        .value_kind:      global_buffer
+        .value_type:      struct
+        .address_space:   generic
+      - .name:            B
+        .size:            8
+        .offset:          48
+        .value_kind:      global_buffer
+        .value_type:      struct
+        .address_space:   generic
+      - .name:            alpha
+        .size:            4
+        .offset:          56
+        .value_kind:      by_value
+        .value_type:      f16
+      - .name:            beta
+        .size:            4
+        .offset:          60
+        .value_kind:      by_value
+        .value_type:      f16
+      - .name:            strideD0
+        .size:            4
+        .offset:          64
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideD1
+        .size:            4
+        .offset:          68
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideC0
+        .size:            4
+        .offset:          72
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideC1
+        .size:            4
+        .offset:          76
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideA0
+        .size:            4
+        .offset:          80
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideA1
+        .size:            4
+        .offset:          84
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideB0
+        .size:            4
+        .offset:          88
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideB1
+        .size:            4
+        .offset:          92
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree0
+        .size:            4
+        .offset:          96
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree1
+        .size:            4
+        .offset:          100
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree2
+        .size:            4
+        .offset:          104
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesSum0
+        .size:            4
+        .offset:          108
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            OrigStaggerUIter
+        .size:            4
+        .offset:          112
+        .value_kind:      by_value
+        .value_type:      i32
+      - .name:            NumWorkGroups0
+        .size:            4
+        .offset:          116
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            NumWorkGroups1
+        .size:            4
+        .offset:          120
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            MagicNumberProblemNumGroupTiles0
+        .size:            4
+        .offset:          124
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            GridNumWorkGroups0
+        .size:            4
+        .offset:          128
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            NumFullBlocks
+        .size:            4
+        .offset:          132
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            WgmRemainder1
+        .size:            4
+        .offset:          136
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            MagicNumberWgmRemainder1
+        .size:            4
+        .offset:          140
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            padding
+        .size:            4
+        .offset:          144
+        .value_kind:      by_value
+        .value_type:      u32
+    .group_segment_fixed_size:   57344
+    .kernarg_segment_align:      8
+    .kernarg_segment_size:       152
+    .max_flat_workgroup_size:    512
+    .private_segment_fixed_size: 0
+    .sgpr_count:                 98
+    .sgpr_spill_count:           0
+    .vgpr_count:                 128
+    .vgpr_spill_count:           0
+    .wavefront_size:             64
+...
+.end_amdgpu_metadata
+Cijk_Alik_Bljk_HBH_MT128x256x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW8_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT8_8_USFGRO1_VAW2_VW8_WG16_32_1_WGM8:
+
+/******************************************/
+/* Asm syntax workarounds                 */
+/******************************************/
+.macro _v_add_co_u32 dst, cc, src0, src1, dpp=
+   v_add_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+
+.macro _v_add_u32 dst, src0, src1, dpp=
+   v_add_u32 \dst, \src0, \src1 \dpp
+.endm
+
+.macro _v_sub_co_u32 dst, cc, src0, src1, dpp=
+   v_sub_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+
+.macro _v_sub_u32 dst, src0, src1, dpp=
+   v_sub_u32 \dst, \src0, \src1 \dpp
+.endm
+
+.macro _v_addc_co_u32 dst, ccOut, src0, ccIn, src1, dpp=
+   v_addc_co_u32 \dst, \ccOut, \src0, \ccIn, \src1 \dpp
+.endm
+
+.macro _v_add_lshl_u32 dst, src0, src1, shiftCnt
+    v_add_lshl_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+.macro _v_lshl_add_u32 dst, src0, src1, shiftCnt
+    v_lshl_add_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+/******************************************/
+/* Magic div and mod functions            */
+/******************************************/
+.macro V_MAGIC_DIV dstIdx, dividend, magicNumber, magicShift
+    v_mul_hi_u32 v[\dstIdx+1], \dividend, \magicNumber
+    v_mul_lo_u32 v[\dstIdx+0], \dividend, \magicNumber
+    v_lshrrev_b64 v[\dstIdx:\dstIdx+1], \magicShift, v[\dstIdx:\dstIdx+1]
+.endm
+
+/******************************************/
+/* VGPR Assignments                       */
+/******************************************/
+.set vgprValuC, 0
+/* ValuA/B   Xn=PLR buffer idx,  In=InnerUnroll idx */
+.set vgprValuA_X0_I0, 32
+.set vgprValuA_X1_I0, 34
+.set vgprG2LA, 36
+.set vgprValuB_X0_I0, 40
+.set vgprValuB_X1_I0, 44
+.set vgprG2LB, 48
+.set vgprLocalWriteAddrA, 56
+.set vgprLocalWriteAddrB, 57
+.set vgprGlobalReadOffsetA, 58
+.set vgprGlobalReadOffsetB, 59
+.set vgprLocalReadAddrA, 60
+.set vgprLocalReadAddrB, 61
+.set vgprSerial, 62
+/* Num VGPR=63 */
+
+/******************************************/
+/* SGPR Assignments                       */
+/******************************************/
+.set sgprKernArgAddress, 0
+.set sgprWorkGroup0, 2
+.set sgprWorkGroup1, 3
+.set sgprWorkGroup2, 4
+.set sgprNumWorkGroups0, 5
+.set sgprNumWorkGroups1, 6
+.set sgprSrdA, 8
+.set sgprSrdB, 12
+.set sgprSrdD, 16
+.set sgprSrdC, 20
+.set sgprTensor2dSizeC, 24
+.set sgprTensor2dSizeA, 26
+.set sgprTensor2dSizeB, 28
+.set sgprSaveExecMask, 30
+.set sgprAddressD, 32
+.set sgprAddressC, 34
+.set sgprStridesD, 36
+.set sgprStridesC, 38
+.set sgprAlpha, 40
+.set sgprBeta, 41
+.set sgprSizesFree, 42
+.set sgprSizesSum, 45
+.set sgprLoopCounters, 46
+.set sgprOrigLoopCounter, 47
+.set sgprStridesA, 48
+.set sgprStridesB, 50
+.set sgprAddressA, 52
+.set sgprAddressB, 54
+.set sgprShadowLimitA, 56
+.set sgprShadowLimitB, 58
+.set sgprOrigStaggerUIter, 60
+.set sgprStaggerUIter, 61
+.set sgprWrapUA, 62
+.set sgprWrapUB, 64
+.set sgprNumFullBlocks, 66
+.set sgprWgmRemainder1, 67
+.set sgprMagicNumberWgmRemainder1, 68
+.set sgprGlobalReadIncsA, 69
+.set sgprGlobalReadIncsB, 70
+.set sgprScalarGlobalReadOffsetA, 71
+.set sgprScalarGlobalReadOffsetB, 72
+/* max SGPR=98 */
+
+/* Size Assignments */
+.set sgprSizeD0I, sgprSizesFree+0
+.set sgprSizeD1J, sgprSizesFree+1
+.set sgprSizeDK, sgprSizesFree+2
+.set sgprSizeC0I, sgprSizesFree+0
+.set sgprSizeC1J, sgprSizesFree+1
+.set sgprSizeCK, sgprSizesFree+2
+.set sgprSizeAL, sgprSizesSum+0
+.set sgprSizeA0I, sgprSizesFree+0
+.set sgprSizeAK, sgprSizesFree+2
+.set sgprSizeBL, sgprSizesSum+0
+.set sgprSizeB1J, sgprSizesFree+1
+.set sgprSizeBK, sgprSizesFree+2
+
+/* Stride Assignments */
+.set constStrideD0I, 1
+.set sgprStrideD1J, sgprStridesD+0
+.set sgprStrideDK, sgprStridesD+1
+.set constStrideC0I, 1
+.set sgprStrideC1J, sgprStridesC+0
+.set sgprStrideCK, sgprStridesC+1
+.set constStrideAL, 1
+.set sgprStrideA0I, sgprStridesA+0
+.set sgprStrideAK, sgprStridesA+1
+.set constStrideBL, 1
+.set sgprStrideB1J, sgprStridesB+0
+.set sgprStrideBK, sgprStridesB+1
+
+.set DepthU, 32
+/* Number of elements to shift-left SRD */
+.set SrdShiftLeftA, 4
+.set SrdShiftLeftB, 4
+/* 2GB limit - set offsets to -1 to exceed this and clamp */
+.set BufferLimit, 0x80000000
+/* Bits 127:96 of SRD.  Set DataFormat = 32 bit */
+.set Srd127_96, 0x0020000
+.set BufferOOB, 0x80000000
+
+/* Global Offset A */
+.macro GLOBAL_OFFSET_A vgprAddr vgprOffsetL vgprOffset0I vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStrideA0I], v[\vgprOffset0I] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprOffsetL], v[\vgprTmp+0] // accumulate d1 lower
+_v_add_u32 v[\vgprAddr+0], 0x4, v[\vgprAddr+0]     // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/* Global Offset B */
+.macro GLOBAL_OFFSET_B vgprAddr vgprOffsetL vgprOffset1J vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStrideB1J], v[\vgprOffset1J] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprOffsetL], v[\vgprTmp+0] // accumulate d1 lower
+_v_add_u32 v[\vgprAddr+0], 0x4, v[\vgprAddr+0]     // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/******************************************/
+/* Dynamic Scalar Divide: vQuotient=vDividend/vDivisor; vRemainder=vDividend%vDivisor; */
+/******************************************/
+.macro DYNAMIC_VECTOR_DIVIDE vQuotient vRemainder vDividend vDivisor vTmp0 vTmp1 sTmp
+v_cvt_f32_u32 v[\vQuotient], v[\vDivisor]          //
+v_rcp_f32 v[\vQuotient], v[\vQuotient]             //
+v_mul_f32 v[\vQuotient], 0x4f800000, v[\vQuotient] //
+v_cvt_u32_f32 v[\vQuotient], v[\vQuotient]         //
+v_mul_lo_u32 v[\vRemainder], v[\vDivisor], v[\vQuotient] //
+v_mul_hi_u32 v[\vTmp0], v[\vDivisor], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp1], vcc, 0x0, v[\vRemainder]  //
+v_cmp_ne_i32 s[\sTmp:\sTmp+1], 0x0, v[\vTmp0]      //
+v_cndmask_b32 v[\vRemainder], v[\vTmp1], v[\vRemainder], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vRemainder], v[\vRemainder], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vQuotient], v[\vRemainder] //
+_v_add_co_u32 v[\vQuotient], vcc, v[\vQuotient], v[\vRemainder] //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vTmp0], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vQuotient], v[\vQuotient], v[\vDividend] //
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vDividend], v[\vRemainder] //
+v_cmp_ge_u32 s[\sTmp:\sTmp+1], v[\vDividend], v[\vRemainder] //
+_v_add_co_u32 v[\vRemainder], vcc, 0x1, v[\vQuotient] //
+_v_add_co_u32 v[\vTmp1], vcc, -1, v[\vQuotient]    //
+v_cmp_le_u32 vcc, v[\vDivisor], v[\vTmp0]          //
+s_and_b64 vcc, s[\sTmp:\sTmp+1], vcc               //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vRemainder], vcc //
+v_cndmask_b32 v[\vQuotient], v[\vTmp1], v[\vQuotient], s[\sTmp:\sTmp+1] //
+v_cmp_ne_i32 vcc, 0x0, v[\vDivisor]                //
+v_cndmask_b32 v[\vQuotient], -1, v[\vQuotient], vcc // final result
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vRemainder], vcc, v[\vDividend], v[\vRemainder] // final result
+.endm
+
+/******************************************/
+/* 4x8 thread-tile                        */
+/******************************************/
+.macro MAC_4x8_X0
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[0] iui=0
+s_setprio 1 // Raise priority while processing macs
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[1]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[4]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[5]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[2] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[3]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[6]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[7]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[8] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[9]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[12]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[13]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[10] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[11]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[14]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[15]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[16] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[17]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[20]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[21]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[18] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[19]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[22]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[23]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[24] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[25]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[28]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[29]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[26] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[27]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[30]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[31]
+s_setprio 0 // Reset priority after macs
+.endm
+.macro MAC_4x8_X1
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[0] iui=0
+s_setprio 1 // Raise priority while processing macs
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[1]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[4]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[5]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[2] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[3]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[6]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[7]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[8] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[9]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[12]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[13]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[10] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[11]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[14]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[15]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[16] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[17]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[20]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[21]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[18] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[19]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[22]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[23]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[24] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[25]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[28]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[29]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[26] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[27]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[30]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[31]
+s_setprio 0 // Reset priority after macs
+.endm
+
+
+
+
+/***** program start from here *****/
+
+.long 0xC00A0D00, 0x00000028
+.long 0xC00A0C00, 0x00000050
+.long 0xC00A0600, 0x00000008
+.long 0xC0020B40, 0x0000006C
+.long 0xC0020140, 0x00000074
+.long 0xBEFC00FF, 0x0000FFFF
+.long 0x7ECA0300
+.long 0x26CC00BF
+.long 0x2004CA86
+.long 0xB8D0F804
+.long 0xD1130004, 0x0000A0B0
+.long 0x20CE0884
+.long 0x7EA40567
+.long 0xD1130068, 0x0000A08F
+.long 0x7EA20568
+.long 0xBF068151
+.long 0xBF8400EF
+.long 0xBF8CC07F
+.long 0xBE880034
+.long 0xBE890035
+.long 0xBE8B00FF, 0x00020000
+.long 0xBE8A00FF, 0x80000000
+.long 0x9254FF30, 0x00000080
+.long 0x92545402
+.long 0x9255A052
+.long 0x92533055
+.long 0x81545354
+.long 0x2000CC82
+.long 0xD2850004, 0x00020030
+.long 0x2602CC83
+.long 0x24020283
+.long 0x32AC0304
+.long 0x68ACAC54
+.long 0x24ACAC81
+.long 0x8E478530
+.long 0x68AEAC47
+.long 0xBECC00FF, 0x00000880
+.long 0x924C4C52
+.long 0xBE8C0036
+.long 0xBE8D0037
+.long 0xBE8F00FF, 0x00020000
+.long 0xBE8E00FF, 0x80000000
+.long 0x9254FF32, 0x00000100
+.long 0x92545403
+.long 0x9255C052
+.long 0x92533255
+.long 0x81545354
+.long 0x2004CC82
+.long 0xD2850004, 0x00020432
+.long 0x2606CC83
+.long 0x24060683
+.long 0x32B40704
+.long 0x68B4B454
+.long 0x24B4B481
+.long 0x8E4A8532
+.long 0x68B6B44A
+.long 0x68B8B64A
+.long 0x68BAB84A
+.long 0xBECE00FF, 0x00001100
+.long 0x924E4E52
+.long 0x814EFF4E, 0x00004400
+.long 0xBF8A0000
+.long 0x814DFF4C, 0x00002200
+.long 0x24A0CC84
+.long 0x68A0A04C
+.long 0x24A2CC84
+.long 0x68A2A24D
+.long 0x814FFF4E, 0x00004400
+.long 0x24A4CC84
+.long 0x68A4A44E
+.long 0x24A6CC84
+.long 0x68A6A64F
+.long 0x2002CC83
+.long 0xD2850001, 0x00020288
+.long 0x68A0A101
+.long 0x68A2A301
+.long 0x68A4A501
+.long 0x68A6A701
+.long 0xD1340058, 0x00018156
+.long 0xD1340059, 0x00018157
+.long 0xD134005E, 0x0001815A
+.long 0xD134005F, 0x0001815B
+.long 0xD1340060, 0x0001815C
+.long 0xD1340061, 0x0001815D
+.long 0xE05E1000, 0x80022056
+.long 0xE05E1000, 0x80022457
+.long 0xE05E1000, 0x8003305A
+.long 0xE05E1000, 0x8003345B
+.long 0xE05E1000, 0x8003385C
+.long 0xE05E1000, 0x80033C5D
+.long 0xE05E1000, 0x80022858
+.long 0xE05E1000, 0x80022C59
+.long 0xE05E1000, 0x8003405E
+.long 0xE05E1000, 0x8003445F
+.long 0xE05E1000, 0x80034860
+.long 0xE05E1000, 0x80034C61
+.long 0x68ACACFF, 0x00000080
+.long 0x68AEAEFF, 0x00000080
+.long 0x8F2E852D
+.long 0x80AE2E80
+.long 0xBF06802E
+.long 0xBF850059
+.long 0xBF8C0F7A
+.long 0xD9BE0000, 0x00002050
+.long 0xD9BE0440, 0x00002450
+.long 0xBF8CC07F
+.long 0xE05E1000, 0x80022056
+.long 0xE05E1000, 0x80022457
+.long 0xBF8C0F78
+.long 0xD9BE0000, 0x00003052
+.long 0xD9BE0440, 0x00003452
+.long 0xD9BE0880, 0x00003852
+.long 0xD9BE0CC0, 0x00003C52
+.long 0x68ACACFF, 0x00000080
+.long 0x68AEAEFF, 0x00000080
+.long 0x68B4B4FF, 0x00000080
+.long 0x68B6B6FF, 0x00000080
+.long 0x68B8B8FF, 0x00000080
+.long 0x68BABAFF, 0x00000080
+.long 0x68B0B0FF, 0x00000080
+.long 0x68B2B2FF, 0x00000080
+.long 0x68BCBCFF, 0x00000080
+.long 0x68BEBEFF, 0x00000080
+.long 0x68C0C0FF, 0x00000080
+.long 0x68C2C2FF, 0x00000080
+.long 0xBF8CC07F
+.long 0xE05E1000, 0x8003305A
+.long 0xE05E1000, 0x8003345B
+.long 0xE05E1000, 0x8003385C
+.long 0xE05E1000, 0x80033C5D
+.long 0xBF8C0F7A
+.long 0xD9BE0000, 0x00002851
+.long 0xD9BE0440, 0x00002C51
+.long 0xBF8CC07F
+.long 0xE05E1000, 0x80022858
+.long 0xE05E1000, 0x80022C59
+.long 0xBF8C0F78
+.long 0xD9BE0000, 0x00004053
+.long 0xD9BE0440, 0x00004453
+.long 0xD9BE0880, 0x00004853
+.long 0xD9BE0CC0, 0x00004C53
+.long 0xBF8CC07F
+.long 0xBF8A0000
+.long 0xBF800018
+.long 0xE05E1000, 0x8003405E
+.long 0xBF80000B
+.long 0xE05E1000, 0x8003445F
+.long 0xBF80000B
+.long 0xE05E1000, 0x80034860
+.long 0xBF80000B
+.long 0xE05E1000, 0x80034C61
+.long 0xBF8A0000
+.long 0x802E822E
+.long 0xBF00C22E
+.long 0xBF84FFA7
+.long 0xBF8C0F7A
+.long 0xD9BE0000, 0x00002050
+.long 0xD9BE0440, 0x00002450
+.long 0xBF8C0F76
+.long 0xD9BE0000, 0x00003052
+.long 0xD9BE0440, 0x00003452
+.long 0xD9BE0880, 0x00003852
+.long 0xD9BE0CC0, 0x00003C52
+.long 0xBF8C0F74
+.long 0xD9BE0000, 0x00002851
+.long 0xD9BE0440, 0x00002C51
+.long 0xBF8C0F70
+.long 0xD9BE0000, 0x00004053
+.long 0xD9BE0440, 0x00004453
+.long 0xD9BE0880, 0x00004853
+.long 0xD9BE0CC0, 0x00004C53
+.long 0xBF8CC07F
+.long 0xBF8A0000
+.long 0xBF810000
+.long 0xD3D94000, 0x18000080
+.long 0xD3D94001, 0x18000080
+.long 0xD3D94002, 0x18000080
+.long 0xD3D94003, 0x18000080
+.long 0xD3D94004, 0x18000080
+.long 0xD3D94005, 0x18000080
+.long 0xD3D94006, 0x18000080
+.long 0xD3D94007, 0x18000080
+.long 0xD3D94008, 0x18000080
+.long 0xD3D94009, 0x18000080
+.long 0xD3D9400A, 0x18000080
+.long 0xD3D9400B, 0x18000080
+.long 0xD3D9400C, 0x18000080
+.long 0xD3D9400D, 0x18000080
+.long 0xD3D9400E, 0x18000080
+.long 0xD3D9400F, 0x18000080
+.long 0xD3D94010, 0x18000080
+.long 0xD3D94011, 0x18000080
+.long 0xD3D94012, 0x18000080
+.long 0xD3D94013, 0x18000080
+.long 0xD3D94014, 0x18000080
+.long 0xD3D94015, 0x18000080
+.long 0xD3D94016, 0x18000080
+.long 0xD3D94017, 0x18000080
+.long 0xD3D94018, 0x18000080
+.long 0xD3D94019, 0x18000080
+.long 0xD3D9401A, 0x18000080
+.long 0xD3D9401B, 0x18000080
+.long 0xD3D9401C, 0x18000080
+.long 0xD3D9401D, 0x18000080
+.long 0xD3D9401E, 0x18000080
+.long 0xD3D9401F, 0x18000080
+.long 0xD3D94020, 0x18000080
+.long 0xD3D94021, 0x18000080
+.long 0xD3D94022, 0x18000080
+.long 0xD3D94023, 0x18000080
+.long 0xD3D94024, 0x18000080
+.long 0xD3D94025, 0x18000080
+.long 0xD3D94026, 0x18000080
+.long 0xD3D94027, 0x18000080
+.long 0xD3D94028, 0x18000080
+.long 0xD3D94029, 0x18000080
+.long 0xD3D9402A, 0x18000080
+.long 0xD3D9402B, 0x18000080
+.long 0xD3D9402C, 0x18000080
+.long 0xD3D9402D, 0x18000080
+.long 0xD3D9402E, 0x18000080
+.long 0xD3D9402F, 0x18000080
+.long 0xD3D94030, 0x18000080
+.long 0xD3D94031, 0x18000080
+.long 0xD3D94032, 0x18000080
+.long 0xD3D94033, 0x18000080
+.long 0xD3D94034, 0x18000080
+.long 0xD3D94035, 0x18000080
+.long 0xD3D94036, 0x18000080
+.long 0xD3D94037, 0x18000080
+.long 0xD3D94038, 0x18000080
+.long 0xD3D94039, 0x18000080
+.long 0xD3D9403A, 0x18000080
+.long 0xD3D9403B, 0x18000080
+.long 0xD3D9403C, 0x18000080
+.long 0xD3D9403D, 0x18000080
+.long 0xD3D9403E, 0x18000080
+.long 0xD3D9403F, 0x18000080
+.long 0xD3D94040, 0x18000080
+.long 0xD3D94041, 0x18000080
+.long 0xD3D94042, 0x18000080
+.long 0xD3D94043, 0x18000080
+.long 0xD3D94044, 0x18000080
+.long 0xD3D94045, 0x18000080
+.long 0xD3D94046, 0x18000080
+.long 0xD3D94047, 0x18000080
+.long 0xD3D94048, 0x18000080
+.long 0xD3D94049, 0x18000080
+.long 0xD3D9404A, 0x18000080
+.long 0xD3D9404B, 0x18000080
+.long 0xD3D9404C, 0x18000080
+.long 0xD3D9404D, 0x18000080
+.long 0xD3D9404E, 0x18000080
+.long 0xD3D9404F, 0x18000080
+.long 0xD3D94050, 0x18000080
+.long 0xD3D94051, 0x18000080
+.long 0xD3D94052, 0x18000080
+.long 0xD3D94053, 0x18000080
+.long 0xD3D94054, 0x18000080
+.long 0xD3D94055, 0x18000080
+.long 0xD3D94056, 0x18000080
+.long 0xD3D94057, 0x18000080
+.long 0xD3D94058, 0x18000080
+.long 0xD3D94059, 0x18000080
+.long 0xD3D9405A, 0x18000080
+.long 0xD3D9405B, 0x18000080
+.long 0xD3D9405C, 0x18000080
+.long 0xD3D9405D, 0x18000080
+.long 0xD3D9405E, 0x18000080
+.long 0xD3D9405F, 0x18000080
+.long 0xD3D94060, 0x18000080
+.long 0xD3D94061, 0x18000080
+.long 0xD3D94062, 0x18000080
+.long 0xD3D94063, 0x18000080
+.long 0xD3D94064, 0x18000080
+.long 0xD3D94065, 0x18000080
+.long 0xD3D94066, 0x18000080
+.long 0xD3D94067, 0x18000080
+.long 0xD3D94068, 0x18000080
+.long 0xD3D94069, 0x18000080
+.long 0xD3D9406A, 0x18000080
+.long 0xD3D9406B, 0x18000080
+.long 0xD3D9406C, 0x18000080
+.long 0xD3D9406D, 0x18000080
+.long 0xD3D9406E, 0x18000080
+.long 0xD3D9406F, 0x18000080
+.long 0xD3D94070, 0x18000080
+.long 0xD3D94071, 0x18000080
+.long 0xD3D94072, 0x18000080
+.long 0xD3D94073, 0x18000080
+.long 0xD3D94074, 0x18000080
+.long 0xD3D94075, 0x18000080
+.long 0xD3D94076, 0x18000080
+.long 0xD3D94077, 0x18000080
+.long 0xD3D94078, 0x18000080
+.long 0xD3D94079, 0x18000080
+.long 0xD3D9407A, 0x18000080
+.long 0xD3D9407B, 0x18000080
+.long 0xD3D9407C, 0x18000080
+.long 0xD3D9407D, 0x18000080
+.long 0xD3D9407E, 0x18000080
+.long 0xD3D9407F, 0x18000080
+.long 0xC0060700, 0x00000000
+.long 0xC00A0A00, 0x00000038
+.long 0xC00A0900, 0x00000040
+.long 0xC00A0800, 0x00000018
+.long 0xC00A0A00, 0x00000038
+.long 0xD1130001, 0x00013F66
+.long 0xD2850061, 0x000202A0
+.long 0x20040281
+.long 0xD2850002, 0x00020488
+.long 0x2002CC85
+.long 0x24020282
+.long 0x68C2C301
+.long 0x24C2C281
+.long 0x68C2C302
+.long 0x86548152
+.long 0x9254FF54, 0x00001100
+.long 0x68C2C254
+.long 0x68C2C280
+.long 0x68C4C2FF, 0x00002200
+.long 0xBF8A0000
+.long 0xD1130001, 0x00013F66
+.long 0xD2850063, 0x000202A0
+.long 0x20040281
+.long 0xD2850002, 0x00020488
+.long 0x2002CC85
+.long 0x24020282
+.long 0x68C6C701
+.long 0x24C6C681
+.long 0x68C6C702
+.long 0x86548252
+.long 0x8F548154
+.long 0x9254FF54, 0x00002200
+.long 0x68C6C654
+.long 0x68C6C6FF, 0x00004400
+.long 0x68C8C6FF, 0x00004400
+.long 0xBF8CC07F
+.long 0xBE900022
+.long 0xBE910023
+.long 0xBE9200FF, 0x80000000
+.long 0xBE9300FF, 0x00020000
+.long 0xBE940020
+.long 0xBE950021
+.long 0xBE9600FF, 0x80000000
+.long 0xBE9700FF, 0x00020000
+.long 0x925603FF, 0x00000100
+.long 0x96552656
+.long 0x92542656
+.long 0x8ED48154
+.long 0x80105410
+.long 0x82115511
+.long 0x80145414
+.long 0x82155515
+.long 0x96552704
+.long 0x92542704
+.long 0x8ED48154
+.long 0x80105410
+.long 0x82115511
+.long 0x80145414
+.long 0x82155515
+.long 0x24CACE86
+.long 0x68CACB66
+.long 0x2608CE82
+.long 0x20080881
+.long 0x24080887
+.long 0xD2850003, 0x00004D04
+.long 0x2608CE81
+.long 0xD2850004, 0x000208C0
+.long 0x68060903
+.long 0x2608CA9F
+.long 0xD2850005, 0x00004D04
+.long 0x68D40B03
+.long 0x2608CABF
+.long 0x200C0885
+.long 0x240C0C82
+.long 0x925402FF, 0x00000080
+.long 0x32D20C54
+.long 0xD1FE0060, 0x0206D569
+.long 0xBF8A0000
+.long 0xD8EC0000, 0x00000061
+.long 0xD8EC0000, 0x20000063
+.long 0xD8EC0010, 0x02000061
+.long 0xD8EC0010, 0x22000063
+.long 0xBF8CC27F
+.long 0xD3CC0000, 0x04024100
+.long 0xD8EC0020, 0x04000061
+.long 0xD8EC0020, 0x24000063
+.long 0xD8EC0030, 0x06000061
+.long 0xD8EC0030, 0x26000063
+.long 0xBF8CC47F
+.long 0xD3CC0000, 0x04024502
+.long 0xD8EC0000, 0x10000062
+.long 0xD8EC0000, 0x40000064
+.long 0xD8EC0010, 0x12000062
+.long 0xD8EC0010, 0x42000064
+.long 0xD3CC0000, 0x04024904
+.long 0xD8EC0020, 0x14000062
+.long 0xD8EC0020, 0x44000064
+.long 0xD8EC0030, 0x16000062
+.long 0xD8EC0030, 0x46000064
+.long 0xD3CC0000, 0x04024D06
+.long 0xD8EC0880, 0x08000061
+.long 0xD8EC0880, 0x28000063
+.long 0xD8EC0890, 0x0A000061
+.long 0xD8EC0890, 0x2A000063
+.long 0xD3CC0000, 0x04028110
+.long 0xD8EC08A0, 0x0C000061
+.long 0xD8EC08A0, 0x2C000063
+.long 0xD8EC08B0, 0x0E000061
+.long 0xD8EC08B0, 0x2E000063
+.long 0xD3CC0000, 0x04028512
+.long 0xD8EC0880, 0x18000062
+.long 0xD8EC0890, 0x1A000062
+.long 0xD8EC08A0, 0x1C000062
+.long 0xD8EC08B0, 0x1E000062
+.long 0xD3CC0000, 0x04028914
+.long 0xD8EC0880, 0x48000064
+.long 0xD8EC0890, 0x4A000064
+.long 0xD8EC08A0, 0x4C000064
+.long 0xD8EC08B0, 0x4E000064
+.long 0xD3CC0000, 0x04028D16
+.long 0xD8EC1100, 0x30000063
+.long 0xD8EC1110, 0x32000063
+.long 0xD8EC1120, 0x34000063
+.long 0xD8EC1130, 0x36000063
+.long 0xD3CC0010, 0x04424108
+.long 0xD8EC1980, 0x38000063
+.long 0xD8EC1990, 0x3A000063
+.long 0xD8EC19A0, 0x3C000063
+.long 0xD8EC19B0, 0x3E000063
+.long 0xD3CC0010, 0x0442450A
+.long 0xD8EC1100, 0x50000064
+.long 0xD8EC1110, 0x52000064
+.long 0xD8EC1120, 0x54000064
+.long 0xD8EC1130, 0x56000064
+.long 0xD3CC0010, 0x0442490C
+.long 0xD8EC1980, 0x58000064
+.long 0xD8EC1990, 0x5A000064
+.long 0xD8EC19A0, 0x5C000064
+.long 0xD8EC19B0, 0x5E000064
+.long 0x8F2E852D
+.long 0x80AE2E80
+.long 0xBF06802E
+.long 0xBF850119
+.long 0xD3CC0010, 0x04424D0E
+.long 0xBF8CC07F
+.long 0xBF8A0000
+.long 0xD3CC0010, 0x04428118
+.long 0xBF80000C
+.long 0xD3CC0010, 0x0442851A
+.long 0xBF80000C
+.long 0xD3CC0010, 0x0442891C
+.long 0xBF80000C
+.long 0xD3CC0010, 0x04428D1E
+.long 0xBF80000C
+.long 0xD3CC0020, 0x04825100
+.long 0xBF80000C
+.long 0xD3CC0020, 0x04825502
+.long 0xBF80000C
+.long 0xD3CC0020, 0x04825904
+.long 0xBF80000C
+.long 0xD3CC0020, 0x04825D06
+.long 0xBF80000C
+.long 0xD3CC0020, 0x04829110
+.long 0xBF80000C
+.long 0xD3CC0020, 0x04829512
+.long 0xBF80000C
+.long 0xD3CC0020, 0x04829914
+.long 0xBF80000C
+.long 0xD3CC0020, 0x04829D16
+.long 0xBF80000C
+.long 0xD3CC0030, 0x04C25108
+.long 0xBF80000C
+.long 0xD3CC0030, 0x04C2550A
+.long 0xBF80000C
+.long 0xD3CC0030, 0x04C2590C
+.long 0xBF80000C
+.long 0xD3CC0030, 0x04C25D0E
+.long 0xBF80000C
+.long 0xD3CC0030, 0x04C29118
+.long 0xBF80000C
+.long 0xD3CC0030, 0x04C2951A
+.long 0xBF80000C
+.long 0xD3CC0030, 0x04C2991C
+.long 0xBF80000C
+.long 0xD3CC0030, 0x04C29D1E
+.long 0xBF80000C
+.long 0xD3CC0040, 0x05026100
+.long 0xBF80000C
+.long 0xD3CC0040, 0x05026502
+.long 0xBF80000C
+.long 0xD3CC0040, 0x05026904
+.long 0xBF80000C
+.long 0xD3CC0040, 0x05026D06
+.long 0xBF80000C
+.long 0xD3CC0040, 0x0502A110
+.long 0xBF80000C
+.long 0xD3CC0040, 0x0502A512
+.long 0xBF80000C
+.long 0xD3CC0040, 0x0502A914
+.long 0xBF80000C
+.long 0xD3CC0040, 0x0502AD16
+.long 0xBF80000C
+.long 0xD3CC0050, 0x05426108
+.long 0xBF80000C
+.long 0xD3CC0050, 0x0542650A
+.long 0xBF80000C
+.long 0xD3CC0050, 0x0542690C
+.long 0xBF80000C
+.long 0xD3CC0050, 0x05426D0E
+.long 0xBF80000C
+.long 0xD3CC0050, 0x0542A118
+.long 0xBF80000C
+.long 0xD3CC0050, 0x0542A51A
+.long 0xBF80000C
+.long 0xD3CC0050, 0x0542A91C
+.long 0xBF80000C
+.long 0xD3CC0050, 0x0542AD1E
+.long 0xBF80000C
+.long 0xD3CC0060, 0x05827100
+.long 0xBF80000C
+.long 0xD3CC0060, 0x05827502
+.long 0xBF80000C
+.long 0xD3CC0060, 0x05827904
+.long 0xBF80000C
+.long 0xD3CC0060, 0x05827D06
+.long 0xBF80000C
+.long 0xD3CC0060, 0x0582B110
+.long 0xBF80000C
+.long 0xD3CC0060, 0x0582B512
+.long 0xBF80000C
+.long 0xD3CC0060, 0x0582B914
+.long 0xBF80000C
+.long 0xD3CC0060, 0x0582BD16
+.long 0xBF80000C
+.long 0xD3CC0070, 0x05C27108
+.long 0xBF80000C
+.long 0xD3CC0070, 0x05C2750A
+.long 0xBF80000C
+.long 0xD3CC0070, 0x05C2790C
+.long 0xBF80000C
+.long 0xD3CC0070, 0x05C27D0E
+.long 0xBF80000C
+.long 0xD3CC0070, 0x05C2B118
+.long 0xBF80000C
+.long 0xD3CC0070, 0x05C2B51A
+.long 0xBF80000C
+.long 0xD3CC0070, 0x05C2B91C
+.long 0xBF8A0000
+.long 0xD8EC0000, 0x00000061
+.long 0xD8EC0000, 0x20000063
+.long 0xD8EC0010, 0x02000061
+.long 0xD8EC0010, 0x22000063
+.long 0xD3CC0070, 0x05C2BD1E
+.long 0xD8EC0020, 0x04000061
+.long 0xD8EC0020, 0x24000063
+.long 0xD8EC0030, 0x06000061
+.long 0xD8EC0030, 0x26000063
+.long 0xBF8CC67F
+.long 0xD3CC0000, 0x04024100
+.long 0xD8EC0000, 0x10000062
+.long 0xD8EC0000, 0x40000064
+.long 0xD8EC0010, 0x12000062
+.long 0xD8EC0010, 0x42000064
+.long 0xD3CC0000, 0x04024502
+.long 0xD8EC0020, 0x14000062
+.long 0xD8EC0020, 0x44000064
+.long 0xD8EC0030, 0x16000062
+.long 0xD8EC0030, 0x46000064
+.long 0xD3CC0000, 0x04024904
+.long 0xD8EC0880, 0x08000061
+.long 0xD8EC0880, 0x28000063
+.long 0xD8EC0890, 0x0A000061
+.long 0xD8EC0890, 0x2A000063
+.long 0xD3CC0000, 0x04024D06
+.long 0xD8EC08A0, 0x0C000061
+.long 0xD8EC08A0, 0x2C000063
+.long 0xD8EC08B0, 0x0E000061
+.long 0xD8EC08B0, 0x2E000063
+.long 0xD3CC0000, 0x04028110
+.long 0xD8EC0880, 0x18000062
+.long 0xD8EC0890, 0x1A000062
+.long 0xD8EC08A0, 0x1C000062
+.long 0xD8EC08B0, 0x1E000062
+.long 0xD3CC0000, 0x04028512
+.long 0xD8EC0880, 0x48000064
+.long 0xD8EC0890, 0x4A000064
+.long 0xD8EC08A0, 0x4C000064
+.long 0xD8EC08B0, 0x4E000064
+.long 0xD3CC0000, 0x04028914
+.long 0xD8EC1100, 0x30000063
+.long 0xD8EC1110, 0x32000063
+.long 0xD8EC1120, 0x34000063
+.long 0xD8EC1130, 0x36000063
+.long 0xD3CC0000, 0x04028D16
+.long 0xD8EC1980, 0x38000063
+.long 0xD8EC1990, 0x3A000063
+.long 0xD8EC19A0, 0x3C000063
+.long 0xD8EC19B0, 0x3E000063
+.long 0xD3CC0010, 0x04424108
+.long 0xD8EC1100, 0x50000064
+.long 0xD8EC1110, 0x52000064
+.long 0xD8EC1120, 0x54000064
+.long 0xD8EC1130, 0x56000064
+.long 0xD3CC0010, 0x0442450A
+.long 0xD8EC1980, 0x58000064
+.long 0xD8EC1990, 0x5A000064
+.long 0xD8EC19A0, 0x5C000064
+.long 0xD8EC19B0, 0x5E000064
+.long 0xD3CC0010, 0x0442490C
+.long 0x802E822E
+.long 0xBF00C22E
+.long 0xBF84FEE7
+.long 0x9254C026
+.long 0xD3CC0010, 0x04424D0E
+.long 0xE0541000, 0x80046160
+.long 0xE0541010, 0x80046360
+.long 0xE0541020, 0x80046560
+.long 0xE0541030, 0x80046760
+.long 0xD3D84069, 0x18000100
+.long 0xD3D8406A, 0x18000101
+.long 0xD3D8406B, 0x18000102
+.long 0xD3D8406C, 0x18000103
+.long 0xD3D8406D, 0x18000104
+.long 0xD3D8406E, 0x18000105
+.long 0xD3D8406F, 0x18000106
+.long 0xD3D84070, 0x18000107
+.long 0xD3CC0010, 0x04428118
+.long 0x7ED21569
+.long 0x7ED4156A
+.long 0xD2000069, 0x05A5216A
+.long 0xD3904069, 0x1802D228
+.long 0xD3CC0010, 0x0442851A
+.long 0x7ED6156B
+.long 0x7ED8156C
+.long 0xD200006A, 0x05AD216C
+.long 0xD390406A, 0x1802D428
+.long 0x7EDA156D
+.long 0x7EDC156E
+.long 0xD200006B, 0x05B5216E
+.long 0xD390406B, 0x1802D628
+.long 0xBF8C0F73
+.long 0xD38E4069, 0x1DA6C229
+.long 0xD38E406A, 0x1DAAC429
+.long 0xE0741000, 0x80056960
+.long 0xD3CC0010, 0x0442891C
+.long 0x7EDE156F
+.long 0x7EE01570
+.long 0xD200006C, 0x05BD2170
+.long 0xD390406C, 0x1802D828
+.long 0xD3D84071, 0x18000108
+.long 0xD3D84072, 0x18000109
+.long 0xD3D84073, 0x1800010A
+.long 0xD3D84074, 0x1800010B
+.long 0xD3CC0010, 0x04428D1E
+.long 0xBF8C0F73
+.long 0xD38E406B, 0x1DAEC629
+.long 0xD38E406C, 0x1DB2C829
+.long 0xE0741010, 0x80056B60
+.long 0x7EE21571
+.long 0x7EE41572
+.long 0xD200006D, 0x05C52172
+.long 0xD390406D, 0x1802DA28
+.long 0x7EE61573
+.long 0x7EE81574
+.long 0xD200006E, 0x05CD2174
+.long 0xD390406E, 0x1802DC28
+.long 0xD3D84075, 0x1800010C
+.long 0xD3D84076, 0x1800010D
+.long 0xD3D84077, 0x1800010E
+.long 0xD3D84078, 0x1800010F
+.long 0xD3CC0020, 0x04825100
+.long 0xBF8C0F73
+.long 0xD38E406D, 0x1DB6CA29
+.long 0xD38E406E, 0x1DBACC29
+.long 0xE0741020, 0x80056D60
+.long 0x7EEA1575
+.long 0x7EEC1576
+.long 0xD200006F, 0x05D52176
+.long 0xD390406F, 0x1802DE28
+.long 0x7EEE1577
+.long 0x7EF01578
+.long 0xD2000070, 0x05DD2178
+.long 0xD3904070, 0x1802E028
+.long 0xD3CC0020, 0x04825502
+.long 0xBF8C0F73
+.long 0xD38E406F, 0x1DBECE29
+.long 0xD38E4070, 0x1DC2D029
+.long 0xE0741030, 0x80056F60
+.long 0xE0541040, 0x80046160
+.long 0xE0541050, 0x80046360
+.long 0xE0541060, 0x80046560
+.long 0xE0541070, 0x80046760
+.long 0xD3D84069, 0x18000110
+.long 0xD3D8406A, 0x18000111
+.long 0xD3D8406B, 0x18000112
+.long 0xD3D8406C, 0x18000113
+.long 0xD3D8406D, 0x18000114
+.long 0xD3D8406E, 0x18000115
+.long 0xD3D8406F, 0x18000116
+.long 0xD3D84070, 0x18000117
+.long 0xD3CC0020, 0x04825904
+.long 0x7ED21569
+.long 0x7ED4156A
+.long 0xD2000069, 0x05A5216A
+.long 0xD3904069, 0x1802D228
+.long 0x7ED6156B
+.long 0x7ED8156C
+.long 0xD200006A, 0x05AD216C
+.long 0xD390406A, 0x1802D428
+.long 0x7EDA156D
+.long 0x7EDC156E
+.long 0xD200006B, 0x05B5216E
+.long 0xD390406B, 0x1802D628
+.long 0xD3CC0020, 0x04825D06
+.long 0xBF8C0F73
+.long 0xD38E4069, 0x1DA6C229
+.long 0xD38E406A, 0x1DAAC429
+.long 0xE0741040, 0x80056960
+.long 0x7EDE156F
+.long 0x7EE01570
+.long 0xD200006C, 0x05BD2170
+.long 0xD390406C, 0x1802D828
+.long 0xD3D84071, 0x18000118
+.long 0xD3D84072, 0x18000119
+.long 0xD3D84073, 0x1800011A
+.long 0xD3D84074, 0x1800011B
+.long 0xD3CC0020, 0x04829110
+.long 0xBF8C0F73
+.long 0xD38E406B, 0x1DAEC629
+.long 0xD38E406C, 0x1DB2C829
+.long 0xE0741050, 0x80056B60
+.long 0xD3CC0020, 0x04829512
+.long 0x7EE21571
+.long 0x7EE41572
+.long 0xD200006D, 0x05C52172
+.long 0xD390406D, 0x1802DA28
+.long 0x7EE61573
+.long 0x7EE81574
+.long 0xD200006E, 0x05CD2174
+.long 0xD390406E, 0x1802DC28
+.long 0xD3D84075, 0x1800011C
+.long 0xD3D84076, 0x1800011D
+.long 0xD3D84077, 0x1800011E
+.long 0xD3D84078, 0x1800011F
+.long 0xD3CC0020, 0x04829914
+.long 0xBF8C0F73
+.long 0xD38E406D, 0x1DB6CA29
+.long 0xD38E406E, 0x1DBACC29
+.long 0xE0741060, 0x80056D60
+.long 0xD3CC0020, 0x04829D16
+.long 0x7EEA1575
+.long 0x7EEC1576
+.long 0xD200006F, 0x05D52176
+.long 0xD390406F, 0x1802DE28
+.long 0x7EEE1577
+.long 0x7EF01578
+.long 0xD2000070, 0x05DD2178
+.long 0xD3904070, 0x1802E028
+.long 0xD3CC0030, 0x04C25108
+.long 0xBF8C0F73
+.long 0xD38E406F, 0x1DBECE29
+.long 0xD38E4070, 0x1DC2D029
+.long 0xE0741070, 0x80056F60
+.long 0xD3CC0030, 0x04C2550A
+.long 0xD1340060, 0x0000A960
+.long 0xE0541000, 0x80046160
+.long 0xE0541010, 0x80046360
+.long 0xE0541020, 0x80046560
+.long 0xE0541030, 0x80046760
+.long 0xD3D84069, 0x18000120
+.long 0xD3D8406A, 0x18000121
+.long 0xD3D8406B, 0x18000122
+.long 0xD3D8406C, 0x18000123
+.long 0xD3D8406D, 0x18000124
+.long 0xD3D8406E, 0x18000125
+.long 0xD3D8406F, 0x18000126
+.long 0xD3D84070, 0x18000127
+.long 0x7ED21569
+.long 0x7ED4156A
+.long 0xD2000069, 0x05A5216A
+.long 0xD3904069, 0x1802D228
+.long 0x7ED6156B
+.long 0x7ED8156C
+.long 0xD200006A, 0x05AD216C
+.long 0xD390406A, 0x1802D428
+.long 0x7EDA156D
+.long 0x7EDC156E
+.long 0xD200006B, 0x05B5216E
+.long 0xD390406B, 0x1802D628
+.long 0xD3CC0030, 0x04C2590C
+.long 0xBF8C0F73
+.long 0xD38E4069, 0x1DA6C229
+.long 0xD38E406A, 0x1DAAC429
+.long 0xE0741000, 0x80056960
+.long 0xD3CC0030, 0x04C25D0E
+.long 0x7EDE156F
+.long 0x7EE01570
+.long 0xD200006C, 0x05BD2170
+.long 0xD390406C, 0x1802D828
+.long 0xD3D84071, 0x18000128
+.long 0xD3D84072, 0x18000129
+.long 0xD3D84073, 0x1800012A
+.long 0xD3D84074, 0x1800012B
+.long 0xD3CC0030, 0x04C29118
+.long 0xBF8C0F73
+.long 0xD38E406B, 0x1DAEC629
+.long 0xD38E406C, 0x1DB2C829
+.long 0xE0741010, 0x80056B60
+.long 0xD3CC0030, 0x04C2951A
+.long 0x7EE21571
+.long 0x7EE41572
+.long 0xD200006D, 0x05C52172
+.long 0xD390406D, 0x1802DA28
+.long 0x7EE61573
+.long 0x7EE81574
+.long 0xD200006E, 0x05CD2174
+.long 0xD390406E, 0x1802DC28
+.long 0xD3D84075, 0x1800012C
+.long 0xD3D84076, 0x1800012D
+.long 0xD3D84077, 0x1800012E
+.long 0xD3D84078, 0x1800012F
+.long 0xD3CC0030, 0x04C2991C
+.long 0xBF8C0F73
+.long 0xD38E406D, 0x1DB6CA29
+.long 0xD38E406E, 0x1DBACC29
+.long 0xE0741020, 0x80056D60
+.long 0xD3CC0030, 0x04C29D1E
+.long 0x7EEA1575
+.long 0x7EEC1576
+.long 0xD200006F, 0x05D52176
+.long 0xD390406F, 0x1802DE28
+.long 0x7EEE1577
+.long 0x7EF01578
+.long 0xD2000070, 0x05DD2178
+.long 0xD3904070, 0x1802E028
+.long 0xD3CC0040, 0x05026100
+.long 0xBF8C0F73
+.long 0xD38E406F, 0x1DBECE29
+.long 0xD38E4070, 0x1DC2D029
+.long 0xE0741030, 0x80056F60
+.long 0xD3CC0040, 0x05026502
+.long 0xE0541040, 0x80046160
+.long 0xE0541050, 0x80046360
+.long 0xE0541060, 0x80046560
+.long 0xE0541070, 0x80046760
+.long 0xD3D84069, 0x18000130
+.long 0xD3D8406A, 0x18000131
+.long 0xD3D8406B, 0x18000132
+.long 0xD3D8406C, 0x18000133
+.long 0xD3D8406D, 0x18000134
+.long 0xD3D8406E, 0x18000135
+.long 0xD3D8406F, 0x18000136
+.long 0xD3D84070, 0x18000137
+.long 0x7ED21569
+.long 0x7ED4156A
+.long 0xD2000069, 0x05A5216A
+.long 0xD3904069, 0x1802D228
+.long 0x7ED6156B
+.long 0x7ED8156C
+.long 0xD200006A, 0x05AD216C
+.long 0xD390406A, 0x1802D428
+.long 0x7EDA156D
+.long 0x7EDC156E
+.long 0xD200006B, 0x05B5216E
+.long 0xD390406B, 0x1802D628
+.long 0xD3CC0040, 0x05026904
+.long 0xBF8C0F73
+.long 0xD38E4069, 0x1DA6C229
+.long 0xD38E406A, 0x1DAAC429
+.long 0xE0741040, 0x80056960
+.long 0xD3CC0040, 0x05026D06
+.long 0x7EDE156F
+.long 0x7EE01570
+.long 0xD200006C, 0x05BD2170
+.long 0xD390406C, 0x1802D828
+.long 0xD3D84071, 0x18000138
+.long 0xD3D84072, 0x18000139
+.long 0xD3D84073, 0x1800013A
+.long 0xD3D84074, 0x1800013B
+.long 0xD3CC0040, 0x0502A110
+.long 0xBF8C0F73
+.long 0xD38E406B, 0x1DAEC629
+.long 0xD38E406C, 0x1DB2C829
+.long 0xE0741050, 0x80056B60
+.long 0xD3CC0040, 0x0502A512
+.long 0x7EE21571
+.long 0x7EE41572
+.long 0xD200006D, 0x05C52172
+.long 0xD390406D, 0x1802DA28
+.long 0x7EE61573
+.long 0x7EE81574
+.long 0xD200006E, 0x05CD2174
+.long 0xD390406E, 0x1802DC28
+.long 0xD3D84075, 0x1800013C
+.long 0xD3D84076, 0x1800013D
+.long 0xD3D84077, 0x1800013E
+.long 0xD3D84078, 0x1800013F
+.long 0xD3CC0040, 0x0502A914
+.long 0xBF8C0F73
+.long 0xD38E406D, 0x1DB6CA29
+.long 0xD38E406E, 0x1DBACC29
+.long 0xE0741060, 0x80056D60
+.long 0xD3CC0040, 0x0502AD16
+.long 0x7EEA1575
+.long 0x7EEC1576
+.long 0xD200006F, 0x05D52176
+.long 0xD390406F, 0x1802DE28
+.long 0x7EEE1577
+.long 0x7EF01578
+.long 0xD2000070, 0x05DD2178
+.long 0xD3904070, 0x1802E028
+.long 0xD3CC0050, 0x05426108
+.long 0xBF8C0F73
+.long 0xD38E406F, 0x1DBECE29
+.long 0xD38E4070, 0x1DC2D029
+.long 0xE0741070, 0x80056F60
+.long 0xD3CC0050, 0x0542650A
+.long 0xD1340060, 0x0000A960
+.long 0xE0541000, 0x80046160
+.long 0xE0541010, 0x80046360
+.long 0xE0541020, 0x80046560
+.long 0xE0541030, 0x80046760
+.long 0xD3D84069, 0x18000140
+.long 0xD3D8406A, 0x18000141
+.long 0xD3D8406B, 0x18000142
+.long 0xD3D8406C, 0x18000143
+.long 0xD3D8406D, 0x18000144
+.long 0xD3D8406E, 0x18000145
+.long 0xD3D8406F, 0x18000146
+.long 0xD3D84070, 0x18000147
+.long 0x7ED21569
+.long 0x7ED4156A
+.long 0xD2000069, 0x05A5216A
+.long 0xD3904069, 0x1802D228
+.long 0x7ED6156B
+.long 0x7ED8156C
+.long 0xD200006A, 0x05AD216C
+.long 0xD390406A, 0x1802D428
+.long 0x7EDA156D
+.long 0x7EDC156E
+.long 0xD200006B, 0x05B5216E
+.long 0xD390406B, 0x1802D628
+.long 0xD3CC0050, 0x0542690C
+.long 0xBF8C0F73
+.long 0xD38E4069, 0x1DA6C229
+.long 0xD38E406A, 0x1DAAC429
+.long 0xE0741000, 0x80056960
+.long 0xD3CC0050, 0x05426D0E
+.long 0x7EDE156F
+.long 0x7EE01570
+.long 0xD200006C, 0x05BD2170
+.long 0xD390406C, 0x1802D828
+.long 0xD3D84071, 0x18000148
+.long 0xD3D84072, 0x18000149
+.long 0xD3D84073, 0x1800014A
+.long 0xD3D84074, 0x1800014B
+.long 0xD3CC0050, 0x0542A118
+.long 0xBF8C0F73
+.long 0xD38E406B, 0x1DAEC629
+.long 0xD38E406C, 0x1DB2C829
+.long 0xE0741010, 0x80056B60
+.long 0xD3CC0050, 0x0542A51A
+.long 0x7EE21571
+.long 0x7EE41572
+.long 0xD200006D, 0x05C52172
+.long 0xD390406D, 0x1802DA28
+.long 0x7EE61573
+.long 0x7EE81574
+.long 0xD200006E, 0x05CD2174
+.long 0xD390406E, 0x1802DC28
+.long 0xD3D84075, 0x1800014C
+.long 0xD3D84076, 0x1800014D
+.long 0xD3D84077, 0x1800014E
+.long 0xD3D84078, 0x1800014F
+.long 0xD3CC0050, 0x0542A91C
+.long 0xBF8C0F73
+.long 0xD38E406D, 0x1DB6CA29
+.long 0xD38E406E, 0x1DBACC29
+.long 0xE0741020, 0x80056D60
+.long 0xD3CC0050, 0x0542AD1E
+.long 0x7EEA1575
+.long 0x7EEC1576
+.long 0xD200006F, 0x05D52176
+.long 0xD390406F, 0x1802DE28
+.long 0x7EEE1577
+.long 0x7EF01578
+.long 0xD2000070, 0x05DD2178
+.long 0xD3904070, 0x1802E028
+.long 0xD3CC0060, 0x05827100
+.long 0xBF8C0F73
+.long 0xD38E406F, 0x1DBECE29
+.long 0xD38E4070, 0x1DC2D029
+.long 0xE0741030, 0x80056F60
+.long 0xD3CC0060, 0x05827502
+.long 0xE0541040, 0x80046160
+.long 0xE0541050, 0x80046360
+.long 0xE0541060, 0x80046560
+.long 0xE0541070, 0x80046760
+.long 0xD3D84069, 0x18000150
+.long 0xD3D8406A, 0x18000151
+.long 0xD3D8406B, 0x18000152
+.long 0xD3D8406C, 0x18000153
+.long 0xD3D8406D, 0x18000154
+.long 0xD3D8406E, 0x18000155
+.long 0xD3D8406F, 0x18000156
+.long 0xD3D84070, 0x18000157
+.long 0x7ED21569
+.long 0x7ED4156A
+.long 0xD2000069, 0x05A5216A
+.long 0xD3904069, 0x1802D228
+.long 0x7ED6156B
+.long 0x7ED8156C
+.long 0xD200006A, 0x05AD216C
+.long 0xD390406A, 0x1802D428
+.long 0x7EDA156D
+.long 0x7EDC156E
+.long 0xD200006B, 0x05B5216E
+.long 0xD390406B, 0x1802D628
+.long 0xD3CC0060, 0x05827904
+.long 0xBF8C0F73
+.long 0xD38E4069, 0x1DA6C229
+.long 0xD38E406A, 0x1DAAC429
+.long 0xE0741040, 0x80056960
+.long 0xD3CC0060, 0x05827D06
+.long 0x7EDE156F
+.long 0x7EE01570
+.long 0xD200006C, 0x05BD2170
+.long 0xD390406C, 0x1802D828
+.long 0xD3D84071, 0x18000158
+.long 0xD3D84072, 0x18000159
+.long 0xD3D84073, 0x1800015A
+.long 0xD3D84074, 0x1800015B
+.long 0xD3CC0060, 0x0582B110
+.long 0xBF8C0F73
+.long 0xD38E406B, 0x1DAEC629
+.long 0xD38E406C, 0x1DB2C829
+.long 0xE0741050, 0x80056B60
+.long 0xD3CC0060, 0x0582B512
+.long 0x7EE21571
+.long 0x7EE41572
+.long 0xD200006D, 0x05C52172
+.long 0xD390406D, 0x1802DA28
+.long 0x7EE61573
+.long 0x7EE81574
+.long 0xD200006E, 0x05CD2174
+.long 0xD390406E, 0x1802DC28
+.long 0xD3D84075, 0x1800015C
+.long 0xD3D84076, 0x1800015D
+.long 0xD3D84077, 0x1800015E
+.long 0xD3D84078, 0x1800015F
+.long 0xD3CC0060, 0x0582B914
+.long 0xBF8C0F73
+.long 0xD38E406D, 0x1DB6CA29
+.long 0xD38E406E, 0x1DBACC29
+.long 0xE0741060, 0x80056D60
+.long 0xD3CC0060, 0x0582BD16
+.long 0x7EEA1575
+.long 0x7EEC1576
+.long 0xD200006F, 0x05D52176
+.long 0xD390406F, 0x1802DE28
+.long 0x7EEE1577
+.long 0x7EF01578
+.long 0xD2000070, 0x05DD2178
+.long 0xD3904070, 0x1802E028
+.long 0xD3CC0070, 0x05C27108
+.long 0xBF8C0F73
+.long 0xD38E406F, 0x1DBECE29
+.long 0xD38E4070, 0x1DC2D029
+.long 0xE0741070, 0x80056F60
+.long 0xD3CC0070, 0x05C2750A
+.long 0xD1340060, 0x0000A960
+.long 0xE0541000, 0x80046160
+.long 0xE0541010, 0x80046360
+.long 0xE0541020, 0x80046560
+.long 0xE0541030, 0x80046760
+.long 0xD3D84069, 0x18000160
+.long 0xD3D8406A, 0x18000161
+.long 0xD3D8406B, 0x18000162
+.long 0xD3D8406C, 0x18000163
+.long 0xD3D8406D, 0x18000164
+.long 0xD3D8406E, 0x18000165
+.long 0xD3D8406F, 0x18000166
+.long 0xD3D84070, 0x18000167
+.long 0x7ED21569
+.long 0x7ED4156A
+.long 0xD2000069, 0x05A5216A
+.long 0xD3904069, 0x1802D228
+.long 0x7ED6156B
+.long 0x7ED8156C
+.long 0xD200006A, 0x05AD216C
+.long 0xD390406A, 0x1802D428
+.long 0x7EDA156D
+.long 0x7EDC156E
+.long 0xD200006B, 0x05B5216E
+.long 0xD390406B, 0x1802D628
+.long 0xD3CC0070, 0x05C2790C
+.long 0xBF8C0F73
+.long 0xD38E4069, 0x1DA6C229
+.long 0xD38E406A, 0x1DAAC429
+.long 0xE0741000, 0x80056960
+.long 0xD3CC0070, 0x05C27D0E
+.long 0x7EDE156F
+.long 0x7EE01570
+.long 0xD200006C, 0x05BD2170
+.long 0xD390406C, 0x1802D828
+.long 0xD3D84071, 0x18000168
+.long 0xD3D84072, 0x18000169
+.long 0xD3D84073, 0x1800016A
+.long 0xD3D84074, 0x1800016B
+.long 0xD3CC0070, 0x05C2B118
+.long 0xBF8C0F73
+.long 0xD38E406B, 0x1DAEC629
+.long 0xD38E406C, 0x1DB2C829
+.long 0xE0741010, 0x80056B60
+.long 0xD3CC0070, 0x05C2B51A
+.long 0x7EE21571
+.long 0x7EE41572
+.long 0xD200006D, 0x05C52172
+.long 0xD390406D, 0x1802DA28
+.long 0x7EE61573
+.long 0x7EE81574
+.long 0xD200006E, 0x05CD2174
+.long 0xD390406E, 0x1802DC28
+.long 0xD3D84075, 0x1800016C
+.long 0xD3D84076, 0x1800016D
+.long 0xD3D84077, 0x1800016E
+.long 0xD3D84078, 0x1800016F
+.long 0xD3CC0070, 0x05C2B91C
+.long 0xBF8C0F73
+.long 0xD38E406D, 0x1DB6CA29
+.long 0xD38E406E, 0x1DBACC29
+.long 0xE0741020, 0x80056D60
+.long 0xD3CC0070, 0x05C2BD1E
+.long 0xBF800007
+.long 0x7EEA1575
+.long 0x7EEC1576
+.long 0xD200006F, 0x05D52176
+.long 0xD390406F, 0x1802DE28
+.long 0x7EEE1577
+.long 0x7EF01578
+.long 0xD2000070, 0x05DD2178
+.long 0xD3904070, 0x1802E028
+.long 0xBF8C0F73
+.long 0xD38E406F, 0x1DBECE29
+.long 0xD38E4070, 0x1DC2D029
+.long 0xE0741030, 0x80056F60
+.long 0xE0541040, 0x80046160
+.long 0xE0541050, 0x80046360
+.long 0xE0541060, 0x80046560
+.long 0xE0541070, 0x80046760
+.long 0xD3D84069, 0x18000170
+.long 0xD3D8406A, 0x18000171
+.long 0xD3D8406B, 0x18000172
+.long 0xD3D8406C, 0x18000173
+.long 0xD3D8406D, 0x18000174
+.long 0xD3D8406E, 0x18000175
+.long 0xD3D8406F, 0x18000176
+.long 0xD3D84070, 0x18000177
+.long 0x7ED21569
+.long 0x7ED4156A
+.long 0xD2000069, 0x05A5216A
+.long 0xD3904069, 0x1802D228
+.long 0x7ED6156B
+.long 0x7ED8156C
+.long 0xD200006A, 0x05AD216C
+.long 0xD390406A, 0x1802D428
+.long 0x7EDA156D
+.long 0x7EDC156E
+.long 0xD200006B, 0x05B5216E
+.long 0xD390406B, 0x1802D628
+.long 0xBF8C0F73
+.long 0xD38E4069, 0x1DA6C229
+.long 0xD38E406A, 0x1DAAC429
+.long 0xE0741040, 0x80056960
+.long 0x7EDE156F
+.long 0x7EE01570
+.long 0xD200006C, 0x05BD2170
+.long 0xD390406C, 0x1802D828
+.long 0xD3D84071, 0x18000178
+.long 0xD3D84072, 0x18000179
+.long 0xD3D84073, 0x1800017A
+.long 0xD3D84074, 0x1800017B
+.long 0xBF8C0F73
+.long 0xD38E406B, 0x1DAEC629
+.long 0xD38E406C, 0x1DB2C829
+.long 0xE0741050, 0x80056B60
+.long 0x7EE21571
+.long 0x7EE41572
+.long 0xD200006D, 0x05C52172
+.long 0xD390406D, 0x1802DA28
+.long 0x7EE61573
+.long 0x7EE81574
+.long 0xD200006E, 0x05CD2174
+.long 0xD390406E, 0x1802DC28
+.long 0xD3D84075, 0x1800017C
+.long 0xD3D84076, 0x1800017D
+.long 0xD3D84077, 0x1800017E
+.long 0xD3D84078, 0x1800017F
+.long 0xBF8C0F73
+.long 0xD38E406D, 0x1DB6CA29
+.long 0xD38E406E, 0x1DBACC29
+.long 0xE0741060, 0x80056D60
+.long 0x7EEA1575
+.long 0x7EEC1576
+.long 0xD200006F, 0x05D52176
+.long 0xD390406F, 0x1802DE28
+.long 0x7EEE1577
+.long 0x7EF01578
+.long 0xD2000070, 0x05DD2178
+.long 0xD3904070, 0x1802E028
+.long 0xBF8C0F73
+.long 0xD38E406F, 0x1DBECE29
+.long 0xD38E4070, 0x1DC2D029
+.long 0xE0741070, 0x80056F60
+.long 0xBF8C0000
+.long 0xBF810000

--- a/Tensile/ReplacementKernels-cov3/Cijk_Alik_Bljk_HBH_MT128x256x32_SE_K1.s.txt
+++ b/Tensile/ReplacementKernels-cov3/Cijk_Alik_Bljk_HBH_MT128x256x32_SE_K1.s.txt
@@ -1,0 +1,1716 @@
+
+
+/******************************************/
+/* Function Prefix                        */
+/******************************************/
+
+
+
+/******************************************/
+/* Begin Kernel                           */
+/******************************************/
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx908+sram-ecc"
+.text
+.protected Cijk_Alik_Bljk_HBH_MT128x256x32_SE_K1
+.globl Cijk_Alik_Bljk_HBH_MT128x256x32_SE_K1
+.p2align 8
+.type Cijk_Alik_Bljk_HBH_MT128x256x32_SE_K1,@function
+.section .rodata,#alloc
+.p2align 6
+.amdhsa_kernel Cijk_Alik_Bljk_HBH_MT128x256x32_SE_K1
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_next_free_vgpr 128 // vgprs
+  .amdhsa_next_free_sgpr 98 // sgprs
+  .amdhsa_group_segment_fixed_size 57344 // lds bytes
+  .amdhsa_private_segment_fixed_size 0
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+.text
+
+/******************************************/
+/* Optimizations and Config:              */
+/******************************************/
+/* ThreadTile= 8 x 8 */
+/* SubGroup= 16 x 32 */
+/* VectorWidth=8 */
+/* GlobalLoadVectorWidthA=8, GlobalLoadVectorWidthB=8 */
+/* DirectToLdsA=False */
+/* DirectToLdsB=False */
+/* UseSgprForGRO=1 */
+.amdgpu_metadata
+---
+amdhsa.version:
+  - 1
+  - 0
+amdhsa.kernels:
+  - .name: Cijk_Alik_Bljk_HBH_MT128x256x32_SE_K1
+    .symbol: 'Cijk_Alik_Bljk_HBH_MT128x256x32_SE_K1.kd'
+    .language:                   OpenCL C
+    .language_version:
+      - 2
+      - 0
+    .args:
+      - .name:            sizeC
+        .size:            8
+        .offset:          0
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            sizeA
+        .size:            8
+        .offset:          8
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            sizeB
+        .size:            8
+        .offset:          16
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            D
+        .size:            8
+        .offset:          24
+        .value_kind:      global_buffer
+        .value_type:      struct
+        .address_space:   generic
+      - .name:            C
+        .size:            8
+        .offset:          32
+        .value_kind:      global_buffer
+        .value_type:      struct
+        .address_space:   generic
+      - .name:            A
+        .size:            8
+        .offset:          40
+        .value_kind:      global_buffer
+        .value_type:      struct
+        .address_space:   generic
+      - .name:            B
+        .size:            8
+        .offset:          48
+        .value_kind:      global_buffer
+        .value_type:      struct
+        .address_space:   generic
+      - .name:            alpha
+        .size:            4
+        .offset:          56
+        .value_kind:      by_value
+        .value_type:      f16
+      - .name:            beta
+        .size:            4
+        .offset:          60
+        .value_kind:      by_value
+        .value_type:      f16
+      - .name:            strideD0
+        .size:            4
+        .offset:          64
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideD1
+        .size:            4
+        .offset:          68
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideC0
+        .size:            4
+        .offset:          72
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideC1
+        .size:            4
+        .offset:          76
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideA0
+        .size:            4
+        .offset:          80
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideA1
+        .size:            4
+        .offset:          84
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideB0
+        .size:            4
+        .offset:          88
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideB1
+        .size:            4
+        .offset:          92
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree0
+        .size:            4
+        .offset:          96
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree1
+        .size:            4
+        .offset:          100
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree2
+        .size:            4
+        .offset:          104
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesSum0
+        .size:            4
+        .offset:          108
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            OrigStaggerUIter
+        .size:            4
+        .offset:          112
+        .value_kind:      by_value
+        .value_type:      i32
+      - .name:            NumWorkGroups0
+        .size:            4
+        .offset:          116
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            NumWorkGroups1
+        .size:            4
+        .offset:          120
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            MagicNumberProblemNumGroupTiles0
+        .size:            4
+        .offset:          124
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            GridNumWorkGroups0
+        .size:            4
+        .offset:          128
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            NumFullBlocks
+        .size:            4
+        .offset:          132
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            WgmRemainder1
+        .size:            4
+        .offset:          136
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            MagicNumberWgmRemainder1
+        .size:            4
+        .offset:          140
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            padding
+        .size:            4
+        .offset:          144
+        .value_kind:      by_value
+        .value_type:      u32
+    .group_segment_fixed_size:   57344
+    .kernarg_segment_align:      8
+    .kernarg_segment_size:       152
+    .max_flat_workgroup_size:    512
+    .private_segment_fixed_size: 0
+    .sgpr_count:                 98
+    .sgpr_spill_count:           0
+    .vgpr_count:                 128
+    .vgpr_spill_count:           0
+    .wavefront_size:             64
+...
+.end_amdgpu_metadata
+Cijk_Alik_Bljk_HBH_MT128x256x32_SE_K1:
+
+/******************************************/
+/* Asm syntax workarounds                 */
+/******************************************/
+.macro _v_add_co_u32 dst, cc, src0, src1, dpp=
+   v_add_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+
+.macro _v_add_u32 dst, src0, src1, dpp=
+   v_add_u32 \dst, \src0, \src1 \dpp
+.endm
+
+.macro _v_sub_co_u32 dst, cc, src0, src1, dpp=
+   v_sub_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+
+.macro _v_sub_u32 dst, src0, src1, dpp=
+   v_sub_u32 \dst, \src0, \src1 \dpp
+.endm
+
+.macro _v_addc_co_u32 dst, ccOut, src0, ccIn, src1, dpp=
+   v_addc_co_u32 \dst, \ccOut, \src0, \ccIn, \src1 \dpp
+.endm
+
+.macro _v_add_lshl_u32 dst, src0, src1, shiftCnt
+    v_add_lshl_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+.macro _v_lshl_add_u32 dst, src0, src1, shiftCnt
+    v_lshl_add_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+/******************************************/
+/* Magic div and mod functions            */
+/******************************************/
+.macro V_MAGIC_DIV dstIdx, dividend, magicNumber, magicShift
+    v_mul_hi_u32 v[\dstIdx+1], \dividend, \magicNumber
+    v_mul_lo_u32 v[\dstIdx+0], \dividend, \magicNumber
+    v_lshrrev_b64 v[\dstIdx:\dstIdx+1], \magicShift, v[\dstIdx:\dstIdx+1]
+.endm
+
+/******************************************/
+/* VGPR Assignments                       */
+/******************************************/
+.set vgprValuC, 0
+/* ValuA/B   Xn=PLR buffer idx,  In=InnerUnroll idx */
+.set vgprValuA_X0_I0, 32
+.set vgprValuA_X1_I0, 34
+.set vgprG2LA, 36
+.set vgprValuB_X0_I0, 40
+.set vgprValuB_X1_I0, 44
+.set vgprG2LB, 48
+.set vgprLocalWriteAddrA, 56
+.set vgprLocalWriteAddrB, 57
+.set vgprGlobalReadOffsetA, 58
+.set vgprGlobalReadOffsetB, 59
+.set vgprLocalReadAddrA, 60
+.set vgprLocalReadAddrB, 61
+.set vgprSerial, 62
+/* Num VGPR=63 */
+
+/******************************************/
+/* SGPR Assignments                       */
+/******************************************/
+.set sgprKernArgAddress, 0
+.set sgprWorkGroup0, 2
+.set sgprWorkGroup1, 3
+.set sgprWorkGroup2, 4
+.set sgprNumWorkGroups0, 5
+.set sgprNumWorkGroups1, 6
+.set sgprSrdA, 8
+.set sgprSrdB, 12
+.set sgprSrdD, 16
+.set sgprSrdC, 20
+.set sgprTensor2dSizeC, 24
+.set sgprTensor2dSizeA, 26
+.set sgprTensor2dSizeB, 28
+.set sgprSaveExecMask, 30
+.set sgprAddressD, 32
+.set sgprAddressC, 34
+.set sgprStridesD, 36
+.set sgprStridesC, 38
+.set sgprAlpha, 40
+.set sgprBeta, 41
+.set sgprSizesFree, 42
+.set sgprSizesSum, 45
+.set sgprLoopCounters, 46
+.set sgprOrigLoopCounter, 47
+.set sgprStridesA, 48
+.set sgprStridesB, 50
+.set sgprAddressA, 52
+.set sgprAddressB, 54
+.set sgprShadowLimitA, 56
+.set sgprShadowLimitB, 58
+.set sgprOrigStaggerUIter, 60
+.set sgprStaggerUIter, 61
+.set sgprWrapUA, 62
+.set sgprWrapUB, 64
+.set sgprNumFullBlocks, 66
+.set sgprWgmRemainder1, 67
+.set sgprMagicNumberWgmRemainder1, 68
+.set sgprGlobalReadIncsA, 69
+.set sgprGlobalReadIncsB, 70
+.set sgprScalarGlobalReadOffsetA, 71
+.set sgprScalarGlobalReadOffsetB, 72
+/* max SGPR=98 */
+
+/* Size Assignments */
+.set sgprSizeD0I, sgprSizesFree+0
+.set sgprSizeD1J, sgprSizesFree+1
+.set sgprSizeDK, sgprSizesFree+2
+.set sgprSizeC0I, sgprSizesFree+0
+.set sgprSizeC1J, sgprSizesFree+1
+.set sgprSizeCK, sgprSizesFree+2
+.set sgprSizeAL, sgprSizesSum+0
+.set sgprSizeA0I, sgprSizesFree+0
+.set sgprSizeAK, sgprSizesFree+2
+.set sgprSizeBL, sgprSizesSum+0
+.set sgprSizeB1J, sgprSizesFree+1
+.set sgprSizeBK, sgprSizesFree+2
+
+/* Stride Assignments */
+.set constStrideD0I, 1
+.set sgprStrideD1J, sgprStridesD+0
+.set sgprStrideDK, sgprStridesD+1
+.set constStrideC0I, 1
+.set sgprStrideC1J, sgprStridesC+0
+.set sgprStrideCK, sgprStridesC+1
+.set constStrideAL, 1
+.set sgprStrideA0I, sgprStridesA+0
+.set sgprStrideAK, sgprStridesA+1
+.set constStrideBL, 1
+.set sgprStrideB1J, sgprStridesB+0
+.set sgprStrideBK, sgprStridesB+1
+
+.set DepthU, 32
+/* Number of elements to shift-left SRD */
+.set SrdShiftLeftA, 4
+.set SrdShiftLeftB, 4
+/* 2GB limit - set offsets to -1 to exceed this and clamp */
+.set BufferLimit, 0x80000000
+/* Bits 127:96 of SRD.  Set DataFormat = 32 bit */
+.set Srd127_96, 0x0020000
+.set BufferOOB, 0x80000000
+
+/* Global Offset A */
+.macro GLOBAL_OFFSET_A vgprAddr vgprOffsetL vgprOffset0I vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStrideA0I], v[\vgprOffset0I] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprOffsetL], v[\vgprTmp+0] // accumulate d1 lower
+_v_add_u32 v[\vgprAddr+0], 0x4, v[\vgprAddr+0]     // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/* Global Offset B */
+.macro GLOBAL_OFFSET_B vgprAddr vgprOffsetL vgprOffset1J vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStrideB1J], v[\vgprOffset1J] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprOffsetL], v[\vgprTmp+0] // accumulate d1 lower
+_v_add_u32 v[\vgprAddr+0], 0x4, v[\vgprAddr+0]     // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/******************************************/
+/* Dynamic Scalar Divide: vQuotient=vDividend/vDivisor; vRemainder=vDividend%vDivisor; */
+/******************************************/
+.macro DYNAMIC_VECTOR_DIVIDE vQuotient vRemainder vDividend vDivisor vTmp0 vTmp1 sTmp
+v_cvt_f32_u32 v[\vQuotient], v[\vDivisor]          //
+v_rcp_f32 v[\vQuotient], v[\vQuotient]             //
+v_mul_f32 v[\vQuotient], 0x4f800000, v[\vQuotient] //
+v_cvt_u32_f32 v[\vQuotient], v[\vQuotient]         //
+v_mul_lo_u32 v[\vRemainder], v[\vDivisor], v[\vQuotient] //
+v_mul_hi_u32 v[\vTmp0], v[\vDivisor], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp1], vcc, 0x0, v[\vRemainder]  //
+v_cmp_ne_i32 s[\sTmp:\sTmp+1], 0x0, v[\vTmp0]      //
+v_cndmask_b32 v[\vRemainder], v[\vTmp1], v[\vRemainder], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vRemainder], v[\vRemainder], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vQuotient], v[\vRemainder] //
+_v_add_co_u32 v[\vQuotient], vcc, v[\vQuotient], v[\vRemainder] //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vTmp0], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vQuotient], v[\vQuotient], v[\vDividend] //
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vDividend], v[\vRemainder] //
+v_cmp_ge_u32 s[\sTmp:\sTmp+1], v[\vDividend], v[\vRemainder] //
+_v_add_co_u32 v[\vRemainder], vcc, 0x1, v[\vQuotient] //
+_v_add_co_u32 v[\vTmp1], vcc, -1, v[\vQuotient]    //
+v_cmp_le_u32 vcc, v[\vDivisor], v[\vTmp0]          //
+s_and_b64 vcc, s[\sTmp:\sTmp+1], vcc               //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vRemainder], vcc //
+v_cndmask_b32 v[\vQuotient], v[\vTmp1], v[\vQuotient], s[\sTmp:\sTmp+1] //
+v_cmp_ne_i32 vcc, 0x0, v[\vDivisor]                //
+v_cndmask_b32 v[\vQuotient], -1, v[\vQuotient], vcc // final result
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vRemainder], vcc, v[\vDividend], v[\vRemainder] // final result
+.endm
+
+/******************************************/
+/* 4x8 thread-tile                        */
+/******************************************/
+.macro MAC_4x8_X0
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[0] iui=0
+s_setprio 1 // Raise priority while processing macs
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[1]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[4]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[5]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[2] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[3]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[6]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[7]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[8] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[9]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[12]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[13]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[10] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[11]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[14]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[15]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[16] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[17]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[20]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[21]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[18] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[19]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[22]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[23]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[24] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[25]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[28]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[29]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[26] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[27]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[30]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[31]
+s_setprio 0 // Reset priority after macs
+.endm
+.macro MAC_4x8_X1
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[0] iui=0
+s_setprio 1 // Raise priority while processing macs
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[1]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[4]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[5]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[2] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[3]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[6]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[7]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[8] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[9]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[12]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[13]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[10] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[11]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[14]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[15]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[16] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[17]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[20]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[21]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[18] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[19]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[22]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[23]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[24] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[25]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[28]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[29]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[26] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[27]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[30]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[31]
+s_setprio 0 // Reset priority after macs
+.endm
+
+
+
+
+/***** program start from here *****/
+
+.long 0xC00A0D00, 0x00000028
+.long 0xC00A0C00, 0x00000050
+.long 0xC00A0600, 0x00000008
+.long 0xC0020B40, 0x0000006C
+.long 0xC0020140, 0x00000074
+.long 0xBEFC00FF, 0x0000FFFF
+.long 0x7ECA0300
+.long 0x26CC00BF
+.long 0x2004CA86
+.long 0xB8D0F804
+.long 0xD1130004, 0x0000A0B0
+.long 0x20CE0884
+.long 0x7EA40567
+.long 0xD1130068, 0x0000A08F
+.long 0x7EA20568
+.long 0xBF068151
+.long 0xBF8400EF
+.long 0xBF8CC07F
+.long 0xBE880034
+.long 0xBE890035
+.long 0xBE8B00FF, 0x00020000
+.long 0xBE8A00FF, 0x80000000
+.long 0x9254FF30, 0x00000080
+.long 0x92545402
+.long 0x9255A052
+.long 0x92533055
+.long 0x81545354
+.long 0x2000CC82
+.long 0xD2850004, 0x00020030
+.long 0x2602CC83
+.long 0x24020283
+.long 0x32AC0304
+.long 0x68ACAC54
+.long 0x24ACAC81
+.long 0x8E478530
+.long 0x68AEAC47
+.long 0xBECC00FF, 0x00000880
+.long 0x924C4C52
+.long 0xBE8C0036
+.long 0xBE8D0037
+.long 0xBE8F00FF, 0x00020000
+.long 0xBE8E00FF, 0x80000000
+.long 0x9254FF32, 0x00000100
+.long 0x92545403
+.long 0x9255C052
+.long 0x92533255
+.long 0x81545354
+.long 0x2004CC82
+.long 0xD2850004, 0x00020432
+.long 0x2606CC83
+.long 0x24060683
+.long 0x32B40704
+.long 0x68B4B454
+.long 0x24B4B481
+.long 0x8E4A8532
+.long 0x68B6B44A
+.long 0x68B8B64A
+.long 0x68BAB84A
+.long 0xBECE00FF, 0x00001100
+.long 0x924E4E52
+.long 0x814EFF4E, 0x00004400
+.long 0xBF8A0000
+.long 0x814DFF4C, 0x00002200
+.long 0x24A0CC84
+.long 0x68A0A04C
+.long 0x24A2CC84
+.long 0x68A2A24D
+.long 0x814FFF4E, 0x00004400
+.long 0x24A4CC84
+.long 0x68A4A44E
+.long 0x24A6CC84
+.long 0x68A6A64F
+.long 0x2002CC83
+.long 0xD2850001, 0x00020288
+.long 0x68A0A101
+.long 0x68A2A301
+.long 0x68A4A501
+.long 0x68A6A701
+.long 0xD1340058, 0x00018156
+.long 0xD1340059, 0x00018157
+.long 0xD134005E, 0x0001815A
+.long 0xD134005F, 0x0001815B
+.long 0xD1340060, 0x0001815C
+.long 0xD1340061, 0x0001815D
+.long 0xE05E1000, 0x80022056
+.long 0xE05E1000, 0x80022457
+.long 0xE05E1000, 0x8003305A
+.long 0xE05E1000, 0x8003345B
+.long 0xE05E1000, 0x8003385C
+.long 0xE05E1000, 0x80033C5D
+.long 0xE05E1000, 0x80022858
+.long 0xE05E1000, 0x80022C59
+.long 0xE05E1000, 0x8003405E
+.long 0xE05E1000, 0x8003445F
+.long 0xE05E1000, 0x80034860
+.long 0xE05E1000, 0x80034C61
+.long 0x68ACACFF, 0x00000080
+.long 0x68AEAEFF, 0x00000080
+.long 0x8F2E852D
+.long 0x80AE2E80
+.long 0xBF06802E
+.long 0xBF850059
+.long 0xBF8C0F7A
+.long 0xD9BE0000, 0x00002050
+.long 0xD9BE0440, 0x00002450
+.long 0xBF8CC07F
+.long 0xE05E1000, 0x80022056
+.long 0xE05E1000, 0x80022457
+.long 0xBF8C0F78
+.long 0xD9BE0000, 0x00003052
+.long 0xD9BE0440, 0x00003452
+.long 0xD9BE0880, 0x00003852
+.long 0xD9BE0CC0, 0x00003C52
+.long 0x68ACACFF, 0x00000080
+.long 0x68AEAEFF, 0x00000080
+.long 0x68B4B4FF, 0x00000080
+.long 0x68B6B6FF, 0x00000080
+.long 0x68B8B8FF, 0x00000080
+.long 0x68BABAFF, 0x00000080
+.long 0x68B0B0FF, 0x00000080
+.long 0x68B2B2FF, 0x00000080
+.long 0x68BCBCFF, 0x00000080
+.long 0x68BEBEFF, 0x00000080
+.long 0x68C0C0FF, 0x00000080
+.long 0x68C2C2FF, 0x00000080
+.long 0xBF8CC07F
+.long 0xE05E1000, 0x8003305A
+.long 0xE05E1000, 0x8003345B
+.long 0xE05E1000, 0x8003385C
+.long 0xE05E1000, 0x80033C5D
+.long 0xBF8C0F7A
+.long 0xD9BE0000, 0x00002851
+.long 0xD9BE0440, 0x00002C51
+.long 0xBF8CC07F
+.long 0xE05E1000, 0x80022858
+.long 0xE05E1000, 0x80022C59
+.long 0xBF8C0F78
+.long 0xD9BE0000, 0x00004053
+.long 0xD9BE0440, 0x00004453
+.long 0xD9BE0880, 0x00004853
+.long 0xD9BE0CC0, 0x00004C53
+.long 0xBF8CC07F
+.long 0xBF8A0000
+.long 0xBF800018
+.long 0xE05E1000, 0x8003405E
+.long 0xBF80000B
+.long 0xE05E1000, 0x8003445F
+.long 0xBF80000B
+.long 0xE05E1000, 0x80034860
+.long 0xBF80000B
+.long 0xE05E1000, 0x80034C61
+.long 0xBF8A0000
+.long 0x802E822E
+.long 0xBF00C22E
+.long 0xBF84FFA7
+.long 0xBF8C0F7A
+.long 0xD9BE0000, 0x00002050
+.long 0xD9BE0440, 0x00002450
+.long 0xBF8C0F76
+.long 0xD9BE0000, 0x00003052
+.long 0xD9BE0440, 0x00003452
+.long 0xD9BE0880, 0x00003852
+.long 0xD9BE0CC0, 0x00003C52
+.long 0xBF8C0F74
+.long 0xD9BE0000, 0x00002851
+.long 0xD9BE0440, 0x00002C51
+.long 0xBF8C0F70
+.long 0xD9BE0000, 0x00004053
+.long 0xD9BE0440, 0x00004453
+.long 0xD9BE0880, 0x00004853
+.long 0xD9BE0CC0, 0x00004C53
+.long 0xBF8CC07F
+.long 0xBF8A0000
+.long 0xBF810000
+.long 0xD3D94000, 0x18000080
+.long 0xD3D94001, 0x18000080
+.long 0xD3D94002, 0x18000080
+.long 0xD3D94003, 0x18000080
+.long 0xD3D94004, 0x18000080
+.long 0xD3D94005, 0x18000080
+.long 0xD3D94006, 0x18000080
+.long 0xD3D94007, 0x18000080
+.long 0xD3D94008, 0x18000080
+.long 0xD3D94009, 0x18000080
+.long 0xD3D9400A, 0x18000080
+.long 0xD3D9400B, 0x18000080
+.long 0xD3D9400C, 0x18000080
+.long 0xD3D9400D, 0x18000080
+.long 0xD3D9400E, 0x18000080
+.long 0xD3D9400F, 0x18000080
+.long 0xD3D94010, 0x18000080
+.long 0xD3D94011, 0x18000080
+.long 0xD3D94012, 0x18000080
+.long 0xD3D94013, 0x18000080
+.long 0xD3D94014, 0x18000080
+.long 0xD3D94015, 0x18000080
+.long 0xD3D94016, 0x18000080
+.long 0xD3D94017, 0x18000080
+.long 0xD3D94018, 0x18000080
+.long 0xD3D94019, 0x18000080
+.long 0xD3D9401A, 0x18000080
+.long 0xD3D9401B, 0x18000080
+.long 0xD3D9401C, 0x18000080
+.long 0xD3D9401D, 0x18000080
+.long 0xD3D9401E, 0x18000080
+.long 0xD3D9401F, 0x18000080
+.long 0xD3D94020, 0x18000080
+.long 0xD3D94021, 0x18000080
+.long 0xD3D94022, 0x18000080
+.long 0xD3D94023, 0x18000080
+.long 0xD3D94024, 0x18000080
+.long 0xD3D94025, 0x18000080
+.long 0xD3D94026, 0x18000080
+.long 0xD3D94027, 0x18000080
+.long 0xD3D94028, 0x18000080
+.long 0xD3D94029, 0x18000080
+.long 0xD3D9402A, 0x18000080
+.long 0xD3D9402B, 0x18000080
+.long 0xD3D9402C, 0x18000080
+.long 0xD3D9402D, 0x18000080
+.long 0xD3D9402E, 0x18000080
+.long 0xD3D9402F, 0x18000080
+.long 0xD3D94030, 0x18000080
+.long 0xD3D94031, 0x18000080
+.long 0xD3D94032, 0x18000080
+.long 0xD3D94033, 0x18000080
+.long 0xD3D94034, 0x18000080
+.long 0xD3D94035, 0x18000080
+.long 0xD3D94036, 0x18000080
+.long 0xD3D94037, 0x18000080
+.long 0xD3D94038, 0x18000080
+.long 0xD3D94039, 0x18000080
+.long 0xD3D9403A, 0x18000080
+.long 0xD3D9403B, 0x18000080
+.long 0xD3D9403C, 0x18000080
+.long 0xD3D9403D, 0x18000080
+.long 0xD3D9403E, 0x18000080
+.long 0xD3D9403F, 0x18000080
+.long 0xD3D94040, 0x18000080
+.long 0xD3D94041, 0x18000080
+.long 0xD3D94042, 0x18000080
+.long 0xD3D94043, 0x18000080
+.long 0xD3D94044, 0x18000080
+.long 0xD3D94045, 0x18000080
+.long 0xD3D94046, 0x18000080
+.long 0xD3D94047, 0x18000080
+.long 0xD3D94048, 0x18000080
+.long 0xD3D94049, 0x18000080
+.long 0xD3D9404A, 0x18000080
+.long 0xD3D9404B, 0x18000080
+.long 0xD3D9404C, 0x18000080
+.long 0xD3D9404D, 0x18000080
+.long 0xD3D9404E, 0x18000080
+.long 0xD3D9404F, 0x18000080
+.long 0xD3D94050, 0x18000080
+.long 0xD3D94051, 0x18000080
+.long 0xD3D94052, 0x18000080
+.long 0xD3D94053, 0x18000080
+.long 0xD3D94054, 0x18000080
+.long 0xD3D94055, 0x18000080
+.long 0xD3D94056, 0x18000080
+.long 0xD3D94057, 0x18000080
+.long 0xD3D94058, 0x18000080
+.long 0xD3D94059, 0x18000080
+.long 0xD3D9405A, 0x18000080
+.long 0xD3D9405B, 0x18000080
+.long 0xD3D9405C, 0x18000080
+.long 0xD3D9405D, 0x18000080
+.long 0xD3D9405E, 0x18000080
+.long 0xD3D9405F, 0x18000080
+.long 0xD3D94060, 0x18000080
+.long 0xD3D94061, 0x18000080
+.long 0xD3D94062, 0x18000080
+.long 0xD3D94063, 0x18000080
+.long 0xD3D94064, 0x18000080
+.long 0xD3D94065, 0x18000080
+.long 0xD3D94066, 0x18000080
+.long 0xD3D94067, 0x18000080
+.long 0xD3D94068, 0x18000080
+.long 0xD3D94069, 0x18000080
+.long 0xD3D9406A, 0x18000080
+.long 0xD3D9406B, 0x18000080
+.long 0xD3D9406C, 0x18000080
+.long 0xD3D9406D, 0x18000080
+.long 0xD3D9406E, 0x18000080
+.long 0xD3D9406F, 0x18000080
+.long 0xD3D94070, 0x18000080
+.long 0xD3D94071, 0x18000080
+.long 0xD3D94072, 0x18000080
+.long 0xD3D94073, 0x18000080
+.long 0xD3D94074, 0x18000080
+.long 0xD3D94075, 0x18000080
+.long 0xD3D94076, 0x18000080
+.long 0xD3D94077, 0x18000080
+.long 0xD3D94078, 0x18000080
+.long 0xD3D94079, 0x18000080
+.long 0xD3D9407A, 0x18000080
+.long 0xD3D9407B, 0x18000080
+.long 0xD3D9407C, 0x18000080
+.long 0xD3D9407D, 0x18000080
+.long 0xD3D9407E, 0x18000080
+.long 0xD3D9407F, 0x18000080
+.long 0xC0060700, 0x00000000
+.long 0xC00A0A00, 0x00000038
+.long 0xC00A0900, 0x00000040
+.long 0xC00A0800, 0x00000018
+.long 0xC00A0A00, 0x00000038
+.long 0xD1130001, 0x00013F66
+.long 0xD2850061, 0x000202A0
+.long 0x20040281
+.long 0xD2850002, 0x00020488
+.long 0x2002CC85
+.long 0x24020282
+.long 0x68C2C301
+.long 0x24C2C281
+.long 0x68C2C302
+.long 0x86548152
+.long 0x9254FF54, 0x00001100
+.long 0x68C2C254
+.long 0x68C2C280
+.long 0x68C4C2FF, 0x00002200
+.long 0xBF8A0000
+.long 0xD1130001, 0x00013F66
+.long 0xD2850063, 0x000202A0
+.long 0x20040281
+.long 0xD2850002, 0x00020488
+.long 0x2002CC85
+.long 0x24020282
+.long 0x68C6C701
+.long 0x24C6C681
+.long 0x68C6C702
+.long 0x86548252
+.long 0x8F548154
+.long 0x9254FF54, 0x00002200
+.long 0x68C6C654
+.long 0x68C6C6FF, 0x00004400
+.long 0x68C8C6FF, 0x00004400
+.long 0xBF8CC07F
+.long 0xBE900022
+.long 0xBE910023
+.long 0xBE9200FF, 0x80000000
+.long 0xBE9300FF, 0x00020000
+.long 0xBE940020
+.long 0xBE950021
+.long 0xBE9600FF, 0x80000000
+.long 0xBE9700FF, 0x00020000
+.long 0x925603FF, 0x00000100
+.long 0x96552656
+.long 0x92542656
+.long 0x8ED48154
+.long 0x80105410
+.long 0x82115511
+.long 0x80145414
+.long 0x82155515
+.long 0x96552704
+.long 0x92542704
+.long 0x8ED48154
+.long 0x80105410
+.long 0x82115511
+.long 0x80145414
+.long 0x82155515
+.long 0x24CACE86
+.long 0x68CACB66
+.long 0x2608CE82
+.long 0x20080881
+.long 0x24080887
+.long 0xD2850003, 0x00004D04
+.long 0x2608CE81
+.long 0xD2850004, 0x000208C0
+.long 0x68060903
+.long 0x2608CA9F
+.long 0xD2850005, 0x00004D04
+.long 0x68D40B03
+.long 0x2608CABF
+.long 0x200C0885
+.long 0x240C0C82
+.long 0x925402FF, 0x00000080
+.long 0x32D20C54
+.long 0xD1FE0060, 0x0206D569
+.long 0xBF8A0000
+.long 0xD8EC0000, 0x00000061
+.long 0xD8EC0000, 0x20000063
+.long 0xD8EC0010, 0x02000061
+.long 0xD8EC0010, 0x22000063
+.long 0xBF8CC27F
+.long 0xD3CC0000, 0x04024100
+.long 0xD8EC0020, 0x04000061
+.long 0xD8EC0020, 0x24000063
+.long 0xD8EC0030, 0x06000061
+.long 0xD8EC0030, 0x26000063
+.long 0xBF8CC47F
+.long 0xD3CC0000, 0x04024502
+.long 0xD8EC0000, 0x10000062
+.long 0xD8EC0000, 0x40000064
+.long 0xD8EC0010, 0x12000062
+.long 0xD8EC0010, 0x42000064
+.long 0xD3CC0000, 0x04024904
+.long 0xD8EC0020, 0x14000062
+.long 0xD8EC0020, 0x44000064
+.long 0xD8EC0030, 0x16000062
+.long 0xD8EC0030, 0x46000064
+.long 0xD3CC0000, 0x04024D06
+.long 0xD8EC0880, 0x08000061
+.long 0xD8EC0880, 0x28000063
+.long 0xD8EC0890, 0x0A000061
+.long 0xD8EC0890, 0x2A000063
+.long 0xD3CC0000, 0x04028110
+.long 0xD8EC08A0, 0x0C000061
+.long 0xD8EC08A0, 0x2C000063
+.long 0xD8EC08B0, 0x0E000061
+.long 0xD8EC08B0, 0x2E000063
+.long 0xD3CC0000, 0x04028512
+.long 0xD8EC0880, 0x18000062
+.long 0xD8EC0890, 0x1A000062
+.long 0xD8EC08A0, 0x1C000062
+.long 0xD8EC08B0, 0x1E000062
+.long 0xD3CC0000, 0x04028914
+.long 0xD8EC0880, 0x48000064
+.long 0xD8EC0890, 0x4A000064
+.long 0xD8EC08A0, 0x4C000064
+.long 0xD8EC08B0, 0x4E000064
+.long 0xD3CC0000, 0x04028D16
+.long 0xD8EC1100, 0x30000063
+.long 0xD8EC1110, 0x32000063
+.long 0xD8EC1120, 0x34000063
+.long 0xD8EC1130, 0x36000063
+.long 0xD3CC0010, 0x04424108
+.long 0xD8EC1980, 0x38000063
+.long 0xD8EC1990, 0x3A000063
+.long 0xD8EC19A0, 0x3C000063
+.long 0xD8EC19B0, 0x3E000063
+.long 0xD3CC0010, 0x0442450A
+.long 0xD8EC1100, 0x50000064
+.long 0xD8EC1110, 0x52000064
+.long 0xD8EC1120, 0x54000064
+.long 0xD8EC1130, 0x56000064
+.long 0xD3CC0010, 0x0442490C
+.long 0xD8EC1980, 0x58000064
+.long 0xD8EC1990, 0x5A000064
+.long 0xD8EC19A0, 0x5C000064
+.long 0xD8EC19B0, 0x5E000064
+.long 0x8F2E852D
+.long 0x80AE2E80
+.long 0xBF06802E
+.long 0xBF850119
+.long 0xD3CC0010, 0x04424D0E
+.long 0xBF8CC07F
+.long 0xBF8A0000
+.long 0xD3CC0010, 0x04428118
+.long 0xBF80000C
+.long 0xD3CC0010, 0x0442851A
+.long 0xBF80000C
+.long 0xD3CC0010, 0x0442891C
+.long 0xBF80000C
+.long 0xD3CC0010, 0x04428D1E
+.long 0xBF80000C
+.long 0xD3CC0020, 0x04825100
+.long 0xBF80000C
+.long 0xD3CC0020, 0x04825502
+.long 0xBF80000C
+.long 0xD3CC0020, 0x04825904
+.long 0xBF80000C
+.long 0xD3CC0020, 0x04825D06
+.long 0xBF80000C
+.long 0xD3CC0020, 0x04829110
+.long 0xBF80000C
+.long 0xD3CC0020, 0x04829512
+.long 0xBF80000C
+.long 0xD3CC0020, 0x04829914
+.long 0xBF80000C
+.long 0xD3CC0020, 0x04829D16
+.long 0xBF80000C
+.long 0xD3CC0030, 0x04C25108
+.long 0xBF80000C
+.long 0xD3CC0030, 0x04C2550A
+.long 0xBF80000C
+.long 0xD3CC0030, 0x04C2590C
+.long 0xBF80000C
+.long 0xD3CC0030, 0x04C25D0E
+.long 0xBF80000C
+.long 0xD3CC0030, 0x04C29118
+.long 0xBF80000C
+.long 0xD3CC0030, 0x04C2951A
+.long 0xBF80000C
+.long 0xD3CC0030, 0x04C2991C
+.long 0xBF80000C
+.long 0xD3CC0030, 0x04C29D1E
+.long 0xBF80000C
+.long 0xD3CC0040, 0x05026100
+.long 0xBF80000C
+.long 0xD3CC0040, 0x05026502
+.long 0xBF80000C
+.long 0xD3CC0040, 0x05026904
+.long 0xBF80000C
+.long 0xD3CC0040, 0x05026D06
+.long 0xBF80000C
+.long 0xD3CC0040, 0x0502A110
+.long 0xBF80000C
+.long 0xD3CC0040, 0x0502A512
+.long 0xBF80000C
+.long 0xD3CC0040, 0x0502A914
+.long 0xBF80000C
+.long 0xD3CC0040, 0x0502AD16
+.long 0xBF80000C
+.long 0xD3CC0050, 0x05426108
+.long 0xBF80000C
+.long 0xD3CC0050, 0x0542650A
+.long 0xBF80000C
+.long 0xD3CC0050, 0x0542690C
+.long 0xBF80000C
+.long 0xD3CC0050, 0x05426D0E
+.long 0xBF80000C
+.long 0xD3CC0050, 0x0542A118
+.long 0xBF80000C
+.long 0xD3CC0050, 0x0542A51A
+.long 0xBF80000C
+.long 0xD3CC0050, 0x0542A91C
+.long 0xBF80000C
+.long 0xD3CC0050, 0x0542AD1E
+.long 0xBF80000C
+.long 0xD3CC0060, 0x05827100
+.long 0xBF80000C
+.long 0xD3CC0060, 0x05827502
+.long 0xBF80000C
+.long 0xD3CC0060, 0x05827904
+.long 0xBF80000C
+.long 0xD3CC0060, 0x05827D06
+.long 0xBF80000C
+.long 0xD3CC0060, 0x0582B110
+.long 0xBF80000C
+.long 0xD3CC0060, 0x0582B512
+.long 0xBF80000C
+.long 0xD3CC0060, 0x0582B914
+.long 0xBF80000C
+.long 0xD3CC0060, 0x0582BD16
+.long 0xBF80000C
+.long 0xD3CC0070, 0x05C27108
+.long 0xBF80000C
+.long 0xD3CC0070, 0x05C2750A
+.long 0xBF80000C
+.long 0xD3CC0070, 0x05C2790C
+.long 0xBF80000C
+.long 0xD3CC0070, 0x05C27D0E
+.long 0xBF80000C
+.long 0xD3CC0070, 0x05C2B118
+.long 0xBF80000C
+.long 0xD3CC0070, 0x05C2B51A
+.long 0xBF80000C
+.long 0xD3CC0070, 0x05C2B91C
+.long 0xBF8A0000
+.long 0xD8EC0000, 0x00000061
+.long 0xD8EC0000, 0x20000063
+.long 0xD8EC0010, 0x02000061
+.long 0xD8EC0010, 0x22000063
+.long 0xD3CC0070, 0x05C2BD1E
+.long 0xD8EC0020, 0x04000061
+.long 0xD8EC0020, 0x24000063
+.long 0xD8EC0030, 0x06000061
+.long 0xD8EC0030, 0x26000063
+.long 0xBF8CC67F
+.long 0xD3CC0000, 0x04024100
+.long 0xD8EC0000, 0x10000062
+.long 0xD8EC0000, 0x40000064
+.long 0xD8EC0010, 0x12000062
+.long 0xD8EC0010, 0x42000064
+.long 0xD3CC0000, 0x04024502
+.long 0xD8EC0020, 0x14000062
+.long 0xD8EC0020, 0x44000064
+.long 0xD8EC0030, 0x16000062
+.long 0xD8EC0030, 0x46000064
+.long 0xD3CC0000, 0x04024904
+.long 0xD8EC0880, 0x08000061
+.long 0xD8EC0880, 0x28000063
+.long 0xD8EC0890, 0x0A000061
+.long 0xD8EC0890, 0x2A000063
+.long 0xD3CC0000, 0x04024D06
+.long 0xD8EC08A0, 0x0C000061
+.long 0xD8EC08A0, 0x2C000063
+.long 0xD8EC08B0, 0x0E000061
+.long 0xD8EC08B0, 0x2E000063
+.long 0xD3CC0000, 0x04028110
+.long 0xD8EC0880, 0x18000062
+.long 0xD8EC0890, 0x1A000062
+.long 0xD8EC08A0, 0x1C000062
+.long 0xD8EC08B0, 0x1E000062
+.long 0xD3CC0000, 0x04028512
+.long 0xD8EC0880, 0x48000064
+.long 0xD8EC0890, 0x4A000064
+.long 0xD8EC08A0, 0x4C000064
+.long 0xD8EC08B0, 0x4E000064
+.long 0xD3CC0000, 0x04028914
+.long 0xD8EC1100, 0x30000063
+.long 0xD8EC1110, 0x32000063
+.long 0xD8EC1120, 0x34000063
+.long 0xD8EC1130, 0x36000063
+.long 0xD3CC0000, 0x04028D16
+.long 0xD8EC1980, 0x38000063
+.long 0xD8EC1990, 0x3A000063
+.long 0xD8EC19A0, 0x3C000063
+.long 0xD8EC19B0, 0x3E000063
+.long 0xD3CC0010, 0x04424108
+.long 0xD8EC1100, 0x50000064
+.long 0xD8EC1110, 0x52000064
+.long 0xD8EC1120, 0x54000064
+.long 0xD8EC1130, 0x56000064
+.long 0xD3CC0010, 0x0442450A
+.long 0xD8EC1980, 0x58000064
+.long 0xD8EC1990, 0x5A000064
+.long 0xD8EC19A0, 0x5C000064
+.long 0xD8EC19B0, 0x5E000064
+.long 0xD3CC0010, 0x0442490C
+.long 0x802E822E
+.long 0xBF00C22E
+.long 0xBF84FEE7
+.long 0x9254C026
+.long 0xD3CC0010, 0x04424D0E
+.long 0xE0541000, 0x80046160
+.long 0xE0541010, 0x80046360
+.long 0xE0541020, 0x80046560
+.long 0xE0541030, 0x80046760
+.long 0xD3D84069, 0x18000100
+.long 0xD3D8406A, 0x18000101
+.long 0xD3D8406B, 0x18000102
+.long 0xD3D8406C, 0x18000103
+.long 0xD3D8406D, 0x18000104
+.long 0xD3D8406E, 0x18000105
+.long 0xD3D8406F, 0x18000106
+.long 0xD3D84070, 0x18000107
+.long 0xD3CC0010, 0x04428118
+.long 0x7ED21569
+.long 0x7ED4156A
+.long 0xD2000069, 0x05A5216A
+.long 0xD3904069, 0x1802D228
+.long 0xD3CC0010, 0x0442851A
+.long 0x7ED6156B
+.long 0x7ED8156C
+.long 0xD200006A, 0x05AD216C
+.long 0xD390406A, 0x1802D428
+.long 0x7EDA156D
+.long 0x7EDC156E
+.long 0xD200006B, 0x05B5216E
+.long 0xD390406B, 0x1802D628
+.long 0xBF8C0F73
+.long 0xD38E4069, 0x1DA6C229
+.long 0xD38E406A, 0x1DAAC429
+.long 0xE0741000, 0x80056960
+.long 0xD3CC0010, 0x0442891C
+.long 0x7EDE156F
+.long 0x7EE01570
+.long 0xD200006C, 0x05BD2170
+.long 0xD390406C, 0x1802D828
+.long 0xD3D84071, 0x18000108
+.long 0xD3D84072, 0x18000109
+.long 0xD3D84073, 0x1800010A
+.long 0xD3D84074, 0x1800010B
+.long 0xD3CC0010, 0x04428D1E
+.long 0xBF8C0F73
+.long 0xD38E406B, 0x1DAEC629
+.long 0xD38E406C, 0x1DB2C829
+.long 0xE0741010, 0x80056B60
+.long 0x7EE21571
+.long 0x7EE41572
+.long 0xD200006D, 0x05C52172
+.long 0xD390406D, 0x1802DA28
+.long 0x7EE61573
+.long 0x7EE81574
+.long 0xD200006E, 0x05CD2174
+.long 0xD390406E, 0x1802DC28
+.long 0xD3D84075, 0x1800010C
+.long 0xD3D84076, 0x1800010D
+.long 0xD3D84077, 0x1800010E
+.long 0xD3D84078, 0x1800010F
+.long 0xD3CC0020, 0x04825100
+.long 0xBF8C0F73
+.long 0xD38E406D, 0x1DB6CA29
+.long 0xD38E406E, 0x1DBACC29
+.long 0xE0741020, 0x80056D60
+.long 0x7EEA1575
+.long 0x7EEC1576
+.long 0xD200006F, 0x05D52176
+.long 0xD390406F, 0x1802DE28
+.long 0x7EEE1577
+.long 0x7EF01578
+.long 0xD2000070, 0x05DD2178
+.long 0xD3904070, 0x1802E028
+.long 0xD3CC0020, 0x04825502
+.long 0xBF8C0F73
+.long 0xD38E406F, 0x1DBECE29
+.long 0xD38E4070, 0x1DC2D029
+.long 0xE0741030, 0x80056F60
+.long 0xE0541040, 0x80046160
+.long 0xE0541050, 0x80046360
+.long 0xE0541060, 0x80046560
+.long 0xE0541070, 0x80046760
+.long 0xD3D84069, 0x18000110
+.long 0xD3D8406A, 0x18000111
+.long 0xD3D8406B, 0x18000112
+.long 0xD3D8406C, 0x18000113
+.long 0xD3D8406D, 0x18000114
+.long 0xD3D8406E, 0x18000115
+.long 0xD3D8406F, 0x18000116
+.long 0xD3D84070, 0x18000117
+.long 0xD3CC0020, 0x04825904
+.long 0x7ED21569
+.long 0x7ED4156A
+.long 0xD2000069, 0x05A5216A
+.long 0xD3904069, 0x1802D228
+.long 0x7ED6156B
+.long 0x7ED8156C
+.long 0xD200006A, 0x05AD216C
+.long 0xD390406A, 0x1802D428
+.long 0x7EDA156D
+.long 0x7EDC156E
+.long 0xD200006B, 0x05B5216E
+.long 0xD390406B, 0x1802D628
+.long 0xD3CC0020, 0x04825D06
+.long 0xBF8C0F73
+.long 0xD38E4069, 0x1DA6C229
+.long 0xD38E406A, 0x1DAAC429
+.long 0xE0741040, 0x80056960
+.long 0x7EDE156F
+.long 0x7EE01570
+.long 0xD200006C, 0x05BD2170
+.long 0xD390406C, 0x1802D828
+.long 0xD3D84071, 0x18000118
+.long 0xD3D84072, 0x18000119
+.long 0xD3D84073, 0x1800011A
+.long 0xD3D84074, 0x1800011B
+.long 0xD3CC0020, 0x04829110
+.long 0xBF8C0F73
+.long 0xD38E406B, 0x1DAEC629
+.long 0xD38E406C, 0x1DB2C829
+.long 0xE0741050, 0x80056B60
+.long 0xD3CC0020, 0x04829512
+.long 0x7EE21571
+.long 0x7EE41572
+.long 0xD200006D, 0x05C52172
+.long 0xD390406D, 0x1802DA28
+.long 0x7EE61573
+.long 0x7EE81574
+.long 0xD200006E, 0x05CD2174
+.long 0xD390406E, 0x1802DC28
+.long 0xD3D84075, 0x1800011C
+.long 0xD3D84076, 0x1800011D
+.long 0xD3D84077, 0x1800011E
+.long 0xD3D84078, 0x1800011F
+.long 0xD3CC0020, 0x04829914
+.long 0xBF8C0F73
+.long 0xD38E406D, 0x1DB6CA29
+.long 0xD38E406E, 0x1DBACC29
+.long 0xE0741060, 0x80056D60
+.long 0xD3CC0020, 0x04829D16
+.long 0x7EEA1575
+.long 0x7EEC1576
+.long 0xD200006F, 0x05D52176
+.long 0xD390406F, 0x1802DE28
+.long 0x7EEE1577
+.long 0x7EF01578
+.long 0xD2000070, 0x05DD2178
+.long 0xD3904070, 0x1802E028
+.long 0xD3CC0030, 0x04C25108
+.long 0xBF8C0F73
+.long 0xD38E406F, 0x1DBECE29
+.long 0xD38E4070, 0x1DC2D029
+.long 0xE0741070, 0x80056F60
+.long 0xD3CC0030, 0x04C2550A
+.long 0xD1340060, 0x0000A960
+.long 0xE0541000, 0x80046160
+.long 0xE0541010, 0x80046360
+.long 0xE0541020, 0x80046560
+.long 0xE0541030, 0x80046760
+.long 0xD3D84069, 0x18000120
+.long 0xD3D8406A, 0x18000121
+.long 0xD3D8406B, 0x18000122
+.long 0xD3D8406C, 0x18000123
+.long 0xD3D8406D, 0x18000124
+.long 0xD3D8406E, 0x18000125
+.long 0xD3D8406F, 0x18000126
+.long 0xD3D84070, 0x18000127
+.long 0x7ED21569
+.long 0x7ED4156A
+.long 0xD2000069, 0x05A5216A
+.long 0xD3904069, 0x1802D228
+.long 0x7ED6156B
+.long 0x7ED8156C
+.long 0xD200006A, 0x05AD216C
+.long 0xD390406A, 0x1802D428
+.long 0x7EDA156D
+.long 0x7EDC156E
+.long 0xD200006B, 0x05B5216E
+.long 0xD390406B, 0x1802D628
+.long 0xD3CC0030, 0x04C2590C
+.long 0xBF8C0F73
+.long 0xD38E4069, 0x1DA6C229
+.long 0xD38E406A, 0x1DAAC429
+.long 0xE0741000, 0x80056960
+.long 0xD3CC0030, 0x04C25D0E
+.long 0x7EDE156F
+.long 0x7EE01570
+.long 0xD200006C, 0x05BD2170
+.long 0xD390406C, 0x1802D828
+.long 0xD3D84071, 0x18000128
+.long 0xD3D84072, 0x18000129
+.long 0xD3D84073, 0x1800012A
+.long 0xD3D84074, 0x1800012B
+.long 0xD3CC0030, 0x04C29118
+.long 0xBF8C0F73
+.long 0xD38E406B, 0x1DAEC629
+.long 0xD38E406C, 0x1DB2C829
+.long 0xE0741010, 0x80056B60
+.long 0xD3CC0030, 0x04C2951A
+.long 0x7EE21571
+.long 0x7EE41572
+.long 0xD200006D, 0x05C52172
+.long 0xD390406D, 0x1802DA28
+.long 0x7EE61573
+.long 0x7EE81574
+.long 0xD200006E, 0x05CD2174
+.long 0xD390406E, 0x1802DC28
+.long 0xD3D84075, 0x1800012C
+.long 0xD3D84076, 0x1800012D
+.long 0xD3D84077, 0x1800012E
+.long 0xD3D84078, 0x1800012F
+.long 0xD3CC0030, 0x04C2991C
+.long 0xBF8C0F73
+.long 0xD38E406D, 0x1DB6CA29
+.long 0xD38E406E, 0x1DBACC29
+.long 0xE0741020, 0x80056D60
+.long 0xD3CC0030, 0x04C29D1E
+.long 0x7EEA1575
+.long 0x7EEC1576
+.long 0xD200006F, 0x05D52176
+.long 0xD390406F, 0x1802DE28
+.long 0x7EEE1577
+.long 0x7EF01578
+.long 0xD2000070, 0x05DD2178
+.long 0xD3904070, 0x1802E028
+.long 0xD3CC0040, 0x05026100
+.long 0xBF8C0F73
+.long 0xD38E406F, 0x1DBECE29
+.long 0xD38E4070, 0x1DC2D029
+.long 0xE0741030, 0x80056F60
+.long 0xD3CC0040, 0x05026502
+.long 0xE0541040, 0x80046160
+.long 0xE0541050, 0x80046360
+.long 0xE0541060, 0x80046560
+.long 0xE0541070, 0x80046760
+.long 0xD3D84069, 0x18000130
+.long 0xD3D8406A, 0x18000131
+.long 0xD3D8406B, 0x18000132
+.long 0xD3D8406C, 0x18000133
+.long 0xD3D8406D, 0x18000134
+.long 0xD3D8406E, 0x18000135
+.long 0xD3D8406F, 0x18000136
+.long 0xD3D84070, 0x18000137
+.long 0x7ED21569
+.long 0x7ED4156A
+.long 0xD2000069, 0x05A5216A
+.long 0xD3904069, 0x1802D228
+.long 0x7ED6156B
+.long 0x7ED8156C
+.long 0xD200006A, 0x05AD216C
+.long 0xD390406A, 0x1802D428
+.long 0x7EDA156D
+.long 0x7EDC156E
+.long 0xD200006B, 0x05B5216E
+.long 0xD390406B, 0x1802D628
+.long 0xD3CC0040, 0x05026904
+.long 0xBF8C0F73
+.long 0xD38E4069, 0x1DA6C229
+.long 0xD38E406A, 0x1DAAC429
+.long 0xE0741040, 0x80056960
+.long 0xD3CC0040, 0x05026D06
+.long 0x7EDE156F
+.long 0x7EE01570
+.long 0xD200006C, 0x05BD2170
+.long 0xD390406C, 0x1802D828
+.long 0xD3D84071, 0x18000138
+.long 0xD3D84072, 0x18000139
+.long 0xD3D84073, 0x1800013A
+.long 0xD3D84074, 0x1800013B
+.long 0xD3CC0040, 0x0502A110
+.long 0xBF8C0F73
+.long 0xD38E406B, 0x1DAEC629
+.long 0xD38E406C, 0x1DB2C829
+.long 0xE0741050, 0x80056B60
+.long 0xD3CC0040, 0x0502A512
+.long 0x7EE21571
+.long 0x7EE41572
+.long 0xD200006D, 0x05C52172
+.long 0xD390406D, 0x1802DA28
+.long 0x7EE61573
+.long 0x7EE81574
+.long 0xD200006E, 0x05CD2174
+.long 0xD390406E, 0x1802DC28
+.long 0xD3D84075, 0x1800013C
+.long 0xD3D84076, 0x1800013D
+.long 0xD3D84077, 0x1800013E
+.long 0xD3D84078, 0x1800013F
+.long 0xD3CC0040, 0x0502A914
+.long 0xBF8C0F73
+.long 0xD38E406D, 0x1DB6CA29
+.long 0xD38E406E, 0x1DBACC29
+.long 0xE0741060, 0x80056D60
+.long 0xD3CC0040, 0x0502AD16
+.long 0x7EEA1575
+.long 0x7EEC1576
+.long 0xD200006F, 0x05D52176
+.long 0xD390406F, 0x1802DE28
+.long 0x7EEE1577
+.long 0x7EF01578
+.long 0xD2000070, 0x05DD2178
+.long 0xD3904070, 0x1802E028
+.long 0xD3CC0050, 0x05426108
+.long 0xBF8C0F73
+.long 0xD38E406F, 0x1DBECE29
+.long 0xD38E4070, 0x1DC2D029
+.long 0xE0741070, 0x80056F60
+.long 0xD3CC0050, 0x0542650A
+.long 0xD1340060, 0x0000A960
+.long 0xE0541000, 0x80046160
+.long 0xE0541010, 0x80046360
+.long 0xE0541020, 0x80046560
+.long 0xE0541030, 0x80046760
+.long 0xD3D84069, 0x18000140
+.long 0xD3D8406A, 0x18000141
+.long 0xD3D8406B, 0x18000142
+.long 0xD3D8406C, 0x18000143
+.long 0xD3D8406D, 0x18000144
+.long 0xD3D8406E, 0x18000145
+.long 0xD3D8406F, 0x18000146
+.long 0xD3D84070, 0x18000147
+.long 0x7ED21569
+.long 0x7ED4156A
+.long 0xD2000069, 0x05A5216A
+.long 0xD3904069, 0x1802D228
+.long 0x7ED6156B
+.long 0x7ED8156C
+.long 0xD200006A, 0x05AD216C
+.long 0xD390406A, 0x1802D428
+.long 0x7EDA156D
+.long 0x7EDC156E
+.long 0xD200006B, 0x05B5216E
+.long 0xD390406B, 0x1802D628
+.long 0xD3CC0050, 0x0542690C
+.long 0xBF8C0F73
+.long 0xD38E4069, 0x1DA6C229
+.long 0xD38E406A, 0x1DAAC429
+.long 0xE0741000, 0x80056960
+.long 0xD3CC0050, 0x05426D0E
+.long 0x7EDE156F
+.long 0x7EE01570
+.long 0xD200006C, 0x05BD2170
+.long 0xD390406C, 0x1802D828
+.long 0xD3D84071, 0x18000148
+.long 0xD3D84072, 0x18000149
+.long 0xD3D84073, 0x1800014A
+.long 0xD3D84074, 0x1800014B
+.long 0xD3CC0050, 0x0542A118
+.long 0xBF8C0F73
+.long 0xD38E406B, 0x1DAEC629
+.long 0xD38E406C, 0x1DB2C829
+.long 0xE0741010, 0x80056B60
+.long 0xD3CC0050, 0x0542A51A
+.long 0x7EE21571
+.long 0x7EE41572
+.long 0xD200006D, 0x05C52172
+.long 0xD390406D, 0x1802DA28
+.long 0x7EE61573
+.long 0x7EE81574
+.long 0xD200006E, 0x05CD2174
+.long 0xD390406E, 0x1802DC28
+.long 0xD3D84075, 0x1800014C
+.long 0xD3D84076, 0x1800014D
+.long 0xD3D84077, 0x1800014E
+.long 0xD3D84078, 0x1800014F
+.long 0xD3CC0050, 0x0542A91C
+.long 0xBF8C0F73
+.long 0xD38E406D, 0x1DB6CA29
+.long 0xD38E406E, 0x1DBACC29
+.long 0xE0741020, 0x80056D60
+.long 0xD3CC0050, 0x0542AD1E
+.long 0x7EEA1575
+.long 0x7EEC1576
+.long 0xD200006F, 0x05D52176
+.long 0xD390406F, 0x1802DE28
+.long 0x7EEE1577
+.long 0x7EF01578
+.long 0xD2000070, 0x05DD2178
+.long 0xD3904070, 0x1802E028
+.long 0xD3CC0060, 0x05827100
+.long 0xBF8C0F73
+.long 0xD38E406F, 0x1DBECE29
+.long 0xD38E4070, 0x1DC2D029
+.long 0xE0741030, 0x80056F60
+.long 0xD3CC0060, 0x05827502
+.long 0xE0541040, 0x80046160
+.long 0xE0541050, 0x80046360
+.long 0xE0541060, 0x80046560
+.long 0xE0541070, 0x80046760
+.long 0xD3D84069, 0x18000150
+.long 0xD3D8406A, 0x18000151
+.long 0xD3D8406B, 0x18000152
+.long 0xD3D8406C, 0x18000153
+.long 0xD3D8406D, 0x18000154
+.long 0xD3D8406E, 0x18000155
+.long 0xD3D8406F, 0x18000156
+.long 0xD3D84070, 0x18000157
+.long 0x7ED21569
+.long 0x7ED4156A
+.long 0xD2000069, 0x05A5216A
+.long 0xD3904069, 0x1802D228
+.long 0x7ED6156B
+.long 0x7ED8156C
+.long 0xD200006A, 0x05AD216C
+.long 0xD390406A, 0x1802D428
+.long 0x7EDA156D
+.long 0x7EDC156E
+.long 0xD200006B, 0x05B5216E
+.long 0xD390406B, 0x1802D628
+.long 0xD3CC0060, 0x05827904
+.long 0xBF8C0F73
+.long 0xD38E4069, 0x1DA6C229
+.long 0xD38E406A, 0x1DAAC429
+.long 0xE0741040, 0x80056960
+.long 0xD3CC0060, 0x05827D06
+.long 0x7EDE156F
+.long 0x7EE01570
+.long 0xD200006C, 0x05BD2170
+.long 0xD390406C, 0x1802D828
+.long 0xD3D84071, 0x18000158
+.long 0xD3D84072, 0x18000159
+.long 0xD3D84073, 0x1800015A
+.long 0xD3D84074, 0x1800015B
+.long 0xD3CC0060, 0x0582B110
+.long 0xBF8C0F73
+.long 0xD38E406B, 0x1DAEC629
+.long 0xD38E406C, 0x1DB2C829
+.long 0xE0741050, 0x80056B60
+.long 0xD3CC0060, 0x0582B512
+.long 0x7EE21571
+.long 0x7EE41572
+.long 0xD200006D, 0x05C52172
+.long 0xD390406D, 0x1802DA28
+.long 0x7EE61573
+.long 0x7EE81574
+.long 0xD200006E, 0x05CD2174
+.long 0xD390406E, 0x1802DC28
+.long 0xD3D84075, 0x1800015C
+.long 0xD3D84076, 0x1800015D
+.long 0xD3D84077, 0x1800015E
+.long 0xD3D84078, 0x1800015F
+.long 0xD3CC0060, 0x0582B914
+.long 0xBF8C0F73
+.long 0xD38E406D, 0x1DB6CA29
+.long 0xD38E406E, 0x1DBACC29
+.long 0xE0741060, 0x80056D60
+.long 0xD3CC0060, 0x0582BD16
+.long 0x7EEA1575
+.long 0x7EEC1576
+.long 0xD200006F, 0x05D52176
+.long 0xD390406F, 0x1802DE28
+.long 0x7EEE1577
+.long 0x7EF01578
+.long 0xD2000070, 0x05DD2178
+.long 0xD3904070, 0x1802E028
+.long 0xD3CC0070, 0x05C27108
+.long 0xBF8C0F73
+.long 0xD38E406F, 0x1DBECE29
+.long 0xD38E4070, 0x1DC2D029
+.long 0xE0741070, 0x80056F60
+.long 0xD3CC0070, 0x05C2750A
+.long 0xD1340060, 0x0000A960
+.long 0xE0541000, 0x80046160
+.long 0xE0541010, 0x80046360
+.long 0xE0541020, 0x80046560
+.long 0xE0541030, 0x80046760
+.long 0xD3D84069, 0x18000160
+.long 0xD3D8406A, 0x18000161
+.long 0xD3D8406B, 0x18000162
+.long 0xD3D8406C, 0x18000163
+.long 0xD3D8406D, 0x18000164
+.long 0xD3D8406E, 0x18000165
+.long 0xD3D8406F, 0x18000166
+.long 0xD3D84070, 0x18000167
+.long 0x7ED21569
+.long 0x7ED4156A
+.long 0xD2000069, 0x05A5216A
+.long 0xD3904069, 0x1802D228
+.long 0x7ED6156B
+.long 0x7ED8156C
+.long 0xD200006A, 0x05AD216C
+.long 0xD390406A, 0x1802D428
+.long 0x7EDA156D
+.long 0x7EDC156E
+.long 0xD200006B, 0x05B5216E
+.long 0xD390406B, 0x1802D628
+.long 0xD3CC0070, 0x05C2790C
+.long 0xBF8C0F73
+.long 0xD38E4069, 0x1DA6C229
+.long 0xD38E406A, 0x1DAAC429
+.long 0xE0741000, 0x80056960
+.long 0xD3CC0070, 0x05C27D0E
+.long 0x7EDE156F
+.long 0x7EE01570
+.long 0xD200006C, 0x05BD2170
+.long 0xD390406C, 0x1802D828
+.long 0xD3D84071, 0x18000168
+.long 0xD3D84072, 0x18000169
+.long 0xD3D84073, 0x1800016A
+.long 0xD3D84074, 0x1800016B
+.long 0xD3CC0070, 0x05C2B118
+.long 0xBF8C0F73
+.long 0xD38E406B, 0x1DAEC629
+.long 0xD38E406C, 0x1DB2C829
+.long 0xE0741010, 0x80056B60
+.long 0xD3CC0070, 0x05C2B51A
+.long 0x7EE21571
+.long 0x7EE41572
+.long 0xD200006D, 0x05C52172
+.long 0xD390406D, 0x1802DA28
+.long 0x7EE61573
+.long 0x7EE81574
+.long 0xD200006E, 0x05CD2174
+.long 0xD390406E, 0x1802DC28
+.long 0xD3D84075, 0x1800016C
+.long 0xD3D84076, 0x1800016D
+.long 0xD3D84077, 0x1800016E
+.long 0xD3D84078, 0x1800016F
+.long 0xD3CC0070, 0x05C2B91C
+.long 0xBF8C0F73
+.long 0xD38E406D, 0x1DB6CA29
+.long 0xD38E406E, 0x1DBACC29
+.long 0xE0741020, 0x80056D60
+.long 0xD3CC0070, 0x05C2BD1E
+.long 0xBF800007
+.long 0x7EEA1575
+.long 0x7EEC1576
+.long 0xD200006F, 0x05D52176
+.long 0xD390406F, 0x1802DE28
+.long 0x7EEE1577
+.long 0x7EF01578
+.long 0xD2000070, 0x05DD2178
+.long 0xD3904070, 0x1802E028
+.long 0xBF8C0F73
+.long 0xD38E406F, 0x1DBECE29
+.long 0xD38E4070, 0x1DC2D029
+.long 0xE0741030, 0x80056F60
+.long 0xE0541040, 0x80046160
+.long 0xE0541050, 0x80046360
+.long 0xE0541060, 0x80046560
+.long 0xE0541070, 0x80046760
+.long 0xD3D84069, 0x18000170
+.long 0xD3D8406A, 0x18000171
+.long 0xD3D8406B, 0x18000172
+.long 0xD3D8406C, 0x18000173
+.long 0xD3D8406D, 0x18000174
+.long 0xD3D8406E, 0x18000175
+.long 0xD3D8406F, 0x18000176
+.long 0xD3D84070, 0x18000177
+.long 0x7ED21569
+.long 0x7ED4156A
+.long 0xD2000069, 0x05A5216A
+.long 0xD3904069, 0x1802D228
+.long 0x7ED6156B
+.long 0x7ED8156C
+.long 0xD200006A, 0x05AD216C
+.long 0xD390406A, 0x1802D428
+.long 0x7EDA156D
+.long 0x7EDC156E
+.long 0xD200006B, 0x05B5216E
+.long 0xD390406B, 0x1802D628
+.long 0xBF8C0F73
+.long 0xD38E4069, 0x1DA6C229
+.long 0xD38E406A, 0x1DAAC429
+.long 0xE0741040, 0x80056960
+.long 0x7EDE156F
+.long 0x7EE01570
+.long 0xD200006C, 0x05BD2170
+.long 0xD390406C, 0x1802D828
+.long 0xD3D84071, 0x18000178
+.long 0xD3D84072, 0x18000179
+.long 0xD3D84073, 0x1800017A
+.long 0xD3D84074, 0x1800017B
+.long 0xBF8C0F73
+.long 0xD38E406B, 0x1DAEC629
+.long 0xD38E406C, 0x1DB2C829
+.long 0xE0741050, 0x80056B60
+.long 0x7EE21571
+.long 0x7EE41572
+.long 0xD200006D, 0x05C52172
+.long 0xD390406D, 0x1802DA28
+.long 0x7EE61573
+.long 0x7EE81574
+.long 0xD200006E, 0x05CD2174
+.long 0xD390406E, 0x1802DC28
+.long 0xD3D84075, 0x1800017C
+.long 0xD3D84076, 0x1800017D
+.long 0xD3D84077, 0x1800017E
+.long 0xD3D84078, 0x1800017F
+.long 0xBF8C0F73
+.long 0xD38E406D, 0x1DB6CA29
+.long 0xD38E406E, 0x1DBACC29
+.long 0xE0741060, 0x80056D60
+.long 0x7EEA1575
+.long 0x7EEC1576
+.long 0xD200006F, 0x05D52176
+.long 0xD390406F, 0x1802DE28
+.long 0x7EEE1577
+.long 0x7EF01578
+.long 0xD2000070, 0x05DD2178
+.long 0xD3904070, 0x1802E028
+.long 0xBF8C0F73
+.long 0xD38E406F, 0x1DBECE29
+.long 0xD38E4070, 0x1DC2D029
+.long 0xE0741070, 0x80056F60
+.long 0xBF8C0000
+.long 0xBF810000

--- a/Tensile/ReplacementKernels-cov3/Cijk_Alik_Bljk_HBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_4_USFGRO1_VAW2_VW4_WG16_32_1_WGM8.s.txt
+++ b/Tensile/ReplacementKernels-cov3/Cijk_Alik_Bljk_HBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_4_USFGRO1_VAW2_VW4_WG16_32_1_WGM8.s.txt
@@ -1,0 +1,1006 @@
+
+
+/******************************************/
+/* Function Prefix                        */
+/******************************************/
+
+
+
+/******************************************/
+/* Begin Kernel                           */
+/******************************************/
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx908+sram-ecc"
+.text
+.protected Cijk_Alik_Bljk_HBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_4_USFGRO1_VAW2_VW4_WG16_32_1_WGM8
+.globl Cijk_Alik_Bljk_HBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_4_USFGRO1_VAW2_VW4_WG16_32_1_WGM8
+.p2align 8
+.type Cijk_Alik_Bljk_HBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_4_USFGRO1_VAW2_VW4_WG16_32_1_WGM8,@function
+.section .rodata,#alloc
+.p2align 6
+.amdhsa_kernel Cijk_Alik_Bljk_HBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_4_USFGRO1_VAW2_VW4_WG16_32_1_WGM8
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_next_free_vgpr 108 // vgprs
+  .amdhsa_next_free_sgpr 98 // sgprs
+  .amdhsa_group_segment_fixed_size 30000 // lds bytes
+  .amdhsa_private_segment_fixed_size 0
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+.text
+
+/******************************************/
+/* Optimizations and Config:              */
+/******************************************/
+/* ThreadTile= 4 x 4 */
+/* SubGroup= 16 x 32 */
+/* VectorWidth=4 */
+/* GlobalLoadVectorWidthA=4, GlobalLoadVectorWidthB=4 */
+/* DirectToLdsA=False */
+/* DirectToLdsB=False */
+/* UseSgprForGRO=1 */
+.amdgpu_metadata
+---
+amdhsa.version:
+  - 1
+  - 0
+amdhsa.kernels:
+  - .name: Cijk_Alik_Bljk_HBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_4_USFGRO1_VAW2_VW4_WG16_32_1_WGM8
+    .symbol: 'Cijk_Alik_Bljk_HBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_4_USFGRO1_VAW2_VW4_WG16_32_1_WGM8.kd'
+    .language:                   OpenCL C
+    .language_version:
+      - 2
+      - 0
+    .args:
+      - .name:            sizeC
+        .size:            8
+        .offset:          0
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            sizeA
+        .size:            8
+        .offset:          8
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            sizeB
+        .size:            8
+        .offset:          16
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            D
+        .size:            8
+        .offset:          24
+        .value_kind:      global_buffer
+        .value_type:      struct
+        .address_space:   generic
+      - .name:            C
+        .size:            8
+        .offset:          32
+        .value_kind:      global_buffer
+        .value_type:      struct
+        .address_space:   generic
+      - .name:            A
+        .size:            8
+        .offset:          40
+        .value_kind:      global_buffer
+        .value_type:      struct
+        .address_space:   generic
+      - .name:            B
+        .size:            8
+        .offset:          48
+        .value_kind:      global_buffer
+        .value_type:      struct
+        .address_space:   generic
+      - .name:            alpha
+        .size:            4
+        .offset:          56
+        .value_kind:      by_value
+        .value_type:      f16
+      - .name:            beta
+        .size:            4
+        .offset:          60
+        .value_kind:      by_value
+        .value_type:      f16
+      - .name:            strideD0
+        .size:            4
+        .offset:          64
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideD1
+        .size:            4
+        .offset:          68
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideC0
+        .size:            4
+        .offset:          72
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideC1
+        .size:            4
+        .offset:          76
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideA0
+        .size:            4
+        .offset:          80
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideA1
+        .size:            4
+        .offset:          84
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideB0
+        .size:            4
+        .offset:          88
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideB1
+        .size:            4
+        .offset:          92
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree0
+        .size:            4
+        .offset:          96
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree1
+        .size:            4
+        .offset:          100
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree2
+        .size:            4
+        .offset:          104
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesSum0
+        .size:            4
+        .offset:          108
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            OrigStaggerUIter
+        .size:            4
+        .offset:          112
+        .value_kind:      by_value
+        .value_type:      i32
+      - .name:            NumWorkGroups0
+        .size:            4
+        .offset:          116
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            NumWorkGroups1
+        .size:            4
+        .offset:          120
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            MagicNumberProblemNumGroupTiles0
+        .size:            4
+        .offset:          124
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            GridNumWorkGroups0
+        .size:            4
+        .offset:          128
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            NumFullBlocks
+        .size:            4
+        .offset:          132
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            WgmRemainder1
+        .size:            4
+        .offset:          136
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            MagicNumberWgmRemainder1
+        .size:            4
+        .offset:          140
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            padding
+        .size:            4
+        .offset:          144
+        .value_kind:      by_value
+        .value_type:      u32
+    .group_segment_fixed_size:   28672
+    .kernarg_segment_align:      8
+    .kernarg_segment_size:       152
+    .max_flat_workgroup_size:    512
+    .private_segment_fixed_size: 0
+    .sgpr_count:                 98
+    .sgpr_spill_count:           0
+    .vgpr_count:                 108
+    .vgpr_spill_count:           0
+    .wavefront_size:             64
+...
+.end_amdgpu_metadata
+Cijk_Alik_Bljk_HBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_4_USFGRO1_VAW2_VW4_WG16_32_1_WGM8:
+
+/******************************************/
+/* Asm syntax workarounds                 */
+/******************************************/
+.macro _v_add_co_u32 dst, cc, src0, src1, dpp=
+   v_add_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+
+.macro _v_add_u32 dst, src0, src1, dpp=
+   v_add_u32 \dst, \src0, \src1 \dpp
+.endm
+
+.macro _v_sub_co_u32 dst, cc, src0, src1, dpp=
+   v_sub_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+
+.macro _v_sub_u32 dst, src0, src1, dpp=
+   v_sub_u32 \dst, \src0, \src1 \dpp
+.endm
+
+.macro _v_addc_co_u32 dst, ccOut, src0, ccIn, src1, dpp=
+   v_addc_co_u32 \dst, \ccOut, \src0, \ccIn, \src1 \dpp
+.endm
+
+.macro _v_add_lshl_u32 dst, src0, src1, shiftCnt
+    v_add_lshl_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+.macro _v_lshl_add_u32 dst, src0, src1, shiftCnt
+    v_lshl_add_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+/******************************************/
+/* Magic div and mod functions            */
+/******************************************/
+.macro V_MAGIC_DIV dstIdx, dividend, magicNumber, magicShift
+    v_mul_hi_u32 v[\dstIdx+1], \dividend, \magicNumber
+    v_mul_lo_u32 v[\dstIdx+0], \dividend, \magicNumber
+    v_lshrrev_b64 v[\dstIdx:\dstIdx+1], \magicShift, v[\dstIdx:\dstIdx+1]
+.endm
+
+/******************************************/
+/* VGPR Assignments                       */
+/******************************************/
+.set vgprValuC, 0
+/* ValuA/B   Xn=PLR buffer idx,  In=InnerUnroll idx */
+.set vgprValuA_X0_I0, 32
+.set vgprValuA_X1_I0, 34
+.set vgprG2LA, 36
+.set vgprValuB_X0_I0, 40
+.set vgprValuB_X1_I0, 44
+.set vgprG2LB, 48
+.set vgprLocalWriteAddrA, 56
+.set vgprLocalWriteAddrB, 57
+.set vgprGlobalReadOffsetA, 58
+.set vgprGlobalReadOffsetB, 59
+.set vgprLocalReadAddrA, 60
+.set vgprLocalReadAddrB, 61
+.set vgprSerial, 62
+/* Num VGPR=63 */
+
+/******************************************/
+/* SGPR Assignments                       */
+/******************************************/
+.set sgprKernArgAddress, 0
+.set sgprWorkGroup0, 2
+.set sgprWorkGroup1, 3
+.set sgprWorkGroup2, 4
+.set sgprNumWorkGroups0, 5
+.set sgprNumWorkGroups1, 6
+.set sgprSrdA, 8
+.set sgprSrdB, 12
+.set sgprSrdD, 16
+.set sgprSrdC, 20
+.set sgprTensor2dSizeC, 24
+.set sgprTensor2dSizeA, 26
+.set sgprTensor2dSizeB, 28
+.set sgprSaveExecMask, 30
+.set sgprAddressD, 32
+.set sgprAddressC, 34
+.set sgprStridesD, 36
+.set sgprStridesC, 38
+.set sgprAlpha, 40
+.set sgprBeta, 41
+.set sgprSizesFree, 42
+.set sgprSizesSum, 45
+.set sgprLoopCounters, 46
+.set sgprOrigLoopCounter, 47
+.set sgprStridesA, 48
+.set sgprStridesB, 50
+.set sgprAddressA, 52
+.set sgprAddressB, 54
+.set sgprShadowLimitA, 56
+.set sgprShadowLimitB, 58
+.set sgprOrigStaggerUIter, 60
+.set sgprStaggerUIter, 61
+.set sgprWrapUA, 62
+.set sgprWrapUB, 64
+.set sgprNumFullBlocks, 66
+.set sgprWgmRemainder1, 67
+.set sgprMagicNumberWgmRemainder1, 68
+.set sgprGlobalReadIncsA, 69
+.set sgprGlobalReadIncsB, 70
+.set sgprScalarGlobalReadOffsetA, 71
+.set sgprScalarGlobalReadOffsetB, 72
+/* max SGPR=98 */
+
+/* Size Assignments */
+.set sgprSizeD0I, sgprSizesFree+0
+.set sgprSizeD1J, sgprSizesFree+1
+.set sgprSizeDK, sgprSizesFree+2
+.set sgprSizeC0I, sgprSizesFree+0
+.set sgprSizeC1J, sgprSizesFree+1
+.set sgprSizeCK, sgprSizesFree+2
+.set sgprSizeAL, sgprSizesSum+0
+.set sgprSizeA0I, sgprSizesFree+0
+.set sgprSizeAK, sgprSizesFree+2
+.set sgprSizeBL, sgprSizesSum+0
+.set sgprSizeB1J, sgprSizesFree+1
+.set sgprSizeBK, sgprSizesFree+2
+
+/* Stride Assignments */
+.set constStrideD0I, 1
+.set sgprStrideD1J, sgprStridesD+0
+.set sgprStrideDK, sgprStridesD+1
+.set constStrideC0I, 1
+.set sgprStrideC1J, sgprStridesC+0
+.set sgprStrideCK, sgprStridesC+1
+.set constStrideAL, 1
+.set sgprStrideA0I, sgprStridesA+0
+.set sgprStrideAK, sgprStridesA+1
+.set constStrideBL, 1
+.set sgprStrideB1J, sgprStridesB+0
+.set sgprStrideBK, sgprStridesB+1
+
+.set DepthU, 32
+/* Number of elements to shift-left SRD */
+.set SrdShiftLeftA, 4
+.set SrdShiftLeftB, 4
+/* 2GB limit - set offsets to -1 to exceed this and clamp */
+.set BufferLimit, 0x80000000
+/* Bits 127:96 of SRD.  Set DataFormat = 32 bit */
+.set Srd127_96, 0x0020000
+.set BufferOOB, 0x80000000
+
+/* Global Offset A */
+.macro GLOBAL_OFFSET_A vgprAddr vgprOffsetL vgprOffset0I vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStrideA0I], v[\vgprOffset0I] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprOffsetL], v[\vgprTmp+0] // accumulate d1 lower
+_v_add_u32 v[\vgprAddr+0], 0x4, v[\vgprAddr+0]     // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/* Global Offset B */
+.macro GLOBAL_OFFSET_B vgprAddr vgprOffsetL vgprOffset1J vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStrideB1J], v[\vgprOffset1J] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprOffsetL], v[\vgprTmp+0] // accumulate d1 lower
+_v_add_u32 v[\vgprAddr+0], 0x4, v[\vgprAddr+0]     // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/******************************************/
+/* Dynamic Scalar Divide: vQuotient=vDividend/vDivisor; vRemainder=vDividend%vDivisor; */
+/******************************************/
+.macro DYNAMIC_VECTOR_DIVIDE vQuotient vRemainder vDividend vDivisor vTmp0 vTmp1 sTmp
+v_cvt_f32_u32 v[\vQuotient], v[\vDivisor]          //
+v_rcp_f32 v[\vQuotient], v[\vQuotient]             //
+v_mul_f32 v[\vQuotient], 0x4f800000, v[\vQuotient] //
+v_cvt_u32_f32 v[\vQuotient], v[\vQuotient]         //
+v_mul_lo_u32 v[\vRemainder], v[\vDivisor], v[\vQuotient] //
+v_mul_hi_u32 v[\vTmp0], v[\vDivisor], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp1], vcc, 0x0, v[\vRemainder]  //
+v_cmp_ne_i32 s[\sTmp:\sTmp+1], 0x0, v[\vTmp0]      //
+v_cndmask_b32 v[\vRemainder], v[\vTmp1], v[\vRemainder], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vRemainder], v[\vRemainder], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vQuotient], v[\vRemainder] //
+_v_add_co_u32 v[\vQuotient], vcc, v[\vQuotient], v[\vRemainder] //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vTmp0], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vQuotient], v[\vQuotient], v[\vDividend] //
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vDividend], v[\vRemainder] //
+v_cmp_ge_u32 s[\sTmp:\sTmp+1], v[\vDividend], v[\vRemainder] //
+_v_add_co_u32 v[\vRemainder], vcc, 0x1, v[\vQuotient] //
+_v_add_co_u32 v[\vTmp1], vcc, -1, v[\vQuotient]    //
+v_cmp_le_u32 vcc, v[\vDivisor], v[\vTmp0]          //
+s_and_b64 vcc, s[\sTmp:\sTmp+1], vcc               //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vRemainder], vcc //
+v_cndmask_b32 v[\vQuotient], v[\vTmp1], v[\vQuotient], s[\sTmp:\sTmp+1] //
+v_cmp_ne_i32 vcc, 0x0, v[\vDivisor]                //
+v_cndmask_b32 v[\vQuotient], -1, v[\vQuotient], vcc // final result
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vRemainder], vcc, v[\vDividend], v[\vRemainder] // final result
+.endm
+
+/******************************************/
+/* 4x8 thread-tile                        */
+/******************************************/
+.macro MAC_4x8_X0
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[0] iui=0
+s_setprio 1 // Raise priority while processing macs
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[1]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[4]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[5]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[2] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[3]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[6]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[7]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[8] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[9]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[12]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[13]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[10] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[11]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[14]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[15]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[16] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[17]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[20]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[21]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[18] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[19]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[22]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[23]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[24] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[25]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[28]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[29]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[26] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[27]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[30]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[31]
+s_setprio 0 // Reset priority after macs
+.endm
+.macro MAC_4x8_X1
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[0] iui=0
+s_setprio 1 // Raise priority while processing macs
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[1]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[4]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[5]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[2] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[3]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[6]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[7]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[8] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[9]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[12]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[13]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[10] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[11]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[14]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[15]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[16] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[17]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[20]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[21]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[18] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[19]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[22]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[23]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[24] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[25]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[28]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[29]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[26] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[27]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[30]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[31]
+s_setprio 0 // Reset priority after macs
+.endm
+
+
+
+
+/***** program start from here *****/
+
+.long 0xC00A0D00, 0x00000028
+.long 0xC00A0C00, 0x00000050
+.long 0xC00A0600, 0x00000008
+.long 0xC0020B40, 0x0000006C
+.long 0xBEFC00FF, 0x00006600
+.long 0x7EC80300
+.long 0x26CA00BF
+.long 0x2004C886
+.long 0xB8D0F804
+.long 0xD1130004, 0x0000A0B0
+.long 0x20CC0884
+.long 0x7EA40566
+.long 0xD1130067, 0x0000A08F
+.long 0x7EA20567
+.long 0xC0020140, 0x00000074
+.long 0xBF068151
+.long 0xBF8400B3
+.long 0xBF8CC07F
+.long 0x86580387
+.long 0x92580558
+.long 0x81580258
+.long 0x8F598358
+.long 0xBE820059
+.long 0x86595887
+.long 0x8F5A8303
+.long 0x8E5A835A
+.long 0x81595A59
+.long 0xBE830059
+.long 0xBE880034
+.long 0xBE890035
+.long 0xBE8B00FF, 0x00020000
+.long 0xBE8A00FF, 0x80000000
+.long 0x9254C030
+.long 0x92545402
+.long 0x92559052
+.long 0x92533055
+.long 0x81545354
+.long 0x2000CA82
+.long 0xD2850004, 0x00020030
+.long 0x2602CA83
+.long 0x24020283
+.long 0x32A40304
+.long 0x68A4A454
+.long 0x24A4A481
+.long 0xBECC00FF, 0x00000440
+.long 0x924C4C52
+.long 0xBE8C0036
+.long 0xBE8D0037
+.long 0xBE8F00FF, 0x00020000
+.long 0xBE8E00FF, 0x80000000
+.long 0x9254FF32, 0x00000080
+.long 0x92545403
+.long 0x9255A052
+.long 0x92533255
+.long 0x81545354
+.long 0x2004CA82
+.long 0xD2850004, 0x00020432
+.long 0x2606CA83
+.long 0x24060683
+.long 0x32AC0704
+.long 0x68ACAC54
+.long 0x24ACAC81
+.long 0x8E4A8532
+.long 0x68AEAC4A
+.long 0xBECE00FF, 0x00000880
+.long 0x924E4E52
+.long 0x814EFF4E, 0x00002200
+.long 0x814DFF4C, 0x00001100
+.long 0x2498CA84
+.long 0x6898984C
+.long 0x249ACA84
+.long 0x689A9A4D
+.long 0x814FFF4E, 0x00002200
+.long 0x249CCA84
+.long 0x689C9C4E
+.long 0x249ECA84
+.long 0x689E9E4F
+.long 0x2002CA83
+.long 0xD2850001, 0x00020288
+.long 0x68989901
+.long 0x689A9B01
+.long 0x689C9D01
+.long 0x689E9F01
+.long 0xD1340054, 0x00018152
+.long 0xD1340058, 0x00018156
+.long 0xD1340059, 0x00018157
+.long 0xBF8A0000
+.long 0xE05C1000, 0x80022052
+.long 0xE05C1000, 0x80033056
+.long 0xE05C1000, 0x80033457
+.long 0xE05C1000, 0x80022854
+.long 0xE05C1000, 0x80033858
+.long 0xE05C1000, 0x80033C59
+.long 0x68A4A4FF, 0x00000080
+.long 0x68ACACFF, 0x00000080
+.long 0x68AEAEFF, 0x00000080
+.long 0x8F2E852D
+.long 0x80AE2E80
+.long 0xBF06C22E
+.long 0xBF850034
+.long 0xBF8C0F75
+.long 0xD9BE0000, 0x0000204C
+.long 0xBF8C0F73
+.long 0xD9BE0000, 0x0000304E
+.long 0xD9BE0440, 0x0000344E
+.long 0xBF8CC27F
+.long 0xE05C1000, 0x80022052
+.long 0xBF8CC17F
+.long 0xE05C1000, 0x80033056
+.long 0xBF8CC07F
+.long 0xE05C1000, 0x80033457
+.long 0xBF8F0001
+.long 0x68A4A4FF, 0x00000080
+.long 0x68ACACFF, 0x00000080
+.long 0x68AEAEFF, 0x00000080
+.long 0x68A8A8FF, 0x00000080
+.long 0x68B0B0FF, 0x00000080
+.long 0x68B2B2FF, 0x00000080
+.long 0xBF8F0000
+.long 0xBF8C0F75
+.long 0xD9BE0000, 0x0000284D
+.long 0xBF8C0F73
+.long 0xD9BE0000, 0x0000384F
+.long 0xD9BE0440, 0x00003C4F
+.long 0xBF8CC27F
+.long 0xE05C1000, 0x80022854
+.long 0xBF8CC07F
+.long 0xBF8A0000
+.long 0xE05C1000, 0x80033858
+.long 0xE05C1000, 0x80033C59
+.long 0xBF8A0000
+.long 0x802E822E
+.long 0xBF00C22E
+.long 0xBF84FFCC
+.long 0xBF8C0F75
+.long 0xD9BE0000, 0x0000204C
+.long 0xBF8C0F73
+.long 0xD9BE0000, 0x0000304E
+.long 0xD9BE0440, 0x0000344E
+.long 0xBF8C0F72
+.long 0xD9BE0000, 0x0000284D
+.long 0xBF8C0F70
+.long 0xD9BE0000, 0x0000384F
+.long 0xD9BE0440, 0x00003C4F
+.long 0xBF8CC07F
+.long 0xBF8A0000
+.long 0xBF810000
+.long 0xD3D94000, 0x18000080
+.long 0xD3D94001, 0x18000080
+.long 0xD3D94002, 0x18000080
+.long 0xD3D94003, 0x18000080
+.long 0xD3D94004, 0x18000080
+.long 0xD3D94005, 0x18000080
+.long 0xD3D94006, 0x18000080
+.long 0xD3D94007, 0x18000080
+.long 0xD3D94008, 0x18000080
+.long 0xD3D94009, 0x18000080
+.long 0xD3D9400A, 0x18000080
+.long 0xD3D9400B, 0x18000080
+.long 0xD3D9400C, 0x18000080
+.long 0xD3D9400D, 0x18000080
+.long 0xD3D9400E, 0x18000080
+.long 0xD3D9400F, 0x18000080
+.long 0xD3D94010, 0x18000080
+.long 0xD3D94011, 0x18000080
+.long 0xD3D94012, 0x18000080
+.long 0xD3D94013, 0x18000080
+.long 0xD3D94014, 0x18000080
+.long 0xD3D94015, 0x18000080
+.long 0xD3D94016, 0x18000080
+.long 0xD3D94017, 0x18000080
+.long 0xD3D94018, 0x18000080
+.long 0xD3D94019, 0x18000080
+.long 0xD3D9401A, 0x18000080
+.long 0xD3D9401B, 0x18000080
+.long 0xD3D9401C, 0x18000080
+.long 0xD3D9401D, 0x18000080
+.long 0xD3D9401E, 0x18000080
+.long 0xD3D9401F, 0x18000080
+.long 0xC0060700, 0x00000000
+.long 0xC00A0A00, 0x00000038
+.long 0xC00A0900, 0x00000040
+.long 0xC00A0800, 0x00000018
+.long 0xD1130001, 0x00013F65
+.long 0xD2850060, 0x000202A0
+.long 0x20040281
+.long 0xD2850002, 0x00020488
+.long 0x2002CA85
+.long 0x24020282
+.long 0x68C0C101
+.long 0x24C0C081
+.long 0x68C0C102
+.long 0x68C0C080
+.long 0x68C2C0FF, 0x00001100
+.long 0xBF8A0000
+.long 0xD1130001, 0x00013F65
+.long 0xD2850062, 0x000202A0
+.long 0x20040281
+.long 0xD2850002, 0x00020488
+.long 0x2002CA85
+.long 0x24020282
+.long 0x68C4C501
+.long 0x24C4C481
+.long 0x68C4C502
+.long 0x9254FF52, 0x00000880
+.long 0x68C4C454
+.long 0x68C4C4FF, 0x00002200
+.long 0x68C6C4FF, 0x00002200
+.long 0xBF8CC07F
+.long 0x86580387
+.long 0x92580558
+.long 0x81580258
+.long 0x8F598358
+.long 0xBE820059
+.long 0x86595887
+.long 0x8F5A8303
+.long 0x8E5A835A
+.long 0x81595A59
+.long 0xBE830059
+.long 0xBE900022
+.long 0xBE910023
+.long 0xBE9200FF, 0x80000000
+.long 0xBE9300FF, 0x00020000
+.long 0xBE940020
+.long 0xBE950021
+.long 0xBE9600FF, 0x80000000
+.long 0xBE9700FF, 0x00020000
+.long 0x925603FF, 0x00000080
+.long 0x96552656
+.long 0x92542656
+.long 0x8ED48154
+.long 0x80105410
+.long 0x82115511
+.long 0x80145414
+.long 0x82155515
+.long 0x96552704
+.long 0x92542704
+.long 0x8ED48154
+.long 0x80105410
+.long 0x82115511
+.long 0x80145414
+.long 0x82155515
+.long 0x24C8CC86
+.long 0x68C8C965
+.long 0xD2850004, 0x0002CCA0
+.long 0xD2850003, 0x00004D04
+.long 0x2608C89F
+.long 0xD2850005, 0x00004D04
+.long 0x2608C8BF
+.long 0x200C0885
+.long 0x240C0C82
+.long 0x68D60B03
+.long 0x925402C0
+.long 0x32D40C54
+.long 0xD1FE0068, 0x0206D76A
+.long 0xBF8A0000
+.long 0xD8EC0000, 0x20000060
+.long 0xD8EC0000, 0x40000062
+.long 0xD8EC0000, 0x30000061
+.long 0xD8EC0000, 0x48000063
+.long 0xBF8CC27F
+.long 0xD3CC0000, 0x04028120
+.long 0xD8EC0010, 0x22000060
+.long 0xD8EC0010, 0x42000062
+.long 0xD8EC0010, 0x32000061
+.long 0xD8EC0010, 0x4A000063
+.long 0xBF8CC47F
+.long 0xD3CC0000, 0x04029130
+.long 0xD8EC0020, 0x24000060
+.long 0xD8EC0020, 0x44000062
+.long 0xD8EC0020, 0x34000061
+.long 0xD8EC0020, 0x4C000063
+.long 0xE0541000, 0x80041068
+.long 0xE0541010, 0x80041268
+.long 0xBF8CC67F
+.long 0xD3CC0000, 0x04028522
+.long 0xD8EC0030, 0x26000060
+.long 0xD8EC0030, 0x46000062
+.long 0xD8EC0030, 0x36000061
+.long 0xD8EC0030, 0x4E000063
+.long 0xE0541020, 0x80041468
+.long 0xE0541030, 0x80041668
+.long 0xBF8CC87F
+.long 0xD3CC0000, 0x04029532
+.long 0xD8EC0880, 0x28000060
+.long 0xD8EC0880, 0x38000061
+.long 0xD8EC0890, 0x2A000060
+.long 0xD8EC0890, 0x3A000061
+.long 0xBF8CCA7F
+.long 0xD3CC0000, 0x04028924
+.long 0xD8EC08A0, 0x2C000060
+.long 0xD8EC08A0, 0x3C000061
+.long 0xD8EC08B0, 0x2E000060
+.long 0xD8EC08B0, 0x3E000061
+.long 0xBF8CCC7F
+.long 0xD3CC0000, 0x04029934
+.long 0xBF8CCE7F
+.long 0xD3CC0000, 0x04028D26
+.long 0xBF8CC07F
+.long 0xBF8A0000
+.long 0x8F2E852D
+.long 0x80AE2E80
+.long 0xBF06C22E
+.long 0xBF850157
+.long 0xD3CC0000, 0x04029D36
+.long 0xBF80000C
+.long 0xD3CC0010, 0x04428128
+.long 0xBF80000C
+.long 0xD3CC0010, 0x04429138
+.long 0xBF80000C
+.long 0xD3CC0010, 0x0442852A
+.long 0xBF80000C
+.long 0xD3CC0010, 0x0442953A
+.long 0xBF80000C
+.long 0xD3CC0010, 0x0442892C
+.long 0xBF80000C
+.long 0xD3CC0010, 0x0442993C
+.long 0xBF80000C
+.long 0xD3CC0010, 0x04428D2E
+.long 0xBF8A0000
+.long 0xD8EC0000, 0x20000060
+.long 0xD8EC0000, 0x40000062
+.long 0xD8EC0000, 0x30000061
+.long 0xD8EC0000, 0x48000063
+.long 0xD3CC0010, 0x04429D3E
+.long 0xD8EC0010, 0x22000060
+.long 0xD8EC0010, 0x42000062
+.long 0xD8EC0010, 0x32000061
+.long 0xD8EC0010, 0x4A000063
+.long 0xBF8CC67F
+.long 0xD3CC0000, 0x04028120
+.long 0xD8EC0020, 0x24000060
+.long 0xD8EC0020, 0x44000062
+.long 0xD8EC0020, 0x34000061
+.long 0xD8EC0020, 0x4C000063
+.long 0xBF8CC87F
+.long 0xD3CC0000, 0x04029130
+.long 0xD8EC0030, 0x26000060
+.long 0xD8EC0030, 0x46000062
+.long 0xD8EC0030, 0x36000061
+.long 0xD8EC0030, 0x4E000063
+.long 0xBF8CCA7F
+.long 0xD3CC0000, 0x04028522
+.long 0xD8EC0880, 0x28000060
+.long 0xD8EC0880, 0x38000061
+.long 0xD8EC0890, 0x2A000060
+.long 0xD8EC0890, 0x3A000061
+.long 0xBF8CCC7F
+.long 0xD3CC0000, 0x04029532
+.long 0xD8EC08A0, 0x2C000060
+.long 0xD8EC08A0, 0x3C000061
+.long 0xD8EC08B0, 0x2E000060
+.long 0xD8EC08B0, 0x3E000061
+.long 0xBF8CCE7F
+.long 0xD3CC0000, 0x04028924
+.long 0xBF80000C
+.long 0xBF8CCC7F
+.long 0xD3CC0000, 0x04029934
+.long 0xBF8CC07F
+.long 0xBF8A0000
+.long 0xD3CC0000, 0x04028D26
+.long 0x802E822E
+.long 0xBF00C22E
+.long 0xBF84FF9C
+.long 0xE0541040, 0x80041868
+.long 0xE0541050, 0x80041A68
+.long 0xD3CC0000, 0x04029D36
+.long 0xE0541060, 0x80041C68
+.long 0xE0541070, 0x80041E68
+.long 0xD3CC0010, 0x04428128
+.long 0xD3D84000, 0x18000100
+.long 0xD3D84001, 0x18000101
+.long 0xD3D84002, 0x18000102
+.long 0xD3D84003, 0x18000103
+.long 0xD3D84004, 0x18000104
+.long 0xD3D84005, 0x18000105
+.long 0xD3D84006, 0x18000106
+.long 0xD3D84007, 0x18000107
+.long 0x7E001500
+.long 0x7E021501
+.long 0xD2000000, 0x04012101
+.long 0xD3904000, 0x18020028
+.long 0xD3CC0010, 0x04429138
+.long 0x7E041502
+.long 0x7E061503
+.long 0xD2000001, 0x04092103
+.long 0xD3904001, 0x18020228
+.long 0x7E081504
+.long 0x7E0A1505
+.long 0xD2000002, 0x04112105
+.long 0xD3904002, 0x18020428
+.long 0xBF8C0F77
+.long 0xD38E4000, 0x1C022029
+.long 0xD38E4001, 0x1C062229
+.long 0xE0741000, 0x80050068
+.long 0xD3CC0010, 0x0442852A
+.long 0x7E0C1506
+.long 0x7E0E1507
+.long 0xD2000003, 0x04192107
+.long 0xD3904003, 0x18020628
+.long 0xD3CC0010, 0x0442953A
+.long 0xBF8C0F77
+.long 0xD38E4002, 0x1C0A2429
+.long 0xD38E4003, 0x1C0E2629
+.long 0xE0741010, 0x80050268
+.long 0xD3CC0010, 0x0442892C
+.long 0xD3D84008, 0x18000108
+.long 0xD3D84009, 0x18000109
+.long 0xD3D8400A, 0x1800010A
+.long 0xD3D8400B, 0x1800010B
+.long 0x7E101508
+.long 0x7E121509
+.long 0xD2000004, 0x04212109
+.long 0xD3904004, 0x18020828
+.long 0x7E14150A
+.long 0x7E16150B
+.long 0xD2000005, 0x0429210B
+.long 0xD3904005, 0x18020A28
+.long 0xD3CC0010, 0x0442993C
+.long 0xBF8C0F77
+.long 0xD38E4004, 0x1C122829
+.long 0xD38E4005, 0x1C162A29
+.long 0xE0741020, 0x80050468
+.long 0xD3CC0010, 0x04428D2E
+.long 0xD3D8400C, 0x1800010C
+.long 0xD3D8400D, 0x1800010D
+.long 0xD3D8400E, 0x1800010E
+.long 0xD3D8400F, 0x1800010F
+.long 0x7E18150C
+.long 0x7E1A150D
+.long 0xD2000006, 0x0431210D
+.long 0xD3904006, 0x18020C28
+.long 0x7E1C150E
+.long 0x7E1E150F
+.long 0xD2000007, 0x0439210F
+.long 0xD3904007, 0x18020E28
+.long 0xD3CC0010, 0x04429D3E
+.long 0xBF800008
+.long 0xBF8C0F77
+.long 0xD38E4006, 0x1C1A2C29
+.long 0xD38E4007, 0x1C1E2E29
+.long 0xE0741030, 0x80050668
+.long 0xD3D84000, 0x18000110
+.long 0xD3D84001, 0x18000111
+.long 0xD3D84002, 0x18000112
+.long 0xD3D84003, 0x18000113
+.long 0xD3D84004, 0x18000114
+.long 0xD3D84005, 0x18000115
+.long 0xD3D84006, 0x18000116
+.long 0xD3D84007, 0x18000117
+.long 0x7E001500
+.long 0x7E021501
+.long 0xD2000000, 0x04012101
+.long 0xD3904000, 0x18020028
+.long 0x7E041502
+.long 0x7E061503
+.long 0xD2000001, 0x04092103
+.long 0xD3904001, 0x18020228
+.long 0x7E081504
+.long 0x7E0A1505
+.long 0xD2000002, 0x04112105
+.long 0xD3904002, 0x18020428
+.long 0xBF8C0F77
+.long 0xD38E4000, 0x1C023029
+.long 0xD38E4001, 0x1C063229
+.long 0xE0741040, 0x80050068
+.long 0x7E0C1506
+.long 0x7E0E1507
+.long 0xD2000003, 0x04192107
+.long 0xD3904003, 0x18020628
+.long 0xD3D84008, 0x18000118
+.long 0xD3D84009, 0x18000119
+.long 0xD3D8400A, 0x1800011A
+.long 0xD3D8400B, 0x1800011B
+.long 0xBF8C0F77
+.long 0xD38E4002, 0x1C0A3429
+.long 0xD38E4003, 0x1C0E3629
+.long 0xE0741050, 0x80050268
+.long 0x7E101508
+.long 0x7E121509
+.long 0xD2000004, 0x04212109
+.long 0xD3904004, 0x18020828
+.long 0x7E14150A
+.long 0x7E16150B
+.long 0xD2000005, 0x0429210B
+.long 0xD3904005, 0x18020A28
+.long 0xD3D8400C, 0x1800011C
+.long 0xD3D8400D, 0x1800011D
+.long 0xD3D8400E, 0x1800011E
+.long 0xD3D8400F, 0x1800011F
+.long 0xBF8C0F77
+.long 0xD38E4004, 0x1C123829
+.long 0xD38E4005, 0x1C163A29
+.long 0xE0741060, 0x80050468
+.long 0x7E18150C
+.long 0x7E1A150D
+.long 0xD2000006, 0x0431210D
+.long 0xD3904006, 0x18020C28
+.long 0x7E1C150E
+.long 0x7E1E150F
+.long 0xD2000007, 0x0439210F
+.long 0xD3904007, 0x18020E28
+.long 0xBF8C0F77
+.long 0xD38E4006, 0x1C1A3C29
+.long 0xD38E4007, 0x1C1E3E29
+.long 0xE0741070, 0x80050668
+.long 0xBF8C0000
+.long 0xBF810000

--- a/Tensile/ReplacementKernels-cov3/Cijk_Alik_Bljk_HBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_4_USFGRO1_VAW2_VW4_WG16_32_1_WGM8.s.txt
+++ b/Tensile/ReplacementKernels-cov3/Cijk_Alik_Bljk_HBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_4_USFGRO1_VAW2_VW4_WG16_32_1_WGM8.s.txt
@@ -510,20 +510,9 @@ s_setprio 0 // Reset priority after macs
 .long 0x7EA40566
 .long 0xD1130067, 0x0000A08F
 .long 0x7EA20567
-.long 0xC0020140, 0x00000074
 .long 0xBF068151
-.long 0xBF8400B3
+.long 0xBF8400A9
 .long 0xBF8CC07F
-.long 0x86580387
-.long 0x92580558
-.long 0x81580258
-.long 0x8F598358
-.long 0xBE820059
-.long 0x86595887
-.long 0x8F5A8303
-.long 0x8E5A835A
-.long 0x81595A59
-.long 0xBE830059
 .long 0xBE880034
 .long 0xBE890035
 .long 0xBE8B00FF, 0x00020000
@@ -705,16 +694,6 @@ s_setprio 0 // Reset priority after macs
 .long 0x68C4C4FF, 0x00002200
 .long 0x68C6C4FF, 0x00002200
 .long 0xBF8CC07F
-.long 0x86580387
-.long 0x92580558
-.long 0x81580258
-.long 0x8F598358
-.long 0xBE820059
-.long 0x86595887
-.long 0x8F5A8303
-.long 0x8E5A835A
-.long 0x81595A59
-.long 0xBE830059
 .long 0xBE900022
 .long 0xBE910023
 .long 0xBE9200FF, 0x80000000

--- a/Tensile/ReplacementKernels-cov3/Cijk_Alik_Bljk_HBH_MT64x128x32_SE_K1.s.txt
+++ b/Tensile/ReplacementKernels-cov3/Cijk_Alik_Bljk_HBH_MT64x128x32_SE_K1.s.txt
@@ -510,20 +510,9 @@ s_setprio 0 // Reset priority after macs
 .long 0x7EA40566
 .long 0xD1130067, 0x0000A08F
 .long 0x7EA20567
-.long 0xC0020140, 0x00000074
 .long 0xBF068151
-.long 0xBF8400B3
+.long 0xBF8400A9
 .long 0xBF8CC07F
-.long 0x86580387
-.long 0x92580558
-.long 0x81580258
-.long 0x8F598358
-.long 0xBE820059
-.long 0x86595887
-.long 0x8F5A8303
-.long 0x8E5A835A
-.long 0x81595A59
-.long 0xBE830059
 .long 0xBE880034
 .long 0xBE890035
 .long 0xBE8B00FF, 0x00020000
@@ -705,16 +694,6 @@ s_setprio 0 // Reset priority after macs
 .long 0x68C4C4FF, 0x00002200
 .long 0x68C6C4FF, 0x00002200
 .long 0xBF8CC07F
-.long 0x86580387
-.long 0x92580558
-.long 0x81580258
-.long 0x8F598358
-.long 0xBE820059
-.long 0x86595887
-.long 0x8F5A8303
-.long 0x8E5A835A
-.long 0x81595A59
-.long 0xBE830059
 .long 0xBE900022
 .long 0xBE910023
 .long 0xBE9200FF, 0x80000000

--- a/Tensile/ReplacementKernels-cov3/Cijk_Alik_Bljk_HBH_MT64x128x32_SE_K1.s.txt
+++ b/Tensile/ReplacementKernels-cov3/Cijk_Alik_Bljk_HBH_MT64x128x32_SE_K1.s.txt
@@ -1,0 +1,1006 @@
+
+
+/******************************************/
+/* Function Prefix                        */
+/******************************************/
+
+
+
+/******************************************/
+/* Begin Kernel                           */
+/******************************************/
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx908+sram-ecc"
+.text
+.protected Cijk_Alik_Bljk_HBH_MT64x128x32_SE_K1
+.globl Cijk_Alik_Bljk_HBH_MT64x128x32_SE_K1
+.p2align 8
+.type Cijk_Alik_Bljk_HBH_MT64x128x32_SE_K1,@function
+.section .rodata,#alloc
+.p2align 6
+.amdhsa_kernel Cijk_Alik_Bljk_HBH_MT64x128x32_SE_K1
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_next_free_vgpr 108 // vgprs
+  .amdhsa_next_free_sgpr 98 // sgprs
+  .amdhsa_group_segment_fixed_size 30000 // lds bytes
+  .amdhsa_private_segment_fixed_size 0
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+.text
+
+/******************************************/
+/* Optimizations and Config:              */
+/******************************************/
+/* ThreadTile= 4 x 4 */
+/* SubGroup= 16 x 32 */
+/* VectorWidth=4 */
+/* GlobalLoadVectorWidthA=4, GlobalLoadVectorWidthB=4 */
+/* DirectToLdsA=False */
+/* DirectToLdsB=False */
+/* UseSgprForGRO=1 */
+.amdgpu_metadata
+---
+amdhsa.version:
+  - 1
+  - 0
+amdhsa.kernels:
+  - .name: Cijk_Alik_Bljk_HBH_MT64x128x32_SE_K1
+    .symbol: 'Cijk_Alik_Bljk_HBH_MT64x128x32_SE_K1.kd'
+    .language:                   OpenCL C
+    .language_version:
+      - 2
+      - 0
+    .args:
+      - .name:            sizeC
+        .size:            8
+        .offset:          0
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            sizeA
+        .size:            8
+        .offset:          8
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            sizeB
+        .size:            8
+        .offset:          16
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            D
+        .size:            8
+        .offset:          24
+        .value_kind:      global_buffer
+        .value_type:      struct
+        .address_space:   generic
+      - .name:            C
+        .size:            8
+        .offset:          32
+        .value_kind:      global_buffer
+        .value_type:      struct
+        .address_space:   generic
+      - .name:            A
+        .size:            8
+        .offset:          40
+        .value_kind:      global_buffer
+        .value_type:      struct
+        .address_space:   generic
+      - .name:            B
+        .size:            8
+        .offset:          48
+        .value_kind:      global_buffer
+        .value_type:      struct
+        .address_space:   generic
+      - .name:            alpha
+        .size:            4
+        .offset:          56
+        .value_kind:      by_value
+        .value_type:      f16
+      - .name:            beta
+        .size:            4
+        .offset:          60
+        .value_kind:      by_value
+        .value_type:      f16
+      - .name:            strideD0
+        .size:            4
+        .offset:          64
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideD1
+        .size:            4
+        .offset:          68
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideC0
+        .size:            4
+        .offset:          72
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideC1
+        .size:            4
+        .offset:          76
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideA0
+        .size:            4
+        .offset:          80
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideA1
+        .size:            4
+        .offset:          84
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideB0
+        .size:            4
+        .offset:          88
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideB1
+        .size:            4
+        .offset:          92
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree0
+        .size:            4
+        .offset:          96
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree1
+        .size:            4
+        .offset:          100
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree2
+        .size:            4
+        .offset:          104
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesSum0
+        .size:            4
+        .offset:          108
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            OrigStaggerUIter
+        .size:            4
+        .offset:          112
+        .value_kind:      by_value
+        .value_type:      i32
+      - .name:            NumWorkGroups0
+        .size:            4
+        .offset:          116
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            NumWorkGroups1
+        .size:            4
+        .offset:          120
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            MagicNumberProblemNumGroupTiles0
+        .size:            4
+        .offset:          124
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            GridNumWorkGroups0
+        .size:            4
+        .offset:          128
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            NumFullBlocks
+        .size:            4
+        .offset:          132
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            WgmRemainder1
+        .size:            4
+        .offset:          136
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            MagicNumberWgmRemainder1
+        .size:            4
+        .offset:          140
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            padding
+        .size:            4
+        .offset:          144
+        .value_kind:      by_value
+        .value_type:      u32
+    .group_segment_fixed_size:   28672
+    .kernarg_segment_align:      8
+    .kernarg_segment_size:       152
+    .max_flat_workgroup_size:    512
+    .private_segment_fixed_size: 0
+    .sgpr_count:                 98
+    .sgpr_spill_count:           0
+    .vgpr_count:                 108
+    .vgpr_spill_count:           0
+    .wavefront_size:             64
+...
+.end_amdgpu_metadata
+Cijk_Alik_Bljk_HBH_MT64x128x32_SE_K1:
+
+/******************************************/
+/* Asm syntax workarounds                 */
+/******************************************/
+.macro _v_add_co_u32 dst, cc, src0, src1, dpp=
+   v_add_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+
+.macro _v_add_u32 dst, src0, src1, dpp=
+   v_add_u32 \dst, \src0, \src1 \dpp
+.endm
+
+.macro _v_sub_co_u32 dst, cc, src0, src1, dpp=
+   v_sub_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+
+.macro _v_sub_u32 dst, src0, src1, dpp=
+   v_sub_u32 \dst, \src0, \src1 \dpp
+.endm
+
+.macro _v_addc_co_u32 dst, ccOut, src0, ccIn, src1, dpp=
+   v_addc_co_u32 \dst, \ccOut, \src0, \ccIn, \src1 \dpp
+.endm
+
+.macro _v_add_lshl_u32 dst, src0, src1, shiftCnt
+    v_add_lshl_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+.macro _v_lshl_add_u32 dst, src0, src1, shiftCnt
+    v_lshl_add_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+/******************************************/
+/* Magic div and mod functions            */
+/******************************************/
+.macro V_MAGIC_DIV dstIdx, dividend, magicNumber, magicShift
+    v_mul_hi_u32 v[\dstIdx+1], \dividend, \magicNumber
+    v_mul_lo_u32 v[\dstIdx+0], \dividend, \magicNumber
+    v_lshrrev_b64 v[\dstIdx:\dstIdx+1], \magicShift, v[\dstIdx:\dstIdx+1]
+.endm
+
+/******************************************/
+/* VGPR Assignments                       */
+/******************************************/
+.set vgprValuC, 0
+/* ValuA/B   Xn=PLR buffer idx,  In=InnerUnroll idx */
+.set vgprValuA_X0_I0, 32
+.set vgprValuA_X1_I0, 34
+.set vgprG2LA, 36
+.set vgprValuB_X0_I0, 40
+.set vgprValuB_X1_I0, 44
+.set vgprG2LB, 48
+.set vgprLocalWriteAddrA, 56
+.set vgprLocalWriteAddrB, 57
+.set vgprGlobalReadOffsetA, 58
+.set vgprGlobalReadOffsetB, 59
+.set vgprLocalReadAddrA, 60
+.set vgprLocalReadAddrB, 61
+.set vgprSerial, 62
+/* Num VGPR=63 */
+
+/******************************************/
+/* SGPR Assignments                       */
+/******************************************/
+.set sgprKernArgAddress, 0
+.set sgprWorkGroup0, 2
+.set sgprWorkGroup1, 3
+.set sgprWorkGroup2, 4
+.set sgprNumWorkGroups0, 5
+.set sgprNumWorkGroups1, 6
+.set sgprSrdA, 8
+.set sgprSrdB, 12
+.set sgprSrdD, 16
+.set sgprSrdC, 20
+.set sgprTensor2dSizeC, 24
+.set sgprTensor2dSizeA, 26
+.set sgprTensor2dSizeB, 28
+.set sgprSaveExecMask, 30
+.set sgprAddressD, 32
+.set sgprAddressC, 34
+.set sgprStridesD, 36
+.set sgprStridesC, 38
+.set sgprAlpha, 40
+.set sgprBeta, 41
+.set sgprSizesFree, 42
+.set sgprSizesSum, 45
+.set sgprLoopCounters, 46
+.set sgprOrigLoopCounter, 47
+.set sgprStridesA, 48
+.set sgprStridesB, 50
+.set sgprAddressA, 52
+.set sgprAddressB, 54
+.set sgprShadowLimitA, 56
+.set sgprShadowLimitB, 58
+.set sgprOrigStaggerUIter, 60
+.set sgprStaggerUIter, 61
+.set sgprWrapUA, 62
+.set sgprWrapUB, 64
+.set sgprNumFullBlocks, 66
+.set sgprWgmRemainder1, 67
+.set sgprMagicNumberWgmRemainder1, 68
+.set sgprGlobalReadIncsA, 69
+.set sgprGlobalReadIncsB, 70
+.set sgprScalarGlobalReadOffsetA, 71
+.set sgprScalarGlobalReadOffsetB, 72
+/* max SGPR=98 */
+
+/* Size Assignments */
+.set sgprSizeD0I, sgprSizesFree+0
+.set sgprSizeD1J, sgprSizesFree+1
+.set sgprSizeDK, sgprSizesFree+2
+.set sgprSizeC0I, sgprSizesFree+0
+.set sgprSizeC1J, sgprSizesFree+1
+.set sgprSizeCK, sgprSizesFree+2
+.set sgprSizeAL, sgprSizesSum+0
+.set sgprSizeA0I, sgprSizesFree+0
+.set sgprSizeAK, sgprSizesFree+2
+.set sgprSizeBL, sgprSizesSum+0
+.set sgprSizeB1J, sgprSizesFree+1
+.set sgprSizeBK, sgprSizesFree+2
+
+/* Stride Assignments */
+.set constStrideD0I, 1
+.set sgprStrideD1J, sgprStridesD+0
+.set sgprStrideDK, sgprStridesD+1
+.set constStrideC0I, 1
+.set sgprStrideC1J, sgprStridesC+0
+.set sgprStrideCK, sgprStridesC+1
+.set constStrideAL, 1
+.set sgprStrideA0I, sgprStridesA+0
+.set sgprStrideAK, sgprStridesA+1
+.set constStrideBL, 1
+.set sgprStrideB1J, sgprStridesB+0
+.set sgprStrideBK, sgprStridesB+1
+
+.set DepthU, 32
+/* Number of elements to shift-left SRD */
+.set SrdShiftLeftA, 4
+.set SrdShiftLeftB, 4
+/* 2GB limit - set offsets to -1 to exceed this and clamp */
+.set BufferLimit, 0x80000000
+/* Bits 127:96 of SRD.  Set DataFormat = 32 bit */
+.set Srd127_96, 0x0020000
+.set BufferOOB, 0x80000000
+
+/* Global Offset A */
+.macro GLOBAL_OFFSET_A vgprAddr vgprOffsetL vgprOffset0I vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStrideA0I], v[\vgprOffset0I] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprOffsetL], v[\vgprTmp+0] // accumulate d1 lower
+_v_add_u32 v[\vgprAddr+0], 0x4, v[\vgprAddr+0]     // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/* Global Offset B */
+.macro GLOBAL_OFFSET_B vgprAddr vgprOffsetL vgprOffset1J vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStrideB1J], v[\vgprOffset1J] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprOffsetL], v[\vgprTmp+0] // accumulate d1 lower
+_v_add_u32 v[\vgprAddr+0], 0x4, v[\vgprAddr+0]     // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/******************************************/
+/* Dynamic Scalar Divide: vQuotient=vDividend/vDivisor; vRemainder=vDividend%vDivisor; */
+/******************************************/
+.macro DYNAMIC_VECTOR_DIVIDE vQuotient vRemainder vDividend vDivisor vTmp0 vTmp1 sTmp
+v_cvt_f32_u32 v[\vQuotient], v[\vDivisor]          //
+v_rcp_f32 v[\vQuotient], v[\vQuotient]             //
+v_mul_f32 v[\vQuotient], 0x4f800000, v[\vQuotient] //
+v_cvt_u32_f32 v[\vQuotient], v[\vQuotient]         //
+v_mul_lo_u32 v[\vRemainder], v[\vDivisor], v[\vQuotient] //
+v_mul_hi_u32 v[\vTmp0], v[\vDivisor], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp1], vcc, 0x0, v[\vRemainder]  //
+v_cmp_ne_i32 s[\sTmp:\sTmp+1], 0x0, v[\vTmp0]      //
+v_cndmask_b32 v[\vRemainder], v[\vTmp1], v[\vRemainder], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vRemainder], v[\vRemainder], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vQuotient], v[\vRemainder] //
+_v_add_co_u32 v[\vQuotient], vcc, v[\vQuotient], v[\vRemainder] //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vTmp0], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vQuotient], v[\vQuotient], v[\vDividend] //
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vDividend], v[\vRemainder] //
+v_cmp_ge_u32 s[\sTmp:\sTmp+1], v[\vDividend], v[\vRemainder] //
+_v_add_co_u32 v[\vRemainder], vcc, 0x1, v[\vQuotient] //
+_v_add_co_u32 v[\vTmp1], vcc, -1, v[\vQuotient]    //
+v_cmp_le_u32 vcc, v[\vDivisor], v[\vTmp0]          //
+s_and_b64 vcc, s[\sTmp:\sTmp+1], vcc               //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vRemainder], vcc //
+v_cndmask_b32 v[\vQuotient], v[\vTmp1], v[\vQuotient], s[\sTmp:\sTmp+1] //
+v_cmp_ne_i32 vcc, 0x0, v[\vDivisor]                //
+v_cndmask_b32 v[\vQuotient], -1, v[\vQuotient], vcc // final result
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vRemainder], vcc, v[\vDividend], v[\vRemainder] // final result
+.endm
+
+/******************************************/
+/* 4x8 thread-tile                        */
+/******************************************/
+.macro MAC_4x8_X0
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[0] iui=0
+s_setprio 1 // Raise priority while processing macs
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[1]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[4]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[5]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[2] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[3]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[6]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[7]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[8] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[9]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[12]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[13]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[10] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[11]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[14]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[15]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[16] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[17]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[20]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[21]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[18] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[19]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[22]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[23]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[24] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[25]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[28]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[29]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[26] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[27]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[30]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[31]
+s_setprio 0 // Reset priority after macs
+.endm
+.macro MAC_4x8_X1
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[0] iui=0
+s_setprio 1 // Raise priority while processing macs
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[1]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[4]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[5]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[2] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[3]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[6]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[7]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[8] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[9]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[12]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[13]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[10] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[11]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[14]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[15]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[16] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[17]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[20]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[21]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[18] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[19]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[22]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[23]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[24] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[25]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[28]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[29]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[26] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[27]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[30]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[31]
+s_setprio 0 // Reset priority after macs
+.endm
+
+
+
+
+/***** program start from here *****/
+
+.long 0xC00A0D00, 0x00000028
+.long 0xC00A0C00, 0x00000050
+.long 0xC00A0600, 0x00000008
+.long 0xC0020B40, 0x0000006C
+.long 0xBEFC00FF, 0x00006600
+.long 0x7EC80300
+.long 0x26CA00BF
+.long 0x2004C886
+.long 0xB8D0F804
+.long 0xD1130004, 0x0000A0B0
+.long 0x20CC0884
+.long 0x7EA40566
+.long 0xD1130067, 0x0000A08F
+.long 0x7EA20567
+.long 0xC0020140, 0x00000074
+.long 0xBF068151
+.long 0xBF8400B3
+.long 0xBF8CC07F
+.long 0x86580387
+.long 0x92580558
+.long 0x81580258
+.long 0x8F598358
+.long 0xBE820059
+.long 0x86595887
+.long 0x8F5A8303
+.long 0x8E5A835A
+.long 0x81595A59
+.long 0xBE830059
+.long 0xBE880034
+.long 0xBE890035
+.long 0xBE8B00FF, 0x00020000
+.long 0xBE8A00FF, 0x80000000
+.long 0x9254C030
+.long 0x92545402
+.long 0x92559052
+.long 0x92533055
+.long 0x81545354
+.long 0x2000CA82
+.long 0xD2850004, 0x00020030
+.long 0x2602CA83
+.long 0x24020283
+.long 0x32A40304
+.long 0x68A4A454
+.long 0x24A4A481
+.long 0xBECC00FF, 0x00000440
+.long 0x924C4C52
+.long 0xBE8C0036
+.long 0xBE8D0037
+.long 0xBE8F00FF, 0x00020000
+.long 0xBE8E00FF, 0x80000000
+.long 0x9254FF32, 0x00000080
+.long 0x92545403
+.long 0x9255A052
+.long 0x92533255
+.long 0x81545354
+.long 0x2004CA82
+.long 0xD2850004, 0x00020432
+.long 0x2606CA83
+.long 0x24060683
+.long 0x32AC0704
+.long 0x68ACAC54
+.long 0x24ACAC81
+.long 0x8E4A8532
+.long 0x68AEAC4A
+.long 0xBECE00FF, 0x00000880
+.long 0x924E4E52
+.long 0x814EFF4E, 0x00002200
+.long 0x814DFF4C, 0x00001100
+.long 0x2498CA84
+.long 0x6898984C
+.long 0x249ACA84
+.long 0x689A9A4D
+.long 0x814FFF4E, 0x00002200
+.long 0x249CCA84
+.long 0x689C9C4E
+.long 0x249ECA84
+.long 0x689E9E4F
+.long 0x2002CA83
+.long 0xD2850001, 0x00020288
+.long 0x68989901
+.long 0x689A9B01
+.long 0x689C9D01
+.long 0x689E9F01
+.long 0xD1340054, 0x00018152
+.long 0xD1340058, 0x00018156
+.long 0xD1340059, 0x00018157
+.long 0xBF8A0000
+.long 0xE05C1000, 0x80022052
+.long 0xE05C1000, 0x80033056
+.long 0xE05C1000, 0x80033457
+.long 0xE05C1000, 0x80022854
+.long 0xE05C1000, 0x80033858
+.long 0xE05C1000, 0x80033C59
+.long 0x68A4A4FF, 0x00000080
+.long 0x68ACACFF, 0x00000080
+.long 0x68AEAEFF, 0x00000080
+.long 0x8F2E852D
+.long 0x80AE2E80
+.long 0xBF06C22E
+.long 0xBF850034
+.long 0xBF8C0F75
+.long 0xD9BE0000, 0x0000204C
+.long 0xBF8C0F73
+.long 0xD9BE0000, 0x0000304E
+.long 0xD9BE0440, 0x0000344E
+.long 0xBF8CC27F
+.long 0xE05C1000, 0x80022052
+.long 0xBF8CC17F
+.long 0xE05C1000, 0x80033056
+.long 0xBF8CC07F
+.long 0xE05C1000, 0x80033457
+.long 0xBF8F0001
+.long 0x68A4A4FF, 0x00000080
+.long 0x68ACACFF, 0x00000080
+.long 0x68AEAEFF, 0x00000080
+.long 0x68A8A8FF, 0x00000080
+.long 0x68B0B0FF, 0x00000080
+.long 0x68B2B2FF, 0x00000080
+.long 0xBF8F0000
+.long 0xBF8C0F75
+.long 0xD9BE0000, 0x0000284D
+.long 0xBF8C0F73
+.long 0xD9BE0000, 0x0000384F
+.long 0xD9BE0440, 0x00003C4F
+.long 0xBF8CC27F
+.long 0xE05C1000, 0x80022854
+.long 0xBF8CC07F
+.long 0xBF8A0000
+.long 0xE05C1000, 0x80033858
+.long 0xE05C1000, 0x80033C59
+.long 0xBF8A0000
+.long 0x802E822E
+.long 0xBF00C22E
+.long 0xBF84FFCC
+.long 0xBF8C0F75
+.long 0xD9BE0000, 0x0000204C
+.long 0xBF8C0F73
+.long 0xD9BE0000, 0x0000304E
+.long 0xD9BE0440, 0x0000344E
+.long 0xBF8C0F72
+.long 0xD9BE0000, 0x0000284D
+.long 0xBF8C0F70
+.long 0xD9BE0000, 0x0000384F
+.long 0xD9BE0440, 0x00003C4F
+.long 0xBF8CC07F
+.long 0xBF8A0000
+.long 0xBF810000
+.long 0xD3D94000, 0x18000080
+.long 0xD3D94001, 0x18000080
+.long 0xD3D94002, 0x18000080
+.long 0xD3D94003, 0x18000080
+.long 0xD3D94004, 0x18000080
+.long 0xD3D94005, 0x18000080
+.long 0xD3D94006, 0x18000080
+.long 0xD3D94007, 0x18000080
+.long 0xD3D94008, 0x18000080
+.long 0xD3D94009, 0x18000080
+.long 0xD3D9400A, 0x18000080
+.long 0xD3D9400B, 0x18000080
+.long 0xD3D9400C, 0x18000080
+.long 0xD3D9400D, 0x18000080
+.long 0xD3D9400E, 0x18000080
+.long 0xD3D9400F, 0x18000080
+.long 0xD3D94010, 0x18000080
+.long 0xD3D94011, 0x18000080
+.long 0xD3D94012, 0x18000080
+.long 0xD3D94013, 0x18000080
+.long 0xD3D94014, 0x18000080
+.long 0xD3D94015, 0x18000080
+.long 0xD3D94016, 0x18000080
+.long 0xD3D94017, 0x18000080
+.long 0xD3D94018, 0x18000080
+.long 0xD3D94019, 0x18000080
+.long 0xD3D9401A, 0x18000080
+.long 0xD3D9401B, 0x18000080
+.long 0xD3D9401C, 0x18000080
+.long 0xD3D9401D, 0x18000080
+.long 0xD3D9401E, 0x18000080
+.long 0xD3D9401F, 0x18000080
+.long 0xC0060700, 0x00000000
+.long 0xC00A0A00, 0x00000038
+.long 0xC00A0900, 0x00000040
+.long 0xC00A0800, 0x00000018
+.long 0xD1130001, 0x00013F65
+.long 0xD2850060, 0x000202A0
+.long 0x20040281
+.long 0xD2850002, 0x00020488
+.long 0x2002CA85
+.long 0x24020282
+.long 0x68C0C101
+.long 0x24C0C081
+.long 0x68C0C102
+.long 0x68C0C080
+.long 0x68C2C0FF, 0x00001100
+.long 0xBF8A0000
+.long 0xD1130001, 0x00013F65
+.long 0xD2850062, 0x000202A0
+.long 0x20040281
+.long 0xD2850002, 0x00020488
+.long 0x2002CA85
+.long 0x24020282
+.long 0x68C4C501
+.long 0x24C4C481
+.long 0x68C4C502
+.long 0x9254FF52, 0x00000880
+.long 0x68C4C454
+.long 0x68C4C4FF, 0x00002200
+.long 0x68C6C4FF, 0x00002200
+.long 0xBF8CC07F
+.long 0x86580387
+.long 0x92580558
+.long 0x81580258
+.long 0x8F598358
+.long 0xBE820059
+.long 0x86595887
+.long 0x8F5A8303
+.long 0x8E5A835A
+.long 0x81595A59
+.long 0xBE830059
+.long 0xBE900022
+.long 0xBE910023
+.long 0xBE9200FF, 0x80000000
+.long 0xBE9300FF, 0x00020000
+.long 0xBE940020
+.long 0xBE950021
+.long 0xBE9600FF, 0x80000000
+.long 0xBE9700FF, 0x00020000
+.long 0x925603FF, 0x00000080
+.long 0x96552656
+.long 0x92542656
+.long 0x8ED48154
+.long 0x80105410
+.long 0x82115511
+.long 0x80145414
+.long 0x82155515
+.long 0x96552704
+.long 0x92542704
+.long 0x8ED48154
+.long 0x80105410
+.long 0x82115511
+.long 0x80145414
+.long 0x82155515
+.long 0x24C8CC86
+.long 0x68C8C965
+.long 0xD2850004, 0x0002CCA0
+.long 0xD2850003, 0x00004D04
+.long 0x2608C89F
+.long 0xD2850005, 0x00004D04
+.long 0x2608C8BF
+.long 0x200C0885
+.long 0x240C0C82
+.long 0x68D60B03
+.long 0x925402C0
+.long 0x32D40C54
+.long 0xD1FE0068, 0x0206D76A
+.long 0xBF8A0000
+.long 0xD8EC0000, 0x20000060
+.long 0xD8EC0000, 0x40000062
+.long 0xD8EC0000, 0x30000061
+.long 0xD8EC0000, 0x48000063
+.long 0xBF8CC27F
+.long 0xD3CC0000, 0x04028120
+.long 0xD8EC0010, 0x22000060
+.long 0xD8EC0010, 0x42000062
+.long 0xD8EC0010, 0x32000061
+.long 0xD8EC0010, 0x4A000063
+.long 0xBF8CC47F
+.long 0xD3CC0000, 0x04029130
+.long 0xD8EC0020, 0x24000060
+.long 0xD8EC0020, 0x44000062
+.long 0xD8EC0020, 0x34000061
+.long 0xD8EC0020, 0x4C000063
+.long 0xE0541000, 0x80041068
+.long 0xE0541010, 0x80041268
+.long 0xBF8CC67F
+.long 0xD3CC0000, 0x04028522
+.long 0xD8EC0030, 0x26000060
+.long 0xD8EC0030, 0x46000062
+.long 0xD8EC0030, 0x36000061
+.long 0xD8EC0030, 0x4E000063
+.long 0xE0541020, 0x80041468
+.long 0xE0541030, 0x80041668
+.long 0xBF8CC87F
+.long 0xD3CC0000, 0x04029532
+.long 0xD8EC0880, 0x28000060
+.long 0xD8EC0880, 0x38000061
+.long 0xD8EC0890, 0x2A000060
+.long 0xD8EC0890, 0x3A000061
+.long 0xBF8CCA7F
+.long 0xD3CC0000, 0x04028924
+.long 0xD8EC08A0, 0x2C000060
+.long 0xD8EC08A0, 0x3C000061
+.long 0xD8EC08B0, 0x2E000060
+.long 0xD8EC08B0, 0x3E000061
+.long 0xBF8CCC7F
+.long 0xD3CC0000, 0x04029934
+.long 0xBF8CCE7F
+.long 0xD3CC0000, 0x04028D26
+.long 0xBF8CC07F
+.long 0xBF8A0000
+.long 0x8F2E852D
+.long 0x80AE2E80
+.long 0xBF06C22E
+.long 0xBF850157
+.long 0xD3CC0000, 0x04029D36
+.long 0xBF80000C
+.long 0xD3CC0010, 0x04428128
+.long 0xBF80000C
+.long 0xD3CC0010, 0x04429138
+.long 0xBF80000C
+.long 0xD3CC0010, 0x0442852A
+.long 0xBF80000C
+.long 0xD3CC0010, 0x0442953A
+.long 0xBF80000C
+.long 0xD3CC0010, 0x0442892C
+.long 0xBF80000C
+.long 0xD3CC0010, 0x0442993C
+.long 0xBF80000C
+.long 0xD3CC0010, 0x04428D2E
+.long 0xBF8A0000
+.long 0xD8EC0000, 0x20000060
+.long 0xD8EC0000, 0x40000062
+.long 0xD8EC0000, 0x30000061
+.long 0xD8EC0000, 0x48000063
+.long 0xD3CC0010, 0x04429D3E
+.long 0xD8EC0010, 0x22000060
+.long 0xD8EC0010, 0x42000062
+.long 0xD8EC0010, 0x32000061
+.long 0xD8EC0010, 0x4A000063
+.long 0xBF8CC67F
+.long 0xD3CC0000, 0x04028120
+.long 0xD8EC0020, 0x24000060
+.long 0xD8EC0020, 0x44000062
+.long 0xD8EC0020, 0x34000061
+.long 0xD8EC0020, 0x4C000063
+.long 0xBF8CC87F
+.long 0xD3CC0000, 0x04029130
+.long 0xD8EC0030, 0x26000060
+.long 0xD8EC0030, 0x46000062
+.long 0xD8EC0030, 0x36000061
+.long 0xD8EC0030, 0x4E000063
+.long 0xBF8CCA7F
+.long 0xD3CC0000, 0x04028522
+.long 0xD8EC0880, 0x28000060
+.long 0xD8EC0880, 0x38000061
+.long 0xD8EC0890, 0x2A000060
+.long 0xD8EC0890, 0x3A000061
+.long 0xBF8CCC7F
+.long 0xD3CC0000, 0x04029532
+.long 0xD8EC08A0, 0x2C000060
+.long 0xD8EC08A0, 0x3C000061
+.long 0xD8EC08B0, 0x2E000060
+.long 0xD8EC08B0, 0x3E000061
+.long 0xBF8CCE7F
+.long 0xD3CC0000, 0x04028924
+.long 0xBF80000C
+.long 0xBF8CCC7F
+.long 0xD3CC0000, 0x04029934
+.long 0xBF8CC07F
+.long 0xBF8A0000
+.long 0xD3CC0000, 0x04028D26
+.long 0x802E822E
+.long 0xBF00C22E
+.long 0xBF84FF9C
+.long 0xE0541040, 0x80041868
+.long 0xE0541050, 0x80041A68
+.long 0xD3CC0000, 0x04029D36
+.long 0xE0541060, 0x80041C68
+.long 0xE0541070, 0x80041E68
+.long 0xD3CC0010, 0x04428128
+.long 0xD3D84000, 0x18000100
+.long 0xD3D84001, 0x18000101
+.long 0xD3D84002, 0x18000102
+.long 0xD3D84003, 0x18000103
+.long 0xD3D84004, 0x18000104
+.long 0xD3D84005, 0x18000105
+.long 0xD3D84006, 0x18000106
+.long 0xD3D84007, 0x18000107
+.long 0x7E001500
+.long 0x7E021501
+.long 0xD2000000, 0x04012101
+.long 0xD3904000, 0x18020028
+.long 0xD3CC0010, 0x04429138
+.long 0x7E041502
+.long 0x7E061503
+.long 0xD2000001, 0x04092103
+.long 0xD3904001, 0x18020228
+.long 0x7E081504
+.long 0x7E0A1505
+.long 0xD2000002, 0x04112105
+.long 0xD3904002, 0x18020428
+.long 0xBF8C0F77
+.long 0xD38E4000, 0x1C022029
+.long 0xD38E4001, 0x1C062229
+.long 0xE0741000, 0x80050068
+.long 0xD3CC0010, 0x0442852A
+.long 0x7E0C1506
+.long 0x7E0E1507
+.long 0xD2000003, 0x04192107
+.long 0xD3904003, 0x18020628
+.long 0xD3CC0010, 0x0442953A
+.long 0xBF8C0F77
+.long 0xD38E4002, 0x1C0A2429
+.long 0xD38E4003, 0x1C0E2629
+.long 0xE0741010, 0x80050268
+.long 0xD3CC0010, 0x0442892C
+.long 0xD3D84008, 0x18000108
+.long 0xD3D84009, 0x18000109
+.long 0xD3D8400A, 0x1800010A
+.long 0xD3D8400B, 0x1800010B
+.long 0x7E101508
+.long 0x7E121509
+.long 0xD2000004, 0x04212109
+.long 0xD3904004, 0x18020828
+.long 0x7E14150A
+.long 0x7E16150B
+.long 0xD2000005, 0x0429210B
+.long 0xD3904005, 0x18020A28
+.long 0xD3CC0010, 0x0442993C
+.long 0xBF8C0F77
+.long 0xD38E4004, 0x1C122829
+.long 0xD38E4005, 0x1C162A29
+.long 0xE0741020, 0x80050468
+.long 0xD3CC0010, 0x04428D2E
+.long 0xD3D8400C, 0x1800010C
+.long 0xD3D8400D, 0x1800010D
+.long 0xD3D8400E, 0x1800010E
+.long 0xD3D8400F, 0x1800010F
+.long 0x7E18150C
+.long 0x7E1A150D
+.long 0xD2000006, 0x0431210D
+.long 0xD3904006, 0x18020C28
+.long 0x7E1C150E
+.long 0x7E1E150F
+.long 0xD2000007, 0x0439210F
+.long 0xD3904007, 0x18020E28
+.long 0xD3CC0010, 0x04429D3E
+.long 0xBF800008
+.long 0xBF8C0F77
+.long 0xD38E4006, 0x1C1A2C29
+.long 0xD38E4007, 0x1C1E2E29
+.long 0xE0741030, 0x80050668
+.long 0xD3D84000, 0x18000110
+.long 0xD3D84001, 0x18000111
+.long 0xD3D84002, 0x18000112
+.long 0xD3D84003, 0x18000113
+.long 0xD3D84004, 0x18000114
+.long 0xD3D84005, 0x18000115
+.long 0xD3D84006, 0x18000116
+.long 0xD3D84007, 0x18000117
+.long 0x7E001500
+.long 0x7E021501
+.long 0xD2000000, 0x04012101
+.long 0xD3904000, 0x18020028
+.long 0x7E041502
+.long 0x7E061503
+.long 0xD2000001, 0x04092103
+.long 0xD3904001, 0x18020228
+.long 0x7E081504
+.long 0x7E0A1505
+.long 0xD2000002, 0x04112105
+.long 0xD3904002, 0x18020428
+.long 0xBF8C0F77
+.long 0xD38E4000, 0x1C023029
+.long 0xD38E4001, 0x1C063229
+.long 0xE0741040, 0x80050068
+.long 0x7E0C1506
+.long 0x7E0E1507
+.long 0xD2000003, 0x04192107
+.long 0xD3904003, 0x18020628
+.long 0xD3D84008, 0x18000118
+.long 0xD3D84009, 0x18000119
+.long 0xD3D8400A, 0x1800011A
+.long 0xD3D8400B, 0x1800011B
+.long 0xBF8C0F77
+.long 0xD38E4002, 0x1C0A3429
+.long 0xD38E4003, 0x1C0E3629
+.long 0xE0741050, 0x80050268
+.long 0x7E101508
+.long 0x7E121509
+.long 0xD2000004, 0x04212109
+.long 0xD3904004, 0x18020828
+.long 0x7E14150A
+.long 0x7E16150B
+.long 0xD2000005, 0x0429210B
+.long 0xD3904005, 0x18020A28
+.long 0xD3D8400C, 0x1800011C
+.long 0xD3D8400D, 0x1800011D
+.long 0xD3D8400E, 0x1800011E
+.long 0xD3D8400F, 0x1800011F
+.long 0xBF8C0F77
+.long 0xD38E4004, 0x1C123829
+.long 0xD38E4005, 0x1C163A29
+.long 0xE0741060, 0x80050468
+.long 0x7E18150C
+.long 0x7E1A150D
+.long 0xD2000006, 0x0431210D
+.long 0xD3904006, 0x18020C28
+.long 0x7E1C150E
+.long 0x7E1E150F
+.long 0xD2000007, 0x0439210F
+.long 0xD3904007, 0x18020E28
+.long 0xBF8C0F77
+.long 0xD38E4006, 0x1C1A3C29
+.long 0xD38E4007, 0x1C1E3E29
+.long 0xE0741070, 0x80050668
+.long 0xBF8C0000
+.long 0xBF810000

--- a/Tensile/ReplacementKernels/Cijk_Alik_Bljk_HBH_MT128x256x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW8_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT8_8_USFGRO1_VAW2_VW8_WG16_32_1_WGM8.s.txt
+++ b/Tensile/ReplacementKernels/Cijk_Alik_Bljk_HBH_MT128x256x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW8_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT8_8_USFGRO1_VAW2_VW8_WG16_32_1_WGM8.s.txt
@@ -1,0 +1,1715 @@
+
+
+/******************************************/
+/* Function Prefix                        */
+/******************************************/
+
+
+
+/******************************************/
+/* Begin Kernel                           */
+/******************************************/
+
+.hsa_code_object_version 2,0
+.hsa_code_object_isa 9, 0, 8, "AMD", "AMDGPU" 
+.text
+.protected Cijk_Alik_Bljk_HBH_MT128x256x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW8_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT8_8_USFGRO1_VAW2_VW8_WG16_32_1_WGM8
+.globl Cijk_Alik_Bljk_HBH_MT128x256x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW8_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT8_8_USFGRO1_VAW2_VW8_WG16_32_1_WGM8
+.p2align 8
+.type Cijk_Alik_Bljk_HBH_MT128x256x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW8_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT8_8_USFGRO1_VAW2_VW8_WG16_32_1_WGM8,@function
+.amdgpu_hsa_kernel Cijk_Alik_Bljk_HBH_MT128x256x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW8_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT8_8_USFGRO1_VAW2_VW8_WG16_32_1_WGM8
+Cijk_Alik_Bljk_HBH_MT128x256x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW8_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT8_8_USFGRO1_VAW2_VW8_WG16_32_1_WGM8:
+.amd_kernel_code_t
+  is_ptr64 = 1
+  enable_sgpr_kernarg_segment_ptr = 1
+  kernarg_segment_byte_size = 148 // bytes of kern args
+  workitem_vgpr_count = 128 // vgprs
+  wavefront_sgpr_count = 98 // sgprs
+  compute_pgm_rsrc1_vgprs = 31 // floor((128-1)/4)
+  compute_pgm_rsrc1_sgprs = 13 // floor((98-1)/8)
+  compute_pgm_rsrc2_tidig_comp_cnt = 0 // 1D wg
+  compute_pgm_rsrc2_tgid_x_en = 1 // wg.x
+  compute_pgm_rsrc2_tgid_y_en = 1 // wg.y
+  compute_pgm_rsrc2_tgid_z_en = 1 // wg.z
+  workgroup_group_segment_byte_size = 57344 // lds bytes
+  compute_pgm_rsrc2_user_sgpr = 2 // vcc
+  kernarg_segment_alignment = 4
+  group_segment_alignment = 4
+  private_segment_alignment = 4
+.end_amd_kernel_code_t
+
+/******************************************/
+/* Optimizations and Config:              */
+/******************************************/
+/* ThreadTile= 8 x 8 */
+/* SubGroup= 16 x 32 */
+/* VectorWidth=8 */
+/* GlobalLoadVectorWidthA=8, GlobalLoadVectorWidthB=8 */
+/* DirectToLdsA=False */
+/* DirectToLdsB=False */
+/* UseSgprForGRO=1 */
+.amd_amdgpu_hsa_metadata
+Version: [ 1, 0 ]
+Kernels:
+  - Name: Cijk_Alik_Bljk_HBH_MT128x256x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW8_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT8_8_USFGRO1_VAW2_VW8_WG16_32_1_WGM8
+    SymbolName: 'Cijk_Alik_Bljk_HBH_MT128x256x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW8_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT8_8_USFGRO1_VAW2_VW8_WG16_32_1_WGM8@kd'
+    Language: OpenCL C
+    LanguageVersion: [ 2, 0 ]
+    Args:
+      - Name:            sizeC
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            sizeA
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            sizeB
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            D
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       Struct
+        AddrSpaceQual:   Generic
+      - Name:            C
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       Struct
+        AddrSpaceQual:   Generic
+      - Name:            A
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       Struct
+        AddrSpaceQual:   Generic
+      - Name:            B
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       Struct
+        AddrSpaceQual:   Generic
+      - Name:            alpha
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       F16
+      - Name:            beta
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       F16
+      - Name:            strideD0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideD1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideC0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideC1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideA0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideA1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideB0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideB1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree2
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesSum0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            OrigStaggerUIter
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       I32
+      - Name:            NumWorkGroups0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            NumWorkGroups1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            MagicNumberProblemNumGroupTiles0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            GridNumWorkGroups0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            NumFullBlocks
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            WgmRemainder1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            MagicNumberWgmRemainder1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            padding
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+    CodeProps:
+      KernargSegmentSize: 148
+      GroupSegmentFixedSize: 57344
+      PrivateSegmentFixedSize: 0
+      KernargSegmentAlign:  8
+      WavefrontSize:        64
+      NumSGPRs:             98
+      NumVGPRs:             128
+      MaxFlatWorkGroupSize: 512
+.end_amd_amdgpu_hsa_metadata
+
+/******************************************/
+/* Asm syntax workarounds                 */
+/******************************************/
+.macro _v_add_co_u32 dst, cc, src0, src1, dpp=
+   v_add_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+
+.macro _v_add_u32 dst, src0, src1, dpp=
+   v_add_u32 \dst, \src0, \src1 \dpp
+.endm
+
+.macro _v_sub_co_u32 dst, cc, src0, src1, dpp=
+   v_sub_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+
+.macro _v_sub_u32 dst, src0, src1, dpp=
+   v_sub_u32 \dst, \src0, \src1 \dpp
+.endm
+
+.macro _v_addc_co_u32 dst, ccOut, src0, ccIn, src1, dpp=
+   v_addc_co_u32 \dst, \ccOut, \src0, \ccIn, \src1 \dpp
+.endm
+
+.macro _v_add_lshl_u32 dst, src0, src1, shiftCnt
+    v_add_lshl_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+.macro _v_lshl_add_u32 dst, src0, src1, shiftCnt
+    v_lshl_add_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+/******************************************/
+/* Magic div and mod functions            */
+/******************************************/
+.macro V_MAGIC_DIV dstIdx, dividend, magicNumber, magicShift
+    v_mul_hi_u32 v[\dstIdx+1], \dividend, \magicNumber
+    v_mul_lo_u32 v[\dstIdx+0], \dividend, \magicNumber
+    v_lshrrev_b64 v[\dstIdx:\dstIdx+1], \magicShift, v[\dstIdx:\dstIdx+1]
+.endm
+
+/******************************************/
+/* VGPR Assignments                       */
+/******************************************/
+.set vgprValuC, 0
+/* ValuA/B   Xn=PLR buffer idx,  In=InnerUnroll idx */
+.set vgprValuA_X0_I0, 32
+.set vgprValuA_X1_I0, 34
+.set vgprG2LA, 36
+.set vgprValuB_X0_I0, 40
+.set vgprValuB_X1_I0, 44
+.set vgprG2LB, 48
+.set vgprLocalWriteAddrA, 56
+.set vgprLocalWriteAddrB, 57
+.set vgprGlobalReadOffsetA, 58
+.set vgprGlobalReadOffsetB, 59
+.set vgprLocalReadAddrA, 60
+.set vgprLocalReadAddrB, 61
+.set vgprSerial, 62
+/* Num VGPR=63 */
+
+/******************************************/
+/* SGPR Assignments                       */
+/******************************************/
+.set sgprKernArgAddress, 0
+.set sgprWorkGroup0, 2
+.set sgprWorkGroup1, 3
+.set sgprWorkGroup2, 4
+.set sgprNumWorkGroups0, 5
+.set sgprNumWorkGroups1, 6
+.set sgprSrdA, 8
+.set sgprSrdB, 12
+.set sgprSrdD, 16
+.set sgprSrdC, 20
+.set sgprTensor2dSizeC, 24
+.set sgprTensor2dSizeA, 26
+.set sgprTensor2dSizeB, 28
+.set sgprSaveExecMask, 30
+.set sgprAddressD, 32
+.set sgprAddressC, 34
+.set sgprStridesD, 36
+.set sgprStridesC, 38
+.set sgprAlpha, 40
+.set sgprBeta, 41
+.set sgprSizesFree, 42
+.set sgprSizesSum, 45
+.set sgprLoopCounters, 46
+.set sgprOrigLoopCounter, 47
+.set sgprStridesA, 48
+.set sgprStridesB, 50
+.set sgprAddressA, 52
+.set sgprAddressB, 54
+.set sgprShadowLimitA, 56
+.set sgprShadowLimitB, 58
+.set sgprOrigStaggerUIter, 60
+.set sgprStaggerUIter, 61
+.set sgprWrapUA, 62
+.set sgprWrapUB, 64
+.set sgprNumFullBlocks, 66
+.set sgprWgmRemainder1, 67
+.set sgprMagicNumberWgmRemainder1, 68
+.set sgprGlobalReadIncsA, 69
+.set sgprGlobalReadIncsB, 70
+.set sgprScalarGlobalReadOffsetA, 71
+.set sgprScalarGlobalReadOffsetB, 72
+/* max SGPR=98 */
+
+/* Size Assignments */
+.set sgprSizeD0I, sgprSizesFree+0
+.set sgprSizeD1J, sgprSizesFree+1
+.set sgprSizeDK, sgprSizesFree+2
+.set sgprSizeC0I, sgprSizesFree+0
+.set sgprSizeC1J, sgprSizesFree+1
+.set sgprSizeCK, sgprSizesFree+2
+.set sgprSizeAL, sgprSizesSum+0
+.set sgprSizeA0I, sgprSizesFree+0
+.set sgprSizeAK, sgprSizesFree+2
+.set sgprSizeBL, sgprSizesSum+0
+.set sgprSizeB1J, sgprSizesFree+1
+.set sgprSizeBK, sgprSizesFree+2
+
+/* Stride Assignments */
+.set constStrideD0I, 1
+.set sgprStrideD1J, sgprStridesD+0
+.set sgprStrideDK, sgprStridesD+1
+.set constStrideC0I, 1
+.set sgprStrideC1J, sgprStridesC+0
+.set sgprStrideCK, sgprStridesC+1
+.set constStrideAL, 1
+.set sgprStrideA0I, sgprStridesA+0
+.set sgprStrideAK, sgprStridesA+1
+.set constStrideBL, 1
+.set sgprStrideB1J, sgprStridesB+0
+.set sgprStrideBK, sgprStridesB+1
+
+.set DepthU, 32
+/* Number of elements to shift-left SRD */
+.set SrdShiftLeftA, 4
+.set SrdShiftLeftB, 4
+/* 2GB limit - set offsets to -1 to exceed this and clamp */
+.set BufferLimit, 0x80000000
+/* Bits 127:96 of SRD.  Set DataFormat = 32 bit */
+.set Srd127_96, 0x0020000
+.set BufferOOB, 0x80000000
+
+/* Global Offset A */
+.macro GLOBAL_OFFSET_A vgprAddr vgprOffsetL vgprOffset0I vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStrideA0I], v[\vgprOffset0I] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprOffsetL], v[\vgprTmp+0] // accumulate d1 lower
+_v_add_u32 v[\vgprAddr+0], 0x4, v[\vgprAddr+0]     // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/* Global Offset B */
+.macro GLOBAL_OFFSET_B vgprAddr vgprOffsetL vgprOffset1J vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStrideB1J], v[\vgprOffset1J] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprOffsetL], v[\vgprTmp+0] // accumulate d1 lower
+_v_add_u32 v[\vgprAddr+0], 0x4, v[\vgprAddr+0]     // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/******************************************/
+/* Dynamic Scalar Divide: vQuotient=vDividend/vDivisor; vRemainder=vDividend%vDivisor; */
+/******************************************/
+.macro DYNAMIC_VECTOR_DIVIDE vQuotient vRemainder vDividend vDivisor vTmp0 vTmp1 sTmp
+v_cvt_f32_u32 v[\vQuotient], v[\vDivisor]          //
+v_rcp_f32 v[\vQuotient], v[\vQuotient]             //
+v_mul_f32 v[\vQuotient], 0x4f800000, v[\vQuotient] //
+v_cvt_u32_f32 v[\vQuotient], v[\vQuotient]         //
+v_mul_lo_u32 v[\vRemainder], v[\vDivisor], v[\vQuotient] //
+v_mul_hi_u32 v[\vTmp0], v[\vDivisor], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp1], vcc, 0x0, v[\vRemainder]  //
+v_cmp_ne_i32 s[\sTmp:\sTmp+1], 0x0, v[\vTmp0]      //
+v_cndmask_b32 v[\vRemainder], v[\vTmp1], v[\vRemainder], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vRemainder], v[\vRemainder], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vQuotient], v[\vRemainder] //
+_v_add_co_u32 v[\vQuotient], vcc, v[\vQuotient], v[\vRemainder] //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vTmp0], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vQuotient], v[\vQuotient], v[\vDividend] //
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vDividend], v[\vRemainder] //
+v_cmp_ge_u32 s[\sTmp:\sTmp+1], v[\vDividend], v[\vRemainder] //
+_v_add_co_u32 v[\vRemainder], vcc, 0x1, v[\vQuotient] //
+_v_add_co_u32 v[\vTmp1], vcc, -1, v[\vQuotient]    //
+v_cmp_le_u32 vcc, v[\vDivisor], v[\vTmp0]          //
+s_and_b64 vcc, s[\sTmp:\sTmp+1], vcc               //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vRemainder], vcc //
+v_cndmask_b32 v[\vQuotient], v[\vTmp1], v[\vQuotient], s[\sTmp:\sTmp+1] //
+v_cmp_ne_i32 vcc, 0x0, v[\vDivisor]                //
+v_cndmask_b32 v[\vQuotient], -1, v[\vQuotient], vcc // final result
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vRemainder], vcc, v[\vDividend], v[\vRemainder] // final result
+.endm
+
+/******************************************/
+/* 4x8 thread-tile                        */
+/******************************************/
+.macro MAC_4x8_X0
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[0] iui=0
+s_setprio 1 // Raise priority while processing macs
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[1]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[4]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[5]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[2] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[3]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[6]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[7]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[8] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[9]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[12]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[13]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[10] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[11]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[14]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[15]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[16] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[17]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[20]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[21]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[18] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[19]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[22]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[23]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[24] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[25]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[28]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[29]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[26] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[27]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[30]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[31]
+s_setprio 0 // Reset priority after macs
+.endm
+.macro MAC_4x8_X1
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[0] iui=0
+s_setprio 1 // Raise priority while processing macs
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[1]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[4]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[5]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[2] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[3]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[6]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[7]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[8] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[9]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[12]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[13]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[10] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[11]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[14]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[15]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[16] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[17]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[20]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[21]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[18] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[19]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[22]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[23]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[24] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[25]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[28]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[29]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[26] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[27]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[30]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[31]
+s_setprio 0 // Reset priority after macs
+.endm
+
+
+
+
+/***** program start from here *****/
+
+.long 0xC00A0D00, 0x00000028
+.long 0xC00A0C00, 0x00000050
+.long 0xC00A0600, 0x00000008
+.long 0xC0020B40, 0x0000006C
+.long 0xC0020140, 0x00000074
+.long 0xBEFC00FF, 0x0000FFFF
+.long 0x7ECA0300
+.long 0x26CC00BF
+.long 0x2004CA86
+.long 0xB8D0F804
+.long 0xD1130004, 0x0000A0B0
+.long 0x20CE0884
+.long 0x7EA40567
+.long 0xD1130068, 0x0000A08F
+.long 0x7EA20568
+.long 0xBF068151
+.long 0xBF8400EF
+.long 0xBF8CC07F
+.long 0xBE880034
+.long 0xBE890035
+.long 0xBE8B00FF, 0x00020000
+.long 0xBE8A00FF, 0x80000000
+.long 0x9254FF30, 0x00000080
+.long 0x92545402
+.long 0x9255A052
+.long 0x92533055
+.long 0x81545354
+.long 0x2000CC82
+.long 0xD2850004, 0x00020030
+.long 0x2602CC83
+.long 0x24020283
+.long 0x32AC0304
+.long 0x68ACAC54
+.long 0x24ACAC81
+.long 0x8E478530
+.long 0x68AEAC47
+.long 0xBECC00FF, 0x00000880
+.long 0x924C4C52
+.long 0xBE8C0036
+.long 0xBE8D0037
+.long 0xBE8F00FF, 0x00020000
+.long 0xBE8E00FF, 0x80000000
+.long 0x9254FF32, 0x00000100
+.long 0x92545403
+.long 0x9255C052
+.long 0x92533255
+.long 0x81545354
+.long 0x2004CC82
+.long 0xD2850004, 0x00020432
+.long 0x2606CC83
+.long 0x24060683
+.long 0x32B40704
+.long 0x68B4B454
+.long 0x24B4B481
+.long 0x8E4A8532
+.long 0x68B6B44A
+.long 0x68B8B64A
+.long 0x68BAB84A
+.long 0xBECE00FF, 0x00001100
+.long 0x924E4E52
+.long 0x814EFF4E, 0x00004400
+.long 0xBF8A0000
+.long 0x814DFF4C, 0x00002200
+.long 0x24A0CC84
+.long 0x68A0A04C
+.long 0x24A2CC84
+.long 0x68A2A24D
+.long 0x814FFF4E, 0x00004400
+.long 0x24A4CC84
+.long 0x68A4A44E
+.long 0x24A6CC84
+.long 0x68A6A64F
+.long 0x2002CC83
+.long 0xD2850001, 0x00020288
+.long 0x68A0A101
+.long 0x68A2A301
+.long 0x68A4A501
+.long 0x68A6A701
+.long 0xD1340058, 0x00018156
+.long 0xD1340059, 0x00018157
+.long 0xD134005E, 0x0001815A
+.long 0xD134005F, 0x0001815B
+.long 0xD1340060, 0x0001815C
+.long 0xD1340061, 0x0001815D
+.long 0xE05E1000, 0x80022056
+.long 0xE05E1000, 0x80022457
+.long 0xE05E1000, 0x8003305A
+.long 0xE05E1000, 0x8003345B
+.long 0xE05E1000, 0x8003385C
+.long 0xE05E1000, 0x80033C5D
+.long 0xE05E1000, 0x80022858
+.long 0xE05E1000, 0x80022C59
+.long 0xE05E1000, 0x8003405E
+.long 0xE05E1000, 0x8003445F
+.long 0xE05E1000, 0x80034860
+.long 0xE05E1000, 0x80034C61
+.long 0x68ACACFF, 0x00000080
+.long 0x68AEAEFF, 0x00000080
+.long 0x8F2E852D
+.long 0x80AE2E80
+.long 0xBF06802E
+.long 0xBF850059
+.long 0xBF8C0F7A
+.long 0xD9BE0000, 0x00002050
+.long 0xD9BE0440, 0x00002450
+.long 0xBF8CC07F
+.long 0xE05E1000, 0x80022056
+.long 0xE05E1000, 0x80022457
+.long 0xBF8C0F78
+.long 0xD9BE0000, 0x00003052
+.long 0xD9BE0440, 0x00003452
+.long 0xD9BE0880, 0x00003852
+.long 0xD9BE0CC0, 0x00003C52
+.long 0x68ACACFF, 0x00000080
+.long 0x68AEAEFF, 0x00000080
+.long 0x68B4B4FF, 0x00000080
+.long 0x68B6B6FF, 0x00000080
+.long 0x68B8B8FF, 0x00000080
+.long 0x68BABAFF, 0x00000080
+.long 0x68B0B0FF, 0x00000080
+.long 0x68B2B2FF, 0x00000080
+.long 0x68BCBCFF, 0x00000080
+.long 0x68BEBEFF, 0x00000080
+.long 0x68C0C0FF, 0x00000080
+.long 0x68C2C2FF, 0x00000080
+.long 0xBF8CC07F
+.long 0xE05E1000, 0x8003305A
+.long 0xE05E1000, 0x8003345B
+.long 0xE05E1000, 0x8003385C
+.long 0xE05E1000, 0x80033C5D
+.long 0xBF8C0F7A
+.long 0xD9BE0000, 0x00002851
+.long 0xD9BE0440, 0x00002C51
+.long 0xBF8CC07F
+.long 0xE05E1000, 0x80022858
+.long 0xE05E1000, 0x80022C59
+.long 0xBF8C0F78
+.long 0xD9BE0000, 0x00004053
+.long 0xD9BE0440, 0x00004453
+.long 0xD9BE0880, 0x00004853
+.long 0xD9BE0CC0, 0x00004C53
+.long 0xBF8CC07F
+.long 0xBF8A0000
+.long 0xBF800018
+.long 0xE05E1000, 0x8003405E
+.long 0xBF80000B
+.long 0xE05E1000, 0x8003445F
+.long 0xBF80000B
+.long 0xE05E1000, 0x80034860
+.long 0xBF80000B
+.long 0xE05E1000, 0x80034C61
+.long 0xBF8A0000
+.long 0x802E822E
+.long 0xBF00C22E
+.long 0xBF84FFA7
+.long 0xBF8C0F7A
+.long 0xD9BE0000, 0x00002050
+.long 0xD9BE0440, 0x00002450
+.long 0xBF8C0F76
+.long 0xD9BE0000, 0x00003052
+.long 0xD9BE0440, 0x00003452
+.long 0xD9BE0880, 0x00003852
+.long 0xD9BE0CC0, 0x00003C52
+.long 0xBF8C0F74
+.long 0xD9BE0000, 0x00002851
+.long 0xD9BE0440, 0x00002C51
+.long 0xBF8C0F70
+.long 0xD9BE0000, 0x00004053
+.long 0xD9BE0440, 0x00004453
+.long 0xD9BE0880, 0x00004853
+.long 0xD9BE0CC0, 0x00004C53
+.long 0xBF8CC07F
+.long 0xBF8A0000
+.long 0xBF810000
+.long 0xD3D94000, 0x18000080
+.long 0xD3D94001, 0x18000080
+.long 0xD3D94002, 0x18000080
+.long 0xD3D94003, 0x18000080
+.long 0xD3D94004, 0x18000080
+.long 0xD3D94005, 0x18000080
+.long 0xD3D94006, 0x18000080
+.long 0xD3D94007, 0x18000080
+.long 0xD3D94008, 0x18000080
+.long 0xD3D94009, 0x18000080
+.long 0xD3D9400A, 0x18000080
+.long 0xD3D9400B, 0x18000080
+.long 0xD3D9400C, 0x18000080
+.long 0xD3D9400D, 0x18000080
+.long 0xD3D9400E, 0x18000080
+.long 0xD3D9400F, 0x18000080
+.long 0xD3D94010, 0x18000080
+.long 0xD3D94011, 0x18000080
+.long 0xD3D94012, 0x18000080
+.long 0xD3D94013, 0x18000080
+.long 0xD3D94014, 0x18000080
+.long 0xD3D94015, 0x18000080
+.long 0xD3D94016, 0x18000080
+.long 0xD3D94017, 0x18000080
+.long 0xD3D94018, 0x18000080
+.long 0xD3D94019, 0x18000080
+.long 0xD3D9401A, 0x18000080
+.long 0xD3D9401B, 0x18000080
+.long 0xD3D9401C, 0x18000080
+.long 0xD3D9401D, 0x18000080
+.long 0xD3D9401E, 0x18000080
+.long 0xD3D9401F, 0x18000080
+.long 0xD3D94020, 0x18000080
+.long 0xD3D94021, 0x18000080
+.long 0xD3D94022, 0x18000080
+.long 0xD3D94023, 0x18000080
+.long 0xD3D94024, 0x18000080
+.long 0xD3D94025, 0x18000080
+.long 0xD3D94026, 0x18000080
+.long 0xD3D94027, 0x18000080
+.long 0xD3D94028, 0x18000080
+.long 0xD3D94029, 0x18000080
+.long 0xD3D9402A, 0x18000080
+.long 0xD3D9402B, 0x18000080
+.long 0xD3D9402C, 0x18000080
+.long 0xD3D9402D, 0x18000080
+.long 0xD3D9402E, 0x18000080
+.long 0xD3D9402F, 0x18000080
+.long 0xD3D94030, 0x18000080
+.long 0xD3D94031, 0x18000080
+.long 0xD3D94032, 0x18000080
+.long 0xD3D94033, 0x18000080
+.long 0xD3D94034, 0x18000080
+.long 0xD3D94035, 0x18000080
+.long 0xD3D94036, 0x18000080
+.long 0xD3D94037, 0x18000080
+.long 0xD3D94038, 0x18000080
+.long 0xD3D94039, 0x18000080
+.long 0xD3D9403A, 0x18000080
+.long 0xD3D9403B, 0x18000080
+.long 0xD3D9403C, 0x18000080
+.long 0xD3D9403D, 0x18000080
+.long 0xD3D9403E, 0x18000080
+.long 0xD3D9403F, 0x18000080
+.long 0xD3D94040, 0x18000080
+.long 0xD3D94041, 0x18000080
+.long 0xD3D94042, 0x18000080
+.long 0xD3D94043, 0x18000080
+.long 0xD3D94044, 0x18000080
+.long 0xD3D94045, 0x18000080
+.long 0xD3D94046, 0x18000080
+.long 0xD3D94047, 0x18000080
+.long 0xD3D94048, 0x18000080
+.long 0xD3D94049, 0x18000080
+.long 0xD3D9404A, 0x18000080
+.long 0xD3D9404B, 0x18000080
+.long 0xD3D9404C, 0x18000080
+.long 0xD3D9404D, 0x18000080
+.long 0xD3D9404E, 0x18000080
+.long 0xD3D9404F, 0x18000080
+.long 0xD3D94050, 0x18000080
+.long 0xD3D94051, 0x18000080
+.long 0xD3D94052, 0x18000080
+.long 0xD3D94053, 0x18000080
+.long 0xD3D94054, 0x18000080
+.long 0xD3D94055, 0x18000080
+.long 0xD3D94056, 0x18000080
+.long 0xD3D94057, 0x18000080
+.long 0xD3D94058, 0x18000080
+.long 0xD3D94059, 0x18000080
+.long 0xD3D9405A, 0x18000080
+.long 0xD3D9405B, 0x18000080
+.long 0xD3D9405C, 0x18000080
+.long 0xD3D9405D, 0x18000080
+.long 0xD3D9405E, 0x18000080
+.long 0xD3D9405F, 0x18000080
+.long 0xD3D94060, 0x18000080
+.long 0xD3D94061, 0x18000080
+.long 0xD3D94062, 0x18000080
+.long 0xD3D94063, 0x18000080
+.long 0xD3D94064, 0x18000080
+.long 0xD3D94065, 0x18000080
+.long 0xD3D94066, 0x18000080
+.long 0xD3D94067, 0x18000080
+.long 0xD3D94068, 0x18000080
+.long 0xD3D94069, 0x18000080
+.long 0xD3D9406A, 0x18000080
+.long 0xD3D9406B, 0x18000080
+.long 0xD3D9406C, 0x18000080
+.long 0xD3D9406D, 0x18000080
+.long 0xD3D9406E, 0x18000080
+.long 0xD3D9406F, 0x18000080
+.long 0xD3D94070, 0x18000080
+.long 0xD3D94071, 0x18000080
+.long 0xD3D94072, 0x18000080
+.long 0xD3D94073, 0x18000080
+.long 0xD3D94074, 0x18000080
+.long 0xD3D94075, 0x18000080
+.long 0xD3D94076, 0x18000080
+.long 0xD3D94077, 0x18000080
+.long 0xD3D94078, 0x18000080
+.long 0xD3D94079, 0x18000080
+.long 0xD3D9407A, 0x18000080
+.long 0xD3D9407B, 0x18000080
+.long 0xD3D9407C, 0x18000080
+.long 0xD3D9407D, 0x18000080
+.long 0xD3D9407E, 0x18000080
+.long 0xD3D9407F, 0x18000080
+.long 0xC0060700, 0x00000000
+.long 0xC00A0A00, 0x00000038
+.long 0xC00A0900, 0x00000040
+.long 0xC00A0800, 0x00000018
+.long 0xC00A0A00, 0x00000038
+.long 0xD1130001, 0x00013F66
+.long 0xD2850061, 0x000202A0
+.long 0x20040281
+.long 0xD2850002, 0x00020488
+.long 0x2002CC85
+.long 0x24020282
+.long 0x68C2C301
+.long 0x24C2C281
+.long 0x68C2C302
+.long 0x86548152
+.long 0x9254FF54, 0x00001100
+.long 0x68C2C254
+.long 0x68C2C280
+.long 0x68C4C2FF, 0x00002200
+.long 0xBF8A0000
+.long 0xD1130001, 0x00013F66
+.long 0xD2850063, 0x000202A0
+.long 0x20040281
+.long 0xD2850002, 0x00020488
+.long 0x2002CC85
+.long 0x24020282
+.long 0x68C6C701
+.long 0x24C6C681
+.long 0x68C6C702
+.long 0x86548252
+.long 0x8F548154
+.long 0x9254FF54, 0x00002200
+.long 0x68C6C654
+.long 0x68C6C6FF, 0x00004400
+.long 0x68C8C6FF, 0x00004400
+.long 0xBF8CC07F
+.long 0xBE900022
+.long 0xBE910023
+.long 0xBE9200FF, 0x80000000
+.long 0xBE9300FF, 0x00020000
+.long 0xBE940020
+.long 0xBE950021
+.long 0xBE9600FF, 0x80000000
+.long 0xBE9700FF, 0x00020000
+.long 0x925603FF, 0x00000100
+.long 0x96552656
+.long 0x92542656
+.long 0x8ED48154
+.long 0x80105410
+.long 0x82115511
+.long 0x80145414
+.long 0x82155515
+.long 0x96552704
+.long 0x92542704
+.long 0x8ED48154
+.long 0x80105410
+.long 0x82115511
+.long 0x80145414
+.long 0x82155515
+.long 0x24CACE86
+.long 0x68CACB66
+.long 0x2608CE82
+.long 0x20080881
+.long 0x24080887
+.long 0xD2850003, 0x00004D04
+.long 0x2608CE81
+.long 0xD2850004, 0x000208C0
+.long 0x68060903
+.long 0x2608CA9F
+.long 0xD2850005, 0x00004D04
+.long 0x68D40B03
+.long 0x2608CABF
+.long 0x200C0885
+.long 0x240C0C82
+.long 0x925402FF, 0x00000080
+.long 0x32D20C54
+.long 0xD1FE0060, 0x0206D569
+.long 0xBF8A0000
+.long 0xD8EC0000, 0x00000061
+.long 0xD8EC0000, 0x20000063
+.long 0xD8EC0010, 0x02000061
+.long 0xD8EC0010, 0x22000063
+.long 0xBF8CC27F
+.long 0xD3CC0000, 0x04024100
+.long 0xD8EC0020, 0x04000061
+.long 0xD8EC0020, 0x24000063
+.long 0xD8EC0030, 0x06000061
+.long 0xD8EC0030, 0x26000063
+.long 0xBF8CC47F
+.long 0xD3CC0000, 0x04024502
+.long 0xD8EC0000, 0x10000062
+.long 0xD8EC0000, 0x40000064
+.long 0xD8EC0010, 0x12000062
+.long 0xD8EC0010, 0x42000064
+.long 0xD3CC0000, 0x04024904
+.long 0xD8EC0020, 0x14000062
+.long 0xD8EC0020, 0x44000064
+.long 0xD8EC0030, 0x16000062
+.long 0xD8EC0030, 0x46000064
+.long 0xD3CC0000, 0x04024D06
+.long 0xD8EC0880, 0x08000061
+.long 0xD8EC0880, 0x28000063
+.long 0xD8EC0890, 0x0A000061
+.long 0xD8EC0890, 0x2A000063
+.long 0xD3CC0000, 0x04028110
+.long 0xD8EC08A0, 0x0C000061
+.long 0xD8EC08A0, 0x2C000063
+.long 0xD8EC08B0, 0x0E000061
+.long 0xD8EC08B0, 0x2E000063
+.long 0xD3CC0000, 0x04028512
+.long 0xD8EC0880, 0x18000062
+.long 0xD8EC0890, 0x1A000062
+.long 0xD8EC08A0, 0x1C000062
+.long 0xD8EC08B0, 0x1E000062
+.long 0xD3CC0000, 0x04028914
+.long 0xD8EC0880, 0x48000064
+.long 0xD8EC0890, 0x4A000064
+.long 0xD8EC08A0, 0x4C000064
+.long 0xD8EC08B0, 0x4E000064
+.long 0xD3CC0000, 0x04028D16
+.long 0xD8EC1100, 0x30000063
+.long 0xD8EC1110, 0x32000063
+.long 0xD8EC1120, 0x34000063
+.long 0xD8EC1130, 0x36000063
+.long 0xD3CC0010, 0x04424108
+.long 0xD8EC1980, 0x38000063
+.long 0xD8EC1990, 0x3A000063
+.long 0xD8EC19A0, 0x3C000063
+.long 0xD8EC19B0, 0x3E000063
+.long 0xD3CC0010, 0x0442450A
+.long 0xD8EC1100, 0x50000064
+.long 0xD8EC1110, 0x52000064
+.long 0xD8EC1120, 0x54000064
+.long 0xD8EC1130, 0x56000064
+.long 0xD3CC0010, 0x0442490C
+.long 0xD8EC1980, 0x58000064
+.long 0xD8EC1990, 0x5A000064
+.long 0xD8EC19A0, 0x5C000064
+.long 0xD8EC19B0, 0x5E000064
+.long 0x8F2E852D
+.long 0x80AE2E80
+.long 0xBF06802E
+.long 0xBF850119
+.long 0xD3CC0010, 0x04424D0E
+.long 0xBF8CC07F
+.long 0xBF8A0000
+.long 0xD3CC0010, 0x04428118
+.long 0xBF80000C
+.long 0xD3CC0010, 0x0442851A
+.long 0xBF80000C
+.long 0xD3CC0010, 0x0442891C
+.long 0xBF80000C
+.long 0xD3CC0010, 0x04428D1E
+.long 0xBF80000C
+.long 0xD3CC0020, 0x04825100
+.long 0xBF80000C
+.long 0xD3CC0020, 0x04825502
+.long 0xBF80000C
+.long 0xD3CC0020, 0x04825904
+.long 0xBF80000C
+.long 0xD3CC0020, 0x04825D06
+.long 0xBF80000C
+.long 0xD3CC0020, 0x04829110
+.long 0xBF80000C
+.long 0xD3CC0020, 0x04829512
+.long 0xBF80000C
+.long 0xD3CC0020, 0x04829914
+.long 0xBF80000C
+.long 0xD3CC0020, 0x04829D16
+.long 0xBF80000C
+.long 0xD3CC0030, 0x04C25108
+.long 0xBF80000C
+.long 0xD3CC0030, 0x04C2550A
+.long 0xBF80000C
+.long 0xD3CC0030, 0x04C2590C
+.long 0xBF80000C
+.long 0xD3CC0030, 0x04C25D0E
+.long 0xBF80000C
+.long 0xD3CC0030, 0x04C29118
+.long 0xBF80000C
+.long 0xD3CC0030, 0x04C2951A
+.long 0xBF80000C
+.long 0xD3CC0030, 0x04C2991C
+.long 0xBF80000C
+.long 0xD3CC0030, 0x04C29D1E
+.long 0xBF80000C
+.long 0xD3CC0040, 0x05026100
+.long 0xBF80000C
+.long 0xD3CC0040, 0x05026502
+.long 0xBF80000C
+.long 0xD3CC0040, 0x05026904
+.long 0xBF80000C
+.long 0xD3CC0040, 0x05026D06
+.long 0xBF80000C
+.long 0xD3CC0040, 0x0502A110
+.long 0xBF80000C
+.long 0xD3CC0040, 0x0502A512
+.long 0xBF80000C
+.long 0xD3CC0040, 0x0502A914
+.long 0xBF80000C
+.long 0xD3CC0040, 0x0502AD16
+.long 0xBF80000C
+.long 0xD3CC0050, 0x05426108
+.long 0xBF80000C
+.long 0xD3CC0050, 0x0542650A
+.long 0xBF80000C
+.long 0xD3CC0050, 0x0542690C
+.long 0xBF80000C
+.long 0xD3CC0050, 0x05426D0E
+.long 0xBF80000C
+.long 0xD3CC0050, 0x0542A118
+.long 0xBF80000C
+.long 0xD3CC0050, 0x0542A51A
+.long 0xBF80000C
+.long 0xD3CC0050, 0x0542A91C
+.long 0xBF80000C
+.long 0xD3CC0050, 0x0542AD1E
+.long 0xBF80000C
+.long 0xD3CC0060, 0x05827100
+.long 0xBF80000C
+.long 0xD3CC0060, 0x05827502
+.long 0xBF80000C
+.long 0xD3CC0060, 0x05827904
+.long 0xBF80000C
+.long 0xD3CC0060, 0x05827D06
+.long 0xBF80000C
+.long 0xD3CC0060, 0x0582B110
+.long 0xBF80000C
+.long 0xD3CC0060, 0x0582B512
+.long 0xBF80000C
+.long 0xD3CC0060, 0x0582B914
+.long 0xBF80000C
+.long 0xD3CC0060, 0x0582BD16
+.long 0xBF80000C
+.long 0xD3CC0070, 0x05C27108
+.long 0xBF80000C
+.long 0xD3CC0070, 0x05C2750A
+.long 0xBF80000C
+.long 0xD3CC0070, 0x05C2790C
+.long 0xBF80000C
+.long 0xD3CC0070, 0x05C27D0E
+.long 0xBF80000C
+.long 0xD3CC0070, 0x05C2B118
+.long 0xBF80000C
+.long 0xD3CC0070, 0x05C2B51A
+.long 0xBF80000C
+.long 0xD3CC0070, 0x05C2B91C
+.long 0xBF8A0000
+.long 0xD8EC0000, 0x00000061
+.long 0xD8EC0000, 0x20000063
+.long 0xD8EC0010, 0x02000061
+.long 0xD8EC0010, 0x22000063
+.long 0xD3CC0070, 0x05C2BD1E
+.long 0xD8EC0020, 0x04000061
+.long 0xD8EC0020, 0x24000063
+.long 0xD8EC0030, 0x06000061
+.long 0xD8EC0030, 0x26000063
+.long 0xBF8CC67F
+.long 0xD3CC0000, 0x04024100
+.long 0xD8EC0000, 0x10000062
+.long 0xD8EC0000, 0x40000064
+.long 0xD8EC0010, 0x12000062
+.long 0xD8EC0010, 0x42000064
+.long 0xD3CC0000, 0x04024502
+.long 0xD8EC0020, 0x14000062
+.long 0xD8EC0020, 0x44000064
+.long 0xD8EC0030, 0x16000062
+.long 0xD8EC0030, 0x46000064
+.long 0xD3CC0000, 0x04024904
+.long 0xD8EC0880, 0x08000061
+.long 0xD8EC0880, 0x28000063
+.long 0xD8EC0890, 0x0A000061
+.long 0xD8EC0890, 0x2A000063
+.long 0xD3CC0000, 0x04024D06
+.long 0xD8EC08A0, 0x0C000061
+.long 0xD8EC08A0, 0x2C000063
+.long 0xD8EC08B0, 0x0E000061
+.long 0xD8EC08B0, 0x2E000063
+.long 0xD3CC0000, 0x04028110
+.long 0xD8EC0880, 0x18000062
+.long 0xD8EC0890, 0x1A000062
+.long 0xD8EC08A0, 0x1C000062
+.long 0xD8EC08B0, 0x1E000062
+.long 0xD3CC0000, 0x04028512
+.long 0xD8EC0880, 0x48000064
+.long 0xD8EC0890, 0x4A000064
+.long 0xD8EC08A0, 0x4C000064
+.long 0xD8EC08B0, 0x4E000064
+.long 0xD3CC0000, 0x04028914
+.long 0xD8EC1100, 0x30000063
+.long 0xD8EC1110, 0x32000063
+.long 0xD8EC1120, 0x34000063
+.long 0xD8EC1130, 0x36000063
+.long 0xD3CC0000, 0x04028D16
+.long 0xD8EC1980, 0x38000063
+.long 0xD8EC1990, 0x3A000063
+.long 0xD8EC19A0, 0x3C000063
+.long 0xD8EC19B0, 0x3E000063
+.long 0xD3CC0010, 0x04424108
+.long 0xD8EC1100, 0x50000064
+.long 0xD8EC1110, 0x52000064
+.long 0xD8EC1120, 0x54000064
+.long 0xD8EC1130, 0x56000064
+.long 0xD3CC0010, 0x0442450A
+.long 0xD8EC1980, 0x58000064
+.long 0xD8EC1990, 0x5A000064
+.long 0xD8EC19A0, 0x5C000064
+.long 0xD8EC19B0, 0x5E000064
+.long 0xD3CC0010, 0x0442490C
+.long 0x802E822E
+.long 0xBF00C22E
+.long 0xBF84FEE7
+.long 0x9254C026
+.long 0xD3CC0010, 0x04424D0E
+.long 0xE0541000, 0x80046160
+.long 0xE0541010, 0x80046360
+.long 0xE0541020, 0x80046560
+.long 0xE0541030, 0x80046760
+.long 0xD3D84069, 0x18000100
+.long 0xD3D8406A, 0x18000101
+.long 0xD3D8406B, 0x18000102
+.long 0xD3D8406C, 0x18000103
+.long 0xD3D8406D, 0x18000104
+.long 0xD3D8406E, 0x18000105
+.long 0xD3D8406F, 0x18000106
+.long 0xD3D84070, 0x18000107
+.long 0xD3CC0010, 0x04428118
+.long 0x7ED21569
+.long 0x7ED4156A
+.long 0xD2000069, 0x05A5216A
+.long 0xD3904069, 0x1802D228
+.long 0xD3CC0010, 0x0442851A
+.long 0x7ED6156B
+.long 0x7ED8156C
+.long 0xD200006A, 0x05AD216C
+.long 0xD390406A, 0x1802D428
+.long 0x7EDA156D
+.long 0x7EDC156E
+.long 0xD200006B, 0x05B5216E
+.long 0xD390406B, 0x1802D628
+.long 0xBF8C0F73
+.long 0xD38E4069, 0x1DA6C229
+.long 0xD38E406A, 0x1DAAC429
+.long 0xE0741000, 0x80056960
+.long 0xD3CC0010, 0x0442891C
+.long 0x7EDE156F
+.long 0x7EE01570
+.long 0xD200006C, 0x05BD2170
+.long 0xD390406C, 0x1802D828
+.long 0xD3D84071, 0x18000108
+.long 0xD3D84072, 0x18000109
+.long 0xD3D84073, 0x1800010A
+.long 0xD3D84074, 0x1800010B
+.long 0xD3CC0010, 0x04428D1E
+.long 0xBF8C0F73
+.long 0xD38E406B, 0x1DAEC629
+.long 0xD38E406C, 0x1DB2C829
+.long 0xE0741010, 0x80056B60
+.long 0x7EE21571
+.long 0x7EE41572
+.long 0xD200006D, 0x05C52172
+.long 0xD390406D, 0x1802DA28
+.long 0x7EE61573
+.long 0x7EE81574
+.long 0xD200006E, 0x05CD2174
+.long 0xD390406E, 0x1802DC28
+.long 0xD3D84075, 0x1800010C
+.long 0xD3D84076, 0x1800010D
+.long 0xD3D84077, 0x1800010E
+.long 0xD3D84078, 0x1800010F
+.long 0xD3CC0020, 0x04825100
+.long 0xBF8C0F73
+.long 0xD38E406D, 0x1DB6CA29
+.long 0xD38E406E, 0x1DBACC29
+.long 0xE0741020, 0x80056D60
+.long 0x7EEA1575
+.long 0x7EEC1576
+.long 0xD200006F, 0x05D52176
+.long 0xD390406F, 0x1802DE28
+.long 0x7EEE1577
+.long 0x7EF01578
+.long 0xD2000070, 0x05DD2178
+.long 0xD3904070, 0x1802E028
+.long 0xD3CC0020, 0x04825502
+.long 0xBF8C0F73
+.long 0xD38E406F, 0x1DBECE29
+.long 0xD38E4070, 0x1DC2D029
+.long 0xE0741030, 0x80056F60
+.long 0xE0541040, 0x80046160
+.long 0xE0541050, 0x80046360
+.long 0xE0541060, 0x80046560
+.long 0xE0541070, 0x80046760
+.long 0xD3D84069, 0x18000110
+.long 0xD3D8406A, 0x18000111
+.long 0xD3D8406B, 0x18000112
+.long 0xD3D8406C, 0x18000113
+.long 0xD3D8406D, 0x18000114
+.long 0xD3D8406E, 0x18000115
+.long 0xD3D8406F, 0x18000116
+.long 0xD3D84070, 0x18000117
+.long 0xD3CC0020, 0x04825904
+.long 0x7ED21569
+.long 0x7ED4156A
+.long 0xD2000069, 0x05A5216A
+.long 0xD3904069, 0x1802D228
+.long 0x7ED6156B
+.long 0x7ED8156C
+.long 0xD200006A, 0x05AD216C
+.long 0xD390406A, 0x1802D428
+.long 0x7EDA156D
+.long 0x7EDC156E
+.long 0xD200006B, 0x05B5216E
+.long 0xD390406B, 0x1802D628
+.long 0xD3CC0020, 0x04825D06
+.long 0xBF8C0F73
+.long 0xD38E4069, 0x1DA6C229
+.long 0xD38E406A, 0x1DAAC429
+.long 0xE0741040, 0x80056960
+.long 0x7EDE156F
+.long 0x7EE01570
+.long 0xD200006C, 0x05BD2170
+.long 0xD390406C, 0x1802D828
+.long 0xD3D84071, 0x18000118
+.long 0xD3D84072, 0x18000119
+.long 0xD3D84073, 0x1800011A
+.long 0xD3D84074, 0x1800011B
+.long 0xD3CC0020, 0x04829110
+.long 0xBF8C0F73
+.long 0xD38E406B, 0x1DAEC629
+.long 0xD38E406C, 0x1DB2C829
+.long 0xE0741050, 0x80056B60
+.long 0xD3CC0020, 0x04829512
+.long 0x7EE21571
+.long 0x7EE41572
+.long 0xD200006D, 0x05C52172
+.long 0xD390406D, 0x1802DA28
+.long 0x7EE61573
+.long 0x7EE81574
+.long 0xD200006E, 0x05CD2174
+.long 0xD390406E, 0x1802DC28
+.long 0xD3D84075, 0x1800011C
+.long 0xD3D84076, 0x1800011D
+.long 0xD3D84077, 0x1800011E
+.long 0xD3D84078, 0x1800011F
+.long 0xD3CC0020, 0x04829914
+.long 0xBF8C0F73
+.long 0xD38E406D, 0x1DB6CA29
+.long 0xD38E406E, 0x1DBACC29
+.long 0xE0741060, 0x80056D60
+.long 0xD3CC0020, 0x04829D16
+.long 0x7EEA1575
+.long 0x7EEC1576
+.long 0xD200006F, 0x05D52176
+.long 0xD390406F, 0x1802DE28
+.long 0x7EEE1577
+.long 0x7EF01578
+.long 0xD2000070, 0x05DD2178
+.long 0xD3904070, 0x1802E028
+.long 0xD3CC0030, 0x04C25108
+.long 0xBF8C0F73
+.long 0xD38E406F, 0x1DBECE29
+.long 0xD38E4070, 0x1DC2D029
+.long 0xE0741070, 0x80056F60
+.long 0xD3CC0030, 0x04C2550A
+.long 0xD1340060, 0x0000A960
+.long 0xE0541000, 0x80046160
+.long 0xE0541010, 0x80046360
+.long 0xE0541020, 0x80046560
+.long 0xE0541030, 0x80046760
+.long 0xD3D84069, 0x18000120
+.long 0xD3D8406A, 0x18000121
+.long 0xD3D8406B, 0x18000122
+.long 0xD3D8406C, 0x18000123
+.long 0xD3D8406D, 0x18000124
+.long 0xD3D8406E, 0x18000125
+.long 0xD3D8406F, 0x18000126
+.long 0xD3D84070, 0x18000127
+.long 0x7ED21569
+.long 0x7ED4156A
+.long 0xD2000069, 0x05A5216A
+.long 0xD3904069, 0x1802D228
+.long 0x7ED6156B
+.long 0x7ED8156C
+.long 0xD200006A, 0x05AD216C
+.long 0xD390406A, 0x1802D428
+.long 0x7EDA156D
+.long 0x7EDC156E
+.long 0xD200006B, 0x05B5216E
+.long 0xD390406B, 0x1802D628
+.long 0xD3CC0030, 0x04C2590C
+.long 0xBF8C0F73
+.long 0xD38E4069, 0x1DA6C229
+.long 0xD38E406A, 0x1DAAC429
+.long 0xE0741000, 0x80056960
+.long 0xD3CC0030, 0x04C25D0E
+.long 0x7EDE156F
+.long 0x7EE01570
+.long 0xD200006C, 0x05BD2170
+.long 0xD390406C, 0x1802D828
+.long 0xD3D84071, 0x18000128
+.long 0xD3D84072, 0x18000129
+.long 0xD3D84073, 0x1800012A
+.long 0xD3D84074, 0x1800012B
+.long 0xD3CC0030, 0x04C29118
+.long 0xBF8C0F73
+.long 0xD38E406B, 0x1DAEC629
+.long 0xD38E406C, 0x1DB2C829
+.long 0xE0741010, 0x80056B60
+.long 0xD3CC0030, 0x04C2951A
+.long 0x7EE21571
+.long 0x7EE41572
+.long 0xD200006D, 0x05C52172
+.long 0xD390406D, 0x1802DA28
+.long 0x7EE61573
+.long 0x7EE81574
+.long 0xD200006E, 0x05CD2174
+.long 0xD390406E, 0x1802DC28
+.long 0xD3D84075, 0x1800012C
+.long 0xD3D84076, 0x1800012D
+.long 0xD3D84077, 0x1800012E
+.long 0xD3D84078, 0x1800012F
+.long 0xD3CC0030, 0x04C2991C
+.long 0xBF8C0F73
+.long 0xD38E406D, 0x1DB6CA29
+.long 0xD38E406E, 0x1DBACC29
+.long 0xE0741020, 0x80056D60
+.long 0xD3CC0030, 0x04C29D1E
+.long 0x7EEA1575
+.long 0x7EEC1576
+.long 0xD200006F, 0x05D52176
+.long 0xD390406F, 0x1802DE28
+.long 0x7EEE1577
+.long 0x7EF01578
+.long 0xD2000070, 0x05DD2178
+.long 0xD3904070, 0x1802E028
+.long 0xD3CC0040, 0x05026100
+.long 0xBF8C0F73
+.long 0xD38E406F, 0x1DBECE29
+.long 0xD38E4070, 0x1DC2D029
+.long 0xE0741030, 0x80056F60
+.long 0xD3CC0040, 0x05026502
+.long 0xE0541040, 0x80046160
+.long 0xE0541050, 0x80046360
+.long 0xE0541060, 0x80046560
+.long 0xE0541070, 0x80046760
+.long 0xD3D84069, 0x18000130
+.long 0xD3D8406A, 0x18000131
+.long 0xD3D8406B, 0x18000132
+.long 0xD3D8406C, 0x18000133
+.long 0xD3D8406D, 0x18000134
+.long 0xD3D8406E, 0x18000135
+.long 0xD3D8406F, 0x18000136
+.long 0xD3D84070, 0x18000137
+.long 0x7ED21569
+.long 0x7ED4156A
+.long 0xD2000069, 0x05A5216A
+.long 0xD3904069, 0x1802D228
+.long 0x7ED6156B
+.long 0x7ED8156C
+.long 0xD200006A, 0x05AD216C
+.long 0xD390406A, 0x1802D428
+.long 0x7EDA156D
+.long 0x7EDC156E
+.long 0xD200006B, 0x05B5216E
+.long 0xD390406B, 0x1802D628
+.long 0xD3CC0040, 0x05026904
+.long 0xBF8C0F73
+.long 0xD38E4069, 0x1DA6C229
+.long 0xD38E406A, 0x1DAAC429
+.long 0xE0741040, 0x80056960
+.long 0xD3CC0040, 0x05026D06
+.long 0x7EDE156F
+.long 0x7EE01570
+.long 0xD200006C, 0x05BD2170
+.long 0xD390406C, 0x1802D828
+.long 0xD3D84071, 0x18000138
+.long 0xD3D84072, 0x18000139
+.long 0xD3D84073, 0x1800013A
+.long 0xD3D84074, 0x1800013B
+.long 0xD3CC0040, 0x0502A110
+.long 0xBF8C0F73
+.long 0xD38E406B, 0x1DAEC629
+.long 0xD38E406C, 0x1DB2C829
+.long 0xE0741050, 0x80056B60
+.long 0xD3CC0040, 0x0502A512
+.long 0x7EE21571
+.long 0x7EE41572
+.long 0xD200006D, 0x05C52172
+.long 0xD390406D, 0x1802DA28
+.long 0x7EE61573
+.long 0x7EE81574
+.long 0xD200006E, 0x05CD2174
+.long 0xD390406E, 0x1802DC28
+.long 0xD3D84075, 0x1800013C
+.long 0xD3D84076, 0x1800013D
+.long 0xD3D84077, 0x1800013E
+.long 0xD3D84078, 0x1800013F
+.long 0xD3CC0040, 0x0502A914
+.long 0xBF8C0F73
+.long 0xD38E406D, 0x1DB6CA29
+.long 0xD38E406E, 0x1DBACC29
+.long 0xE0741060, 0x80056D60
+.long 0xD3CC0040, 0x0502AD16
+.long 0x7EEA1575
+.long 0x7EEC1576
+.long 0xD200006F, 0x05D52176
+.long 0xD390406F, 0x1802DE28
+.long 0x7EEE1577
+.long 0x7EF01578
+.long 0xD2000070, 0x05DD2178
+.long 0xD3904070, 0x1802E028
+.long 0xD3CC0050, 0x05426108
+.long 0xBF8C0F73
+.long 0xD38E406F, 0x1DBECE29
+.long 0xD38E4070, 0x1DC2D029
+.long 0xE0741070, 0x80056F60
+.long 0xD3CC0050, 0x0542650A
+.long 0xD1340060, 0x0000A960
+.long 0xE0541000, 0x80046160
+.long 0xE0541010, 0x80046360
+.long 0xE0541020, 0x80046560
+.long 0xE0541030, 0x80046760
+.long 0xD3D84069, 0x18000140
+.long 0xD3D8406A, 0x18000141
+.long 0xD3D8406B, 0x18000142
+.long 0xD3D8406C, 0x18000143
+.long 0xD3D8406D, 0x18000144
+.long 0xD3D8406E, 0x18000145
+.long 0xD3D8406F, 0x18000146
+.long 0xD3D84070, 0x18000147
+.long 0x7ED21569
+.long 0x7ED4156A
+.long 0xD2000069, 0x05A5216A
+.long 0xD3904069, 0x1802D228
+.long 0x7ED6156B
+.long 0x7ED8156C
+.long 0xD200006A, 0x05AD216C
+.long 0xD390406A, 0x1802D428
+.long 0x7EDA156D
+.long 0x7EDC156E
+.long 0xD200006B, 0x05B5216E
+.long 0xD390406B, 0x1802D628
+.long 0xD3CC0050, 0x0542690C
+.long 0xBF8C0F73
+.long 0xD38E4069, 0x1DA6C229
+.long 0xD38E406A, 0x1DAAC429
+.long 0xE0741000, 0x80056960
+.long 0xD3CC0050, 0x05426D0E
+.long 0x7EDE156F
+.long 0x7EE01570
+.long 0xD200006C, 0x05BD2170
+.long 0xD390406C, 0x1802D828
+.long 0xD3D84071, 0x18000148
+.long 0xD3D84072, 0x18000149
+.long 0xD3D84073, 0x1800014A
+.long 0xD3D84074, 0x1800014B
+.long 0xD3CC0050, 0x0542A118
+.long 0xBF8C0F73
+.long 0xD38E406B, 0x1DAEC629
+.long 0xD38E406C, 0x1DB2C829
+.long 0xE0741010, 0x80056B60
+.long 0xD3CC0050, 0x0542A51A
+.long 0x7EE21571
+.long 0x7EE41572
+.long 0xD200006D, 0x05C52172
+.long 0xD390406D, 0x1802DA28
+.long 0x7EE61573
+.long 0x7EE81574
+.long 0xD200006E, 0x05CD2174
+.long 0xD390406E, 0x1802DC28
+.long 0xD3D84075, 0x1800014C
+.long 0xD3D84076, 0x1800014D
+.long 0xD3D84077, 0x1800014E
+.long 0xD3D84078, 0x1800014F
+.long 0xD3CC0050, 0x0542A91C
+.long 0xBF8C0F73
+.long 0xD38E406D, 0x1DB6CA29
+.long 0xD38E406E, 0x1DBACC29
+.long 0xE0741020, 0x80056D60
+.long 0xD3CC0050, 0x0542AD1E
+.long 0x7EEA1575
+.long 0x7EEC1576
+.long 0xD200006F, 0x05D52176
+.long 0xD390406F, 0x1802DE28
+.long 0x7EEE1577
+.long 0x7EF01578
+.long 0xD2000070, 0x05DD2178
+.long 0xD3904070, 0x1802E028
+.long 0xD3CC0060, 0x05827100
+.long 0xBF8C0F73
+.long 0xD38E406F, 0x1DBECE29
+.long 0xD38E4070, 0x1DC2D029
+.long 0xE0741030, 0x80056F60
+.long 0xD3CC0060, 0x05827502
+.long 0xE0541040, 0x80046160
+.long 0xE0541050, 0x80046360
+.long 0xE0541060, 0x80046560
+.long 0xE0541070, 0x80046760
+.long 0xD3D84069, 0x18000150
+.long 0xD3D8406A, 0x18000151
+.long 0xD3D8406B, 0x18000152
+.long 0xD3D8406C, 0x18000153
+.long 0xD3D8406D, 0x18000154
+.long 0xD3D8406E, 0x18000155
+.long 0xD3D8406F, 0x18000156
+.long 0xD3D84070, 0x18000157
+.long 0x7ED21569
+.long 0x7ED4156A
+.long 0xD2000069, 0x05A5216A
+.long 0xD3904069, 0x1802D228
+.long 0x7ED6156B
+.long 0x7ED8156C
+.long 0xD200006A, 0x05AD216C
+.long 0xD390406A, 0x1802D428
+.long 0x7EDA156D
+.long 0x7EDC156E
+.long 0xD200006B, 0x05B5216E
+.long 0xD390406B, 0x1802D628
+.long 0xD3CC0060, 0x05827904
+.long 0xBF8C0F73
+.long 0xD38E4069, 0x1DA6C229
+.long 0xD38E406A, 0x1DAAC429
+.long 0xE0741040, 0x80056960
+.long 0xD3CC0060, 0x05827D06
+.long 0x7EDE156F
+.long 0x7EE01570
+.long 0xD200006C, 0x05BD2170
+.long 0xD390406C, 0x1802D828
+.long 0xD3D84071, 0x18000158
+.long 0xD3D84072, 0x18000159
+.long 0xD3D84073, 0x1800015A
+.long 0xD3D84074, 0x1800015B
+.long 0xD3CC0060, 0x0582B110
+.long 0xBF8C0F73
+.long 0xD38E406B, 0x1DAEC629
+.long 0xD38E406C, 0x1DB2C829
+.long 0xE0741050, 0x80056B60
+.long 0xD3CC0060, 0x0582B512
+.long 0x7EE21571
+.long 0x7EE41572
+.long 0xD200006D, 0x05C52172
+.long 0xD390406D, 0x1802DA28
+.long 0x7EE61573
+.long 0x7EE81574
+.long 0xD200006E, 0x05CD2174
+.long 0xD390406E, 0x1802DC28
+.long 0xD3D84075, 0x1800015C
+.long 0xD3D84076, 0x1800015D
+.long 0xD3D84077, 0x1800015E
+.long 0xD3D84078, 0x1800015F
+.long 0xD3CC0060, 0x0582B914
+.long 0xBF8C0F73
+.long 0xD38E406D, 0x1DB6CA29
+.long 0xD38E406E, 0x1DBACC29
+.long 0xE0741060, 0x80056D60
+.long 0xD3CC0060, 0x0582BD16
+.long 0x7EEA1575
+.long 0x7EEC1576
+.long 0xD200006F, 0x05D52176
+.long 0xD390406F, 0x1802DE28
+.long 0x7EEE1577
+.long 0x7EF01578
+.long 0xD2000070, 0x05DD2178
+.long 0xD3904070, 0x1802E028
+.long 0xD3CC0070, 0x05C27108
+.long 0xBF8C0F73
+.long 0xD38E406F, 0x1DBECE29
+.long 0xD38E4070, 0x1DC2D029
+.long 0xE0741070, 0x80056F60
+.long 0xD3CC0070, 0x05C2750A
+.long 0xD1340060, 0x0000A960
+.long 0xE0541000, 0x80046160
+.long 0xE0541010, 0x80046360
+.long 0xE0541020, 0x80046560
+.long 0xE0541030, 0x80046760
+.long 0xD3D84069, 0x18000160
+.long 0xD3D8406A, 0x18000161
+.long 0xD3D8406B, 0x18000162
+.long 0xD3D8406C, 0x18000163
+.long 0xD3D8406D, 0x18000164
+.long 0xD3D8406E, 0x18000165
+.long 0xD3D8406F, 0x18000166
+.long 0xD3D84070, 0x18000167
+.long 0x7ED21569
+.long 0x7ED4156A
+.long 0xD2000069, 0x05A5216A
+.long 0xD3904069, 0x1802D228
+.long 0x7ED6156B
+.long 0x7ED8156C
+.long 0xD200006A, 0x05AD216C
+.long 0xD390406A, 0x1802D428
+.long 0x7EDA156D
+.long 0x7EDC156E
+.long 0xD200006B, 0x05B5216E
+.long 0xD390406B, 0x1802D628
+.long 0xD3CC0070, 0x05C2790C
+.long 0xBF8C0F73
+.long 0xD38E4069, 0x1DA6C229
+.long 0xD38E406A, 0x1DAAC429
+.long 0xE0741000, 0x80056960
+.long 0xD3CC0070, 0x05C27D0E
+.long 0x7EDE156F
+.long 0x7EE01570
+.long 0xD200006C, 0x05BD2170
+.long 0xD390406C, 0x1802D828
+.long 0xD3D84071, 0x18000168
+.long 0xD3D84072, 0x18000169
+.long 0xD3D84073, 0x1800016A
+.long 0xD3D84074, 0x1800016B
+.long 0xD3CC0070, 0x05C2B118
+.long 0xBF8C0F73
+.long 0xD38E406B, 0x1DAEC629
+.long 0xD38E406C, 0x1DB2C829
+.long 0xE0741010, 0x80056B60
+.long 0xD3CC0070, 0x05C2B51A
+.long 0x7EE21571
+.long 0x7EE41572
+.long 0xD200006D, 0x05C52172
+.long 0xD390406D, 0x1802DA28
+.long 0x7EE61573
+.long 0x7EE81574
+.long 0xD200006E, 0x05CD2174
+.long 0xD390406E, 0x1802DC28
+.long 0xD3D84075, 0x1800016C
+.long 0xD3D84076, 0x1800016D
+.long 0xD3D84077, 0x1800016E
+.long 0xD3D84078, 0x1800016F
+.long 0xD3CC0070, 0x05C2B91C
+.long 0xBF8C0F73
+.long 0xD38E406D, 0x1DB6CA29
+.long 0xD38E406E, 0x1DBACC29
+.long 0xE0741020, 0x80056D60
+.long 0xD3CC0070, 0x05C2BD1E
+.long 0xBF800007
+.long 0x7EEA1575
+.long 0x7EEC1576
+.long 0xD200006F, 0x05D52176
+.long 0xD390406F, 0x1802DE28
+.long 0x7EEE1577
+.long 0x7EF01578
+.long 0xD2000070, 0x05DD2178
+.long 0xD3904070, 0x1802E028
+.long 0xBF8C0F73
+.long 0xD38E406F, 0x1DBECE29
+.long 0xD38E4070, 0x1DC2D029
+.long 0xE0741030, 0x80056F60
+.long 0xE0541040, 0x80046160
+.long 0xE0541050, 0x80046360
+.long 0xE0541060, 0x80046560
+.long 0xE0541070, 0x80046760
+.long 0xD3D84069, 0x18000170
+.long 0xD3D8406A, 0x18000171
+.long 0xD3D8406B, 0x18000172
+.long 0xD3D8406C, 0x18000173
+.long 0xD3D8406D, 0x18000174
+.long 0xD3D8406E, 0x18000175
+.long 0xD3D8406F, 0x18000176
+.long 0xD3D84070, 0x18000177
+.long 0x7ED21569
+.long 0x7ED4156A
+.long 0xD2000069, 0x05A5216A
+.long 0xD3904069, 0x1802D228
+.long 0x7ED6156B
+.long 0x7ED8156C
+.long 0xD200006A, 0x05AD216C
+.long 0xD390406A, 0x1802D428
+.long 0x7EDA156D
+.long 0x7EDC156E
+.long 0xD200006B, 0x05B5216E
+.long 0xD390406B, 0x1802D628
+.long 0xBF8C0F73
+.long 0xD38E4069, 0x1DA6C229
+.long 0xD38E406A, 0x1DAAC429
+.long 0xE0741040, 0x80056960
+.long 0x7EDE156F
+.long 0x7EE01570
+.long 0xD200006C, 0x05BD2170
+.long 0xD390406C, 0x1802D828
+.long 0xD3D84071, 0x18000178
+.long 0xD3D84072, 0x18000179
+.long 0xD3D84073, 0x1800017A
+.long 0xD3D84074, 0x1800017B
+.long 0xBF8C0F73
+.long 0xD38E406B, 0x1DAEC629
+.long 0xD38E406C, 0x1DB2C829
+.long 0xE0741050, 0x80056B60
+.long 0x7EE21571
+.long 0x7EE41572
+.long 0xD200006D, 0x05C52172
+.long 0xD390406D, 0x1802DA28
+.long 0x7EE61573
+.long 0x7EE81574
+.long 0xD200006E, 0x05CD2174
+.long 0xD390406E, 0x1802DC28
+.long 0xD3D84075, 0x1800017C
+.long 0xD3D84076, 0x1800017D
+.long 0xD3D84077, 0x1800017E
+.long 0xD3D84078, 0x1800017F
+.long 0xBF8C0F73
+.long 0xD38E406D, 0x1DB6CA29
+.long 0xD38E406E, 0x1DBACC29
+.long 0xE0741060, 0x80056D60
+.long 0x7EEA1575
+.long 0x7EEC1576
+.long 0xD200006F, 0x05D52176
+.long 0xD390406F, 0x1802DE28
+.long 0x7EEE1577
+.long 0x7EF01578
+.long 0xD2000070, 0x05DD2178
+.long 0xD3904070, 0x1802E028
+.long 0xBF8C0F73
+.long 0xD38E406F, 0x1DBECE29
+.long 0xD38E4070, 0x1DC2D029
+.long 0xE0741070, 0x80056F60
+.long 0xBF8C0000
+.long 0xBF810000

--- a/Tensile/ReplacementKernels/Cijk_Alik_Bljk_HBH_MT128x256x32_SE_K1.s.txt
+++ b/Tensile/ReplacementKernels/Cijk_Alik_Bljk_HBH_MT128x256x32_SE_K1.s.txt
@@ -1,0 +1,1715 @@
+
+
+/******************************************/
+/* Function Prefix                        */
+/******************************************/
+
+
+
+/******************************************/
+/* Begin Kernel                           */
+/******************************************/
+
+.hsa_code_object_version 2,0
+.hsa_code_object_isa 9, 0, 8, "AMD", "AMDGPU" 
+.text
+.protected Cijk_Alik_Bljk_HBH_MT128x256x32_SE_K1
+.globl Cijk_Alik_Bljk_HBH_MT128x256x32_SE_K1
+.p2align 8
+.type Cijk_Alik_Bljk_HBH_MT128x256x32_SE_K1,@function
+.amdgpu_hsa_kernel Cijk_Alik_Bljk_HBH_MT128x256x32_SE_K1
+Cijk_Alik_Bljk_HBH_MT128x256x32_SE_K1:
+.amd_kernel_code_t
+  is_ptr64 = 1
+  enable_sgpr_kernarg_segment_ptr = 1
+  kernarg_segment_byte_size = 148 // bytes of kern args
+  workitem_vgpr_count = 128 // vgprs
+  wavefront_sgpr_count = 98 // sgprs
+  compute_pgm_rsrc1_vgprs = 31 // floor((128-1)/4)
+  compute_pgm_rsrc1_sgprs = 13 // floor((98-1)/8)
+  compute_pgm_rsrc2_tidig_comp_cnt = 0 // 1D wg
+  compute_pgm_rsrc2_tgid_x_en = 1 // wg.x
+  compute_pgm_rsrc2_tgid_y_en = 1 // wg.y
+  compute_pgm_rsrc2_tgid_z_en = 1 // wg.z
+  workgroup_group_segment_byte_size = 57344 // lds bytes
+  compute_pgm_rsrc2_user_sgpr = 2 // vcc
+  kernarg_segment_alignment = 4
+  group_segment_alignment = 4
+  private_segment_alignment = 4
+.end_amd_kernel_code_t
+
+/******************************************/
+/* Optimizations and Config:              */
+/******************************************/
+/* ThreadTile= 8 x 8 */
+/* SubGroup= 16 x 32 */
+/* VectorWidth=8 */
+/* GlobalLoadVectorWidthA=8, GlobalLoadVectorWidthB=8 */
+/* DirectToLdsA=False */
+/* DirectToLdsB=False */
+/* UseSgprForGRO=1 */
+.amd_amdgpu_hsa_metadata
+Version: [ 1, 0 ]
+Kernels:
+  - Name: Cijk_Alik_Bljk_HBH_MT128x256x32_SE_K1
+    SymbolName: 'Cijk_Alik_Bljk_HBH_MT128x256x32_SE_K1@kd'
+    Language: OpenCL C
+    LanguageVersion: [ 2, 0 ]
+    Args:
+      - Name:            sizeC
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            sizeA
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            sizeB
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            D
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       Struct
+        AddrSpaceQual:   Generic
+      - Name:            C
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       Struct
+        AddrSpaceQual:   Generic
+      - Name:            A
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       Struct
+        AddrSpaceQual:   Generic
+      - Name:            B
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       Struct
+        AddrSpaceQual:   Generic
+      - Name:            alpha
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       F16
+      - Name:            beta
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       F16
+      - Name:            strideD0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideD1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideC0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideC1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideA0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideA1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideB0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideB1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree2
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesSum0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            OrigStaggerUIter
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       I32
+      - Name:            NumWorkGroups0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            NumWorkGroups1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            MagicNumberProblemNumGroupTiles0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            GridNumWorkGroups0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            NumFullBlocks
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            WgmRemainder1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            MagicNumberWgmRemainder1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            padding
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+    CodeProps:
+      KernargSegmentSize: 148
+      GroupSegmentFixedSize: 57344
+      PrivateSegmentFixedSize: 0
+      KernargSegmentAlign:  8
+      WavefrontSize:        64
+      NumSGPRs:             98
+      NumVGPRs:             128
+      MaxFlatWorkGroupSize: 512
+.end_amd_amdgpu_hsa_metadata
+
+/******************************************/
+/* Asm syntax workarounds                 */
+/******************************************/
+.macro _v_add_co_u32 dst, cc, src0, src1, dpp=
+   v_add_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+
+.macro _v_add_u32 dst, src0, src1, dpp=
+   v_add_u32 \dst, \src0, \src1 \dpp
+.endm
+
+.macro _v_sub_co_u32 dst, cc, src0, src1, dpp=
+   v_sub_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+
+.macro _v_sub_u32 dst, src0, src1, dpp=
+   v_sub_u32 \dst, \src0, \src1 \dpp
+.endm
+
+.macro _v_addc_co_u32 dst, ccOut, src0, ccIn, src1, dpp=
+   v_addc_co_u32 \dst, \ccOut, \src0, \ccIn, \src1 \dpp
+.endm
+
+.macro _v_add_lshl_u32 dst, src0, src1, shiftCnt
+    v_add_lshl_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+.macro _v_lshl_add_u32 dst, src0, src1, shiftCnt
+    v_lshl_add_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+/******************************************/
+/* Magic div and mod functions            */
+/******************************************/
+.macro V_MAGIC_DIV dstIdx, dividend, magicNumber, magicShift
+    v_mul_hi_u32 v[\dstIdx+1], \dividend, \magicNumber
+    v_mul_lo_u32 v[\dstIdx+0], \dividend, \magicNumber
+    v_lshrrev_b64 v[\dstIdx:\dstIdx+1], \magicShift, v[\dstIdx:\dstIdx+1]
+.endm
+
+/******************************************/
+/* VGPR Assignments                       */
+/******************************************/
+.set vgprValuC, 0
+/* ValuA/B   Xn=PLR buffer idx,  In=InnerUnroll idx */
+.set vgprValuA_X0_I0, 32
+.set vgprValuA_X1_I0, 34
+.set vgprG2LA, 36
+.set vgprValuB_X0_I0, 40
+.set vgprValuB_X1_I0, 44
+.set vgprG2LB, 48
+.set vgprLocalWriteAddrA, 56
+.set vgprLocalWriteAddrB, 57
+.set vgprGlobalReadOffsetA, 58
+.set vgprGlobalReadOffsetB, 59
+.set vgprLocalReadAddrA, 60
+.set vgprLocalReadAddrB, 61
+.set vgprSerial, 62
+/* Num VGPR=63 */
+
+/******************************************/
+/* SGPR Assignments                       */
+/******************************************/
+.set sgprKernArgAddress, 0
+.set sgprWorkGroup0, 2
+.set sgprWorkGroup1, 3
+.set sgprWorkGroup2, 4
+.set sgprNumWorkGroups0, 5
+.set sgprNumWorkGroups1, 6
+.set sgprSrdA, 8
+.set sgprSrdB, 12
+.set sgprSrdD, 16
+.set sgprSrdC, 20
+.set sgprTensor2dSizeC, 24
+.set sgprTensor2dSizeA, 26
+.set sgprTensor2dSizeB, 28
+.set sgprSaveExecMask, 30
+.set sgprAddressD, 32
+.set sgprAddressC, 34
+.set sgprStridesD, 36
+.set sgprStridesC, 38
+.set sgprAlpha, 40
+.set sgprBeta, 41
+.set sgprSizesFree, 42
+.set sgprSizesSum, 45
+.set sgprLoopCounters, 46
+.set sgprOrigLoopCounter, 47
+.set sgprStridesA, 48
+.set sgprStridesB, 50
+.set sgprAddressA, 52
+.set sgprAddressB, 54
+.set sgprShadowLimitA, 56
+.set sgprShadowLimitB, 58
+.set sgprOrigStaggerUIter, 60
+.set sgprStaggerUIter, 61
+.set sgprWrapUA, 62
+.set sgprWrapUB, 64
+.set sgprNumFullBlocks, 66
+.set sgprWgmRemainder1, 67
+.set sgprMagicNumberWgmRemainder1, 68
+.set sgprGlobalReadIncsA, 69
+.set sgprGlobalReadIncsB, 70
+.set sgprScalarGlobalReadOffsetA, 71
+.set sgprScalarGlobalReadOffsetB, 72
+/* max SGPR=98 */
+
+/* Size Assignments */
+.set sgprSizeD0I, sgprSizesFree+0
+.set sgprSizeD1J, sgprSizesFree+1
+.set sgprSizeDK, sgprSizesFree+2
+.set sgprSizeC0I, sgprSizesFree+0
+.set sgprSizeC1J, sgprSizesFree+1
+.set sgprSizeCK, sgprSizesFree+2
+.set sgprSizeAL, sgprSizesSum+0
+.set sgprSizeA0I, sgprSizesFree+0
+.set sgprSizeAK, sgprSizesFree+2
+.set sgprSizeBL, sgprSizesSum+0
+.set sgprSizeB1J, sgprSizesFree+1
+.set sgprSizeBK, sgprSizesFree+2
+
+/* Stride Assignments */
+.set constStrideD0I, 1
+.set sgprStrideD1J, sgprStridesD+0
+.set sgprStrideDK, sgprStridesD+1
+.set constStrideC0I, 1
+.set sgprStrideC1J, sgprStridesC+0
+.set sgprStrideCK, sgprStridesC+1
+.set constStrideAL, 1
+.set sgprStrideA0I, sgprStridesA+0
+.set sgprStrideAK, sgprStridesA+1
+.set constStrideBL, 1
+.set sgprStrideB1J, sgprStridesB+0
+.set sgprStrideBK, sgprStridesB+1
+
+.set DepthU, 32
+/* Number of elements to shift-left SRD */
+.set SrdShiftLeftA, 4
+.set SrdShiftLeftB, 4
+/* 2GB limit - set offsets to -1 to exceed this and clamp */
+.set BufferLimit, 0x80000000
+/* Bits 127:96 of SRD.  Set DataFormat = 32 bit */
+.set Srd127_96, 0x0020000
+.set BufferOOB, 0x80000000
+
+/* Global Offset A */
+.macro GLOBAL_OFFSET_A vgprAddr vgprOffsetL vgprOffset0I vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStrideA0I], v[\vgprOffset0I] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprOffsetL], v[\vgprTmp+0] // accumulate d1 lower
+_v_add_u32 v[\vgprAddr+0], 0x4, v[\vgprAddr+0]     // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/* Global Offset B */
+.macro GLOBAL_OFFSET_B vgprAddr vgprOffsetL vgprOffset1J vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStrideB1J], v[\vgprOffset1J] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprOffsetL], v[\vgprTmp+0] // accumulate d1 lower
+_v_add_u32 v[\vgprAddr+0], 0x4, v[\vgprAddr+0]     // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/******************************************/
+/* Dynamic Scalar Divide: vQuotient=vDividend/vDivisor; vRemainder=vDividend%vDivisor; */
+/******************************************/
+.macro DYNAMIC_VECTOR_DIVIDE vQuotient vRemainder vDividend vDivisor vTmp0 vTmp1 sTmp
+v_cvt_f32_u32 v[\vQuotient], v[\vDivisor]          //
+v_rcp_f32 v[\vQuotient], v[\vQuotient]             //
+v_mul_f32 v[\vQuotient], 0x4f800000, v[\vQuotient] //
+v_cvt_u32_f32 v[\vQuotient], v[\vQuotient]         //
+v_mul_lo_u32 v[\vRemainder], v[\vDivisor], v[\vQuotient] //
+v_mul_hi_u32 v[\vTmp0], v[\vDivisor], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp1], vcc, 0x0, v[\vRemainder]  //
+v_cmp_ne_i32 s[\sTmp:\sTmp+1], 0x0, v[\vTmp0]      //
+v_cndmask_b32 v[\vRemainder], v[\vTmp1], v[\vRemainder], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vRemainder], v[\vRemainder], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vQuotient], v[\vRemainder] //
+_v_add_co_u32 v[\vQuotient], vcc, v[\vQuotient], v[\vRemainder] //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vTmp0], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vQuotient], v[\vQuotient], v[\vDividend] //
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vDividend], v[\vRemainder] //
+v_cmp_ge_u32 s[\sTmp:\sTmp+1], v[\vDividend], v[\vRemainder] //
+_v_add_co_u32 v[\vRemainder], vcc, 0x1, v[\vQuotient] //
+_v_add_co_u32 v[\vTmp1], vcc, -1, v[\vQuotient]    //
+v_cmp_le_u32 vcc, v[\vDivisor], v[\vTmp0]          //
+s_and_b64 vcc, s[\sTmp:\sTmp+1], vcc               //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vRemainder], vcc //
+v_cndmask_b32 v[\vQuotient], v[\vTmp1], v[\vQuotient], s[\sTmp:\sTmp+1] //
+v_cmp_ne_i32 vcc, 0x0, v[\vDivisor]                //
+v_cndmask_b32 v[\vQuotient], -1, v[\vQuotient], vcc // final result
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vRemainder], vcc, v[\vDividend], v[\vRemainder] // final result
+.endm
+
+/******************************************/
+/* 4x8 thread-tile                        */
+/******************************************/
+.macro MAC_4x8_X0
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[0] iui=0
+s_setprio 1 // Raise priority while processing macs
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[1]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[4]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[5]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[2] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[3]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[6]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[7]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[8] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[9]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[12]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[13]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[10] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[11]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[14]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[15]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[16] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[17]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[20]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[21]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[18] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[19]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[22]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[23]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[24] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[25]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[28]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[29]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[26] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[27]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[30]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[31]
+s_setprio 0 // Reset priority after macs
+.endm
+.macro MAC_4x8_X1
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[0] iui=0
+s_setprio 1 // Raise priority while processing macs
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[1]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[4]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[5]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[2] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[3]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[6]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[7]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[8] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[9]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[12]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[13]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[10] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[11]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[14]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[15]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[16] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[17]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[20]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[21]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[18] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[19]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[22]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[23]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[24] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[25]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[28]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[29]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[26] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[27]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[30]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[31]
+s_setprio 0 // Reset priority after macs
+.endm
+
+
+
+
+/***** program start from here *****/
+
+.long 0xC00A0D00, 0x00000028
+.long 0xC00A0C00, 0x00000050
+.long 0xC00A0600, 0x00000008
+.long 0xC0020B40, 0x0000006C
+.long 0xC0020140, 0x00000074
+.long 0xBEFC00FF, 0x0000FFFF
+.long 0x7ECA0300
+.long 0x26CC00BF
+.long 0x2004CA86
+.long 0xB8D0F804
+.long 0xD1130004, 0x0000A0B0
+.long 0x20CE0884
+.long 0x7EA40567
+.long 0xD1130068, 0x0000A08F
+.long 0x7EA20568
+.long 0xBF068151
+.long 0xBF8400EF
+.long 0xBF8CC07F
+.long 0xBE880034
+.long 0xBE890035
+.long 0xBE8B00FF, 0x00020000
+.long 0xBE8A00FF, 0x80000000
+.long 0x9254FF30, 0x00000080
+.long 0x92545402
+.long 0x9255A052
+.long 0x92533055
+.long 0x81545354
+.long 0x2000CC82
+.long 0xD2850004, 0x00020030
+.long 0x2602CC83
+.long 0x24020283
+.long 0x32AC0304
+.long 0x68ACAC54
+.long 0x24ACAC81
+.long 0x8E478530
+.long 0x68AEAC47
+.long 0xBECC00FF, 0x00000880
+.long 0x924C4C52
+.long 0xBE8C0036
+.long 0xBE8D0037
+.long 0xBE8F00FF, 0x00020000
+.long 0xBE8E00FF, 0x80000000
+.long 0x9254FF32, 0x00000100
+.long 0x92545403
+.long 0x9255C052
+.long 0x92533255
+.long 0x81545354
+.long 0x2004CC82
+.long 0xD2850004, 0x00020432
+.long 0x2606CC83
+.long 0x24060683
+.long 0x32B40704
+.long 0x68B4B454
+.long 0x24B4B481
+.long 0x8E4A8532
+.long 0x68B6B44A
+.long 0x68B8B64A
+.long 0x68BAB84A
+.long 0xBECE00FF, 0x00001100
+.long 0x924E4E52
+.long 0x814EFF4E, 0x00004400
+.long 0xBF8A0000
+.long 0x814DFF4C, 0x00002200
+.long 0x24A0CC84
+.long 0x68A0A04C
+.long 0x24A2CC84
+.long 0x68A2A24D
+.long 0x814FFF4E, 0x00004400
+.long 0x24A4CC84
+.long 0x68A4A44E
+.long 0x24A6CC84
+.long 0x68A6A64F
+.long 0x2002CC83
+.long 0xD2850001, 0x00020288
+.long 0x68A0A101
+.long 0x68A2A301
+.long 0x68A4A501
+.long 0x68A6A701
+.long 0xD1340058, 0x00018156
+.long 0xD1340059, 0x00018157
+.long 0xD134005E, 0x0001815A
+.long 0xD134005F, 0x0001815B
+.long 0xD1340060, 0x0001815C
+.long 0xD1340061, 0x0001815D
+.long 0xE05E1000, 0x80022056
+.long 0xE05E1000, 0x80022457
+.long 0xE05E1000, 0x8003305A
+.long 0xE05E1000, 0x8003345B
+.long 0xE05E1000, 0x8003385C
+.long 0xE05E1000, 0x80033C5D
+.long 0xE05E1000, 0x80022858
+.long 0xE05E1000, 0x80022C59
+.long 0xE05E1000, 0x8003405E
+.long 0xE05E1000, 0x8003445F
+.long 0xE05E1000, 0x80034860
+.long 0xE05E1000, 0x80034C61
+.long 0x68ACACFF, 0x00000080
+.long 0x68AEAEFF, 0x00000080
+.long 0x8F2E852D
+.long 0x80AE2E80
+.long 0xBF06802E
+.long 0xBF850059
+.long 0xBF8C0F7A
+.long 0xD9BE0000, 0x00002050
+.long 0xD9BE0440, 0x00002450
+.long 0xBF8CC07F
+.long 0xE05E1000, 0x80022056
+.long 0xE05E1000, 0x80022457
+.long 0xBF8C0F78
+.long 0xD9BE0000, 0x00003052
+.long 0xD9BE0440, 0x00003452
+.long 0xD9BE0880, 0x00003852
+.long 0xD9BE0CC0, 0x00003C52
+.long 0x68ACACFF, 0x00000080
+.long 0x68AEAEFF, 0x00000080
+.long 0x68B4B4FF, 0x00000080
+.long 0x68B6B6FF, 0x00000080
+.long 0x68B8B8FF, 0x00000080
+.long 0x68BABAFF, 0x00000080
+.long 0x68B0B0FF, 0x00000080
+.long 0x68B2B2FF, 0x00000080
+.long 0x68BCBCFF, 0x00000080
+.long 0x68BEBEFF, 0x00000080
+.long 0x68C0C0FF, 0x00000080
+.long 0x68C2C2FF, 0x00000080
+.long 0xBF8CC07F
+.long 0xE05E1000, 0x8003305A
+.long 0xE05E1000, 0x8003345B
+.long 0xE05E1000, 0x8003385C
+.long 0xE05E1000, 0x80033C5D
+.long 0xBF8C0F7A
+.long 0xD9BE0000, 0x00002851
+.long 0xD9BE0440, 0x00002C51
+.long 0xBF8CC07F
+.long 0xE05E1000, 0x80022858
+.long 0xE05E1000, 0x80022C59
+.long 0xBF8C0F78
+.long 0xD9BE0000, 0x00004053
+.long 0xD9BE0440, 0x00004453
+.long 0xD9BE0880, 0x00004853
+.long 0xD9BE0CC0, 0x00004C53
+.long 0xBF8CC07F
+.long 0xBF8A0000
+.long 0xBF800018
+.long 0xE05E1000, 0x8003405E
+.long 0xBF80000B
+.long 0xE05E1000, 0x8003445F
+.long 0xBF80000B
+.long 0xE05E1000, 0x80034860
+.long 0xBF80000B
+.long 0xE05E1000, 0x80034C61
+.long 0xBF8A0000
+.long 0x802E822E
+.long 0xBF00C22E
+.long 0xBF84FFA7
+.long 0xBF8C0F7A
+.long 0xD9BE0000, 0x00002050
+.long 0xD9BE0440, 0x00002450
+.long 0xBF8C0F76
+.long 0xD9BE0000, 0x00003052
+.long 0xD9BE0440, 0x00003452
+.long 0xD9BE0880, 0x00003852
+.long 0xD9BE0CC0, 0x00003C52
+.long 0xBF8C0F74
+.long 0xD9BE0000, 0x00002851
+.long 0xD9BE0440, 0x00002C51
+.long 0xBF8C0F70
+.long 0xD9BE0000, 0x00004053
+.long 0xD9BE0440, 0x00004453
+.long 0xD9BE0880, 0x00004853
+.long 0xD9BE0CC0, 0x00004C53
+.long 0xBF8CC07F
+.long 0xBF8A0000
+.long 0xBF810000
+.long 0xD3D94000, 0x18000080
+.long 0xD3D94001, 0x18000080
+.long 0xD3D94002, 0x18000080
+.long 0xD3D94003, 0x18000080
+.long 0xD3D94004, 0x18000080
+.long 0xD3D94005, 0x18000080
+.long 0xD3D94006, 0x18000080
+.long 0xD3D94007, 0x18000080
+.long 0xD3D94008, 0x18000080
+.long 0xD3D94009, 0x18000080
+.long 0xD3D9400A, 0x18000080
+.long 0xD3D9400B, 0x18000080
+.long 0xD3D9400C, 0x18000080
+.long 0xD3D9400D, 0x18000080
+.long 0xD3D9400E, 0x18000080
+.long 0xD3D9400F, 0x18000080
+.long 0xD3D94010, 0x18000080
+.long 0xD3D94011, 0x18000080
+.long 0xD3D94012, 0x18000080
+.long 0xD3D94013, 0x18000080
+.long 0xD3D94014, 0x18000080
+.long 0xD3D94015, 0x18000080
+.long 0xD3D94016, 0x18000080
+.long 0xD3D94017, 0x18000080
+.long 0xD3D94018, 0x18000080
+.long 0xD3D94019, 0x18000080
+.long 0xD3D9401A, 0x18000080
+.long 0xD3D9401B, 0x18000080
+.long 0xD3D9401C, 0x18000080
+.long 0xD3D9401D, 0x18000080
+.long 0xD3D9401E, 0x18000080
+.long 0xD3D9401F, 0x18000080
+.long 0xD3D94020, 0x18000080
+.long 0xD3D94021, 0x18000080
+.long 0xD3D94022, 0x18000080
+.long 0xD3D94023, 0x18000080
+.long 0xD3D94024, 0x18000080
+.long 0xD3D94025, 0x18000080
+.long 0xD3D94026, 0x18000080
+.long 0xD3D94027, 0x18000080
+.long 0xD3D94028, 0x18000080
+.long 0xD3D94029, 0x18000080
+.long 0xD3D9402A, 0x18000080
+.long 0xD3D9402B, 0x18000080
+.long 0xD3D9402C, 0x18000080
+.long 0xD3D9402D, 0x18000080
+.long 0xD3D9402E, 0x18000080
+.long 0xD3D9402F, 0x18000080
+.long 0xD3D94030, 0x18000080
+.long 0xD3D94031, 0x18000080
+.long 0xD3D94032, 0x18000080
+.long 0xD3D94033, 0x18000080
+.long 0xD3D94034, 0x18000080
+.long 0xD3D94035, 0x18000080
+.long 0xD3D94036, 0x18000080
+.long 0xD3D94037, 0x18000080
+.long 0xD3D94038, 0x18000080
+.long 0xD3D94039, 0x18000080
+.long 0xD3D9403A, 0x18000080
+.long 0xD3D9403B, 0x18000080
+.long 0xD3D9403C, 0x18000080
+.long 0xD3D9403D, 0x18000080
+.long 0xD3D9403E, 0x18000080
+.long 0xD3D9403F, 0x18000080
+.long 0xD3D94040, 0x18000080
+.long 0xD3D94041, 0x18000080
+.long 0xD3D94042, 0x18000080
+.long 0xD3D94043, 0x18000080
+.long 0xD3D94044, 0x18000080
+.long 0xD3D94045, 0x18000080
+.long 0xD3D94046, 0x18000080
+.long 0xD3D94047, 0x18000080
+.long 0xD3D94048, 0x18000080
+.long 0xD3D94049, 0x18000080
+.long 0xD3D9404A, 0x18000080
+.long 0xD3D9404B, 0x18000080
+.long 0xD3D9404C, 0x18000080
+.long 0xD3D9404D, 0x18000080
+.long 0xD3D9404E, 0x18000080
+.long 0xD3D9404F, 0x18000080
+.long 0xD3D94050, 0x18000080
+.long 0xD3D94051, 0x18000080
+.long 0xD3D94052, 0x18000080
+.long 0xD3D94053, 0x18000080
+.long 0xD3D94054, 0x18000080
+.long 0xD3D94055, 0x18000080
+.long 0xD3D94056, 0x18000080
+.long 0xD3D94057, 0x18000080
+.long 0xD3D94058, 0x18000080
+.long 0xD3D94059, 0x18000080
+.long 0xD3D9405A, 0x18000080
+.long 0xD3D9405B, 0x18000080
+.long 0xD3D9405C, 0x18000080
+.long 0xD3D9405D, 0x18000080
+.long 0xD3D9405E, 0x18000080
+.long 0xD3D9405F, 0x18000080
+.long 0xD3D94060, 0x18000080
+.long 0xD3D94061, 0x18000080
+.long 0xD3D94062, 0x18000080
+.long 0xD3D94063, 0x18000080
+.long 0xD3D94064, 0x18000080
+.long 0xD3D94065, 0x18000080
+.long 0xD3D94066, 0x18000080
+.long 0xD3D94067, 0x18000080
+.long 0xD3D94068, 0x18000080
+.long 0xD3D94069, 0x18000080
+.long 0xD3D9406A, 0x18000080
+.long 0xD3D9406B, 0x18000080
+.long 0xD3D9406C, 0x18000080
+.long 0xD3D9406D, 0x18000080
+.long 0xD3D9406E, 0x18000080
+.long 0xD3D9406F, 0x18000080
+.long 0xD3D94070, 0x18000080
+.long 0xD3D94071, 0x18000080
+.long 0xD3D94072, 0x18000080
+.long 0xD3D94073, 0x18000080
+.long 0xD3D94074, 0x18000080
+.long 0xD3D94075, 0x18000080
+.long 0xD3D94076, 0x18000080
+.long 0xD3D94077, 0x18000080
+.long 0xD3D94078, 0x18000080
+.long 0xD3D94079, 0x18000080
+.long 0xD3D9407A, 0x18000080
+.long 0xD3D9407B, 0x18000080
+.long 0xD3D9407C, 0x18000080
+.long 0xD3D9407D, 0x18000080
+.long 0xD3D9407E, 0x18000080
+.long 0xD3D9407F, 0x18000080
+.long 0xC0060700, 0x00000000
+.long 0xC00A0A00, 0x00000038
+.long 0xC00A0900, 0x00000040
+.long 0xC00A0800, 0x00000018
+.long 0xC00A0A00, 0x00000038
+.long 0xD1130001, 0x00013F66
+.long 0xD2850061, 0x000202A0
+.long 0x20040281
+.long 0xD2850002, 0x00020488
+.long 0x2002CC85
+.long 0x24020282
+.long 0x68C2C301
+.long 0x24C2C281
+.long 0x68C2C302
+.long 0x86548152
+.long 0x9254FF54, 0x00001100
+.long 0x68C2C254
+.long 0x68C2C280
+.long 0x68C4C2FF, 0x00002200
+.long 0xBF8A0000
+.long 0xD1130001, 0x00013F66
+.long 0xD2850063, 0x000202A0
+.long 0x20040281
+.long 0xD2850002, 0x00020488
+.long 0x2002CC85
+.long 0x24020282
+.long 0x68C6C701
+.long 0x24C6C681
+.long 0x68C6C702
+.long 0x86548252
+.long 0x8F548154
+.long 0x9254FF54, 0x00002200
+.long 0x68C6C654
+.long 0x68C6C6FF, 0x00004400
+.long 0x68C8C6FF, 0x00004400
+.long 0xBF8CC07F
+.long 0xBE900022
+.long 0xBE910023
+.long 0xBE9200FF, 0x80000000
+.long 0xBE9300FF, 0x00020000
+.long 0xBE940020
+.long 0xBE950021
+.long 0xBE9600FF, 0x80000000
+.long 0xBE9700FF, 0x00020000
+.long 0x925603FF, 0x00000100
+.long 0x96552656
+.long 0x92542656
+.long 0x8ED48154
+.long 0x80105410
+.long 0x82115511
+.long 0x80145414
+.long 0x82155515
+.long 0x96552704
+.long 0x92542704
+.long 0x8ED48154
+.long 0x80105410
+.long 0x82115511
+.long 0x80145414
+.long 0x82155515
+.long 0x24CACE86
+.long 0x68CACB66
+.long 0x2608CE82
+.long 0x20080881
+.long 0x24080887
+.long 0xD2850003, 0x00004D04
+.long 0x2608CE81
+.long 0xD2850004, 0x000208C0
+.long 0x68060903
+.long 0x2608CA9F
+.long 0xD2850005, 0x00004D04
+.long 0x68D40B03
+.long 0x2608CABF
+.long 0x200C0885
+.long 0x240C0C82
+.long 0x925402FF, 0x00000080
+.long 0x32D20C54
+.long 0xD1FE0060, 0x0206D569
+.long 0xBF8A0000
+.long 0xD8EC0000, 0x00000061
+.long 0xD8EC0000, 0x20000063
+.long 0xD8EC0010, 0x02000061
+.long 0xD8EC0010, 0x22000063
+.long 0xBF8CC27F
+.long 0xD3CC0000, 0x04024100
+.long 0xD8EC0020, 0x04000061
+.long 0xD8EC0020, 0x24000063
+.long 0xD8EC0030, 0x06000061
+.long 0xD8EC0030, 0x26000063
+.long 0xBF8CC47F
+.long 0xD3CC0000, 0x04024502
+.long 0xD8EC0000, 0x10000062
+.long 0xD8EC0000, 0x40000064
+.long 0xD8EC0010, 0x12000062
+.long 0xD8EC0010, 0x42000064
+.long 0xD3CC0000, 0x04024904
+.long 0xD8EC0020, 0x14000062
+.long 0xD8EC0020, 0x44000064
+.long 0xD8EC0030, 0x16000062
+.long 0xD8EC0030, 0x46000064
+.long 0xD3CC0000, 0x04024D06
+.long 0xD8EC0880, 0x08000061
+.long 0xD8EC0880, 0x28000063
+.long 0xD8EC0890, 0x0A000061
+.long 0xD8EC0890, 0x2A000063
+.long 0xD3CC0000, 0x04028110
+.long 0xD8EC08A0, 0x0C000061
+.long 0xD8EC08A0, 0x2C000063
+.long 0xD8EC08B0, 0x0E000061
+.long 0xD8EC08B0, 0x2E000063
+.long 0xD3CC0000, 0x04028512
+.long 0xD8EC0880, 0x18000062
+.long 0xD8EC0890, 0x1A000062
+.long 0xD8EC08A0, 0x1C000062
+.long 0xD8EC08B0, 0x1E000062
+.long 0xD3CC0000, 0x04028914
+.long 0xD8EC0880, 0x48000064
+.long 0xD8EC0890, 0x4A000064
+.long 0xD8EC08A0, 0x4C000064
+.long 0xD8EC08B0, 0x4E000064
+.long 0xD3CC0000, 0x04028D16
+.long 0xD8EC1100, 0x30000063
+.long 0xD8EC1110, 0x32000063
+.long 0xD8EC1120, 0x34000063
+.long 0xD8EC1130, 0x36000063
+.long 0xD3CC0010, 0x04424108
+.long 0xD8EC1980, 0x38000063
+.long 0xD8EC1990, 0x3A000063
+.long 0xD8EC19A0, 0x3C000063
+.long 0xD8EC19B0, 0x3E000063
+.long 0xD3CC0010, 0x0442450A
+.long 0xD8EC1100, 0x50000064
+.long 0xD8EC1110, 0x52000064
+.long 0xD8EC1120, 0x54000064
+.long 0xD8EC1130, 0x56000064
+.long 0xD3CC0010, 0x0442490C
+.long 0xD8EC1980, 0x58000064
+.long 0xD8EC1990, 0x5A000064
+.long 0xD8EC19A0, 0x5C000064
+.long 0xD8EC19B0, 0x5E000064
+.long 0x8F2E852D
+.long 0x80AE2E80
+.long 0xBF06802E
+.long 0xBF850119
+.long 0xD3CC0010, 0x04424D0E
+.long 0xBF8CC07F
+.long 0xBF8A0000
+.long 0xD3CC0010, 0x04428118
+.long 0xBF80000C
+.long 0xD3CC0010, 0x0442851A
+.long 0xBF80000C
+.long 0xD3CC0010, 0x0442891C
+.long 0xBF80000C
+.long 0xD3CC0010, 0x04428D1E
+.long 0xBF80000C
+.long 0xD3CC0020, 0x04825100
+.long 0xBF80000C
+.long 0xD3CC0020, 0x04825502
+.long 0xBF80000C
+.long 0xD3CC0020, 0x04825904
+.long 0xBF80000C
+.long 0xD3CC0020, 0x04825D06
+.long 0xBF80000C
+.long 0xD3CC0020, 0x04829110
+.long 0xBF80000C
+.long 0xD3CC0020, 0x04829512
+.long 0xBF80000C
+.long 0xD3CC0020, 0x04829914
+.long 0xBF80000C
+.long 0xD3CC0020, 0x04829D16
+.long 0xBF80000C
+.long 0xD3CC0030, 0x04C25108
+.long 0xBF80000C
+.long 0xD3CC0030, 0x04C2550A
+.long 0xBF80000C
+.long 0xD3CC0030, 0x04C2590C
+.long 0xBF80000C
+.long 0xD3CC0030, 0x04C25D0E
+.long 0xBF80000C
+.long 0xD3CC0030, 0x04C29118
+.long 0xBF80000C
+.long 0xD3CC0030, 0x04C2951A
+.long 0xBF80000C
+.long 0xD3CC0030, 0x04C2991C
+.long 0xBF80000C
+.long 0xD3CC0030, 0x04C29D1E
+.long 0xBF80000C
+.long 0xD3CC0040, 0x05026100
+.long 0xBF80000C
+.long 0xD3CC0040, 0x05026502
+.long 0xBF80000C
+.long 0xD3CC0040, 0x05026904
+.long 0xBF80000C
+.long 0xD3CC0040, 0x05026D06
+.long 0xBF80000C
+.long 0xD3CC0040, 0x0502A110
+.long 0xBF80000C
+.long 0xD3CC0040, 0x0502A512
+.long 0xBF80000C
+.long 0xD3CC0040, 0x0502A914
+.long 0xBF80000C
+.long 0xD3CC0040, 0x0502AD16
+.long 0xBF80000C
+.long 0xD3CC0050, 0x05426108
+.long 0xBF80000C
+.long 0xD3CC0050, 0x0542650A
+.long 0xBF80000C
+.long 0xD3CC0050, 0x0542690C
+.long 0xBF80000C
+.long 0xD3CC0050, 0x05426D0E
+.long 0xBF80000C
+.long 0xD3CC0050, 0x0542A118
+.long 0xBF80000C
+.long 0xD3CC0050, 0x0542A51A
+.long 0xBF80000C
+.long 0xD3CC0050, 0x0542A91C
+.long 0xBF80000C
+.long 0xD3CC0050, 0x0542AD1E
+.long 0xBF80000C
+.long 0xD3CC0060, 0x05827100
+.long 0xBF80000C
+.long 0xD3CC0060, 0x05827502
+.long 0xBF80000C
+.long 0xD3CC0060, 0x05827904
+.long 0xBF80000C
+.long 0xD3CC0060, 0x05827D06
+.long 0xBF80000C
+.long 0xD3CC0060, 0x0582B110
+.long 0xBF80000C
+.long 0xD3CC0060, 0x0582B512
+.long 0xBF80000C
+.long 0xD3CC0060, 0x0582B914
+.long 0xBF80000C
+.long 0xD3CC0060, 0x0582BD16
+.long 0xBF80000C
+.long 0xD3CC0070, 0x05C27108
+.long 0xBF80000C
+.long 0xD3CC0070, 0x05C2750A
+.long 0xBF80000C
+.long 0xD3CC0070, 0x05C2790C
+.long 0xBF80000C
+.long 0xD3CC0070, 0x05C27D0E
+.long 0xBF80000C
+.long 0xD3CC0070, 0x05C2B118
+.long 0xBF80000C
+.long 0xD3CC0070, 0x05C2B51A
+.long 0xBF80000C
+.long 0xD3CC0070, 0x05C2B91C
+.long 0xBF8A0000
+.long 0xD8EC0000, 0x00000061
+.long 0xD8EC0000, 0x20000063
+.long 0xD8EC0010, 0x02000061
+.long 0xD8EC0010, 0x22000063
+.long 0xD3CC0070, 0x05C2BD1E
+.long 0xD8EC0020, 0x04000061
+.long 0xD8EC0020, 0x24000063
+.long 0xD8EC0030, 0x06000061
+.long 0xD8EC0030, 0x26000063
+.long 0xBF8CC67F
+.long 0xD3CC0000, 0x04024100
+.long 0xD8EC0000, 0x10000062
+.long 0xD8EC0000, 0x40000064
+.long 0xD8EC0010, 0x12000062
+.long 0xD8EC0010, 0x42000064
+.long 0xD3CC0000, 0x04024502
+.long 0xD8EC0020, 0x14000062
+.long 0xD8EC0020, 0x44000064
+.long 0xD8EC0030, 0x16000062
+.long 0xD8EC0030, 0x46000064
+.long 0xD3CC0000, 0x04024904
+.long 0xD8EC0880, 0x08000061
+.long 0xD8EC0880, 0x28000063
+.long 0xD8EC0890, 0x0A000061
+.long 0xD8EC0890, 0x2A000063
+.long 0xD3CC0000, 0x04024D06
+.long 0xD8EC08A0, 0x0C000061
+.long 0xD8EC08A0, 0x2C000063
+.long 0xD8EC08B0, 0x0E000061
+.long 0xD8EC08B0, 0x2E000063
+.long 0xD3CC0000, 0x04028110
+.long 0xD8EC0880, 0x18000062
+.long 0xD8EC0890, 0x1A000062
+.long 0xD8EC08A0, 0x1C000062
+.long 0xD8EC08B0, 0x1E000062
+.long 0xD3CC0000, 0x04028512
+.long 0xD8EC0880, 0x48000064
+.long 0xD8EC0890, 0x4A000064
+.long 0xD8EC08A0, 0x4C000064
+.long 0xD8EC08B0, 0x4E000064
+.long 0xD3CC0000, 0x04028914
+.long 0xD8EC1100, 0x30000063
+.long 0xD8EC1110, 0x32000063
+.long 0xD8EC1120, 0x34000063
+.long 0xD8EC1130, 0x36000063
+.long 0xD3CC0000, 0x04028D16
+.long 0xD8EC1980, 0x38000063
+.long 0xD8EC1990, 0x3A000063
+.long 0xD8EC19A0, 0x3C000063
+.long 0xD8EC19B0, 0x3E000063
+.long 0xD3CC0010, 0x04424108
+.long 0xD8EC1100, 0x50000064
+.long 0xD8EC1110, 0x52000064
+.long 0xD8EC1120, 0x54000064
+.long 0xD8EC1130, 0x56000064
+.long 0xD3CC0010, 0x0442450A
+.long 0xD8EC1980, 0x58000064
+.long 0xD8EC1990, 0x5A000064
+.long 0xD8EC19A0, 0x5C000064
+.long 0xD8EC19B0, 0x5E000064
+.long 0xD3CC0010, 0x0442490C
+.long 0x802E822E
+.long 0xBF00C22E
+.long 0xBF84FEE7
+.long 0x9254C026
+.long 0xD3CC0010, 0x04424D0E
+.long 0xE0541000, 0x80046160
+.long 0xE0541010, 0x80046360
+.long 0xE0541020, 0x80046560
+.long 0xE0541030, 0x80046760
+.long 0xD3D84069, 0x18000100
+.long 0xD3D8406A, 0x18000101
+.long 0xD3D8406B, 0x18000102
+.long 0xD3D8406C, 0x18000103
+.long 0xD3D8406D, 0x18000104
+.long 0xD3D8406E, 0x18000105
+.long 0xD3D8406F, 0x18000106
+.long 0xD3D84070, 0x18000107
+.long 0xD3CC0010, 0x04428118
+.long 0x7ED21569
+.long 0x7ED4156A
+.long 0xD2000069, 0x05A5216A
+.long 0xD3904069, 0x1802D228
+.long 0xD3CC0010, 0x0442851A
+.long 0x7ED6156B
+.long 0x7ED8156C
+.long 0xD200006A, 0x05AD216C
+.long 0xD390406A, 0x1802D428
+.long 0x7EDA156D
+.long 0x7EDC156E
+.long 0xD200006B, 0x05B5216E
+.long 0xD390406B, 0x1802D628
+.long 0xBF8C0F73
+.long 0xD38E4069, 0x1DA6C229
+.long 0xD38E406A, 0x1DAAC429
+.long 0xE0741000, 0x80056960
+.long 0xD3CC0010, 0x0442891C
+.long 0x7EDE156F
+.long 0x7EE01570
+.long 0xD200006C, 0x05BD2170
+.long 0xD390406C, 0x1802D828
+.long 0xD3D84071, 0x18000108
+.long 0xD3D84072, 0x18000109
+.long 0xD3D84073, 0x1800010A
+.long 0xD3D84074, 0x1800010B
+.long 0xD3CC0010, 0x04428D1E
+.long 0xBF8C0F73
+.long 0xD38E406B, 0x1DAEC629
+.long 0xD38E406C, 0x1DB2C829
+.long 0xE0741010, 0x80056B60
+.long 0x7EE21571
+.long 0x7EE41572
+.long 0xD200006D, 0x05C52172
+.long 0xD390406D, 0x1802DA28
+.long 0x7EE61573
+.long 0x7EE81574
+.long 0xD200006E, 0x05CD2174
+.long 0xD390406E, 0x1802DC28
+.long 0xD3D84075, 0x1800010C
+.long 0xD3D84076, 0x1800010D
+.long 0xD3D84077, 0x1800010E
+.long 0xD3D84078, 0x1800010F
+.long 0xD3CC0020, 0x04825100
+.long 0xBF8C0F73
+.long 0xD38E406D, 0x1DB6CA29
+.long 0xD38E406E, 0x1DBACC29
+.long 0xE0741020, 0x80056D60
+.long 0x7EEA1575
+.long 0x7EEC1576
+.long 0xD200006F, 0x05D52176
+.long 0xD390406F, 0x1802DE28
+.long 0x7EEE1577
+.long 0x7EF01578
+.long 0xD2000070, 0x05DD2178
+.long 0xD3904070, 0x1802E028
+.long 0xD3CC0020, 0x04825502
+.long 0xBF8C0F73
+.long 0xD38E406F, 0x1DBECE29
+.long 0xD38E4070, 0x1DC2D029
+.long 0xE0741030, 0x80056F60
+.long 0xE0541040, 0x80046160
+.long 0xE0541050, 0x80046360
+.long 0xE0541060, 0x80046560
+.long 0xE0541070, 0x80046760
+.long 0xD3D84069, 0x18000110
+.long 0xD3D8406A, 0x18000111
+.long 0xD3D8406B, 0x18000112
+.long 0xD3D8406C, 0x18000113
+.long 0xD3D8406D, 0x18000114
+.long 0xD3D8406E, 0x18000115
+.long 0xD3D8406F, 0x18000116
+.long 0xD3D84070, 0x18000117
+.long 0xD3CC0020, 0x04825904
+.long 0x7ED21569
+.long 0x7ED4156A
+.long 0xD2000069, 0x05A5216A
+.long 0xD3904069, 0x1802D228
+.long 0x7ED6156B
+.long 0x7ED8156C
+.long 0xD200006A, 0x05AD216C
+.long 0xD390406A, 0x1802D428
+.long 0x7EDA156D
+.long 0x7EDC156E
+.long 0xD200006B, 0x05B5216E
+.long 0xD390406B, 0x1802D628
+.long 0xD3CC0020, 0x04825D06
+.long 0xBF8C0F73
+.long 0xD38E4069, 0x1DA6C229
+.long 0xD38E406A, 0x1DAAC429
+.long 0xE0741040, 0x80056960
+.long 0x7EDE156F
+.long 0x7EE01570
+.long 0xD200006C, 0x05BD2170
+.long 0xD390406C, 0x1802D828
+.long 0xD3D84071, 0x18000118
+.long 0xD3D84072, 0x18000119
+.long 0xD3D84073, 0x1800011A
+.long 0xD3D84074, 0x1800011B
+.long 0xD3CC0020, 0x04829110
+.long 0xBF8C0F73
+.long 0xD38E406B, 0x1DAEC629
+.long 0xD38E406C, 0x1DB2C829
+.long 0xE0741050, 0x80056B60
+.long 0xD3CC0020, 0x04829512
+.long 0x7EE21571
+.long 0x7EE41572
+.long 0xD200006D, 0x05C52172
+.long 0xD390406D, 0x1802DA28
+.long 0x7EE61573
+.long 0x7EE81574
+.long 0xD200006E, 0x05CD2174
+.long 0xD390406E, 0x1802DC28
+.long 0xD3D84075, 0x1800011C
+.long 0xD3D84076, 0x1800011D
+.long 0xD3D84077, 0x1800011E
+.long 0xD3D84078, 0x1800011F
+.long 0xD3CC0020, 0x04829914
+.long 0xBF8C0F73
+.long 0xD38E406D, 0x1DB6CA29
+.long 0xD38E406E, 0x1DBACC29
+.long 0xE0741060, 0x80056D60
+.long 0xD3CC0020, 0x04829D16
+.long 0x7EEA1575
+.long 0x7EEC1576
+.long 0xD200006F, 0x05D52176
+.long 0xD390406F, 0x1802DE28
+.long 0x7EEE1577
+.long 0x7EF01578
+.long 0xD2000070, 0x05DD2178
+.long 0xD3904070, 0x1802E028
+.long 0xD3CC0030, 0x04C25108
+.long 0xBF8C0F73
+.long 0xD38E406F, 0x1DBECE29
+.long 0xD38E4070, 0x1DC2D029
+.long 0xE0741070, 0x80056F60
+.long 0xD3CC0030, 0x04C2550A
+.long 0xD1340060, 0x0000A960
+.long 0xE0541000, 0x80046160
+.long 0xE0541010, 0x80046360
+.long 0xE0541020, 0x80046560
+.long 0xE0541030, 0x80046760
+.long 0xD3D84069, 0x18000120
+.long 0xD3D8406A, 0x18000121
+.long 0xD3D8406B, 0x18000122
+.long 0xD3D8406C, 0x18000123
+.long 0xD3D8406D, 0x18000124
+.long 0xD3D8406E, 0x18000125
+.long 0xD3D8406F, 0x18000126
+.long 0xD3D84070, 0x18000127
+.long 0x7ED21569
+.long 0x7ED4156A
+.long 0xD2000069, 0x05A5216A
+.long 0xD3904069, 0x1802D228
+.long 0x7ED6156B
+.long 0x7ED8156C
+.long 0xD200006A, 0x05AD216C
+.long 0xD390406A, 0x1802D428
+.long 0x7EDA156D
+.long 0x7EDC156E
+.long 0xD200006B, 0x05B5216E
+.long 0xD390406B, 0x1802D628
+.long 0xD3CC0030, 0x04C2590C
+.long 0xBF8C0F73
+.long 0xD38E4069, 0x1DA6C229
+.long 0xD38E406A, 0x1DAAC429
+.long 0xE0741000, 0x80056960
+.long 0xD3CC0030, 0x04C25D0E
+.long 0x7EDE156F
+.long 0x7EE01570
+.long 0xD200006C, 0x05BD2170
+.long 0xD390406C, 0x1802D828
+.long 0xD3D84071, 0x18000128
+.long 0xD3D84072, 0x18000129
+.long 0xD3D84073, 0x1800012A
+.long 0xD3D84074, 0x1800012B
+.long 0xD3CC0030, 0x04C29118
+.long 0xBF8C0F73
+.long 0xD38E406B, 0x1DAEC629
+.long 0xD38E406C, 0x1DB2C829
+.long 0xE0741010, 0x80056B60
+.long 0xD3CC0030, 0x04C2951A
+.long 0x7EE21571
+.long 0x7EE41572
+.long 0xD200006D, 0x05C52172
+.long 0xD390406D, 0x1802DA28
+.long 0x7EE61573
+.long 0x7EE81574
+.long 0xD200006E, 0x05CD2174
+.long 0xD390406E, 0x1802DC28
+.long 0xD3D84075, 0x1800012C
+.long 0xD3D84076, 0x1800012D
+.long 0xD3D84077, 0x1800012E
+.long 0xD3D84078, 0x1800012F
+.long 0xD3CC0030, 0x04C2991C
+.long 0xBF8C0F73
+.long 0xD38E406D, 0x1DB6CA29
+.long 0xD38E406E, 0x1DBACC29
+.long 0xE0741020, 0x80056D60
+.long 0xD3CC0030, 0x04C29D1E
+.long 0x7EEA1575
+.long 0x7EEC1576
+.long 0xD200006F, 0x05D52176
+.long 0xD390406F, 0x1802DE28
+.long 0x7EEE1577
+.long 0x7EF01578
+.long 0xD2000070, 0x05DD2178
+.long 0xD3904070, 0x1802E028
+.long 0xD3CC0040, 0x05026100
+.long 0xBF8C0F73
+.long 0xD38E406F, 0x1DBECE29
+.long 0xD38E4070, 0x1DC2D029
+.long 0xE0741030, 0x80056F60
+.long 0xD3CC0040, 0x05026502
+.long 0xE0541040, 0x80046160
+.long 0xE0541050, 0x80046360
+.long 0xE0541060, 0x80046560
+.long 0xE0541070, 0x80046760
+.long 0xD3D84069, 0x18000130
+.long 0xD3D8406A, 0x18000131
+.long 0xD3D8406B, 0x18000132
+.long 0xD3D8406C, 0x18000133
+.long 0xD3D8406D, 0x18000134
+.long 0xD3D8406E, 0x18000135
+.long 0xD3D8406F, 0x18000136
+.long 0xD3D84070, 0x18000137
+.long 0x7ED21569
+.long 0x7ED4156A
+.long 0xD2000069, 0x05A5216A
+.long 0xD3904069, 0x1802D228
+.long 0x7ED6156B
+.long 0x7ED8156C
+.long 0xD200006A, 0x05AD216C
+.long 0xD390406A, 0x1802D428
+.long 0x7EDA156D
+.long 0x7EDC156E
+.long 0xD200006B, 0x05B5216E
+.long 0xD390406B, 0x1802D628
+.long 0xD3CC0040, 0x05026904
+.long 0xBF8C0F73
+.long 0xD38E4069, 0x1DA6C229
+.long 0xD38E406A, 0x1DAAC429
+.long 0xE0741040, 0x80056960
+.long 0xD3CC0040, 0x05026D06
+.long 0x7EDE156F
+.long 0x7EE01570
+.long 0xD200006C, 0x05BD2170
+.long 0xD390406C, 0x1802D828
+.long 0xD3D84071, 0x18000138
+.long 0xD3D84072, 0x18000139
+.long 0xD3D84073, 0x1800013A
+.long 0xD3D84074, 0x1800013B
+.long 0xD3CC0040, 0x0502A110
+.long 0xBF8C0F73
+.long 0xD38E406B, 0x1DAEC629
+.long 0xD38E406C, 0x1DB2C829
+.long 0xE0741050, 0x80056B60
+.long 0xD3CC0040, 0x0502A512
+.long 0x7EE21571
+.long 0x7EE41572
+.long 0xD200006D, 0x05C52172
+.long 0xD390406D, 0x1802DA28
+.long 0x7EE61573
+.long 0x7EE81574
+.long 0xD200006E, 0x05CD2174
+.long 0xD390406E, 0x1802DC28
+.long 0xD3D84075, 0x1800013C
+.long 0xD3D84076, 0x1800013D
+.long 0xD3D84077, 0x1800013E
+.long 0xD3D84078, 0x1800013F
+.long 0xD3CC0040, 0x0502A914
+.long 0xBF8C0F73
+.long 0xD38E406D, 0x1DB6CA29
+.long 0xD38E406E, 0x1DBACC29
+.long 0xE0741060, 0x80056D60
+.long 0xD3CC0040, 0x0502AD16
+.long 0x7EEA1575
+.long 0x7EEC1576
+.long 0xD200006F, 0x05D52176
+.long 0xD390406F, 0x1802DE28
+.long 0x7EEE1577
+.long 0x7EF01578
+.long 0xD2000070, 0x05DD2178
+.long 0xD3904070, 0x1802E028
+.long 0xD3CC0050, 0x05426108
+.long 0xBF8C0F73
+.long 0xD38E406F, 0x1DBECE29
+.long 0xD38E4070, 0x1DC2D029
+.long 0xE0741070, 0x80056F60
+.long 0xD3CC0050, 0x0542650A
+.long 0xD1340060, 0x0000A960
+.long 0xE0541000, 0x80046160
+.long 0xE0541010, 0x80046360
+.long 0xE0541020, 0x80046560
+.long 0xE0541030, 0x80046760
+.long 0xD3D84069, 0x18000140
+.long 0xD3D8406A, 0x18000141
+.long 0xD3D8406B, 0x18000142
+.long 0xD3D8406C, 0x18000143
+.long 0xD3D8406D, 0x18000144
+.long 0xD3D8406E, 0x18000145
+.long 0xD3D8406F, 0x18000146
+.long 0xD3D84070, 0x18000147
+.long 0x7ED21569
+.long 0x7ED4156A
+.long 0xD2000069, 0x05A5216A
+.long 0xD3904069, 0x1802D228
+.long 0x7ED6156B
+.long 0x7ED8156C
+.long 0xD200006A, 0x05AD216C
+.long 0xD390406A, 0x1802D428
+.long 0x7EDA156D
+.long 0x7EDC156E
+.long 0xD200006B, 0x05B5216E
+.long 0xD390406B, 0x1802D628
+.long 0xD3CC0050, 0x0542690C
+.long 0xBF8C0F73
+.long 0xD38E4069, 0x1DA6C229
+.long 0xD38E406A, 0x1DAAC429
+.long 0xE0741000, 0x80056960
+.long 0xD3CC0050, 0x05426D0E
+.long 0x7EDE156F
+.long 0x7EE01570
+.long 0xD200006C, 0x05BD2170
+.long 0xD390406C, 0x1802D828
+.long 0xD3D84071, 0x18000148
+.long 0xD3D84072, 0x18000149
+.long 0xD3D84073, 0x1800014A
+.long 0xD3D84074, 0x1800014B
+.long 0xD3CC0050, 0x0542A118
+.long 0xBF8C0F73
+.long 0xD38E406B, 0x1DAEC629
+.long 0xD38E406C, 0x1DB2C829
+.long 0xE0741010, 0x80056B60
+.long 0xD3CC0050, 0x0542A51A
+.long 0x7EE21571
+.long 0x7EE41572
+.long 0xD200006D, 0x05C52172
+.long 0xD390406D, 0x1802DA28
+.long 0x7EE61573
+.long 0x7EE81574
+.long 0xD200006E, 0x05CD2174
+.long 0xD390406E, 0x1802DC28
+.long 0xD3D84075, 0x1800014C
+.long 0xD3D84076, 0x1800014D
+.long 0xD3D84077, 0x1800014E
+.long 0xD3D84078, 0x1800014F
+.long 0xD3CC0050, 0x0542A91C
+.long 0xBF8C0F73
+.long 0xD38E406D, 0x1DB6CA29
+.long 0xD38E406E, 0x1DBACC29
+.long 0xE0741020, 0x80056D60
+.long 0xD3CC0050, 0x0542AD1E
+.long 0x7EEA1575
+.long 0x7EEC1576
+.long 0xD200006F, 0x05D52176
+.long 0xD390406F, 0x1802DE28
+.long 0x7EEE1577
+.long 0x7EF01578
+.long 0xD2000070, 0x05DD2178
+.long 0xD3904070, 0x1802E028
+.long 0xD3CC0060, 0x05827100
+.long 0xBF8C0F73
+.long 0xD38E406F, 0x1DBECE29
+.long 0xD38E4070, 0x1DC2D029
+.long 0xE0741030, 0x80056F60
+.long 0xD3CC0060, 0x05827502
+.long 0xE0541040, 0x80046160
+.long 0xE0541050, 0x80046360
+.long 0xE0541060, 0x80046560
+.long 0xE0541070, 0x80046760
+.long 0xD3D84069, 0x18000150
+.long 0xD3D8406A, 0x18000151
+.long 0xD3D8406B, 0x18000152
+.long 0xD3D8406C, 0x18000153
+.long 0xD3D8406D, 0x18000154
+.long 0xD3D8406E, 0x18000155
+.long 0xD3D8406F, 0x18000156
+.long 0xD3D84070, 0x18000157
+.long 0x7ED21569
+.long 0x7ED4156A
+.long 0xD2000069, 0x05A5216A
+.long 0xD3904069, 0x1802D228
+.long 0x7ED6156B
+.long 0x7ED8156C
+.long 0xD200006A, 0x05AD216C
+.long 0xD390406A, 0x1802D428
+.long 0x7EDA156D
+.long 0x7EDC156E
+.long 0xD200006B, 0x05B5216E
+.long 0xD390406B, 0x1802D628
+.long 0xD3CC0060, 0x05827904
+.long 0xBF8C0F73
+.long 0xD38E4069, 0x1DA6C229
+.long 0xD38E406A, 0x1DAAC429
+.long 0xE0741040, 0x80056960
+.long 0xD3CC0060, 0x05827D06
+.long 0x7EDE156F
+.long 0x7EE01570
+.long 0xD200006C, 0x05BD2170
+.long 0xD390406C, 0x1802D828
+.long 0xD3D84071, 0x18000158
+.long 0xD3D84072, 0x18000159
+.long 0xD3D84073, 0x1800015A
+.long 0xD3D84074, 0x1800015B
+.long 0xD3CC0060, 0x0582B110
+.long 0xBF8C0F73
+.long 0xD38E406B, 0x1DAEC629
+.long 0xD38E406C, 0x1DB2C829
+.long 0xE0741050, 0x80056B60
+.long 0xD3CC0060, 0x0582B512
+.long 0x7EE21571
+.long 0x7EE41572
+.long 0xD200006D, 0x05C52172
+.long 0xD390406D, 0x1802DA28
+.long 0x7EE61573
+.long 0x7EE81574
+.long 0xD200006E, 0x05CD2174
+.long 0xD390406E, 0x1802DC28
+.long 0xD3D84075, 0x1800015C
+.long 0xD3D84076, 0x1800015D
+.long 0xD3D84077, 0x1800015E
+.long 0xD3D84078, 0x1800015F
+.long 0xD3CC0060, 0x0582B914
+.long 0xBF8C0F73
+.long 0xD38E406D, 0x1DB6CA29
+.long 0xD38E406E, 0x1DBACC29
+.long 0xE0741060, 0x80056D60
+.long 0xD3CC0060, 0x0582BD16
+.long 0x7EEA1575
+.long 0x7EEC1576
+.long 0xD200006F, 0x05D52176
+.long 0xD390406F, 0x1802DE28
+.long 0x7EEE1577
+.long 0x7EF01578
+.long 0xD2000070, 0x05DD2178
+.long 0xD3904070, 0x1802E028
+.long 0xD3CC0070, 0x05C27108
+.long 0xBF8C0F73
+.long 0xD38E406F, 0x1DBECE29
+.long 0xD38E4070, 0x1DC2D029
+.long 0xE0741070, 0x80056F60
+.long 0xD3CC0070, 0x05C2750A
+.long 0xD1340060, 0x0000A960
+.long 0xE0541000, 0x80046160
+.long 0xE0541010, 0x80046360
+.long 0xE0541020, 0x80046560
+.long 0xE0541030, 0x80046760
+.long 0xD3D84069, 0x18000160
+.long 0xD3D8406A, 0x18000161
+.long 0xD3D8406B, 0x18000162
+.long 0xD3D8406C, 0x18000163
+.long 0xD3D8406D, 0x18000164
+.long 0xD3D8406E, 0x18000165
+.long 0xD3D8406F, 0x18000166
+.long 0xD3D84070, 0x18000167
+.long 0x7ED21569
+.long 0x7ED4156A
+.long 0xD2000069, 0x05A5216A
+.long 0xD3904069, 0x1802D228
+.long 0x7ED6156B
+.long 0x7ED8156C
+.long 0xD200006A, 0x05AD216C
+.long 0xD390406A, 0x1802D428
+.long 0x7EDA156D
+.long 0x7EDC156E
+.long 0xD200006B, 0x05B5216E
+.long 0xD390406B, 0x1802D628
+.long 0xD3CC0070, 0x05C2790C
+.long 0xBF8C0F73
+.long 0xD38E4069, 0x1DA6C229
+.long 0xD38E406A, 0x1DAAC429
+.long 0xE0741000, 0x80056960
+.long 0xD3CC0070, 0x05C27D0E
+.long 0x7EDE156F
+.long 0x7EE01570
+.long 0xD200006C, 0x05BD2170
+.long 0xD390406C, 0x1802D828
+.long 0xD3D84071, 0x18000168
+.long 0xD3D84072, 0x18000169
+.long 0xD3D84073, 0x1800016A
+.long 0xD3D84074, 0x1800016B
+.long 0xD3CC0070, 0x05C2B118
+.long 0xBF8C0F73
+.long 0xD38E406B, 0x1DAEC629
+.long 0xD38E406C, 0x1DB2C829
+.long 0xE0741010, 0x80056B60
+.long 0xD3CC0070, 0x05C2B51A
+.long 0x7EE21571
+.long 0x7EE41572
+.long 0xD200006D, 0x05C52172
+.long 0xD390406D, 0x1802DA28
+.long 0x7EE61573
+.long 0x7EE81574
+.long 0xD200006E, 0x05CD2174
+.long 0xD390406E, 0x1802DC28
+.long 0xD3D84075, 0x1800016C
+.long 0xD3D84076, 0x1800016D
+.long 0xD3D84077, 0x1800016E
+.long 0xD3D84078, 0x1800016F
+.long 0xD3CC0070, 0x05C2B91C
+.long 0xBF8C0F73
+.long 0xD38E406D, 0x1DB6CA29
+.long 0xD38E406E, 0x1DBACC29
+.long 0xE0741020, 0x80056D60
+.long 0xD3CC0070, 0x05C2BD1E
+.long 0xBF800007
+.long 0x7EEA1575
+.long 0x7EEC1576
+.long 0xD200006F, 0x05D52176
+.long 0xD390406F, 0x1802DE28
+.long 0x7EEE1577
+.long 0x7EF01578
+.long 0xD2000070, 0x05DD2178
+.long 0xD3904070, 0x1802E028
+.long 0xBF8C0F73
+.long 0xD38E406F, 0x1DBECE29
+.long 0xD38E4070, 0x1DC2D029
+.long 0xE0741030, 0x80056F60
+.long 0xE0541040, 0x80046160
+.long 0xE0541050, 0x80046360
+.long 0xE0541060, 0x80046560
+.long 0xE0541070, 0x80046760
+.long 0xD3D84069, 0x18000170
+.long 0xD3D8406A, 0x18000171
+.long 0xD3D8406B, 0x18000172
+.long 0xD3D8406C, 0x18000173
+.long 0xD3D8406D, 0x18000174
+.long 0xD3D8406E, 0x18000175
+.long 0xD3D8406F, 0x18000176
+.long 0xD3D84070, 0x18000177
+.long 0x7ED21569
+.long 0x7ED4156A
+.long 0xD2000069, 0x05A5216A
+.long 0xD3904069, 0x1802D228
+.long 0x7ED6156B
+.long 0x7ED8156C
+.long 0xD200006A, 0x05AD216C
+.long 0xD390406A, 0x1802D428
+.long 0x7EDA156D
+.long 0x7EDC156E
+.long 0xD200006B, 0x05B5216E
+.long 0xD390406B, 0x1802D628
+.long 0xBF8C0F73
+.long 0xD38E4069, 0x1DA6C229
+.long 0xD38E406A, 0x1DAAC429
+.long 0xE0741040, 0x80056960
+.long 0x7EDE156F
+.long 0x7EE01570
+.long 0xD200006C, 0x05BD2170
+.long 0xD390406C, 0x1802D828
+.long 0xD3D84071, 0x18000178
+.long 0xD3D84072, 0x18000179
+.long 0xD3D84073, 0x1800017A
+.long 0xD3D84074, 0x1800017B
+.long 0xBF8C0F73
+.long 0xD38E406B, 0x1DAEC629
+.long 0xD38E406C, 0x1DB2C829
+.long 0xE0741050, 0x80056B60
+.long 0x7EE21571
+.long 0x7EE41572
+.long 0xD200006D, 0x05C52172
+.long 0xD390406D, 0x1802DA28
+.long 0x7EE61573
+.long 0x7EE81574
+.long 0xD200006E, 0x05CD2174
+.long 0xD390406E, 0x1802DC28
+.long 0xD3D84075, 0x1800017C
+.long 0xD3D84076, 0x1800017D
+.long 0xD3D84077, 0x1800017E
+.long 0xD3D84078, 0x1800017F
+.long 0xBF8C0F73
+.long 0xD38E406D, 0x1DB6CA29
+.long 0xD38E406E, 0x1DBACC29
+.long 0xE0741060, 0x80056D60
+.long 0x7EEA1575
+.long 0x7EEC1576
+.long 0xD200006F, 0x05D52176
+.long 0xD390406F, 0x1802DE28
+.long 0x7EEE1577
+.long 0x7EF01578
+.long 0xD2000070, 0x05DD2178
+.long 0xD3904070, 0x1802E028
+.long 0xBF8C0F73
+.long 0xD38E406F, 0x1DBECE29
+.long 0xD38E4070, 0x1DC2D029
+.long 0xE0741070, 0x80056F60
+.long 0xBF8C0000
+.long 0xBF810000

--- a/Tensile/ReplacementKernels/Cijk_Alik_Bljk_HBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_4_USFGRO1_VAW2_VW4_WG16_32_1_WGM8.s.txt
+++ b/Tensile/ReplacementKernels/Cijk_Alik_Bljk_HBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_4_USFGRO1_VAW2_VW4_WG16_32_1_WGM8.s.txt
@@ -509,20 +509,9 @@ s_setprio 0 // Reset priority after macs
 .long 0x7EA40566
 .long 0xD1130067, 0x0000A08F
 .long 0x7EA20567
-.long 0xC0020140, 0x00000074
 .long 0xBF068151
-.long 0xBF8400B3
+.long 0xBF8400A9
 .long 0xBF8CC07F
-.long 0x86580387
-.long 0x92580558
-.long 0x81580258
-.long 0x8F598358
-.long 0xBE820059
-.long 0x86595887
-.long 0x8F5A8303
-.long 0x8E5A835A
-.long 0x81595A59
-.long 0xBE830059
 .long 0xBE880034
 .long 0xBE890035
 .long 0xBE8B00FF, 0x00020000
@@ -704,16 +693,6 @@ s_setprio 0 // Reset priority after macs
 .long 0x68C4C4FF, 0x00002200
 .long 0x68C6C4FF, 0x00002200
 .long 0xBF8CC07F
-.long 0x86580387
-.long 0x92580558
-.long 0x81580258
-.long 0x8F598358
-.long 0xBE820059
-.long 0x86595887
-.long 0x8F5A8303
-.long 0x8E5A835A
-.long 0x81595A59
-.long 0xBE830059
 .long 0xBE900022
 .long 0xBE910023
 .long 0xBE9200FF, 0x80000000

--- a/Tensile/ReplacementKernels/Cijk_Alik_Bljk_HBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_4_USFGRO1_VAW2_VW4_WG16_32_1_WGM8.s.txt
+++ b/Tensile/ReplacementKernels/Cijk_Alik_Bljk_HBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_4_USFGRO1_VAW2_VW4_WG16_32_1_WGM8.s.txt
@@ -1,0 +1,1005 @@
+
+
+/******************************************/
+/* Function Prefix                        */
+/******************************************/
+
+
+
+/******************************************/
+/* Begin Kernel                           */
+/******************************************/
+
+.hsa_code_object_version 2,0
+.hsa_code_object_isa 9, 0, 8, "AMD", "AMDGPU" 
+.text
+.protected Cijk_Alik_Bljk_HBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_4_USFGRO1_VAW2_VW4_WG16_32_1_WGM8
+.globl Cijk_Alik_Bljk_HBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_4_USFGRO1_VAW2_VW4_WG16_32_1_WGM8
+.p2align 8
+.type Cijk_Alik_Bljk_HBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_4_USFGRO1_VAW2_VW4_WG16_32_1_WGM8,@function
+.amdgpu_hsa_kernel Cijk_Alik_Bljk_HBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_4_USFGRO1_VAW2_VW4_WG16_32_1_WGM8
+Cijk_Alik_Bljk_HBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_4_USFGRO1_VAW2_VW4_WG16_32_1_WGM8:
+.amd_kernel_code_t
+  is_ptr64 = 1
+  enable_sgpr_kernarg_segment_ptr = 1
+  kernarg_segment_byte_size = 148 // bytes of kern args
+  workitem_vgpr_count = 108 // vgprs
+  wavefront_sgpr_count = 98 // sgprs
+  compute_pgm_rsrc1_vgprs = 26 // floor((108-1)/4)
+  compute_pgm_rsrc1_sgprs = 12 // floor((98-1)/8)
+  compute_pgm_rsrc2_tidig_comp_cnt = 0 // 1D wg
+  compute_pgm_rsrc2_tgid_x_en = 1 // wg.x
+  compute_pgm_rsrc2_tgid_y_en = 1 // wg.y
+  compute_pgm_rsrc2_tgid_z_en = 1 // wg.z
+  workgroup_group_segment_byte_size = 30000// lds bytes
+  compute_pgm_rsrc2_user_sgpr = 2 // vcc
+  kernarg_segment_alignment = 4
+  group_segment_alignment = 4
+  private_segment_alignment = 4
+.end_amd_kernel_code_t
+
+/******************************************/
+/* Optimizations and Config:              */
+/******************************************/
+/* ThreadTile= 4 x 4 */
+/* SubGroup= 16 x 32 */
+/* VectorWidth=4 */
+/* GlobalLoadVectorWidthA=4, GlobalLoadVectorWidthB=4 */
+/* DirectToLdsA=False */
+/* DirectToLdsB=False */
+/* UseSgprForGRO=1 */
+.amd_amdgpu_hsa_metadata
+Version: [ 1, 0 ]
+Kernels:
+  - Name: Cijk_Alik_Bljk_HBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_4_USFGRO1_VAW2_VW4_WG16_32_1_WGM8
+    SymbolName: 'Cijk_Alik_Bljk_HBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_MI_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_4_USFGRO1_VAW2_VW4_WG16_32_1_WGM8@kd'
+    Language: OpenCL C
+    LanguageVersion: [ 2, 0 ]
+    Args:
+      - Name:            sizeC
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            sizeA
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            sizeB
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            D
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       Struct
+        AddrSpaceQual:   Generic
+      - Name:            C
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       Struct
+        AddrSpaceQual:   Generic
+      - Name:            A
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       Struct
+        AddrSpaceQual:   Generic
+      - Name:            B
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       Struct
+        AddrSpaceQual:   Generic
+      - Name:            alpha
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       F16
+      - Name:            beta
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       F16
+      - Name:            strideD0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideD1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideC0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideC1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideA0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideA1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideB0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideB1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree2
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesSum0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            OrigStaggerUIter
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       I32
+      - Name:            NumWorkGroups0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            NumWorkGroups1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            MagicNumberProblemNumGroupTiles0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            GridNumWorkGroups0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            NumFullBlocks
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            WgmRemainder1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            MagicNumberWgmRemainder1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            padding
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+    CodeProps:
+      KernargSegmentSize: 148
+      GroupSegmentFixedSize: 28672
+      PrivateSegmentFixedSize: 0
+      KernargSegmentAlign:  8
+      WavefrontSize:        64
+      NumSGPRs:             98
+      NumVGPRs:             108
+      MaxFlatWorkGroupSize: 512
+.end_amd_amdgpu_hsa_metadata
+
+/******************************************/
+/* Asm syntax workarounds                 */
+/******************************************/
+.macro _v_add_co_u32 dst, cc, src0, src1, dpp=
+   v_add_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+
+.macro _v_add_u32 dst, src0, src1, dpp=
+   v_add_u32 \dst, \src0, \src1 \dpp
+.endm
+
+.macro _v_sub_co_u32 dst, cc, src0, src1, dpp=
+   v_sub_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+
+.macro _v_sub_u32 dst, src0, src1, dpp=
+   v_sub_u32 \dst, \src0, \src1 \dpp
+.endm
+
+.macro _v_addc_co_u32 dst, ccOut, src0, ccIn, src1, dpp=
+   v_addc_co_u32 \dst, \ccOut, \src0, \ccIn, \src1 \dpp
+.endm
+
+.macro _v_add_lshl_u32 dst, src0, src1, shiftCnt
+    v_add_lshl_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+.macro _v_lshl_add_u32 dst, src0, src1, shiftCnt
+    v_lshl_add_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+/******************************************/
+/* Magic div and mod functions            */
+/******************************************/
+.macro V_MAGIC_DIV dstIdx, dividend, magicNumber, magicShift
+    v_mul_hi_u32 v[\dstIdx+1], \dividend, \magicNumber
+    v_mul_lo_u32 v[\dstIdx+0], \dividend, \magicNumber
+    v_lshrrev_b64 v[\dstIdx:\dstIdx+1], \magicShift, v[\dstIdx:\dstIdx+1]
+.endm
+
+/******************************************/
+/* VGPR Assignments                       */
+/******************************************/
+.set vgprValuC, 0
+/* ValuA/B   Xn=PLR buffer idx,  In=InnerUnroll idx */
+.set vgprValuA_X0_I0, 32
+.set vgprValuA_X1_I0, 34
+.set vgprG2LA, 36
+.set vgprValuB_X0_I0, 40
+.set vgprValuB_X1_I0, 44
+.set vgprG2LB, 48
+.set vgprLocalWriteAddrA, 56
+.set vgprLocalWriteAddrB, 57
+.set vgprGlobalReadOffsetA, 58
+.set vgprGlobalReadOffsetB, 59
+.set vgprLocalReadAddrA, 60
+.set vgprLocalReadAddrB, 61
+.set vgprSerial, 62
+/* Num VGPR=63 */
+
+/******************************************/
+/* SGPR Assignments                       */
+/******************************************/
+.set sgprKernArgAddress, 0
+.set sgprWorkGroup0, 2
+.set sgprWorkGroup1, 3
+.set sgprWorkGroup2, 4
+.set sgprNumWorkGroups0, 5
+.set sgprNumWorkGroups1, 6
+.set sgprSrdA, 8
+.set sgprSrdB, 12
+.set sgprSrdD, 16
+.set sgprSrdC, 20
+.set sgprTensor2dSizeC, 24
+.set sgprTensor2dSizeA, 26
+.set sgprTensor2dSizeB, 28
+.set sgprSaveExecMask, 30
+.set sgprAddressD, 32
+.set sgprAddressC, 34
+.set sgprStridesD, 36
+.set sgprStridesC, 38
+.set sgprAlpha, 40
+.set sgprBeta, 41
+.set sgprSizesFree, 42
+.set sgprSizesSum, 45
+.set sgprLoopCounters, 46
+.set sgprOrigLoopCounter, 47
+.set sgprStridesA, 48
+.set sgprStridesB, 50
+.set sgprAddressA, 52
+.set sgprAddressB, 54
+.set sgprShadowLimitA, 56
+.set sgprShadowLimitB, 58
+.set sgprOrigStaggerUIter, 60
+.set sgprStaggerUIter, 61
+.set sgprWrapUA, 62
+.set sgprWrapUB, 64
+.set sgprNumFullBlocks, 66
+.set sgprWgmRemainder1, 67
+.set sgprMagicNumberWgmRemainder1, 68
+.set sgprGlobalReadIncsA, 69
+.set sgprGlobalReadIncsB, 70
+.set sgprScalarGlobalReadOffsetA, 71
+.set sgprScalarGlobalReadOffsetB, 72
+/* max SGPR=98 */
+
+/* Size Assignments */
+.set sgprSizeD0I, sgprSizesFree+0
+.set sgprSizeD1J, sgprSizesFree+1
+.set sgprSizeDK, sgprSizesFree+2
+.set sgprSizeC0I, sgprSizesFree+0
+.set sgprSizeC1J, sgprSizesFree+1
+.set sgprSizeCK, sgprSizesFree+2
+.set sgprSizeAL, sgprSizesSum+0
+.set sgprSizeA0I, sgprSizesFree+0
+.set sgprSizeAK, sgprSizesFree+2
+.set sgprSizeBL, sgprSizesSum+0
+.set sgprSizeB1J, sgprSizesFree+1
+.set sgprSizeBK, sgprSizesFree+2
+
+/* Stride Assignments */
+.set constStrideD0I, 1
+.set sgprStrideD1J, sgprStridesD+0
+.set sgprStrideDK, sgprStridesD+1
+.set constStrideC0I, 1
+.set sgprStrideC1J, sgprStridesC+0
+.set sgprStrideCK, sgprStridesC+1
+.set constStrideAL, 1
+.set sgprStrideA0I, sgprStridesA+0
+.set sgprStrideAK, sgprStridesA+1
+.set constStrideBL, 1
+.set sgprStrideB1J, sgprStridesB+0
+.set sgprStrideBK, sgprStridesB+1
+
+.set DepthU, 32
+/* Number of elements to shift-left SRD */
+.set SrdShiftLeftA, 4
+.set SrdShiftLeftB, 4
+/* 2GB limit - set offsets to -1 to exceed this and clamp */
+.set BufferLimit, 0x80000000
+/* Bits 127:96 of SRD.  Set DataFormat = 32 bit */
+.set Srd127_96, 0x0020000
+.set BufferOOB, 0x80000000
+
+/* Global Offset A */
+.macro GLOBAL_OFFSET_A vgprAddr vgprOffsetL vgprOffset0I vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStrideA0I], v[\vgprOffset0I] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprOffsetL], v[\vgprTmp+0] // accumulate d1 lower
+_v_add_u32 v[\vgprAddr+0], 0x4, v[\vgprAddr+0]     // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/* Global Offset B */
+.macro GLOBAL_OFFSET_B vgprAddr vgprOffsetL vgprOffset1J vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStrideB1J], v[\vgprOffset1J] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprOffsetL], v[\vgprTmp+0] // accumulate d1 lower
+_v_add_u32 v[\vgprAddr+0], 0x4, v[\vgprAddr+0]     // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/******************************************/
+/* Dynamic Scalar Divide: vQuotient=vDividend/vDivisor; vRemainder=vDividend%vDivisor; */
+/******************************************/
+.macro DYNAMIC_VECTOR_DIVIDE vQuotient vRemainder vDividend vDivisor vTmp0 vTmp1 sTmp
+v_cvt_f32_u32 v[\vQuotient], v[\vDivisor]          //
+v_rcp_f32 v[\vQuotient], v[\vQuotient]             //
+v_mul_f32 v[\vQuotient], 0x4f800000, v[\vQuotient] //
+v_cvt_u32_f32 v[\vQuotient], v[\vQuotient]         //
+v_mul_lo_u32 v[\vRemainder], v[\vDivisor], v[\vQuotient] //
+v_mul_hi_u32 v[\vTmp0], v[\vDivisor], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp1], vcc, 0x0, v[\vRemainder]  //
+v_cmp_ne_i32 s[\sTmp:\sTmp+1], 0x0, v[\vTmp0]      //
+v_cndmask_b32 v[\vRemainder], v[\vTmp1], v[\vRemainder], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vRemainder], v[\vRemainder], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vQuotient], v[\vRemainder] //
+_v_add_co_u32 v[\vQuotient], vcc, v[\vQuotient], v[\vRemainder] //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vTmp0], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vQuotient], v[\vQuotient], v[\vDividend] //
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vDividend], v[\vRemainder] //
+v_cmp_ge_u32 s[\sTmp:\sTmp+1], v[\vDividend], v[\vRemainder] //
+_v_add_co_u32 v[\vRemainder], vcc, 0x1, v[\vQuotient] //
+_v_add_co_u32 v[\vTmp1], vcc, -1, v[\vQuotient]    //
+v_cmp_le_u32 vcc, v[\vDivisor], v[\vTmp0]          //
+s_and_b64 vcc, s[\sTmp:\sTmp+1], vcc               //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vRemainder], vcc //
+v_cndmask_b32 v[\vQuotient], v[\vTmp1], v[\vQuotient], s[\sTmp:\sTmp+1] //
+v_cmp_ne_i32 vcc, 0x0, v[\vDivisor]                //
+v_cndmask_b32 v[\vQuotient], -1, v[\vQuotient], vcc // final result
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vRemainder], vcc, v[\vDividend], v[\vRemainder] // final result
+.endm
+
+/******************************************/
+/* 4x8 thread-tile                        */
+/******************************************/
+.macro MAC_4x8_X0
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[0] iui=0
+s_setprio 1 // Raise priority while processing macs
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[1]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[4]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[5]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[2] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[3]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[6]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[7]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[8] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[9]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[12]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[13]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[10] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[11]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[14]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[15]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[16] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[17]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[20]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[21]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[18] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[19]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[22]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[23]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[24] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[25]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[28]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[29]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[26] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[27]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[30]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[31]
+s_setprio 0 // Reset priority after macs
+.endm
+.macro MAC_4x8_X1
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[0] iui=0
+s_setprio 1 // Raise priority while processing macs
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[1]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[4]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[5]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[2] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[3]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[6]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[7]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[8] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[9]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[12]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[13]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[10] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[11]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[14]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[15]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[16] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[17]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[20]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[21]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[18] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[19]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[22]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[23]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[24] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[25]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[28]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[29]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[26] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[27]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[30]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[31]
+s_setprio 0 // Reset priority after macs
+.endm
+
+
+
+
+/***** program start from here *****/
+
+.long 0xC00A0D00, 0x00000028
+.long 0xC00A0C00, 0x00000050
+.long 0xC00A0600, 0x00000008
+.long 0xC0020B40, 0x0000006C
+.long 0xBEFC00FF, 0x00006600
+.long 0x7EC80300
+.long 0x26CA00BF
+.long 0x2004C886
+.long 0xB8D0F804
+.long 0xD1130004, 0x0000A0B0
+.long 0x20CC0884
+.long 0x7EA40566
+.long 0xD1130067, 0x0000A08F
+.long 0x7EA20567
+.long 0xC0020140, 0x00000074
+.long 0xBF068151
+.long 0xBF8400B3
+.long 0xBF8CC07F
+.long 0x86580387
+.long 0x92580558
+.long 0x81580258
+.long 0x8F598358
+.long 0xBE820059
+.long 0x86595887
+.long 0x8F5A8303
+.long 0x8E5A835A
+.long 0x81595A59
+.long 0xBE830059
+.long 0xBE880034
+.long 0xBE890035
+.long 0xBE8B00FF, 0x00020000
+.long 0xBE8A00FF, 0x80000000
+.long 0x9254C030
+.long 0x92545402
+.long 0x92559052
+.long 0x92533055
+.long 0x81545354
+.long 0x2000CA82
+.long 0xD2850004, 0x00020030
+.long 0x2602CA83
+.long 0x24020283
+.long 0x32A40304
+.long 0x68A4A454
+.long 0x24A4A481
+.long 0xBECC00FF, 0x00000440
+.long 0x924C4C52
+.long 0xBE8C0036
+.long 0xBE8D0037
+.long 0xBE8F00FF, 0x00020000
+.long 0xBE8E00FF, 0x80000000
+.long 0x9254FF32, 0x00000080
+.long 0x92545403
+.long 0x9255A052
+.long 0x92533255
+.long 0x81545354
+.long 0x2004CA82
+.long 0xD2850004, 0x00020432
+.long 0x2606CA83
+.long 0x24060683
+.long 0x32AC0704
+.long 0x68ACAC54
+.long 0x24ACAC81
+.long 0x8E4A8532
+.long 0x68AEAC4A
+.long 0xBECE00FF, 0x00000880
+.long 0x924E4E52
+.long 0x814EFF4E, 0x00002200
+.long 0x814DFF4C, 0x00001100
+.long 0x2498CA84
+.long 0x6898984C
+.long 0x249ACA84
+.long 0x689A9A4D
+.long 0x814FFF4E, 0x00002200
+.long 0x249CCA84
+.long 0x689C9C4E
+.long 0x249ECA84
+.long 0x689E9E4F
+.long 0x2002CA83
+.long 0xD2850001, 0x00020288
+.long 0x68989901
+.long 0x689A9B01
+.long 0x689C9D01
+.long 0x689E9F01
+.long 0xD1340054, 0x00018152
+.long 0xD1340058, 0x00018156
+.long 0xD1340059, 0x00018157
+.long 0xBF8A0000
+.long 0xE05C1000, 0x80022052
+.long 0xE05C1000, 0x80033056
+.long 0xE05C1000, 0x80033457
+.long 0xE05C1000, 0x80022854
+.long 0xE05C1000, 0x80033858
+.long 0xE05C1000, 0x80033C59
+.long 0x68A4A4FF, 0x00000080
+.long 0x68ACACFF, 0x00000080
+.long 0x68AEAEFF, 0x00000080
+.long 0x8F2E852D
+.long 0x80AE2E80
+.long 0xBF06C22E
+.long 0xBF850034
+.long 0xBF8C0F75
+.long 0xD9BE0000, 0x0000204C
+.long 0xBF8C0F73
+.long 0xD9BE0000, 0x0000304E
+.long 0xD9BE0440, 0x0000344E
+.long 0xBF8CC27F
+.long 0xE05C1000, 0x80022052
+.long 0xBF8CC17F
+.long 0xE05C1000, 0x80033056
+.long 0xBF8CC07F
+.long 0xE05C1000, 0x80033457
+.long 0xBF8F0001
+.long 0x68A4A4FF, 0x00000080
+.long 0x68ACACFF, 0x00000080
+.long 0x68AEAEFF, 0x00000080
+.long 0x68A8A8FF, 0x00000080
+.long 0x68B0B0FF, 0x00000080
+.long 0x68B2B2FF, 0x00000080
+.long 0xBF8F0000
+.long 0xBF8C0F75
+.long 0xD9BE0000, 0x0000284D
+.long 0xBF8C0F73
+.long 0xD9BE0000, 0x0000384F
+.long 0xD9BE0440, 0x00003C4F
+.long 0xBF8CC27F
+.long 0xE05C1000, 0x80022854
+.long 0xBF8CC07F
+.long 0xBF8A0000
+.long 0xE05C1000, 0x80033858
+.long 0xE05C1000, 0x80033C59
+.long 0xBF8A0000
+.long 0x802E822E
+.long 0xBF00C22E
+.long 0xBF84FFCC
+.long 0xBF8C0F75
+.long 0xD9BE0000, 0x0000204C
+.long 0xBF8C0F73
+.long 0xD9BE0000, 0x0000304E
+.long 0xD9BE0440, 0x0000344E
+.long 0xBF8C0F72
+.long 0xD9BE0000, 0x0000284D
+.long 0xBF8C0F70
+.long 0xD9BE0000, 0x0000384F
+.long 0xD9BE0440, 0x00003C4F
+.long 0xBF8CC07F
+.long 0xBF8A0000
+.long 0xBF810000
+.long 0xD3D94000, 0x18000080
+.long 0xD3D94001, 0x18000080
+.long 0xD3D94002, 0x18000080
+.long 0xD3D94003, 0x18000080
+.long 0xD3D94004, 0x18000080
+.long 0xD3D94005, 0x18000080
+.long 0xD3D94006, 0x18000080
+.long 0xD3D94007, 0x18000080
+.long 0xD3D94008, 0x18000080
+.long 0xD3D94009, 0x18000080
+.long 0xD3D9400A, 0x18000080
+.long 0xD3D9400B, 0x18000080
+.long 0xD3D9400C, 0x18000080
+.long 0xD3D9400D, 0x18000080
+.long 0xD3D9400E, 0x18000080
+.long 0xD3D9400F, 0x18000080
+.long 0xD3D94010, 0x18000080
+.long 0xD3D94011, 0x18000080
+.long 0xD3D94012, 0x18000080
+.long 0xD3D94013, 0x18000080
+.long 0xD3D94014, 0x18000080
+.long 0xD3D94015, 0x18000080
+.long 0xD3D94016, 0x18000080
+.long 0xD3D94017, 0x18000080
+.long 0xD3D94018, 0x18000080
+.long 0xD3D94019, 0x18000080
+.long 0xD3D9401A, 0x18000080
+.long 0xD3D9401B, 0x18000080
+.long 0xD3D9401C, 0x18000080
+.long 0xD3D9401D, 0x18000080
+.long 0xD3D9401E, 0x18000080
+.long 0xD3D9401F, 0x18000080
+.long 0xC0060700, 0x00000000
+.long 0xC00A0A00, 0x00000038
+.long 0xC00A0900, 0x00000040
+.long 0xC00A0800, 0x00000018
+.long 0xD1130001, 0x00013F65
+.long 0xD2850060, 0x000202A0
+.long 0x20040281
+.long 0xD2850002, 0x00020488
+.long 0x2002CA85
+.long 0x24020282
+.long 0x68C0C101
+.long 0x24C0C081
+.long 0x68C0C102
+.long 0x68C0C080
+.long 0x68C2C0FF, 0x00001100
+.long 0xBF8A0000
+.long 0xD1130001, 0x00013F65
+.long 0xD2850062, 0x000202A0
+.long 0x20040281
+.long 0xD2850002, 0x00020488
+.long 0x2002CA85
+.long 0x24020282
+.long 0x68C4C501
+.long 0x24C4C481
+.long 0x68C4C502
+.long 0x9254FF52, 0x00000880
+.long 0x68C4C454
+.long 0x68C4C4FF, 0x00002200
+.long 0x68C6C4FF, 0x00002200
+.long 0xBF8CC07F
+.long 0x86580387
+.long 0x92580558
+.long 0x81580258
+.long 0x8F598358
+.long 0xBE820059
+.long 0x86595887
+.long 0x8F5A8303
+.long 0x8E5A835A
+.long 0x81595A59
+.long 0xBE830059
+.long 0xBE900022
+.long 0xBE910023
+.long 0xBE9200FF, 0x80000000
+.long 0xBE9300FF, 0x00020000
+.long 0xBE940020
+.long 0xBE950021
+.long 0xBE9600FF, 0x80000000
+.long 0xBE9700FF, 0x00020000
+.long 0x925603FF, 0x00000080
+.long 0x96552656
+.long 0x92542656
+.long 0x8ED48154
+.long 0x80105410
+.long 0x82115511
+.long 0x80145414
+.long 0x82155515
+.long 0x96552704
+.long 0x92542704
+.long 0x8ED48154
+.long 0x80105410
+.long 0x82115511
+.long 0x80145414
+.long 0x82155515
+.long 0x24C8CC86
+.long 0x68C8C965
+.long 0xD2850004, 0x0002CCA0
+.long 0xD2850003, 0x00004D04
+.long 0x2608C89F
+.long 0xD2850005, 0x00004D04
+.long 0x2608C8BF
+.long 0x200C0885
+.long 0x240C0C82
+.long 0x68D60B03
+.long 0x925402C0
+.long 0x32D40C54
+.long 0xD1FE0068, 0x0206D76A
+.long 0xBF8A0000
+.long 0xD8EC0000, 0x20000060
+.long 0xD8EC0000, 0x40000062
+.long 0xD8EC0000, 0x30000061
+.long 0xD8EC0000, 0x48000063
+.long 0xBF8CC27F
+.long 0xD3CC0000, 0x04028120
+.long 0xD8EC0010, 0x22000060
+.long 0xD8EC0010, 0x42000062
+.long 0xD8EC0010, 0x32000061
+.long 0xD8EC0010, 0x4A000063
+.long 0xBF8CC47F
+.long 0xD3CC0000, 0x04029130
+.long 0xD8EC0020, 0x24000060
+.long 0xD8EC0020, 0x44000062
+.long 0xD8EC0020, 0x34000061
+.long 0xD8EC0020, 0x4C000063
+.long 0xE0541000, 0x80041068
+.long 0xE0541010, 0x80041268
+.long 0xBF8CC67F
+.long 0xD3CC0000, 0x04028522
+.long 0xD8EC0030, 0x26000060
+.long 0xD8EC0030, 0x46000062
+.long 0xD8EC0030, 0x36000061
+.long 0xD8EC0030, 0x4E000063
+.long 0xE0541020, 0x80041468
+.long 0xE0541030, 0x80041668
+.long 0xBF8CC87F
+.long 0xD3CC0000, 0x04029532
+.long 0xD8EC0880, 0x28000060
+.long 0xD8EC0880, 0x38000061
+.long 0xD8EC0890, 0x2A000060
+.long 0xD8EC0890, 0x3A000061
+.long 0xBF8CCA7F
+.long 0xD3CC0000, 0x04028924
+.long 0xD8EC08A0, 0x2C000060
+.long 0xD8EC08A0, 0x3C000061
+.long 0xD8EC08B0, 0x2E000060
+.long 0xD8EC08B0, 0x3E000061
+.long 0xBF8CCC7F
+.long 0xD3CC0000, 0x04029934
+.long 0xBF8CCE7F
+.long 0xD3CC0000, 0x04028D26
+.long 0xBF8CC07F
+.long 0xBF8A0000
+.long 0x8F2E852D
+.long 0x80AE2E80
+.long 0xBF06C22E
+.long 0xBF850157
+.long 0xD3CC0000, 0x04029D36
+.long 0xBF80000C
+.long 0xD3CC0010, 0x04428128
+.long 0xBF80000C
+.long 0xD3CC0010, 0x04429138
+.long 0xBF80000C
+.long 0xD3CC0010, 0x0442852A
+.long 0xBF80000C
+.long 0xD3CC0010, 0x0442953A
+.long 0xBF80000C
+.long 0xD3CC0010, 0x0442892C
+.long 0xBF80000C
+.long 0xD3CC0010, 0x0442993C
+.long 0xBF80000C
+.long 0xD3CC0010, 0x04428D2E
+.long 0xBF8A0000
+.long 0xD8EC0000, 0x20000060
+.long 0xD8EC0000, 0x40000062
+.long 0xD8EC0000, 0x30000061
+.long 0xD8EC0000, 0x48000063
+.long 0xD3CC0010, 0x04429D3E
+.long 0xD8EC0010, 0x22000060
+.long 0xD8EC0010, 0x42000062
+.long 0xD8EC0010, 0x32000061
+.long 0xD8EC0010, 0x4A000063
+.long 0xBF8CC67F
+.long 0xD3CC0000, 0x04028120
+.long 0xD8EC0020, 0x24000060
+.long 0xD8EC0020, 0x44000062
+.long 0xD8EC0020, 0x34000061
+.long 0xD8EC0020, 0x4C000063
+.long 0xBF8CC87F
+.long 0xD3CC0000, 0x04029130
+.long 0xD8EC0030, 0x26000060
+.long 0xD8EC0030, 0x46000062
+.long 0xD8EC0030, 0x36000061
+.long 0xD8EC0030, 0x4E000063
+.long 0xBF8CCA7F
+.long 0xD3CC0000, 0x04028522
+.long 0xD8EC0880, 0x28000060
+.long 0xD8EC0880, 0x38000061
+.long 0xD8EC0890, 0x2A000060
+.long 0xD8EC0890, 0x3A000061
+.long 0xBF8CCC7F
+.long 0xD3CC0000, 0x04029532
+.long 0xD8EC08A0, 0x2C000060
+.long 0xD8EC08A0, 0x3C000061
+.long 0xD8EC08B0, 0x2E000060
+.long 0xD8EC08B0, 0x3E000061
+.long 0xBF8CCE7F
+.long 0xD3CC0000, 0x04028924
+.long 0xBF80000C
+.long 0xBF8CCC7F
+.long 0xD3CC0000, 0x04029934
+.long 0xBF8CC07F
+.long 0xBF8A0000
+.long 0xD3CC0000, 0x04028D26
+.long 0x802E822E
+.long 0xBF00C22E
+.long 0xBF84FF9C
+.long 0xE0541040, 0x80041868
+.long 0xE0541050, 0x80041A68
+.long 0xD3CC0000, 0x04029D36
+.long 0xE0541060, 0x80041C68
+.long 0xE0541070, 0x80041E68
+.long 0xD3CC0010, 0x04428128
+.long 0xD3D84000, 0x18000100
+.long 0xD3D84001, 0x18000101
+.long 0xD3D84002, 0x18000102
+.long 0xD3D84003, 0x18000103
+.long 0xD3D84004, 0x18000104
+.long 0xD3D84005, 0x18000105
+.long 0xD3D84006, 0x18000106
+.long 0xD3D84007, 0x18000107
+.long 0x7E001500
+.long 0x7E021501
+.long 0xD2000000, 0x04012101
+.long 0xD3904000, 0x18020028
+.long 0xD3CC0010, 0x04429138
+.long 0x7E041502
+.long 0x7E061503
+.long 0xD2000001, 0x04092103
+.long 0xD3904001, 0x18020228
+.long 0x7E081504
+.long 0x7E0A1505
+.long 0xD2000002, 0x04112105
+.long 0xD3904002, 0x18020428
+.long 0xBF8C0F77
+.long 0xD38E4000, 0x1C022029
+.long 0xD38E4001, 0x1C062229
+.long 0xE0741000, 0x80050068
+.long 0xD3CC0010, 0x0442852A
+.long 0x7E0C1506
+.long 0x7E0E1507
+.long 0xD2000003, 0x04192107
+.long 0xD3904003, 0x18020628
+.long 0xD3CC0010, 0x0442953A
+.long 0xBF8C0F77
+.long 0xD38E4002, 0x1C0A2429
+.long 0xD38E4003, 0x1C0E2629
+.long 0xE0741010, 0x80050268
+.long 0xD3CC0010, 0x0442892C
+.long 0xD3D84008, 0x18000108
+.long 0xD3D84009, 0x18000109
+.long 0xD3D8400A, 0x1800010A
+.long 0xD3D8400B, 0x1800010B
+.long 0x7E101508
+.long 0x7E121509
+.long 0xD2000004, 0x04212109
+.long 0xD3904004, 0x18020828
+.long 0x7E14150A
+.long 0x7E16150B
+.long 0xD2000005, 0x0429210B
+.long 0xD3904005, 0x18020A28
+.long 0xD3CC0010, 0x0442993C
+.long 0xBF8C0F77
+.long 0xD38E4004, 0x1C122829
+.long 0xD38E4005, 0x1C162A29
+.long 0xE0741020, 0x80050468
+.long 0xD3CC0010, 0x04428D2E
+.long 0xD3D8400C, 0x1800010C
+.long 0xD3D8400D, 0x1800010D
+.long 0xD3D8400E, 0x1800010E
+.long 0xD3D8400F, 0x1800010F
+.long 0x7E18150C
+.long 0x7E1A150D
+.long 0xD2000006, 0x0431210D
+.long 0xD3904006, 0x18020C28
+.long 0x7E1C150E
+.long 0x7E1E150F
+.long 0xD2000007, 0x0439210F
+.long 0xD3904007, 0x18020E28
+.long 0xD3CC0010, 0x04429D3E
+.long 0xBF800008
+.long 0xBF8C0F77
+.long 0xD38E4006, 0x1C1A2C29
+.long 0xD38E4007, 0x1C1E2E29
+.long 0xE0741030, 0x80050668
+.long 0xD3D84000, 0x18000110
+.long 0xD3D84001, 0x18000111
+.long 0xD3D84002, 0x18000112
+.long 0xD3D84003, 0x18000113
+.long 0xD3D84004, 0x18000114
+.long 0xD3D84005, 0x18000115
+.long 0xD3D84006, 0x18000116
+.long 0xD3D84007, 0x18000117
+.long 0x7E001500
+.long 0x7E021501
+.long 0xD2000000, 0x04012101
+.long 0xD3904000, 0x18020028
+.long 0x7E041502
+.long 0x7E061503
+.long 0xD2000001, 0x04092103
+.long 0xD3904001, 0x18020228
+.long 0x7E081504
+.long 0x7E0A1505
+.long 0xD2000002, 0x04112105
+.long 0xD3904002, 0x18020428
+.long 0xBF8C0F77
+.long 0xD38E4000, 0x1C023029
+.long 0xD38E4001, 0x1C063229
+.long 0xE0741040, 0x80050068
+.long 0x7E0C1506
+.long 0x7E0E1507
+.long 0xD2000003, 0x04192107
+.long 0xD3904003, 0x18020628
+.long 0xD3D84008, 0x18000118
+.long 0xD3D84009, 0x18000119
+.long 0xD3D8400A, 0x1800011A
+.long 0xD3D8400B, 0x1800011B
+.long 0xBF8C0F77
+.long 0xD38E4002, 0x1C0A3429
+.long 0xD38E4003, 0x1C0E3629
+.long 0xE0741050, 0x80050268
+.long 0x7E101508
+.long 0x7E121509
+.long 0xD2000004, 0x04212109
+.long 0xD3904004, 0x18020828
+.long 0x7E14150A
+.long 0x7E16150B
+.long 0xD2000005, 0x0429210B
+.long 0xD3904005, 0x18020A28
+.long 0xD3D8400C, 0x1800011C
+.long 0xD3D8400D, 0x1800011D
+.long 0xD3D8400E, 0x1800011E
+.long 0xD3D8400F, 0x1800011F
+.long 0xBF8C0F77
+.long 0xD38E4004, 0x1C123829
+.long 0xD38E4005, 0x1C163A29
+.long 0xE0741060, 0x80050468
+.long 0x7E18150C
+.long 0x7E1A150D
+.long 0xD2000006, 0x0431210D
+.long 0xD3904006, 0x18020C28
+.long 0x7E1C150E
+.long 0x7E1E150F
+.long 0xD2000007, 0x0439210F
+.long 0xD3904007, 0x18020E28
+.long 0xBF8C0F77
+.long 0xD38E4006, 0x1C1A3C29
+.long 0xD38E4007, 0x1C1E3E29
+.long 0xE0741070, 0x80050668
+.long 0xBF8C0000
+.long 0xBF810000

--- a/Tensile/ReplacementKernels/Cijk_Alik_Bljk_HBH_MT64x128x32_SE_K1.s.txt
+++ b/Tensile/ReplacementKernels/Cijk_Alik_Bljk_HBH_MT64x128x32_SE_K1.s.txt
@@ -509,20 +509,9 @@ s_setprio 0 // Reset priority after macs
 .long 0x7EA40566
 .long 0xD1130067, 0x0000A08F
 .long 0x7EA20567
-.long 0xC0020140, 0x00000074
 .long 0xBF068151
-.long 0xBF8400B3
+.long 0xBF8400A9
 .long 0xBF8CC07F
-.long 0x86580387
-.long 0x92580558
-.long 0x81580258
-.long 0x8F598358
-.long 0xBE820059
-.long 0x86595887
-.long 0x8F5A8303
-.long 0x8E5A835A
-.long 0x81595A59
-.long 0xBE830059
 .long 0xBE880034
 .long 0xBE890035
 .long 0xBE8B00FF, 0x00020000
@@ -704,16 +693,6 @@ s_setprio 0 // Reset priority after macs
 .long 0x68C4C4FF, 0x00002200
 .long 0x68C6C4FF, 0x00002200
 .long 0xBF8CC07F
-.long 0x86580387
-.long 0x92580558
-.long 0x81580258
-.long 0x8F598358
-.long 0xBE820059
-.long 0x86595887
-.long 0x8F5A8303
-.long 0x8E5A835A
-.long 0x81595A59
-.long 0xBE830059
 .long 0xBE900022
 .long 0xBE910023
 .long 0xBE9200FF, 0x80000000

--- a/Tensile/ReplacementKernels/Cijk_Alik_Bljk_HBH_MT64x128x32_SE_K1.s.txt
+++ b/Tensile/ReplacementKernels/Cijk_Alik_Bljk_HBH_MT64x128x32_SE_K1.s.txt
@@ -1,0 +1,1005 @@
+
+
+/******************************************/
+/* Function Prefix                        */
+/******************************************/
+
+
+
+/******************************************/
+/* Begin Kernel                           */
+/******************************************/
+
+.hsa_code_object_version 2,0
+.hsa_code_object_isa 9, 0, 8, "AMD", "AMDGPU" 
+.text
+.protected Cijk_Alik_Bljk_HBH_MT64x128x32_SE_K1
+.globl Cijk_Alik_Bljk_HBH_MT64x128x32_SE_K1
+.p2align 8
+.type Cijk_Alik_Bljk_HBH_MT64x128x32_SE_K1,@function
+.amdgpu_hsa_kernel Cijk_Alik_Bljk_HBH_MT64x128x32_SE_K1
+Cijk_Alik_Bljk_HBH_MT64x128x32_SE_K1:
+.amd_kernel_code_t
+  is_ptr64 = 1
+  enable_sgpr_kernarg_segment_ptr = 1
+  kernarg_segment_byte_size = 148 // bytes of kern args
+  workitem_vgpr_count = 108 // vgprs
+  wavefront_sgpr_count = 98 // sgprs
+  compute_pgm_rsrc1_vgprs = 26 // floor((108-1)/4)
+  compute_pgm_rsrc1_sgprs = 12 // floor((98-1)/8)
+  compute_pgm_rsrc2_tidig_comp_cnt = 0 // 1D wg
+  compute_pgm_rsrc2_tgid_x_en = 1 // wg.x
+  compute_pgm_rsrc2_tgid_y_en = 1 // wg.y
+  compute_pgm_rsrc2_tgid_z_en = 1 // wg.z
+  workgroup_group_segment_byte_size = 30000// lds bytes
+  compute_pgm_rsrc2_user_sgpr = 2 // vcc
+  kernarg_segment_alignment = 4
+  group_segment_alignment = 4
+  private_segment_alignment = 4
+.end_amd_kernel_code_t
+
+/******************************************/
+/* Optimizations and Config:              */
+/******************************************/
+/* ThreadTile= 4 x 4 */
+/* SubGroup= 16 x 32 */
+/* VectorWidth=4 */
+/* GlobalLoadVectorWidthA=4, GlobalLoadVectorWidthB=4 */
+/* DirectToLdsA=False */
+/* DirectToLdsB=False */
+/* UseSgprForGRO=1 */
+.amd_amdgpu_hsa_metadata
+Version: [ 1, 0 ]
+Kernels:
+  - Name: Cijk_Alik_Bljk_HBH_MT64x128x32_SE_K1
+    SymbolName: 'Cijk_Alik_Bljk_HBH_MT64x128x32_SE_K1@kd'
+    Language: OpenCL C
+    LanguageVersion: [ 2, 0 ]
+    Args:
+      - Name:            sizeC
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            sizeA
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            sizeB
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            D
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       Struct
+        AddrSpaceQual:   Generic
+      - Name:            C
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       Struct
+        AddrSpaceQual:   Generic
+      - Name:            A
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       Struct
+        AddrSpaceQual:   Generic
+      - Name:            B
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       Struct
+        AddrSpaceQual:   Generic
+      - Name:            alpha
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       F16
+      - Name:            beta
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       F16
+      - Name:            strideD0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideD1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideC0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideC1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideA0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideA1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideB0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideB1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree2
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesSum0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            OrigStaggerUIter
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       I32
+      - Name:            NumWorkGroups0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            NumWorkGroups1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            MagicNumberProblemNumGroupTiles0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            GridNumWorkGroups0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            NumFullBlocks
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            WgmRemainder1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            MagicNumberWgmRemainder1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            padding
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+    CodeProps:
+      KernargSegmentSize: 148
+      GroupSegmentFixedSize: 28672
+      PrivateSegmentFixedSize: 0
+      KernargSegmentAlign:  8
+      WavefrontSize:        64
+      NumSGPRs:             98
+      NumVGPRs:             108
+      MaxFlatWorkGroupSize: 512
+.end_amd_amdgpu_hsa_metadata
+
+/******************************************/
+/* Asm syntax workarounds                 */
+/******************************************/
+.macro _v_add_co_u32 dst, cc, src0, src1, dpp=
+   v_add_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+
+.macro _v_add_u32 dst, src0, src1, dpp=
+   v_add_u32 \dst, \src0, \src1 \dpp
+.endm
+
+.macro _v_sub_co_u32 dst, cc, src0, src1, dpp=
+   v_sub_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+
+.macro _v_sub_u32 dst, src0, src1, dpp=
+   v_sub_u32 \dst, \src0, \src1 \dpp
+.endm
+
+.macro _v_addc_co_u32 dst, ccOut, src0, ccIn, src1, dpp=
+   v_addc_co_u32 \dst, \ccOut, \src0, \ccIn, \src1 \dpp
+.endm
+
+.macro _v_add_lshl_u32 dst, src0, src1, shiftCnt
+    v_add_lshl_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+.macro _v_lshl_add_u32 dst, src0, src1, shiftCnt
+    v_lshl_add_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+/******************************************/
+/* Magic div and mod functions            */
+/******************************************/
+.macro V_MAGIC_DIV dstIdx, dividend, magicNumber, magicShift
+    v_mul_hi_u32 v[\dstIdx+1], \dividend, \magicNumber
+    v_mul_lo_u32 v[\dstIdx+0], \dividend, \magicNumber
+    v_lshrrev_b64 v[\dstIdx:\dstIdx+1], \magicShift, v[\dstIdx:\dstIdx+1]
+.endm
+
+/******************************************/
+/* VGPR Assignments                       */
+/******************************************/
+.set vgprValuC, 0
+/* ValuA/B   Xn=PLR buffer idx,  In=InnerUnroll idx */
+.set vgprValuA_X0_I0, 32
+.set vgprValuA_X1_I0, 34
+.set vgprG2LA, 36
+.set vgprValuB_X0_I0, 40
+.set vgprValuB_X1_I0, 44
+.set vgprG2LB, 48
+.set vgprLocalWriteAddrA, 56
+.set vgprLocalWriteAddrB, 57
+.set vgprGlobalReadOffsetA, 58
+.set vgprGlobalReadOffsetB, 59
+.set vgprLocalReadAddrA, 60
+.set vgprLocalReadAddrB, 61
+.set vgprSerial, 62
+/* Num VGPR=63 */
+
+/******************************************/
+/* SGPR Assignments                       */
+/******************************************/
+.set sgprKernArgAddress, 0
+.set sgprWorkGroup0, 2
+.set sgprWorkGroup1, 3
+.set sgprWorkGroup2, 4
+.set sgprNumWorkGroups0, 5
+.set sgprNumWorkGroups1, 6
+.set sgprSrdA, 8
+.set sgprSrdB, 12
+.set sgprSrdD, 16
+.set sgprSrdC, 20
+.set sgprTensor2dSizeC, 24
+.set sgprTensor2dSizeA, 26
+.set sgprTensor2dSizeB, 28
+.set sgprSaveExecMask, 30
+.set sgprAddressD, 32
+.set sgprAddressC, 34
+.set sgprStridesD, 36
+.set sgprStridesC, 38
+.set sgprAlpha, 40
+.set sgprBeta, 41
+.set sgprSizesFree, 42
+.set sgprSizesSum, 45
+.set sgprLoopCounters, 46
+.set sgprOrigLoopCounter, 47
+.set sgprStridesA, 48
+.set sgprStridesB, 50
+.set sgprAddressA, 52
+.set sgprAddressB, 54
+.set sgprShadowLimitA, 56
+.set sgprShadowLimitB, 58
+.set sgprOrigStaggerUIter, 60
+.set sgprStaggerUIter, 61
+.set sgprWrapUA, 62
+.set sgprWrapUB, 64
+.set sgprNumFullBlocks, 66
+.set sgprWgmRemainder1, 67
+.set sgprMagicNumberWgmRemainder1, 68
+.set sgprGlobalReadIncsA, 69
+.set sgprGlobalReadIncsB, 70
+.set sgprScalarGlobalReadOffsetA, 71
+.set sgprScalarGlobalReadOffsetB, 72
+/* max SGPR=98 */
+
+/* Size Assignments */
+.set sgprSizeD0I, sgprSizesFree+0
+.set sgprSizeD1J, sgprSizesFree+1
+.set sgprSizeDK, sgprSizesFree+2
+.set sgprSizeC0I, sgprSizesFree+0
+.set sgprSizeC1J, sgprSizesFree+1
+.set sgprSizeCK, sgprSizesFree+2
+.set sgprSizeAL, sgprSizesSum+0
+.set sgprSizeA0I, sgprSizesFree+0
+.set sgprSizeAK, sgprSizesFree+2
+.set sgprSizeBL, sgprSizesSum+0
+.set sgprSizeB1J, sgprSizesFree+1
+.set sgprSizeBK, sgprSizesFree+2
+
+/* Stride Assignments */
+.set constStrideD0I, 1
+.set sgprStrideD1J, sgprStridesD+0
+.set sgprStrideDK, sgprStridesD+1
+.set constStrideC0I, 1
+.set sgprStrideC1J, sgprStridesC+0
+.set sgprStrideCK, sgprStridesC+1
+.set constStrideAL, 1
+.set sgprStrideA0I, sgprStridesA+0
+.set sgprStrideAK, sgprStridesA+1
+.set constStrideBL, 1
+.set sgprStrideB1J, sgprStridesB+0
+.set sgprStrideBK, sgprStridesB+1
+
+.set DepthU, 32
+/* Number of elements to shift-left SRD */
+.set SrdShiftLeftA, 4
+.set SrdShiftLeftB, 4
+/* 2GB limit - set offsets to -1 to exceed this and clamp */
+.set BufferLimit, 0x80000000
+/* Bits 127:96 of SRD.  Set DataFormat = 32 bit */
+.set Srd127_96, 0x0020000
+.set BufferOOB, 0x80000000
+
+/* Global Offset A */
+.macro GLOBAL_OFFSET_A vgprAddr vgprOffsetL vgprOffset0I vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStrideA0I], v[\vgprOffset0I] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprOffsetL], v[\vgprTmp+0] // accumulate d1 lower
+_v_add_u32 v[\vgprAddr+0], 0x4, v[\vgprAddr+0]     // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/* Global Offset B */
+.macro GLOBAL_OFFSET_B vgprAddr vgprOffsetL vgprOffset1J vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStrideB1J], v[\vgprOffset1J] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprOffsetL], v[\vgprTmp+0] // accumulate d1 lower
+_v_add_u32 v[\vgprAddr+0], 0x4, v[\vgprAddr+0]     // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/******************************************/
+/* Dynamic Scalar Divide: vQuotient=vDividend/vDivisor; vRemainder=vDividend%vDivisor; */
+/******************************************/
+.macro DYNAMIC_VECTOR_DIVIDE vQuotient vRemainder vDividend vDivisor vTmp0 vTmp1 sTmp
+v_cvt_f32_u32 v[\vQuotient], v[\vDivisor]          //
+v_rcp_f32 v[\vQuotient], v[\vQuotient]             //
+v_mul_f32 v[\vQuotient], 0x4f800000, v[\vQuotient] //
+v_cvt_u32_f32 v[\vQuotient], v[\vQuotient]         //
+v_mul_lo_u32 v[\vRemainder], v[\vDivisor], v[\vQuotient] //
+v_mul_hi_u32 v[\vTmp0], v[\vDivisor], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp1], vcc, 0x0, v[\vRemainder]  //
+v_cmp_ne_i32 s[\sTmp:\sTmp+1], 0x0, v[\vTmp0]      //
+v_cndmask_b32 v[\vRemainder], v[\vTmp1], v[\vRemainder], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vRemainder], v[\vRemainder], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vQuotient], v[\vRemainder] //
+_v_add_co_u32 v[\vQuotient], vcc, v[\vQuotient], v[\vRemainder] //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vTmp0], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vQuotient], v[\vQuotient], v[\vDividend] //
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vDividend], v[\vRemainder] //
+v_cmp_ge_u32 s[\sTmp:\sTmp+1], v[\vDividend], v[\vRemainder] //
+_v_add_co_u32 v[\vRemainder], vcc, 0x1, v[\vQuotient] //
+_v_add_co_u32 v[\vTmp1], vcc, -1, v[\vQuotient]    //
+v_cmp_le_u32 vcc, v[\vDivisor], v[\vTmp0]          //
+s_and_b64 vcc, s[\sTmp:\sTmp+1], vcc               //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vRemainder], vcc //
+v_cndmask_b32 v[\vQuotient], v[\vTmp1], v[\vQuotient], s[\sTmp:\sTmp+1] //
+v_cmp_ne_i32 vcc, 0x0, v[\vDivisor]                //
+v_cndmask_b32 v[\vQuotient], -1, v[\vQuotient], vcc // final result
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vRemainder], vcc, v[\vDividend], v[\vRemainder] // final result
+.endm
+
+/******************************************/
+/* 4x8 thread-tile                        */
+/******************************************/
+.macro MAC_4x8_X0
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[0] iui=0
+s_setprio 1 // Raise priority while processing macs
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[1]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[4]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[5]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[2] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[3]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[6]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[7]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[8] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[9]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[12]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[13]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[10] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[11]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[14]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[15]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[16] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[17]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[20]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[21]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[18] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[19]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[22]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[23]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[24] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[25]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[28]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[29]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[26] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[27]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[30]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[31]
+s_setprio 0 // Reset priority after macs
+.endm
+.macro MAC_4x8_X1
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[0] iui=0
+s_setprio 1 // Raise priority while processing macs
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[1]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[4]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[5]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[2] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[3]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[6]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[7]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[8] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[9]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[12]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[13]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[10] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[11]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[14]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[15]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[16] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[17]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[20]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[21]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[18] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[19]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[22]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[23]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[24] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[25]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[28]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[29]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[26] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[27]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[30]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[31]
+s_setprio 0 // Reset priority after macs
+.endm
+
+
+
+
+/***** program start from here *****/
+
+.long 0xC00A0D00, 0x00000028
+.long 0xC00A0C00, 0x00000050
+.long 0xC00A0600, 0x00000008
+.long 0xC0020B40, 0x0000006C
+.long 0xBEFC00FF, 0x00006600
+.long 0x7EC80300
+.long 0x26CA00BF
+.long 0x2004C886
+.long 0xB8D0F804
+.long 0xD1130004, 0x0000A0B0
+.long 0x20CC0884
+.long 0x7EA40566
+.long 0xD1130067, 0x0000A08F
+.long 0x7EA20567
+.long 0xC0020140, 0x00000074
+.long 0xBF068151
+.long 0xBF8400B3
+.long 0xBF8CC07F
+.long 0x86580387
+.long 0x92580558
+.long 0x81580258
+.long 0x8F598358
+.long 0xBE820059
+.long 0x86595887
+.long 0x8F5A8303
+.long 0x8E5A835A
+.long 0x81595A59
+.long 0xBE830059
+.long 0xBE880034
+.long 0xBE890035
+.long 0xBE8B00FF, 0x00020000
+.long 0xBE8A00FF, 0x80000000
+.long 0x9254C030
+.long 0x92545402
+.long 0x92559052
+.long 0x92533055
+.long 0x81545354
+.long 0x2000CA82
+.long 0xD2850004, 0x00020030
+.long 0x2602CA83
+.long 0x24020283
+.long 0x32A40304
+.long 0x68A4A454
+.long 0x24A4A481
+.long 0xBECC00FF, 0x00000440
+.long 0x924C4C52
+.long 0xBE8C0036
+.long 0xBE8D0037
+.long 0xBE8F00FF, 0x00020000
+.long 0xBE8E00FF, 0x80000000
+.long 0x9254FF32, 0x00000080
+.long 0x92545403
+.long 0x9255A052
+.long 0x92533255
+.long 0x81545354
+.long 0x2004CA82
+.long 0xD2850004, 0x00020432
+.long 0x2606CA83
+.long 0x24060683
+.long 0x32AC0704
+.long 0x68ACAC54
+.long 0x24ACAC81
+.long 0x8E4A8532
+.long 0x68AEAC4A
+.long 0xBECE00FF, 0x00000880
+.long 0x924E4E52
+.long 0x814EFF4E, 0x00002200
+.long 0x814DFF4C, 0x00001100
+.long 0x2498CA84
+.long 0x6898984C
+.long 0x249ACA84
+.long 0x689A9A4D
+.long 0x814FFF4E, 0x00002200
+.long 0x249CCA84
+.long 0x689C9C4E
+.long 0x249ECA84
+.long 0x689E9E4F
+.long 0x2002CA83
+.long 0xD2850001, 0x00020288
+.long 0x68989901
+.long 0x689A9B01
+.long 0x689C9D01
+.long 0x689E9F01
+.long 0xD1340054, 0x00018152
+.long 0xD1340058, 0x00018156
+.long 0xD1340059, 0x00018157
+.long 0xBF8A0000
+.long 0xE05C1000, 0x80022052
+.long 0xE05C1000, 0x80033056
+.long 0xE05C1000, 0x80033457
+.long 0xE05C1000, 0x80022854
+.long 0xE05C1000, 0x80033858
+.long 0xE05C1000, 0x80033C59
+.long 0x68A4A4FF, 0x00000080
+.long 0x68ACACFF, 0x00000080
+.long 0x68AEAEFF, 0x00000080
+.long 0x8F2E852D
+.long 0x80AE2E80
+.long 0xBF06C22E
+.long 0xBF850034
+.long 0xBF8C0F75
+.long 0xD9BE0000, 0x0000204C
+.long 0xBF8C0F73
+.long 0xD9BE0000, 0x0000304E
+.long 0xD9BE0440, 0x0000344E
+.long 0xBF8CC27F
+.long 0xE05C1000, 0x80022052
+.long 0xBF8CC17F
+.long 0xE05C1000, 0x80033056
+.long 0xBF8CC07F
+.long 0xE05C1000, 0x80033457
+.long 0xBF8F0001
+.long 0x68A4A4FF, 0x00000080
+.long 0x68ACACFF, 0x00000080
+.long 0x68AEAEFF, 0x00000080
+.long 0x68A8A8FF, 0x00000080
+.long 0x68B0B0FF, 0x00000080
+.long 0x68B2B2FF, 0x00000080
+.long 0xBF8F0000
+.long 0xBF8C0F75
+.long 0xD9BE0000, 0x0000284D
+.long 0xBF8C0F73
+.long 0xD9BE0000, 0x0000384F
+.long 0xD9BE0440, 0x00003C4F
+.long 0xBF8CC27F
+.long 0xE05C1000, 0x80022854
+.long 0xBF8CC07F
+.long 0xBF8A0000
+.long 0xE05C1000, 0x80033858
+.long 0xE05C1000, 0x80033C59
+.long 0xBF8A0000
+.long 0x802E822E
+.long 0xBF00C22E
+.long 0xBF84FFCC
+.long 0xBF8C0F75
+.long 0xD9BE0000, 0x0000204C
+.long 0xBF8C0F73
+.long 0xD9BE0000, 0x0000304E
+.long 0xD9BE0440, 0x0000344E
+.long 0xBF8C0F72
+.long 0xD9BE0000, 0x0000284D
+.long 0xBF8C0F70
+.long 0xD9BE0000, 0x0000384F
+.long 0xD9BE0440, 0x00003C4F
+.long 0xBF8CC07F
+.long 0xBF8A0000
+.long 0xBF810000
+.long 0xD3D94000, 0x18000080
+.long 0xD3D94001, 0x18000080
+.long 0xD3D94002, 0x18000080
+.long 0xD3D94003, 0x18000080
+.long 0xD3D94004, 0x18000080
+.long 0xD3D94005, 0x18000080
+.long 0xD3D94006, 0x18000080
+.long 0xD3D94007, 0x18000080
+.long 0xD3D94008, 0x18000080
+.long 0xD3D94009, 0x18000080
+.long 0xD3D9400A, 0x18000080
+.long 0xD3D9400B, 0x18000080
+.long 0xD3D9400C, 0x18000080
+.long 0xD3D9400D, 0x18000080
+.long 0xD3D9400E, 0x18000080
+.long 0xD3D9400F, 0x18000080
+.long 0xD3D94010, 0x18000080
+.long 0xD3D94011, 0x18000080
+.long 0xD3D94012, 0x18000080
+.long 0xD3D94013, 0x18000080
+.long 0xD3D94014, 0x18000080
+.long 0xD3D94015, 0x18000080
+.long 0xD3D94016, 0x18000080
+.long 0xD3D94017, 0x18000080
+.long 0xD3D94018, 0x18000080
+.long 0xD3D94019, 0x18000080
+.long 0xD3D9401A, 0x18000080
+.long 0xD3D9401B, 0x18000080
+.long 0xD3D9401C, 0x18000080
+.long 0xD3D9401D, 0x18000080
+.long 0xD3D9401E, 0x18000080
+.long 0xD3D9401F, 0x18000080
+.long 0xC0060700, 0x00000000
+.long 0xC00A0A00, 0x00000038
+.long 0xC00A0900, 0x00000040
+.long 0xC00A0800, 0x00000018
+.long 0xD1130001, 0x00013F65
+.long 0xD2850060, 0x000202A0
+.long 0x20040281
+.long 0xD2850002, 0x00020488
+.long 0x2002CA85
+.long 0x24020282
+.long 0x68C0C101
+.long 0x24C0C081
+.long 0x68C0C102
+.long 0x68C0C080
+.long 0x68C2C0FF, 0x00001100
+.long 0xBF8A0000
+.long 0xD1130001, 0x00013F65
+.long 0xD2850062, 0x000202A0
+.long 0x20040281
+.long 0xD2850002, 0x00020488
+.long 0x2002CA85
+.long 0x24020282
+.long 0x68C4C501
+.long 0x24C4C481
+.long 0x68C4C502
+.long 0x9254FF52, 0x00000880
+.long 0x68C4C454
+.long 0x68C4C4FF, 0x00002200
+.long 0x68C6C4FF, 0x00002200
+.long 0xBF8CC07F
+.long 0x86580387
+.long 0x92580558
+.long 0x81580258
+.long 0x8F598358
+.long 0xBE820059
+.long 0x86595887
+.long 0x8F5A8303
+.long 0x8E5A835A
+.long 0x81595A59
+.long 0xBE830059
+.long 0xBE900022
+.long 0xBE910023
+.long 0xBE9200FF, 0x80000000
+.long 0xBE9300FF, 0x00020000
+.long 0xBE940020
+.long 0xBE950021
+.long 0xBE9600FF, 0x80000000
+.long 0xBE9700FF, 0x00020000
+.long 0x925603FF, 0x00000080
+.long 0x96552656
+.long 0x92542656
+.long 0x8ED48154
+.long 0x80105410
+.long 0x82115511
+.long 0x80145414
+.long 0x82155515
+.long 0x96552704
+.long 0x92542704
+.long 0x8ED48154
+.long 0x80105410
+.long 0x82115511
+.long 0x80145414
+.long 0x82155515
+.long 0x24C8CC86
+.long 0x68C8C965
+.long 0xD2850004, 0x0002CCA0
+.long 0xD2850003, 0x00004D04
+.long 0x2608C89F
+.long 0xD2850005, 0x00004D04
+.long 0x2608C8BF
+.long 0x200C0885
+.long 0x240C0C82
+.long 0x68D60B03
+.long 0x925402C0
+.long 0x32D40C54
+.long 0xD1FE0068, 0x0206D76A
+.long 0xBF8A0000
+.long 0xD8EC0000, 0x20000060
+.long 0xD8EC0000, 0x40000062
+.long 0xD8EC0000, 0x30000061
+.long 0xD8EC0000, 0x48000063
+.long 0xBF8CC27F
+.long 0xD3CC0000, 0x04028120
+.long 0xD8EC0010, 0x22000060
+.long 0xD8EC0010, 0x42000062
+.long 0xD8EC0010, 0x32000061
+.long 0xD8EC0010, 0x4A000063
+.long 0xBF8CC47F
+.long 0xD3CC0000, 0x04029130
+.long 0xD8EC0020, 0x24000060
+.long 0xD8EC0020, 0x44000062
+.long 0xD8EC0020, 0x34000061
+.long 0xD8EC0020, 0x4C000063
+.long 0xE0541000, 0x80041068
+.long 0xE0541010, 0x80041268
+.long 0xBF8CC67F
+.long 0xD3CC0000, 0x04028522
+.long 0xD8EC0030, 0x26000060
+.long 0xD8EC0030, 0x46000062
+.long 0xD8EC0030, 0x36000061
+.long 0xD8EC0030, 0x4E000063
+.long 0xE0541020, 0x80041468
+.long 0xE0541030, 0x80041668
+.long 0xBF8CC87F
+.long 0xD3CC0000, 0x04029532
+.long 0xD8EC0880, 0x28000060
+.long 0xD8EC0880, 0x38000061
+.long 0xD8EC0890, 0x2A000060
+.long 0xD8EC0890, 0x3A000061
+.long 0xBF8CCA7F
+.long 0xD3CC0000, 0x04028924
+.long 0xD8EC08A0, 0x2C000060
+.long 0xD8EC08A0, 0x3C000061
+.long 0xD8EC08B0, 0x2E000060
+.long 0xD8EC08B0, 0x3E000061
+.long 0xBF8CCC7F
+.long 0xD3CC0000, 0x04029934
+.long 0xBF8CCE7F
+.long 0xD3CC0000, 0x04028D26
+.long 0xBF8CC07F
+.long 0xBF8A0000
+.long 0x8F2E852D
+.long 0x80AE2E80
+.long 0xBF06C22E
+.long 0xBF850157
+.long 0xD3CC0000, 0x04029D36
+.long 0xBF80000C
+.long 0xD3CC0010, 0x04428128
+.long 0xBF80000C
+.long 0xD3CC0010, 0x04429138
+.long 0xBF80000C
+.long 0xD3CC0010, 0x0442852A
+.long 0xBF80000C
+.long 0xD3CC0010, 0x0442953A
+.long 0xBF80000C
+.long 0xD3CC0010, 0x0442892C
+.long 0xBF80000C
+.long 0xD3CC0010, 0x0442993C
+.long 0xBF80000C
+.long 0xD3CC0010, 0x04428D2E
+.long 0xBF8A0000
+.long 0xD8EC0000, 0x20000060
+.long 0xD8EC0000, 0x40000062
+.long 0xD8EC0000, 0x30000061
+.long 0xD8EC0000, 0x48000063
+.long 0xD3CC0010, 0x04429D3E
+.long 0xD8EC0010, 0x22000060
+.long 0xD8EC0010, 0x42000062
+.long 0xD8EC0010, 0x32000061
+.long 0xD8EC0010, 0x4A000063
+.long 0xBF8CC67F
+.long 0xD3CC0000, 0x04028120
+.long 0xD8EC0020, 0x24000060
+.long 0xD8EC0020, 0x44000062
+.long 0xD8EC0020, 0x34000061
+.long 0xD8EC0020, 0x4C000063
+.long 0xBF8CC87F
+.long 0xD3CC0000, 0x04029130
+.long 0xD8EC0030, 0x26000060
+.long 0xD8EC0030, 0x46000062
+.long 0xD8EC0030, 0x36000061
+.long 0xD8EC0030, 0x4E000063
+.long 0xBF8CCA7F
+.long 0xD3CC0000, 0x04028522
+.long 0xD8EC0880, 0x28000060
+.long 0xD8EC0880, 0x38000061
+.long 0xD8EC0890, 0x2A000060
+.long 0xD8EC0890, 0x3A000061
+.long 0xBF8CCC7F
+.long 0xD3CC0000, 0x04029532
+.long 0xD8EC08A0, 0x2C000060
+.long 0xD8EC08A0, 0x3C000061
+.long 0xD8EC08B0, 0x2E000060
+.long 0xD8EC08B0, 0x3E000061
+.long 0xBF8CCE7F
+.long 0xD3CC0000, 0x04028924
+.long 0xBF80000C
+.long 0xBF8CCC7F
+.long 0xD3CC0000, 0x04029934
+.long 0xBF8CC07F
+.long 0xBF8A0000
+.long 0xD3CC0000, 0x04028D26
+.long 0x802E822E
+.long 0xBF00C22E
+.long 0xBF84FF9C
+.long 0xE0541040, 0x80041868
+.long 0xE0541050, 0x80041A68
+.long 0xD3CC0000, 0x04029D36
+.long 0xE0541060, 0x80041C68
+.long 0xE0541070, 0x80041E68
+.long 0xD3CC0010, 0x04428128
+.long 0xD3D84000, 0x18000100
+.long 0xD3D84001, 0x18000101
+.long 0xD3D84002, 0x18000102
+.long 0xD3D84003, 0x18000103
+.long 0xD3D84004, 0x18000104
+.long 0xD3D84005, 0x18000105
+.long 0xD3D84006, 0x18000106
+.long 0xD3D84007, 0x18000107
+.long 0x7E001500
+.long 0x7E021501
+.long 0xD2000000, 0x04012101
+.long 0xD3904000, 0x18020028
+.long 0xD3CC0010, 0x04429138
+.long 0x7E041502
+.long 0x7E061503
+.long 0xD2000001, 0x04092103
+.long 0xD3904001, 0x18020228
+.long 0x7E081504
+.long 0x7E0A1505
+.long 0xD2000002, 0x04112105
+.long 0xD3904002, 0x18020428
+.long 0xBF8C0F77
+.long 0xD38E4000, 0x1C022029
+.long 0xD38E4001, 0x1C062229
+.long 0xE0741000, 0x80050068
+.long 0xD3CC0010, 0x0442852A
+.long 0x7E0C1506
+.long 0x7E0E1507
+.long 0xD2000003, 0x04192107
+.long 0xD3904003, 0x18020628
+.long 0xD3CC0010, 0x0442953A
+.long 0xBF8C0F77
+.long 0xD38E4002, 0x1C0A2429
+.long 0xD38E4003, 0x1C0E2629
+.long 0xE0741010, 0x80050268
+.long 0xD3CC0010, 0x0442892C
+.long 0xD3D84008, 0x18000108
+.long 0xD3D84009, 0x18000109
+.long 0xD3D8400A, 0x1800010A
+.long 0xD3D8400B, 0x1800010B
+.long 0x7E101508
+.long 0x7E121509
+.long 0xD2000004, 0x04212109
+.long 0xD3904004, 0x18020828
+.long 0x7E14150A
+.long 0x7E16150B
+.long 0xD2000005, 0x0429210B
+.long 0xD3904005, 0x18020A28
+.long 0xD3CC0010, 0x0442993C
+.long 0xBF8C0F77
+.long 0xD38E4004, 0x1C122829
+.long 0xD38E4005, 0x1C162A29
+.long 0xE0741020, 0x80050468
+.long 0xD3CC0010, 0x04428D2E
+.long 0xD3D8400C, 0x1800010C
+.long 0xD3D8400D, 0x1800010D
+.long 0xD3D8400E, 0x1800010E
+.long 0xD3D8400F, 0x1800010F
+.long 0x7E18150C
+.long 0x7E1A150D
+.long 0xD2000006, 0x0431210D
+.long 0xD3904006, 0x18020C28
+.long 0x7E1C150E
+.long 0x7E1E150F
+.long 0xD2000007, 0x0439210F
+.long 0xD3904007, 0x18020E28
+.long 0xD3CC0010, 0x04429D3E
+.long 0xBF800008
+.long 0xBF8C0F77
+.long 0xD38E4006, 0x1C1A2C29
+.long 0xD38E4007, 0x1C1E2E29
+.long 0xE0741030, 0x80050668
+.long 0xD3D84000, 0x18000110
+.long 0xD3D84001, 0x18000111
+.long 0xD3D84002, 0x18000112
+.long 0xD3D84003, 0x18000113
+.long 0xD3D84004, 0x18000114
+.long 0xD3D84005, 0x18000115
+.long 0xD3D84006, 0x18000116
+.long 0xD3D84007, 0x18000117
+.long 0x7E001500
+.long 0x7E021501
+.long 0xD2000000, 0x04012101
+.long 0xD3904000, 0x18020028
+.long 0x7E041502
+.long 0x7E061503
+.long 0xD2000001, 0x04092103
+.long 0xD3904001, 0x18020228
+.long 0x7E081504
+.long 0x7E0A1505
+.long 0xD2000002, 0x04112105
+.long 0xD3904002, 0x18020428
+.long 0xBF8C0F77
+.long 0xD38E4000, 0x1C023029
+.long 0xD38E4001, 0x1C063229
+.long 0xE0741040, 0x80050068
+.long 0x7E0C1506
+.long 0x7E0E1507
+.long 0xD2000003, 0x04192107
+.long 0xD3904003, 0x18020628
+.long 0xD3D84008, 0x18000118
+.long 0xD3D84009, 0x18000119
+.long 0xD3D8400A, 0x1800011A
+.long 0xD3D8400B, 0x1800011B
+.long 0xBF8C0F77
+.long 0xD38E4002, 0x1C0A3429
+.long 0xD38E4003, 0x1C0E3629
+.long 0xE0741050, 0x80050268
+.long 0x7E101508
+.long 0x7E121509
+.long 0xD2000004, 0x04212109
+.long 0xD3904004, 0x18020828
+.long 0x7E14150A
+.long 0x7E16150B
+.long 0xD2000005, 0x0429210B
+.long 0xD3904005, 0x18020A28
+.long 0xD3D8400C, 0x1800011C
+.long 0xD3D8400D, 0x1800011D
+.long 0xD3D8400E, 0x1800011E
+.long 0xD3D8400F, 0x1800011F
+.long 0xBF8C0F77
+.long 0xD38E4004, 0x1C123829
+.long 0xD38E4005, 0x1C163A29
+.long 0xE0741060, 0x80050468
+.long 0x7E18150C
+.long 0x7E1A150D
+.long 0xD2000006, 0x0431210D
+.long 0xD3904006, 0x18020C28
+.long 0x7E1C150E
+.long 0x7E1E150F
+.long 0xD2000007, 0x0439210F
+.long 0xD3904007, 0x18020E28
+.long 0xBF8C0F77
+.long 0xD38E4006, 0x1C1A3C29
+.long 0xD38E4007, 0x1C1E3E29
+.long 0xE0741070, 0x80050668
+.long 0xBF8C0000
+.long 0xBF810000


### PR DESCRIPTION
Add Taiwan team's arcturus HPA HGEMM (FP16) TN replacement kernels.  They support the following sizes:
512, 512, 1, 512 (MT128x256)
1024, 1024, 1, 1024 (MT128x256)
2048, 2048, 1, 2048 (MT128x256)
3072, 3072, 1, 3072 (MT128x256)
4096, 4096, 1, 4096 (MT128x256)
8192, 8192, 1, 8192 (MT128x256)
960, 1024, 1, 1024  (MT64x128)
1920, 2048, 1, 2048 (MT128x256)
2880, 3072, 1, 3072 (MT64x128)
3840, 4096, 1, 4096 (MT128x256)
7680, 8192, 1, 8192 (MT128x256)