### PR TITLE
Enable Tox on newer systems & run lint first

### DIFF
--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -14,18 +14,18 @@ def runCompileCommand(platform, project, jobName, boolean debug=false)
 
             hostname
 
+            cd ${project.paths.project_build_prefix}
+
             #### temporary fix to remedy incorrect home directory
             export HOME=/home/jenkins
             ####
             tox --version
             tox -v --workdir /tmp/.tensile-tox -e lint
 
-            export PATH=/opt/rocm/bin:$PATH
-            cd ${project.paths.project_build_prefix}
-
             mkdir build
             pushd build
  
+            export PATH=/opt/rocm/bin:$PATH
             cmake -DCMAKE_BUILD_TYPE=${buildType} -DCMAKE_CXX_COMPILER=${compiler} -DCODE_OBJECT_VERSION=${cov} -DTensile_ROOT=\$(pwd)/../Tensile ../HostLibraryTests
             make -j\$(nproc)
 

--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -14,6 +14,12 @@ def runCompileCommand(platform, project, jobName, boolean debug=false)
 
             hostname
 
+            #### temporary fix to remedy incorrect home directory
+            export HOME=/home/jenkins
+            ####
+            tox --version
+            tox -v --workdir /tmp/.tensile-tox -e lint
+
             export PATH=/opt/rocm/bin:$PATH
             cd ${project.paths.project_build_prefix}
 
@@ -24,11 +30,6 @@ def runCompileCommand(platform, project, jobName, boolean debug=false)
             make -j\$(nproc)
 
             popd
-            #### temporary fix to remedy incorrect home directory
-            export HOME=/home/jenkins
-            ####
-            tox --version
-            tox -v --workdir /tmp/.tensile-tox -e lint
 
             doxygen docs/Doxyfile
             """

--- a/tox.ini
+++ b/tox.ini
@@ -1,21 +1,20 @@
 [tox]
-envlist = py35,py27,lint
+envlist = py35,py36,py27,lint
 
 [testenv]
-# Newer Pytest versions have a bug:
+# Some versions of Pytest versions have a bug:
 # https://github.com/pytest-dev/pytest/issues/5971 which causes the whole test
-# process to crash if a multiprocessing job has an exception. Use 5.1.1 until
-# this is fixed.
+# process to crash if a multiprocessing job has an exception. Fixed in 5.3.3.
 deps = 
     -r{toxinidir}/requirements.txt
-    pytest==5.1.1
+    pytest>=5.3.3
     pytest-xdist
     filelock
 commands =
     py.test -v --basetemp={envtmpdir} --junit-xml={toxinidir}/{envname}_tests.xml --junit-prefix={envname} --color=yes -n 4 {posargs}
 
 [testenv:lint]
-basepython = python3.5
+basepython = python3
 deps = 
     -r{toxinidir}/requirements.txt
     pyflakes 


### PR DESCRIPTION
 - `lint` environment just uses `python3` instead of `python3.5`
 - Bug in pytest has been fixed so move to newer version
 - Python 3.6 environment to run tests
 - Run lint first for quicker CI failures