### PR TITLE
fixes arcturus BF16 TN main replacement kernel synchronization issue

### DIFF
--- a/Tensile/ReplacementKernels-cov3/Cijk_Alik_Bljk_BBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_8_USFGRO1_VAW1_VW4_WG16_16_1_WGM8.s.txt
+++ b/Tensile/ReplacementKernels-cov3/Cijk_Alik_Bljk_BBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_8_USFGRO1_VAW1_VW4_WG16_16_1_WGM8.s.txt
@@ -563,6 +563,7 @@ v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
 .long 0xE0511738, 0x80034B5D
 .long 0xBF8CC07F
 .long 0xBF8C4F74
+.long 0xBF8C0070
 .long 0xBF8A0000
 .long 0xD86C0000, 0x2000005E
 .long 0xD86C0840, 0x2100005E
@@ -576,7 +577,7 @@ v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
 .long 0x8F2E852D
 .long 0x80AE2E80
 .long 0xBF06802E
-.long 0xBF850231
+.long 0xBF850234
 .long 0xBF8CC27F
 .long 0xD3EC0000, 0x04026920
 .long 0xD86C0010, 0x2400005E
@@ -640,6 +641,7 @@ v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
 .long 0xE0511738, 0x80034B5D
 .long 0xD3EC0010, 0x0442752D
 .long 0xBF8C4F74
+.long 0xBF8C0070
 .long 0xBF8A0000
 .long 0xD3EC0000, 0x0402772E
 .long 0xD86C0000, 0x2000005F
@@ -716,6 +718,7 @@ v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
 .long 0xE0511738, 0x80034B5D
 .long 0xD3EC0010, 0x0442852D
 .long 0xBF8C4F74
+.long 0xBF8C0070
 .long 0xBF8A0000
 .long 0xD3EC0000, 0x0402872E
 .long 0xD86C0000, 0x2000005E
@@ -730,7 +733,7 @@ v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
 .long 0xD86C0018, 0x37000060
 .long 0x802E812E
 .long 0xBF00C22E
-.long 0xBF84FEFE
+.long 0xBF84FEFC
 .long 0xBF8CC27F
 .long 0xD3EC0000, 0x04026920
 .long 0xD86C0010, 0x2400005E
@@ -768,6 +771,7 @@ v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
 .long 0xD3EC0000, 0x0402752C
 .long 0xD3EC0010, 0x0442752D
 .long 0xBF8C0F78
+.long 0xBF8C0070
 .long 0xBF8A0000
 .long 0xD3EC0000, 0x0402772E
 .long 0xD86C0000, 0x2000005F

--- a/Tensile/ReplacementKernels-cov3/Cijk_Alik_Bljk_BBH_MT64x128x32_SE_K1.s.txt
+++ b/Tensile/ReplacementKernels-cov3/Cijk_Alik_Bljk_BBH_MT64x128x32_SE_K1.s.txt
@@ -561,6 +561,8 @@ v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
 .long 0xE0511528, 0x8003495B
 .long 0xE0511630, 0x80034A5C
 .long 0xE0511738, 0x80034B5D
+.long 0xBF8CC07F
+.long 0xBF8C4F74
 .long 0xBF8C0070
 .long 0xBF8A0000
 .long 0xD86C0000, 0x2000005E
@@ -575,7 +577,7 @@ v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
 .long 0x8F2E852D
 .long 0x80AE2E80
 .long 0xBF06802E
-.long 0xBF850231
+.long 0xBF850234
 .long 0xBF8CC27F
 .long 0xD3EC0000, 0x04026920
 .long 0xD86C0010, 0x2400005E
@@ -638,6 +640,7 @@ v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
 .long 0xE0511630, 0x80034A5C
 .long 0xE0511738, 0x80034B5D
 .long 0xD3EC0010, 0x0442752D
+.long 0xBF8C4F74
 .long 0xBF8C0070
 .long 0xBF8A0000
 .long 0xD3EC0000, 0x0402772E
@@ -714,6 +717,7 @@ v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
 .long 0xE0511630, 0x80034A5C
 .long 0xE0511738, 0x80034B5D
 .long 0xD3EC0010, 0x0442852D
+.long 0xBF8C4F74
 .long 0xBF8C0070
 .long 0xBF8A0000
 .long 0xD3EC0000, 0x0402872E
@@ -729,7 +733,7 @@ v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
 .long 0xD86C0018, 0x37000060
 .long 0x802E812E
 .long 0xBF00C22E
-.long 0xBF84FEFE
+.long 0xBF84FEFC
 .long 0xBF8CC27F
 .long 0xD3EC0000, 0x04026920
 .long 0xD86C0010, 0x2400005E
@@ -766,6 +770,7 @@ v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
 .long 0xBF8CC07F
 .long 0xD3EC0000, 0x0402752C
 .long 0xD3EC0010, 0x0442752D
+.long 0xBF8C0F78
 .long 0xBF8C0070
 .long 0xBF8A0000
 .long 0xD3EC0000, 0x0402772E

