### PR TITLE
Let CI run tests for supported matrix instructions

### DIFF
--- a/Tensile/Tests/pre_checkin/mfma/hpa_bfloat16_gemm_asm_mi32x32x2x2.yaml
+++ b/Tensile/Tests/pre_checkin/mfma/hpa_bfloat16_gemm_asm_mi32x32x2x2.yaml
@@ -2,30 +2,9 @@ TestParameters:
   marks: [skip-gfx900, skip-gfx906, skip-gfx1010] # not supported by arch
 
 GlobalParameters:
-  MinimumRequiredVersion: 4.4.0
-  PrintLevel: 1
-  ForceRedoBenchmarkProblems: True
-  ForceRedoLibraryLogic: True
-  ForceRedoLibraryClient: True
-  CMakeBuildType: Release
-  EnqueuesPerSync: 1
-  SyncsPerBenchmark: 1
-  LibraryPrintDebug: False
   NumElementsToValidate: -1
-  ValidationMaxToPrint: 4
-  ValidationPrintValids: False
-  ShortNames: False
-  MergeFiles: True
-  Platform: 0
-  Device: 0
+  BoundsCheck: True
   KernelTime: True
-  PinClocks: True
-  SleepPercent: 200
-  PrintSolutionRejectionReason: True
-  DataInitTypeA: 3
-  DataInitTypeB: 3
-  DataInitTypeBeta: 1
-  DataInitTypeAlpha: 1
 
 BenchmarkProblems:
   ########################################

--- a/Tensile/Tests/pre_checkin/mfma/hpa_bfloat16_gemm_asm_mi32x32x2x2.yaml
+++ b/Tensile/Tests/pre_checkin/mfma/hpa_bfloat16_gemm_asm_mi32x32x2x2.yaml
@@ -1,0 +1,67 @@
+GlobalParameters:
+  MinimumRequiredVersion: 4.4.0
+  PrintLevel: 1
+  ForceRedoBenchmarkProblems: True
+  ForceRedoLibraryLogic: True
+  ForceRedoLibraryClient: True
+  CMakeBuildType: Release
+  EnqueuesPerSync: 1
+  SyncsPerBenchmark: 1
+  LibraryPrintDebug: False
+  NumElementsToValidate: -1
+  ValidationMaxToPrint: 4
+  ValidationPrintValids: False
+  ShortNames: False
+  MergeFiles: True
+  Platform: 0
+  Device: 0
+  KernelTime: True
+  PinClocks: True
+  SleepPercent: 200
+  PrintSolutionRejectionReason: True
+  DataInitTypeA: 3
+  DataInitTypeB: 3
+  DataInitTypeBeta: 1
+  DataInitTypeAlpha: 1
+
+BenchmarkProblems:
+  ########################################
+  # NT - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: B
+      DestDataType: B
+      ComputeDataType: s
+      HighPrecisionAccumulate: True
+      TransposeA: False
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+        - PrefetchLocalRead: [True]
+      ForkParameters:
+        - MatrixInstruction:
+          - [32, 32, 2, 2]
+        - PrefetchGlobalRead: [True]
+        - ThreadTile:
+          - [ 2, 32 ]
+        - WorkGroup:
+          - [ 16, 16, 1 ]
+        - WorkGroupMapping: [8]
+        - GlobalSplitU: [1]
+        - DepthU: [8]
+        - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [2]
+        - AssertFree0ElementMultiple: [2]
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [ 64, 256, 1, 8 ]

--- a/Tensile/Tests/pre_checkin/mfma/hpa_bfloat16_gemm_asm_mi32x32x2x2.yaml
+++ b/Tensile/Tests/pre_checkin/mfma/hpa_bfloat16_gemm_asm_mi32x32x2x2.yaml
@@ -1,3 +1,6 @@
+TestParameters:
+  marks: [skip-gfx900, skip-gfx906, skip-gfx1010] # not supported by arch
+
 GlobalParameters:
   MinimumRequiredVersion: 4.4.0
   PrintLevel: 1

--- a/Tensile/Tests/pre_checkin/mfma/hpa_hgemm_asm_mi32x32x4x2.yaml
+++ b/Tensile/Tests/pre_checkin/mfma/hpa_hgemm_asm_mi32x32x4x2.yaml
@@ -2,30 +2,9 @@ TestParameters:
   marks: [skip-gfx900, skip-gfx906, skip-gfx1010] # not supported by arch
 
 GlobalParameters:
