### PR TITLE
Force waitcnt0 on arcturus

### DIFF
--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -1113,6 +1113,7 @@ def GetAsmCaps(isaVersion):
 def GetArchCaps(isaVersion):
   rv = {}
   rv["HasEccHalf"]     = (isaVersion==(9,0,6) or isaVersion==(9,0,8))
+  rv["Waitcnt0Disabled"] = isaVersion == (9,0,8)
   rv["SeparateVscnt"]  = isaVersion == (10,1,0)
   rv["CMPXWritesSGPR"] = isaVersion != (10,1,0)
   rv["HasWave32"]      = isaVersion == (10,1,0)

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -9958,6 +9958,8 @@ class KernelWriterAssembly(KernelWriter):
       kStr = ""
       if self.archCaps["SeparateVscnt"]:
         kStr += inst("s_waitcnt_lgkmcnt", "null", "0", "extra navi wait")
+      elif self.archCaps["Waitcnt0Disabled"]:
+        kStr += inst("s_waitcnt", "lgkmcnt(0) & vmcnt(0)", "force waitcnt0" )
 
       kStr += self.indent + self.syncStr + " //" + comment + self.endLine
       return kStr

--- a/Tensile/ReplacementKernels-cov3/Cijk_Alik_Bljk_BBH_MT64x128x32_SE_K1.s.txt
+++ b/Tensile/ReplacementKernels-cov3/Cijk_Alik_Bljk_BBH_MT64x128x32_SE_K1.s.txt
@@ -561,8 +561,7 @@ v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
 .long 0xE0511528, 0x8003495B
 .long 0xE0511630, 0x80034A5C
 .long 0xE0511738, 0x80034B5D
-.long 0xBF8CC07F
-.long 0xBF8C4F74
+.long 0xBF8C0070
 .long 0xBF8A0000
 .long 0xD86C0000, 0x2000005E
 .long 0xD86C0840, 0x2100005E
@@ -639,7 +638,7 @@ v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
 .long 0xE0511630, 0x80034A5C
 .long 0xE0511738, 0x80034B5D
 .long 0xD3EC0010, 0x0442752D
-.long 0xBF8C4F74
+.long 0xBF8C0070
 .long 0xBF8A0000
 .long 0xD3EC0000, 0x0402772E
 .long 0xD86C0000, 0x2000005F
@@ -715,7 +714,7 @@ v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
 .long 0xE0511630, 0x80034A5C
 .long 0xE0511738, 0x80034B5D
 .long 0xD3EC0010, 0x0442852D
-.long 0xBF8C4F74
+.long 0xBF8C0070
 .long 0xBF8A0000
 .long 0xD3EC0000, 0x0402872E
 .long 0xD86C0000, 0x2000005E
@@ -767,7 +766,7 @@ v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
 .long 0xBF8CC07F
 .long 0xD3EC0000, 0x0402752C
 .long 0xD3EC0010, 0x0442752D
-.long 0xBF8C0F78
+.long 0xBF8C0070
 .long 0xBF8A0000
 .long 0xD3EC0000, 0x0402772E
 .long 0xD86C0000, 0x2000005F

--- a/Tensile/ReplacementKernels/Cijk_Alik_Bljk_BBH_MT64x128x32_SE_K1.s.txt
+++ b/Tensile/ReplacementKernels/Cijk_Alik_Bljk_BBH_MT64x128x32_SE_K1.s.txt
@@ -542,8 +542,7 @@ v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
 .long 0xE0511528, 0x8003495B
 .long 0xE0511630, 0x80034A5C
 .long 0xE0511738, 0x80034B5D
-.long 0xBF8CC07F
-.long 0xBF8C4F74
+.long 0xBF8C0070
 .long 0xBF8A0000
 .long 0xD86C0000, 0x2000005E
 .long 0xD86C0840, 0x2100005E
@@ -620,7 +619,7 @@ v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
 .long 0xE0511630, 0x80034A5C
 .long 0xE0511738, 0x80034B5D
 .long 0xD3EC0010, 0x0442752D
-.long 0xBF8C4F74
+.long 0xBF8C0070
 .long 0xBF8A0000
 .long 0xD3EC0000, 0x0402772E
 .long 0xD86C0000, 0x2000005F
@@ -696,7 +695,7 @@ v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
 .long 0xE0511630, 0x80034A5C
 .long 0xE0511738, 0x80034B5D
 .long 0xD3EC0010, 0x0442852D
-.long 0xBF8C4F74
+.long 0xBF8C0070
 .long 0xBF8A0000
 .long 0xD3EC0000, 0x0402872E
 .long 0xD86C0000, 0x2000005E
@@ -748,7 +747,7 @@ v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
 .long 0xBF8CC07F
 .long 0xD3EC0000, 0x0402752C
 .long 0xD3EC0010, 0x0442752D
-.long 0xBF8C0F78
+.long 0xBF8C0070
 .long 0xBF8A0000
 .long 0xD3EC0000, 0x0402772E
 .long 0xD86C0000, 0x2000005F


### PR DESCRIPTION
Force waitcnt 0 on arcturus in anticipation of ROCm kernel driver/VBIOS changes.
BF16 TN main replacement kernel is also updated due to synchronization issues when waitcnt 0 is disabled.