### PR TITLE
avoid race condition and GPU resource contention in CI run

### DIFF
--- a/Tensile/Tests/extended/pre_checkin
+++ b/Tensile/Tests/extended/pre_checkin
@@ -1,1 +1,0 @@
-../pre_checkin

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps =
     pytest-xdist
     filelock
 commands =
-    py.test -v --basetemp={envtmpdir} --junit-xml={toxinidir}/{envname}_tests.xml --junit-prefix={envname} --color=yes -n 4 {posargs}
+    py.test -v --basetemp={envtmpdir} --junit-xml={toxinidir}/{envname}_tests.xml --junit-prefix={envname} --color=yes -n 2 {posargs}
 
 [testenv:lint]
 basepython = python3

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps =
     pytest-xdist
     filelock
 commands =
-    py.test -v --basetemp={envtmpdir} --junit-xml={toxinidir}/{envname}_tests.xml --junit-prefix={envname} --color=yes -n 2 {posargs}
+    py.test -v --basetemp={envtmpdir} --junit-xml={toxinidir}/{envname}_tests.xml --junit-prefix={envname} --color=yes -n 1 {posargs}
 
 [testenv:lint]
 basepython = python3


### PR DESCRIPTION
Both pre_checkin and extended ran fine in a ROCm 3.0 docker container on both gfx906 and gfx908.
Can we please quickly review this simple PR so that we can stand a better chance of getting clean Tensile CI runs - after the 8xgfx908 rack is stabilized that is.