-  MinimumRequiredVersion: 4.4.0
-  PrintLevel: 1
-  ForceRedoBenchmarkProblems: True
-  ForceRedoLibraryLogic: True
-  ForceRedoLibraryClient: True
-  CMakeBuildType: Release
-  EnqueuesPerSync: 1
-  SyncsPerBenchmark: 1
-  LibraryPrintDebug: False
   NumElementsToValidate: -1
-  ValidationMaxToPrint: 4
-  ValidationPrintValids: False
-  ShortNames: False
-  MergeFiles: True
-  Platform: 0
-  Device: 0
+  BoundsCheck: True
   KernelTime: True
-  PinClocks: True
-  SleepPercent: 200
-  PrintSolutionRejectionReason: True
-  DataInitTypeA: 3
-  DataInitTypeB: 3
-  DataInitTypeBeta: 1
-  DataInitTypeAlpha: 1
 
 BenchmarkProblems:
   ########################################

--- a/Tensile/Tests/pre_checkin/mfma/hpa_hgemm_asm_mi32x32x4x2.yaml
+++ b/Tensile/Tests/pre_checkin/mfma/hpa_hgemm_asm_mi32x32x4x2.yaml
@@ -1,0 +1,68 @@
+TestParameters:
+  marks: [skip-gfx900, skip-gfx906, skip-gfx1010] # not supported by arch
+
+GlobalParameters:
+  MinimumRequiredVersion: 4.4.0
+  PrintLevel: 1
+  ForceRedoBenchmarkProblems: True
+  ForceRedoLibraryLogic: True
+  ForceRedoLibraryClient: True
+  CMakeBuildType: Release
+  EnqueuesPerSync: 1
+  SyncsPerBenchmark: 1
+  LibraryPrintDebug: False
+  NumElementsToValidate: -1
+  ValidationMaxToPrint: 4
+  ValidationPrintValids: False
+  ShortNames: False
+  MergeFiles: True
+  Platform: 0
+  Device: 0
+  KernelTime: True
+  PinClocks: True
+  SleepPercent: 200
+  PrintSolutionRejectionReason: True
+  DataInitTypeA: 3
+  DataInitTypeB: 3
+  DataInitTypeBeta: 1
+  DataInitTypeAlpha: 1
+
+BenchmarkProblems:
+  ########################################
+  # NT - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: h
+      HighPrecisionAccumulate: True
+      TransposeA: False
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+        - PrefetchLocalRead: [True]
+      ForkParameters:
+        - MatrixInstruction:
+          - [32, 32, 4, 2]
+        - PrefetchGlobalRead: [True]
+        - ThreadTile:
+          - [ 2, 32 ]
+        - WorkGroup:
+          - [ 16, 16, 1 ]
+        - WorkGroupMapping: [8]
+        - GlobalSplitU: [1]
+        - DepthU: [8]
+        - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [2]
+        - AssertFree0ElementMultiple: [2]
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [ 64, 256, 1, 8 ]

--- a/Tensile/Tests/pre_checkin/mfma/sgemm_asm_mi32x32x1x2.yaml
+++ b/Tensile/Tests/pre_checkin/mfma/sgemm_asm_mi32x32x1x2.yaml
@@ -2,30 +2,9 @@ TestParameters:
   marks: [skip-gfx900, skip-gfx906, skip-gfx1010] # not supported by arch
 
 GlobalParameters:
-  MinimumRequiredVersion: 4.4.0
-  PrintLevel: 1
-  ForceRedoBenchmarkProblems: True
-  ForceRedoLibraryLogic: True
-  ForceRedoLibraryClient: True
-  CMakeBuildType: Release
-  EnqueuesPerSync: 1
-  SyncsPerBenchmark: 1
-  LibraryPrintDebug: False
   NumElementsToValidate: -1
-  ValidationMaxToPrint: 4
-  ValidationPrintValids: False
-  ShortNames: False
-  MergeFiles: True
-  Platform: 0
-  Device: 0
+  BoundsCheck: True
   KernelTime: True
-  PinClocks: True
-  SleepPercent: 200
-  PrintSolutionRejectionReason: True
-  DataInitTypeA: 3
-  DataInitTypeB: 3
-  DataInitTypeBeta: 1
-  DataInitTypeAlpha: 1
 
 BenchmarkProblems:
   ########################################