--- a/Tensile/ReplacementKernels/Cijk_Alik_Bljk_BBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_8_USFGRO1_VAW1_VW4_WG16_16_1_WGM8.s.txt
+++ b/Tensile/ReplacementKernels/Cijk_Alik_Bljk_BBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LPA0_LPB0_LDL1_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SU32_SNLL0_TT4_8_USFGRO1_VAW1_VW4_WG16_16_1_WGM8.s.txt
@@ -544,6 +544,7 @@ v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
 .long 0xE0511738, 0x80034B5D
 .long 0xBF8CC07F
 .long 0xBF8C4F74
+.long 0xBF8C0070
 .long 0xBF8A0000
 .long 0xD86C0000, 0x2000005E
 .long 0xD86C0840, 0x2100005E
@@ -557,7 +558,7 @@ v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
 .long 0x8F2E852D
 .long 0x80AE2E80
 .long 0xBF06802E
-.long 0xBF850231
+.long 0xBF850234
 .long 0xBF8CC27F
 .long 0xD3EC0000, 0x04026920
 .long 0xD86C0010, 0x2400005E
@@ -621,6 +622,7 @@ v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
 .long 0xE0511738, 0x80034B5D
 .long 0xD3EC0010, 0x0442752D
 .long 0xBF8C4F74
+.long 0xBF8C0070
 .long 0xBF8A0000
 .long 0xD3EC0000, 0x0402772E
 .long 0xD86C0000, 0x2000005F
@@ -697,6 +699,7 @@ v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
 .long 0xE0511738, 0x80034B5D
 .long 0xD3EC0010, 0x0442852D
 .long 0xBF8C4F74
+.long 0xBF8C0070
 .long 0xBF8A0000
 .long 0xD3EC0000, 0x0402872E
 .long 0xD86C0000, 0x2000005E
@@ -711,7 +714,7 @@ v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
 .long 0xD86C0018, 0x37000060
 .long 0x802E812E
 .long 0xBF00C22E
-.long 0xBF84FEFE
+.long 0xBF84FEFC
 .long 0xBF8CC27F
 .long 0xD3EC0000, 0x04026920
 .long 0xD86C0010, 0x2400005E
@@ -749,6 +752,7 @@ v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
 .long 0xD3EC0000, 0x0402752C
 .long 0xD3EC0010, 0x0442752D
 .long 0xBF8C0F78
+.long 0xBF8C0070
 .long 0xBF8A0000
 .long 0xD3EC0000, 0x0402772E
 .long 0xD86C0000, 0x2000005F

--- a/Tensile/ReplacementKernels/Cijk_Alik_Bljk_BBH_MT64x128x32_SE_K1.s.txt
+++ b/Tensile/ReplacementKernels/Cijk_Alik_Bljk_BBH_MT64x128x32_SE_K1.s.txt
@@ -542,6 +542,8 @@ v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
 .long 0xE0511528, 0x8003495B
 .long 0xE0511630, 0x80034A5C
 .long 0xE0511738, 0x80034B5D
+.long 0xBF8CC07F
+.long 0xBF8C4F74
 .long 0xBF8C0070
 .long 0xBF8A0000
 .long 0xD86C0000, 0x2000005E
@@ -556,7 +558,7 @@ v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
 .long 0x8F2E852D
 .long 0x80AE2E80
 .long 0xBF06802E
-.long 0xBF850231
+.long 0xBF850234
 .long 0xBF8CC27F
 .long 0xD3EC0000, 0x04026920
 .long 0xD86C0010, 0x2400005E
@@ -619,6 +621,7 @@ v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
 .long 0xE0511630, 0x80034A5C
 .long 0xE0511738, 0x80034B5D
 .long 0xD3EC0010, 0x0442752D
+.long 0xBF8C4F74
 .long 0xBF8C0070
 .long 0xBF8A0000
 .long 0xD3EC0000, 0x0402772E
@@ -695,6 +698,7 @@ v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
 .long 0xE0511630, 0x80034A5C
 .long 0xE0511738, 0x80034B5D
 .long 0xD3EC0010, 0x0442852D
+.long 0xBF8C4F74
 .long 0xBF8C0070
 .long 0xBF8A0000
 .long 0xD3EC0000, 0x0402872E
@@ -710,7 +714,7 @@ v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
 .long 0xD86C0018, 0x37000060
 .long 0x802E812E
 .long 0xBF00C22E
-.long 0xBF84FEFE
+.long 0xBF84FEFC
 .long 0xBF8CC27F
 .long 0xD3EC0000, 0x04026920
 .long 0xD86C0010, 0x2400005E
@@ -747,6 +751,7 @@ v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
 .long 0xBF8CC07F
 .long 0xD3EC0000, 0x0402752C
 .long 0xD3EC0010, 0x0442752D
+.long 0xBF8C0F78
 .long 0xBF8C0070
 .long 0xBF8A0000
 .long 0xD3EC0000, 0x0402772E


### PR DESCRIPTION
This patch fixes the sporadic failures of the BF16 TN main replacement kernel on arcturus when planned driver/VBIOS changes were in place.

Extensive testing of the flaky cases show that the failures are indeed gone.