### PR TITLE
Fix vgpr aliasing in kernel generator

### DIFF
--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -5645,6 +5645,8 @@ class KernelWriterAssembly(KernelWriter):
 
         label = self.getNamedLabel("OptNLL_End")
         kStr += "%s:%s" % (label, self.endLine)
+        del ss # release store state before swapping back saved vgpr pool
+               # so the destructor of ss can refer to the correct vgpr pool
       else:
         label = self.getLabelNum("PrefetchGlobalLastIterEnd")
         kStr += "label_%04u:%s" % (label, self.endLine)

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -5281,8 +5281,6 @@ class KernelWriterAssembly(KernelWriter):
     kStr += self.comment1("endSummation: add vgpr %u...%u to pool" % \
             (self.startVgprValuA, self.lastVgprForReads))
 
-    if self.savedVgprPool != None:
-      self.vgprPool = self.savedVgprPool # restore vgprPool before alternate path
     self.vgprPool.add(self.startVgprValuA, \
         self.lastVgprForReads - self.startVgprValuA, "endSummation")
 
@@ -5650,6 +5648,9 @@ class KernelWriterAssembly(KernelWriter):
       else:
         label = self.getLabelNum("PrefetchGlobalLastIterEnd")
         kStr += "label_%04u:%s" % (label, self.endLine)
+    if self.savedVgprPool != None:
+      self.vgprPool = self.savedVgprPool # restore vgprPool before alternate path 
+      self.savedVgprPool = None
     return kStr
 
   ##############################################################################


### PR DESCRIPTION
The state of `RegisterPool` instance is now restored at the end of "no-load loop," instead of after the normal tail loop. This avoid unwanted side-effect of register aliasing if one tries to get temporary vgpr in the tail loop. 

One example of problematic generated code is as follows. Note the vgpr, v71, is actually an alias of vgprG2LB. 

```c
/* VGPR Assignments */
.set vgprG2LB, 71

/* global read b */
buffer_load_short_d16 v[vgprG2LB+0+0], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 
buffer_load_short_d16_hi v71, v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:2 
//                       ^^^
//                       vgpr dispatched by RegisterPool.checkOut()
```
