### PR TITLE
Set default iteration value to 10 for rocblas-bench calls

### DIFF
--- a/tuning/automation/ExtractSizes.py
+++ b/tuning/automation/ExtractSizes.py
@@ -66,7 +66,7 @@ def GetRocBLASParser():
     lineParser.add_argument("--algo",dest="algo", type=int,default=0)
     lineParser.add_argument("--solution_index",dest="solution_index", type=int,default=0)
     lineParser.add_argument("--flags",dest="flags", type=int,default=0)
-    lineParser.add_argument("-i",dest="i", type=int,default=1)
+    lineParser.add_argument("-i",dest="i", type=int,default=10)
     
     return lineParser
 

--- a/tuning/automation/GenerateTuningConfigurations.py
+++ b/tuning/automation/GenerateTuningConfigurations.py
@@ -376,10 +376,7 @@ def OutputScript(problemMapper, scriptPath, namePart):
             lines.append(rocblas_call)
         with open(outputFileName, 'w') as f:
             for line in lines:
-                if "rocblas-bench" in line:
-                    f.write("%s0\n" % line)
-                else:
-                    f.write("%s\n" % line)
+                f.write("%s\n" % line)
 
     generateRunScript(scriptFileNames, scriptPath)
     
@@ -400,7 +397,7 @@ def OutputScript2(problemMapper, scriptPath, namePart):
         with open(outputFileName, 'w') as f:
             for line in lines:
                 if "rocblas-bench" in line:
-                    f.write("ROCBLAS_TENSILE_LIBPATH=${TENSILE_LIBRARY} %s0" % line)
+                    f.write("ROCBLAS_TENSILE_LIBPATH=${TENSILE_LIBRARY} %s\n" % line)
                 else:
                     f.write("%s\n" % line)
                     

--- a/tuning/automation/GenerateTuningConfigurations.py
+++ b/tuning/automation/GenerateTuningConfigurations.py
@@ -376,7 +376,10 @@ def OutputScript(problemMapper, scriptPath, namePart):
             lines.append(rocblas_call)
         with open(outputFileName, 'w') as f:
             for line in lines:
-                f.write("%s\n" % line)
+                if "rocblas-bench" in line:
+                    f.write("%s0\n" % line)
+                else:
+                    f.write("%s\n" % line)
 
     generateRunScript(scriptFileNames, scriptPath)
     
@@ -397,7 +400,7 @@ def OutputScript2(problemMapper, scriptPath, namePart):
         with open(outputFileName, 'w') as f:
             for line in lines:
                 if "rocblas-bench" in line:
-                    f.write("ROCBLAS_TENSILE_LIBPATH=${TENSILE_LIBRARY} %s\n" % line)
+                    f.write("ROCBLAS_TENSILE_LIBPATH=${TENSILE_LIBRARY} %s0" % line)
                 else:
                     f.write("%s\n" % line)
                     

--- a/tuning/automation/PerformanceAnalysis.py
+++ b/tuning/automation/PerformanceAnalysis.py
@@ -102,6 +102,8 @@ def fillCallCounts(problemMapper, callCounts, callCountNN, callCountNNstrided, c
             midList = list()
             for key in klist:
                 if key == "transposeA" or key == "transposeB" or key == "f" or key == "i":
+                    if klist[key] == 10:
+                        klist[key] = 1
                     midList.append(klist[key])
                 if len(midList) == 4:
                     callCounts.append(midList)


### PR DESCRIPTION
Due to the unreliability of using 1 iteration in rocblas-bench calls, this sets the default value to 10 and makes a change to not affect the weighted average calculation.