--- a/Tensile/Tests/pre_checkin/mfma/sgemm_asm_mi32x32x1x2.yaml
+++ b/Tensile/Tests/pre_checkin/mfma/sgemm_asm_mi32x32x1x2.yaml
@@ -1,0 +1,67 @@
+GlobalParameters:
+  MinimumRequiredVersion: 4.4.0
+  PrintLevel: 1
+  ForceRedoBenchmarkProblems: True
+  ForceRedoLibraryLogic: True
+  ForceRedoLibraryClient: True
+  CMakeBuildType: Release
+  EnqueuesPerSync: 1
+  SyncsPerBenchmark: 1
+  LibraryPrintDebug: False
+  NumElementsToValidate: -1
+  ValidationMaxToPrint: 4
+  ValidationPrintValids: False
+  ShortNames: False
+  MergeFiles: True
+  Platform: 0
+  Device: 0
+  KernelTime: True
+  PinClocks: True
+  SleepPercent: 200
+  PrintSolutionRejectionReason: True
+  DataInitTypeA: 3
+  DataInitTypeB: 3
+  DataInitTypeBeta: 1
+  DataInitTypeAlpha: 1
+
+BenchmarkProblems:
+  ########################################
+  # NT - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: s
+      TransposeA: True
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+        - PrefetchLocalRead: [True]
+      ForkParameters:
+        - MatrixInstruction:
+          - [32, 32, 1, 2]
+        - PrefetchGlobalRead: [True]
+        - ThreadTile:
+          - [ 2, 32 ]
+        - WorkGroup:
+          - [ 16, 16, 1 ]
+        - WorkGroupMapping: [8]
+        - GlobalSplitU: [1]
+        - DepthU: [ 8 ]
+        - VectorWidth: [1]
+      BenchmarkForkParameters:
+      JoinParameters:
+        - MacroTile
+        - GlobalSplitU
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [64], [256], [1], [64] ]
+
+  ########################################

--- a/Tensile/Tests/pre_checkin/mfma/sgemm_asm_mi32x32x1x2.yaml
+++ b/Tensile/Tests/pre_checkin/mfma/sgemm_asm_mi32x32x1x2.yaml
@@ -1,3 +1,6 @@
+TestParameters:
+  marks: [skip-gfx900, skip-gfx906, skip-gfx1010] # not supported by arch
+
 GlobalParameters:
   MinimumRequiredVersion: 4.4.0
   PrintLevel: 1

--- a/Tensile/Tests/pre_checkin/mfma/sgemm_asm_mi32x32x2x1.yaml
+++ b/Tensile/Tests/pre_checkin/mfma/sgemm_asm_mi32x32x2x1.yaml
@@ -1,0 +1,67 @@
+GlobalParameters:
+  MinimumRequiredVersion: 4.4.0
+  PrintLevel: 1
+  ForceRedoBenchmarkProblems: True
+  ForceRedoLibraryLogic: True
+  ForceRedoLibraryClient: True
+  CMakeBuildType: Release
+  EnqueuesPerSync: 1
+  SyncsPerBenchmark: 1
+  LibraryPrintDebug: False
+  NumElementsToValidate: -1
+  ValidationMaxToPrint: 4
+  ValidationPrintValids: False
+  ShortNames: False
+  MergeFiles: True
+  Platform: 0
+  Device: 0
+  KernelTime: True
+  PinClocks: True
+  SleepPercent: 200
+  PrintSolutionRejectionReason: True
+  DataInitTypeA: 3
+  DataInitTypeB: 3
+  DataInitTypeBeta: 1
+  DataInitTypeAlpha: 1
+
+BenchmarkProblems:
+  ########################################
+  # NT - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: s
+      TransposeA: True
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+        - PrefetchLocalRead: [True]
+      ForkParameters:
+        - MatrixInstruction:
+          - [32, 32, 2, 1]
+        - PrefetchGlobalRead: [True]
+        - ThreadTile:
+          - [ 2, 32 ]
+        - WorkGroup:
+          - [ 16, 16, 1 ]
+        - WorkGroupMapping: [8]
+        - GlobalSplitU: [1]
+        - DepthU: [ 8 ]
+        - VectorWidth: [1]
+      BenchmarkForkParameters:
+      JoinParameters:
+        - MacroTile
+        - GlobalSplitU
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [64], [256], [1], [64] ]
+
+  ########################################

--- a/Tensile/Tests/pre_checkin/mfma/sgemm_asm_mi32x32x2x1.yaml
+++ b/Tensile/Tests/pre_checkin/mfma/sgemm_asm_mi32x32x2x1.yaml
@@ -2,30 +2,9 @@ TestParameters:
   marks: [skip-gfx900, skip-gfx906, skip-gfx1010] # not supported by arch
 
 GlobalParameters:
-  MinimumRequiredVersion: 4.4.0
-  PrintLevel: 1
-  ForceRedoBenchmarkProblems: True
-  ForceRedoLibraryLogic: True
-  ForceRedoLibraryClient: True
-  CMakeBuildType: Release
-  EnqueuesPerSync: 1
-  SyncsPerBenchmark: 1
-  LibraryPrintDebug: False
   NumElementsToValidate: -1
-  ValidationMaxToPrint: 4
-  ValidationPrintValids: False
-  ShortNames: False
-  MergeFiles: True
-  Platform: 0
-  Device: 0
+  BoundsCheck: True
   KernelTime: True
-  PinClocks: True
-  SleepPercent: 200
-  PrintSolutionRejectionReason: True
-  DataInitTypeA: 3
-  DataInitTypeB: 3
-  DataInitTypeBeta: 1
-  DataInitTypeAlpha: 1
 
 BenchmarkProblems:
   ########################################

--- a/Tensile/Tests/pre_checkin/mfma/sgemm_asm_mi32x32x2x1.yaml
+++ b/Tensile/Tests/pre_checkin/mfma/sgemm_asm_mi32x32x2x1.yaml
@@ -1,3 +1,6 @@
+TestParameters:
+  marks: [skip-gfx900, skip-gfx906, skip-gfx1010] # not supported by arch
+
 GlobalParameters:
   MinimumRequiredVersion: 4.4.0
   PrintLevel: 1

--- a/Tensile/Tests/pre_checkin/mfma/sgemm_asm_mi32x32x2x1.yaml
+++ b/Tensile/Tests/pre_checkin/mfma/sgemm_asm_mi32x32x2x1.yaml
@@ -51,7 +51,7 @@ BenchmarkProblems:
           - [32, 32, 2, 1]
         - PrefetchGlobalRead: [True]
         - ThreadTile:
-          - [ 2, 32 ]
+          - [ 1, 32 ]
         - WorkGroup:
           - [ 16, 16, 1 ]
         - WorkGroupMapping: [8]

--- a/Tensile/Tests/yaml_only/test_config.py
+++ b/Tensile/Tests/yaml_only/test_config.py
@@ -71,6 +71,9 @@ def configMarks(filepath, rootDir, availableArchs):
         ArchFail = "xfail-%s" % arch
         if markNamed(ArchFail) in marks:
             marks.append(pytest.mark.xfail)
+        ArchSkip = "skip-%s" % arch
+        if markNamed(ArchSkip) in marks:
+            marks.append(pytest.mark.skip)
 
     validate = True
     validateAll = False

--- a/pytest.ini
+++ b/pytest.ini
@@ -54,6 +54,7 @@ markers =
  hpa_source
  igemm
  local_split_u
+ mfma
  multi_sum
  multi_sum_psd
  nonbatched
@@ -71,3 +72,9 @@ markers =
  xfail-gfx906:  architecture
  xfail-gfx908:  architecture
  xfail-gfx1010: architecture
+
+ skip-gfx000:  architecture
+ skip-gfx900:  architecture
+ skip-gfx906:  architecture
+ skip-gfx908:  architecture
+ skip-gfx1010: architecture


### PR DESCRIPTION
EDIT: rebased to latest `develop` branch 

Added tests for currently supported matrix instructions. This PR intends to get jenkins CI run matrix instructions so test cases are not meant to be comprehensive

- fp32 32x32x1x2
- fp32 32x32x2x1
- bf16 32x32x2x2
- fp16 32x32x4x2

Test result:
```
$ python3 -m pytest -v Tensile/Tests/pre_checkin/mfma/
================================================= test session starts =================================================
platform linux -- Python 3.5.2, pytest-5.3.5, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /mnt/Tensile, inifile: pytest.ini
collected 4 items                                                                                                     

Tensile/Tests/pre_checkin/mfma/test_mfma.py::test_sgemm_asm_mi32x32x2x1 PASSED                                  [ 25%]
Tensile/Tests/pre_checkin/mfma/test_mfma.py::test_hpa_bfloat16_gemm_asm_mi32x32x2x2 PASSED                      [ 50%]
Tensile/Tests/pre_checkin/mfma/test_mfma.py::test_sgemm_asm_mi32x32x1x2 PASSED                                  [ 75%]
Tensile/Tests/pre_checkin/mfma/test_mfma.py::test_hpa_hgemm_asm_mi32x32x4x2 PASSED                              [100%]

============================================ 4 passed in 150.43s (0:02:30) ============================================
```