### PR TITLE
Shorten file names

### DIFF
--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -156,6 +156,7 @@ globalParameters["MaxLDS"] = 65536                # max LDS a kernel should atte
 globalParameters["MaxDepthU"] = 256               # max DepthU value to allow
 globalParameters["ShortNames"] = False            # on windows kernel names can get too long; =True will convert solution/kernel names to serial ids
 globalParameters["MergeFiles"] = True             # F=store every solution and kernel in separate file; T=store all solutions in single file
+globalParameters["MaxFileName"] = 128 # If a file name would be longer than this, shorten it with a hash.
 globalParameters["SupportedISA"] = [(8,0,3), (9,0,0), (9,0,6), (9,0,8), (10,1,0)]             # assembly kernels writer supports these architectures
 globalParameters["ClientBuildPath"] = "0_Build"                   # subdirectory for host code build directory.
 globalParameters["NewClient"] = 2                                 # 1=Run old+new client, 2=run new client only (All In)

--- a/Tensile/KernelWriter.py
+++ b/Tensile/KernelWriter.py
@@ -21,7 +21,7 @@
 
 from . import Code
 from . import Common
-from .Common import globalParameters, print2, CHeader, roundUp
+from .Common import globalParameters, CHeader, roundUp
 from .ReplacementKernels import ReplacementKernels
 from .SolutionStructs import Solution
 

--- a/Tensile/KernelWriter.py
+++ b/Tensile/KernelWriter.py
@@ -1302,7 +1302,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
           if kernel["MatrixInstruction"]:
             kl.append(self.shiftVectorComponentsForMatrixInst(kernel, tensorParametersA))
           else:
-          kl.append(self.shiftVectorComponents(kernel, tensorParametersA))
+            kl.append(self.shiftVectorComponents(kernel, tensorParametersA))
         # shift vector components d1
         if not kernel["GuaranteeNoPartialB"] and self.readTileDimVectorB and not kernel["MatrixInstruction"]:
           kl.append(self.comment("shift vector components d1"))

--- a/Tensile/KernelWriterSource.py
+++ b/Tensile/KernelWriterSource.py
@@ -3076,7 +3076,7 @@ class KernelWriterSource(KernelWriter):
   ##############################################################################
   def kernelBodyPrefix(self, kernel, tPA, tPB ):
     kStr = ""
-    kernelName = self.getKernelName(kernel)
+    kernelName = self.getKernelFileBase(kernel)
     if not globalParameters["MergeFiles"]:
       kStr += "\n"
       kStr += "#include \"%s.h\"\n" % kernelName

--- a/Tensile/ReplacementKernels.py
+++ b/Tensile/ReplacementKernels.py
@@ -1,0 +1,90 @@
+################################################################################
+# Copyright (C) 2020-2020 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell cop-
+# ies of the Software, and to permit persons to whom the Software is furnished
+# to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM-
+# PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNE-
+# CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+################################################################################
+
+from .Common import globalParameters
+
+import os
+
+class ReplacementKernels:
+    def __init__(self, dirpath, codeObjectVersion):
+        self.dirpath = dirpath
+        self.codeObjectVersion = codeObjectVersion
+        self._cache = None
+
+    @property
+    def marker(self):
+        if self.codeObjectVersion == 'V3':
+            return '.amdhsa_kernel'
+        return '.amdgpu_hsa_kernel'
+
+    def getKernelName(self, filename):
+        marker = self.marker
+
+        with open(filename, 'r') as f:
+            for line in f:
+                if line.startswith(marker):
+                    return line[len(marker):].strip()
+        raise RuntimeError("Could not parse kernel name from {}".format(filename))
+
+    @property
+    def cache(self):
+        if not self._cache:
+            self._cache = self.generateCache()
+        return self._cache
+
+    def generateCache(self):
+        cache = {}
+
+        for filename in os.listdir(self.dirpath):
+            if filename.endswith('.txt'):
+                filepath = os.path.join(self.dirpath, filename)
+                kernelName = self.getKernelName(filepath)
+                if kernelName in cache:
+                    raise RuntimeError("Duplicate replacement kernels.  Kernel name: {}, file names: {}, {}".format(kernelName, cache[kernelName], filepath))
+                cache[kernelName] = filepath
+
+        return cache
+
+    def get(self, kernelName):
+        if kernelName in self.cache:
+            return self.cache[kernelName]
+
+        return None
+
+    @classmethod
+    def Directory(cls):
+        scriptDir = os.path.dirname(os.path.realpath(__file__))
+        dirName = 'ReplacementKernels'
+        if globalParameters['CodeObjectVersion'] == 'V3':
+            dirName += '-cov3'
+
+        return os.path.join(scriptDir, dirName)
+
+    _instance = None
+    @classmethod
+    def Instance(cls):
+        if cls._instance:
+            return cls._instance
+        return cls(cls.Directory(), globalParameters["CodeObjectVersion"])
+
+    @classmethod
+    def Get(cls, kernelName):
+        return cls.Instance().get(kernelName)

--- a/Tensile/Tests/unit/replacement/bad_file/bad.txt
+++ b/Tensile/Tests/unit/replacement/bad_file/bad.txt
@@ -1,0 +1,1 @@
+No kernel name = bad

--- a/Tensile/Tests/unit/replacement/duplicate_kernel/a.txt
+++ b/Tensile/Tests/unit/replacement/duplicate_kernel/a.txt
@@ -1,0 +1,1 @@
+.amdgpu_hsa_kernel foo

--- a/Tensile/Tests/unit/replacement/duplicate_kernel/b.txt
+++ b/Tensile/Tests/unit/replacement/duplicate_kernel/b.txt
@@ -1,0 +1,1 @@
+.amdgpu_hsa_kernel foo

--- a/Tensile/Tests/unit/replacement/known_kernels_v2/baz.s.txt
+++ b/Tensile/Tests/unit/replacement/known_kernels_v2/baz.s.txt
@@ -1,0 +1,1 @@
+.amdgpu_hsa_kernel baz

--- a/Tensile/Tests/unit/replacement/known_kernels_v2/kernel_named_bar.txt
+++ b/Tensile/Tests/unit/replacement/known_kernels_v2/kernel_named_bar.txt
@@ -1,0 +1,1 @@
+.amdgpu_hsa_kernel bar

--- a/Tensile/Tests/unit/replacement/known_kernels_v2/kernel_named_foo.txt
+++ b/Tensile/Tests/unit/replacement/known_kernels_v2/kernel_named_foo.txt
@@ -1,0 +1,1 @@
+.amdgpu_hsa_kernel foo

--- a/Tensile/Tests/unit/replacement/known_kernels_v3/baz.s.txt
+++ b/Tensile/Tests/unit/replacement/known_kernels_v3/baz.s.txt
@@ -1,0 +1,1 @@
+.amdhsa_kernel baz

--- a/Tensile/Tests/unit/replacement/known_kernels_v3/kernel_named_bar.txt
+++ b/Tensile/Tests/unit/replacement/known_kernels_v3/kernel_named_bar.txt
@@ -1,0 +1,1 @@
+.amdhsa_kernel bar

--- a/Tensile/Tests/unit/replacement/known_kernels_v3/kernel_named_foo.txt
+++ b/Tensile/Tests/unit/replacement/known_kernels_v3/kernel_named_foo.txt
@@ -1,0 +1,1 @@
+.amdhsa_kernel foo

--- a/Tensile/Tests/unit/test_ReplacementKernels.py
+++ b/Tensile/Tests/unit/test_ReplacementKernels.py
@@ -1,0 +1,75 @@
+################################################################################
+# Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell cop-
+# ies of the Software, and to permit persons to whom the Software is furnished
+# to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM-
+# PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNE-
+# CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+################################################################################
+
+import pytest
+import os
+
+from Tensile.ReplacementKernels import ReplacementKernels
+
+def test_DefaultInstance():
+    assert ReplacementKernels.Get("asdf") is None
+
+    myReplacement = ReplacementKernels.Get("Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA906_IU1_K1_KLA_LPA0_LPB0_LDL1_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SU0_SNLL0_TT6_4_USFGRO0_VAW1_VW2_WG8_16_1_WGM4")
+
+    assert os.path.isfile(myReplacement)
+    assert os.path.isabs(myReplacement)
+
+def replacementDir(dirname):
+    scriptDir = os.path.dirname(os.path.realpath(__file__))
+    return os.path.join(scriptDir, 'replacement', dirname)
+
+def test_BadFile():
+    with pytest.raises(RuntimeError):
+        obj = ReplacementKernels(replacementDir('bad_file'), 'V3')
+        obj.get("asdf")
+
+def test_DuplicateKernel():
+    with pytest.raises(RuntimeError):
+        obj = ReplacementKernels(replacementDir('duplicate_kernel'), 'V3')
+        obj.get("asdf")
+
+goodObjs = [ReplacementKernels(replacementDir('known_kernels_v2'), "V2"),
+            ReplacementKernels(replacementDir('known_kernels_v3'), "V3")]
+
+@pytest.mark.parametrize("obj", goodObjs)
+def test_foo(obj):
+    foo = obj.get('foo')
+    assert os.path.isfile(foo)
+    assert os.path.isabs(foo)
+    assert foo.endswith('kernel_named_foo.txt')
+
+@pytest.mark.parametrize("obj", goodObjs)
+def test_bar(obj):
+    bar = obj.get('bar')
+    assert os.path.isfile(bar)
+    assert os.path.isabs(bar)
+    assert bar.endswith('kernel_named_bar.txt')
+
+@pytest.mark.parametrize("obj", goodObjs)
+def test_baz(obj):
+    baz = obj.get('baz')
+    assert os.path.isfile(baz)
+    assert os.path.isabs(baz)
+    assert baz.endswith('baz.s.txt')
+
+@pytest.mark.parametrize("obj", goodObjs)
+def test_unknown(obj):
+    assert obj.get('asdfds') is None

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py27,lint
+envlist = py35,py36,py27,lint
 
 [testenv]
 # Newer Pytest versions have a bug:


### PR DESCRIPTION
Adding a mechanism which will allow kernel file names to be shortened by hashing the rest of the kernel name beyond a certain point.

Note that the kernel name does not change.

Also creating a new replacement kernel mechanism which looks inside the files for the kernel name so that replacement kernels will still work.

I was able to build rocBLAS' kernels with `--no-merge-files` with these changes.