### PR TITLE
Full fp32/fp16/bf16 support for Transpose LDS

### DIFF
--- a/Tensile/KernelWriter.py
+++ b/Tensile/KernelWriter.py
@@ -642,18 +642,18 @@ class KernelWriter(metaclass=abc.ABCMeta):
               (kernel["ProblemType"]["DataType"].isBFloat16() or kernel["ProblemType"]["DataType"].isHalf()):
               # Reading 16-bit data from LDS requires packing when ECC enabled
               kl.append(self.comment("local read a"))
-              localReadCodeA, packCodeA = self.localReadDo(kernel, plrIdx, iui, 0, (u+pflr), tensorParametersA)
+              localReadCodeA, packCodeA = self.localReadDo(kernel, plrIdx, iui, 0, tensorParametersA)
               kl.append(localReadCodeA)
               kl.append(self.comment("local read b"))
-              localReadCodeB, packCodeB = self.localReadDo(kernel, plrIdx, iui, 0, (u+pflr), tensorParametersB)
+              localReadCodeB, packCodeB = self.localReadDo(kernel, plrIdx, iui, 0, tensorParametersB)
               kl.append(localReadCodeB)
               pack[plrIdx].addCode(packCodeA)
               pack[plrIdx].addCode(packCodeB)
             else:
               kl.append(self.comment("local read a"))
-              kl.append(self.localReadDo(kernel, plrIdx, iui, 0,(u+pflr), tensorParametersA))
+              kl.append(self.localReadDo(kernel, plrIdx, iui, 0, tensorParametersA))
               kl.append(self.comment("local read b"))
-              kl.append(self.localReadDo(kernel, plrIdx, iui, 0,(u+pflr), tensorParametersB))
+              kl.append(self.localReadDo(kernel, plrIdx, iui, 0, tensorParametersB))
             kl.append(self.comment("local read inc a"))
             kl.append(self.localReadInc(kernel, iui, tensorParametersA))
             kl.append(self.comment("local read inc b"))
@@ -798,18 +798,18 @@ class KernelWriter(metaclass=abc.ABCMeta):
                   (kernel["ProblemType"]["DataType"].isBFloat16() or kernel["ProblemType"]["DataType"].isHalf()):
                   # Reading 16-bit data from LDS requires packing when ECC enabled
                   kl.append(self.comment("local read prefetch a"))
-                  localReadCodeA, packCodeA = self.localReadDo(kernel, plrIdx, iui, espi, 0, tensorParametersA)
+                  localReadCodeA, packCodeA = self.localReadDo(kernel, plrIdx, iui, espi, tensorParametersA)
                   kl.append(localReadCodeA)
                   kl.append(self.comment("local read prefetch b"))
-                  localReadCodeB, packCodeB = self.localReadDo(kernel, plrIdx, iui, espi, 0, tensorParametersB)
+                  localReadCodeB, packCodeB = self.localReadDo(kernel, plrIdx, iui, espi, tensorParametersB)
                   kl.append(localReadCodeB)
                   pack[plrIdx].addCode(packCodeA)
                   pack[plrIdx].addCode(packCodeB)
                 else:
                   kl.append(self.comment("local read prefetch a"))
-                  kl.append(self.localReadDo(kernel, plrIdx, iui, espi,0, tensorParametersA))
+                  kl.append(self.localReadDo(kernel, plrIdx, iui, espi, tensorParametersA))
                   kl.append(self.comment("local read prefetch b"))
-                  kl.append(self.localReadDo(kernel, plrIdx, iui, espi,0, tensorParametersB))
+                  kl.append(self.localReadDo(kernel, plrIdx, iui, espi, tensorParametersB))
                 kl.append(self.comment("local read inc a"))
                 kl.append(self.localReadInc(kernel, iui, tensorParametersA))
                 kl.append(self.comment("local read inc b"))
@@ -908,18 +908,18 @@ class KernelWriter(metaclass=abc.ABCMeta):
                 (kernel["ProblemType"]["DataType"].isBFloat16() or kernel["ProblemType"]["DataType"].isHalf()):
                 # Reading 16-bit data from LDS requires packing when ECC enabled
                 kl.append(self.comment("prefetch local a"))
-                localReadCodeA, packCodeA = self.localReadDo(kernel, plrIdx, iui, 0, 0, tensorParametersA)
+                localReadCodeA, packCodeA = self.localReadDo(kernel, plrIdx, iui, 0, tensorParametersA)
                 kl.append(localReadCodeA)
                 kl.append(self.comment("prefetch local b"))
-                localReadCodeB, packCodeB = self.localReadDo(kernel, plrIdx, iui, 0, 0, tensorParametersB)
+                localReadCodeB, packCodeB = self.localReadDo(kernel, plrIdx, iui, 0, tensorParametersB)
                 kl.append(localReadCodeB)
                 pack[plrIdx].addCode(packCodeA)
                 pack[plrIdx].addCode(packCodeB)
               else:
                 kl.append(self.comment("prefetch local a"))
-                kl.append(self.localReadDo(kernel, plrIdx, iui, 0, 0, tensorParametersA))
+                kl.append(self.localReadDo(kernel, plrIdx, iui, 0, tensorParametersA))
                 kl.append(self.comment("prefetch local b"))
-                kl.append(self.localReadDo(kernel, plrIdx, iui, 0, 0, tensorParametersB))
+                kl.append(self.localReadDo(kernel, plrIdx, iui, 0, tensorParametersB))
               kl.append(self.comment1("local read increment a"))
               kl.append(self.localReadInc(kernel, iui, tensorParametersA))
               kl.append(self.comment1("local read increment b"))
@@ -954,10 +954,10 @@ class KernelWriter(metaclass=abc.ABCMeta):
               (kernel["ProblemType"]["DataType"].isBFloat16() or kernel["ProblemType"]["DataType"].isHalf()):
               # Reading 16-bit data from LDS requires packing when ECC enabled
               localReads.addText(self.comment("local read a"))
-              localReadCodeA, packCodeA = self.localReadDo(kernel, plrIdx, iui, 0, (u+pflr), tensorParametersA)
+              localReadCodeA, packCodeA = self.localReadDo(kernel, plrIdx, iui, 0, tensorParametersA)
               localReads.addCode(localReadCodeA)
               localReads.addText(self.comment("local read b"))
-              localReadCodeB, packCodeB = self.localReadDo(kernel, plrIdx, iui, 0, (u+pflr), tensorParametersB)
+              localReadCodeB, packCodeB = self.localReadDo(kernel, plrIdx, iui, 0, tensorParametersB)
               localReads.addCode(localReadCodeB)
               localReadsA.addCode(localReadCodeA)
               localReadsB.addCode(localReadCodeB)
@@ -965,12 +965,12 @@ class KernelWriter(metaclass=abc.ABCMeta):
               pack[plrIdx].addCode(packCodeB)
             else:
               localReads.addText(self.comment("local read a"))
-              localReads.addCode(self.localReadDo(kernel, plrIdx, iui, 0,(u+pflr), tensorParametersA))
+              localReads.addCode(self.localReadDo(kernel, plrIdx, iui, 0, tensorParametersA))
               localReads.addText(self.comment("local read b"))
-              localReads.addCode(self.localReadDo(kernel, plrIdx, iui, 0,(u+pflr), tensorParametersB))
+              localReads.addCode(self.localReadDo(kernel, plrIdx, iui, 0, tensorParametersB))
               #container for holding local read A & B elements for later re-ordering
-              localReadsA.addCode(self.localReadDo(kernel, plrIdx, iui, 0,(u+pflr), tensorParametersA))
-              localReadsB.addCode(self.localReadDo(kernel, plrIdx, iui, 0,(u+pflr), tensorParametersB))
+              localReadsA.addCode(self.localReadDo(kernel, plrIdx, iui, 0, tensorParametersA))
+              localReadsB.addCode(self.localReadDo(kernel, plrIdx, iui, 0, tensorParametersB))
 
             # Don't increment the LRO if we are going to reset them below:
             if not isResetLroIter or iui != kernel["InnerUnroll"]-1:
@@ -1223,18 +1223,18 @@ class KernelWriter(metaclass=abc.ABCMeta):
               (kernel["ProblemType"]["DataType"].isBFloat16() or kernel["ProblemType"]["DataType"].isHalf()):
               # Reading 16-bit data from LDS requires packing when ECC enabled
               localReads.addText(self.comment("local read a"))
-              localReadCodeA, packCodeA = self.localReadDo(kernel, plrIdx, iui, 0, (unrollIter+pflr)%kernel["LoopIters"], tensorParametersA)
+              localReadCodeA, packCodeA = self.localReadDo(kernel, plrIdx, iui, 0, tensorParametersA)
               localReads.addCode(localReadCodeA)
               localReads.addText(self.comment("local read b"))
-              localReadCodeB, packCodeB = self.localReadDo(kernel, plrIdx, iui, 0, (unrollIter+pflr)%kernel["LoopIters"], tensorParametersB)
+              localReadCodeB, packCodeB = self.localReadDo(kernel, plrIdx, iui, 0, tensorParametersB)
               localReads.addCode(localReadCodeB)
               pack[plrIdx].addCode(packCodeA)
               pack[plrIdx].addCode(packCodeB)
             else:
               localReads.addText(self.comment("local read a"))
-              localReads.addCode(self.localReadDo(kernel, plrIdx, iui, 0, (unrollIter+pflr)%kernel["LoopIters"], tensorParametersA))
+              localReads.addCode(self.localReadDo(kernel, plrIdx, iui, 0, tensorParametersA))
               localReads.addText(self.comment("local read b"))
-              localReads.addCode(self.localReadDo(kernel, plrIdx, iui, 0, (unrollIter+pflr)%kernel["LoopIters"], tensorParametersB))
+              localReads.addCode(self.localReadDo(kernel, plrIdx, iui, 0, tensorParametersB))
             if kernel["InnerUnroll"] and iui != kernel["InnerUnroll"]-1:
               localReads.addText(self.comment("unroll increments:"))
               localReads.addText(self.comment("local read inc a"))
@@ -1425,18 +1425,18 @@ class KernelWriter(metaclass=abc.ABCMeta):
             (kernel["ProblemType"]["DataType"].isBFloat16() or kernel["ProblemType"]["DataType"].isHalf()):
             # Reading 16-bit data from LDS requires packing when ECC enabled
             kl.append(self.comment("local read a"))
-            localReadCodeA, packCodeA = self.localReadDo(kernel, 0, iui, 0, 0, tensorParametersA)
+            localReadCodeA, packCodeA = self.localReadDo(kernel, 0, iui, 0, tensorParametersA)
             kl.append(localReadCodeA)
             kl.append(self.comment("local read b"))
-            localReadCodeB, packCodeB = self.localReadDo(kernel, 0, iui, 0, 0, tensorParametersB)
+            localReadCodeB, packCodeB = self.localReadDo(kernel, 0, iui, 0, tensorParametersB)
             kl.append(localReadCodeB)
             pack[0].addCode(packCodeA)
             pack[0].addCode(packCodeB)
           else:
             kl.append(self.comment("local read a"))
-            kl.append(self.localReadDo(kernel, 0, iui, 0, 0, tensorParametersA))
+            kl.append(self.localReadDo(kernel, 0, iui, 0, tensorParametersA))
             kl.append(self.comment("local read b"))
-            kl.append(self.localReadDo(kernel, 0, iui, 0, 0, tensorParametersB))
+            kl.append(self.localReadDo(kernel, 0, iui, 0, tensorParametersB))
           kl.append(self.comment("local read inc a"))
           kl.append(self.localReadInc(kernel, iui, tensorParametersA))
           kl.append(self.comment("local read inc b"))

--- a/Tensile/KernelWriter.py
+++ b/Tensile/KernelWriter.py
@@ -2508,7 +2508,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
   # Local Read: Do It A/B
   ##############################################################################
   @abc.abstractmethod
-  def localReadDo(self, kernel, bufferIdx, innerUnrollIndex, epsi, uIdx, tP):
+  def localReadDo(self, kernel, bufferIdx, innerUnrollIndex, epsi, tP):
     return ""
 
   ##############################################################################

--- a/Tensile/KernelWriter.py
+++ b/Tensile/KernelWriter.py
@@ -638,7 +638,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
       for iui in range(0,kernel["InnerUnroll"]):
         if self.enable["LocalRead"]:
           if u < kernel["LoopIters"]-1 or not kernel["PrefetchLocalRead"]:
-            if kernel["MatrixInstruction"] and \
+            if kernel["MatrixInstruction"] and not kernel["TransposeLDS"] and\
               (kernel["ProblemType"]["DataType"].isBFloat16() or kernel["ProblemType"]["DataType"].isHalf()):
               # Reading 16-bit data from LDS requires packing when ECC enabled
               kl.append(self.comment("local read a"))
@@ -794,7 +794,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
             pack[plrIdx] = Code.Module()
             for espi in range(0, (self.prefetchAcrossPersistent and kernel["ExpandPointerSwap"])+1):
               for iui in range(0,kernel["InnerUnroll"]):
-                if kernel["MatrixInstruction"] and \
+                if kernel["MatrixInstruction"] and not kernel["TransposeLDS"] and \
                   (kernel["ProblemType"]["DataType"].isBFloat16() or kernel["ProblemType"]["DataType"].isHalf()):
                   # Reading 16-bit data from LDS requires packing when ECC enabled
                   kl.append(self.comment("local read prefetch a"))
@@ -904,7 +904,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
           for plrIdx in range(0, kernel["PrefetchLocalRead"]):
             pack[plrIdx] = Code.Module()
             for iui in range(0,kernel["InnerUnroll"]):
-              if kernel["MatrixInstruction"] and \
+              if kernel["MatrixInstruction"] and not kernel["TransposeLDS"] and \
                 (kernel["ProblemType"]["DataType"].isBFloat16() or kernel["ProblemType"]["DataType"].isHalf()):
                 # Reading 16-bit data from LDS requires packing when ECC enabled
                 kl.append(self.comment("prefetch local a"))
@@ -950,7 +950,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
         localReadsB = Code.Module()
         for iui in range(0,kernel["InnerUnroll"]):
           if self.enable["LocalRead"]:
-            if kernel["MatrixInstruction"] and \
+            if kernel["MatrixInstruction"] and not kernel["TransposeLDS"] and \
               (kernel["ProblemType"]["DataType"].isBFloat16() or kernel["ProblemType"]["DataType"].isHalf()):
               # Reading 16-bit data from LDS requires packing when ECC enabled
               localReads.addText(self.comment("local read a"))
@@ -1219,7 +1219,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
         pack[plrIdx] = Code.Module()
         for iui in range(0,kernel["InnerUnroll"]):
           if self.enable["LocalRead"]:
-            if kernel["MatrixInstruction"] and \
+            if kernel["MatrixInstruction"] and not kernel["TransposeLDS"] and \
               (kernel["ProblemType"]["DataType"].isBFloat16() or kernel["ProblemType"]["DataType"].isHalf()):
               # Reading 16-bit data from LDS requires packing when ECC enabled
               localReads.addText(self.comment("local read a"))
@@ -1404,7 +1404,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
         # tail loop reload data and store in lds[0]
         # if we have prefetchLocalRead, lds[0] will have prefetch data during main loop without release tempVgpr before tail loop localRead
         # will have Tensile::WARNING: RegisterPool::checkIn(XXX) but it was never checked out
-        if kernel["MatrixInstruction"] and kernel["PrefetchLocalRead"] and \
+        if kernel["MatrixInstruction"] and kernel["PrefetchLocalRead"] and not kernel["TransposeLDS"] and \
           (kernel["ProblemType"]["DataType"].isBFloat16() or kernel["ProblemType"]["DataType"].isHalf()):
           for item in list(pack[0].items()):
             for packCode in list(item.items()):
@@ -1421,7 +1421,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
       pack[0] = Code.Module()
       for iui in range(0,tailLoopInnerUnroll):
         if self.enable["LocalRead"]:
-          if kernel["MatrixInstruction"] and \
+          if kernel["MatrixInstruction"] and not kernel["TransposeLDS"] and \
             (kernel["ProblemType"]["DataType"].isBFloat16() or kernel["ProblemType"]["DataType"].isHalf()):
             # Reading 16-bit data from LDS requires packing when ECC enabled
             kl.append(self.comment("local read a"))

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -7654,7 +7654,10 @@ class KernelWriterAssembly(KernelWriter):
               paramList.append(tmpVgpr)
             paramList.append(vgpr("LocalReadAddr%s"%tc))
             if not kernel["TransposeLDS"]:
-              offset = ((rIdx * kernel["MacroTile%u" % tIdx] // kernel["ThreadTile%u" % tIdx] + kIdx*(kernel["MacroTile%s"%tc]+kernel["LdsPad%s"%tc]) + tP["localReadOffset"]) \
+              readOffsetWidth = kernel["MacroTile%u" % tIdx] // kernel["ThreadTile%u" % tIdx] # WG0
+              if tP["isB"]:
+                readOffsetWidth *= (kernel["ThreadTile1"] // kernel["MatrixInstN"]) * 4 # 4 simds
+              offset = ((rIdx * readOffsetWidth + kIdx*(kernel["MacroTile%s"%tc]+kernel["LdsPad%s"%tc]) + tP["localReadOffset"]) \
                  *tP["bpe"]+tP["localReadSwapByteOffset"])//offsetMultiplier
             else:
               #transposeLDS case

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -5159,18 +5159,20 @@ class KernelWriterAssembly(KernelWriter):
 
         if tc == "B": # For BBlocks, A and B use this case
           #add perWave LDS base offset
-          if tP["grcg"]:
-            if tP["grcv"]:
-              PerpName = tP["lvp"]
-            else:
-              # Fractional load use the more accurate lsc, multiply by VW later
-              PerpName = tP["lsp"]
-          else:
-            if tP["grcv"]:
-              PerpName = tP["lvc"]
-            else:
-              PerpName = tP["lsc"]
-          numPerpElementsPerLoad = kernel[PerpName] if not kernel["DirectToLds%s"%tP["tensorChar"]] else  (globalParameters["WavefrontWidth"] * 4 // (kernel["DepthU"] * tP["bpe"])) 
+          ## FIXME: commented out until intent is clarified
+          # if tP["grcg"]:
+          #   if tP["grcv"]:
+          #     PerpName = tP["lvp"]
+          #   else:
+          #     # Fractional load use the more accurate lsc, multiply by VW later
+          #     PerpName = tP["lsp"]
+          # else:
+          #   if tP["grcv"]:
+          #     PerpName = tP["lvc"]
+          #   else:
+          #     PerpName = tP["lsc"]
+          # numPerpElementsPerLoad = kernel[PerpName] if not kernel["DirectToLds%s"%tP["tensorChar"]] else  (globalParameters["WavefrontWidth"] * 4 // (kernel["DepthU"] * tP["bpe"])) 
+          ## end FIXME
           wavefronts = kernel["NumThreads"] // globalParameters["WavefrontWidth"]
           numPerpElementsPerWave = kernel["MacroTile%s"%tc]//wavefronts
           assert(numPerpElementsPerWave>0)

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -7570,7 +7570,10 @@ class KernelWriterAssembly(KernelWriter):
     kStr = ""
     tc = tP["tensorChar"]
     if self.inTailLoop:
-      inc = kernel["LocalSplitU"]*(kernel["MacroTile%u"%tP["tensorIdx"]]+kernel["LdsPad%s"%tc])*tP["bpe"]
+      if not kernel["TransposeLDS"]:
+        inc = kernel["LocalSplitU"]*(kernel["MacroTile%u"%tP["tensorIdx"]]+kernel["LdsPad%s"%tc])*tP["bpe"]
+      else:
+        inc = kernel["LocalSplitU"]*tP["bpe"]
       if kernel["MatrixInstruction"]:
         inc *= kernel["MatrixInstK"]
       tmpSgpr = self.getTmpSgpr(1)
@@ -7755,7 +7758,7 @@ class KernelWriterAssembly(KernelWriter):
                   InstructionTileOuput = (globalParameters["WavefrontWidth"] // kernel["MIWG0"] ) * (kernel["MatrixInstN"] // kernel["InstSplit"])
                 blockOffset = (InstructionTileOuput) * kernel["DepthU"] * tP["bpe"]
                 ldsPadOffset = (blockOffset//kernel["LdsBlockSizePerPad"])*kernel["LdsPad%s"%tc]*tP["bpe"]
-                offset = (blockOffset + ldsPadOffset)*rIdx + uIdx*kernel["MatrixInstK"]*tP["bpe"] + tP["localReadSwapByteOffset"]
+                offset = (blockOffset + ldsPadOffset)*rIdx + tP["localReadOffset"]*tP["bpe"] + blockWidth*self.bpr*vIdx + tP["localReadSwapByteOffset"]
                 paramList.append(offset)
             else:
               paramList.append(((rIdx*blockWidth + kernel["SubGroup%u"%tP["tensorIdx"]]*(vIdx*numOffsets+oIdx)*kernel["VectorWidth"] \

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -5197,8 +5197,7 @@ class KernelWriterAssembly(KernelWriter):
         else: # For BBlocks, don't use else case
           kStr += inst("s_mov_b32", \
               sgpr(tmpSgpr), \
-              #hex(kernel["MacroTile%u"%tIdx] + kernel["LdsPad%s"%tc]), \
-              hex((kernel["MacroTile%u"%tIdx] + kernel["LdsPad%s"%tc]) // 4), \
+              hex((kernel["MacroTile%u"%tIdx] ) // 4), \
               "MT%u+PAD"%tIdx )
     else:
       kStr += inst("s_mov_b32", \

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -7595,10 +7595,9 @@ class KernelWriterAssembly(KernelWriter):
   ##############################################################################
   # Local Read: Do It A/B
   # iui = Inner Unroll Idx
-  # uIdx - Unroll Idx
   # epsi = expand pointer swap index. Only used for PAP
   ##############################################################################
-  def localReadDo(self, kernel, bufferIdx, iui, epsi, uIdx, tP):
+  def localReadDo(self, kernel, bufferIdx, iui, epsi, tP):
 
     tc=tP["tensorChar"]
     if not self.do["LocalRead%s"%tc]: return ""

--- a/Tensile/KernelWriterSource.py
+++ b/Tensile/KernelWriterSource.py
@@ -2468,7 +2468,7 @@ class KernelWriterSource(KernelWriter):
   ##############################################################################
   # Local Read: Do It A/B
   ##############################################################################
-  def localReadDo(self, kernel, black, iui, epsi, uIdx, tP):
+  def localReadDo(self, kernel, black, iui, epsi, tP):
     kStr = ""
     for r in range(0, kernel[tP["tt"]]//kernel["VectorWidth"]):
       for s in range(0, kernel["VectorWidth"]):

--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -2525,6 +2525,9 @@ class Solution:
     if state["TransposeLDS"] == 1:
       if not state["MatrixInstruction"]:
         reject(state, "TransposeLds Supports only in MatrixInstruction=1")
+      if state["MatrixInstruction"]:
+        if state["VectorWidth"] > state["MatrixInstK"]:
+          reject(state, "VectorWidth cannot be greater than MatrixInstK when TransposeLDS=1")
     if "MatrixInstruction" in state:
       if state["TransposeLDS"] == 1:
         if state["ProblemType"]["TLUA"] or state["ProblemType"]["TLUB"]:

--- a/Tensile/Tests/pre_checkin/mfma/hpa_bfloat16_gemm_asm_mi32x32x2x2.yaml
+++ b/Tensile/Tests/pre_checkin/mfma/hpa_bfloat16_gemm_asm_mi32x32x2x2.yaml
@@ -2,11 +2,55 @@ TestParameters:
   marks: [skip-gfx900, skip-gfx906, skip-gfx1010] # not supported by arch
 
 GlobalParameters:
-  NumElementsToValidate: -1
+  NumElementsToValidate: 65536
   BoundsCheck: True
   KernelTime: True
 
 BenchmarkProblems:
+  ########################################
+  # TN - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: B
+      DestDataType: B
+      ComputeDataType: s
+      HighPrecisionAccumulate: True
+      TransposeA: True
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+        - PrefetchLocalRead: [True]
+      ForkParameters:
+        - MatrixInstruction:
+          - [32, 32, 2, 2]
+        - PrefetchGlobalRead: [True]
+        - ThreadTile:
+          - [ 2, 32 ]
+        - WorkGroup:
+          - [ 16, 16, 1 ]
+        - WorkGroupMapping: [8]
+        - TransposeLDS: [0, 1]
+        - LdsPadA: [0, 2]
+        - LdsPadB: [0, 2]
+        - GlobalSplitU: [1]
+        - DepthU: [8]
+        - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [2]
+        - AssertFree0ElementMultiple: [2]
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [ 64, 256, 1, 8 ]
+
   ########################################
   # NT - standard
   ########################################
@@ -38,6 +82,8 @@ BenchmarkProblems:
           - [ 16, 16, 1 ]
         - WorkGroupMapping: [8]
         - GlobalSplitU: [1]
+        - LdsPadA: [0, 2]
+        - LdsPadB: [0, 2]
         - DepthU: [8]
         - VectorWidth: [-1]
         - AssertSummationElementMultiple: [2]

--- a/Tensile/Tests/pre_checkin/mfma/hpa_hgemm_asm_mi32x32x4x2.yaml
+++ b/Tensile/Tests/pre_checkin/mfma/hpa_hgemm_asm_mi32x32x4x2.yaml
@@ -2,11 +2,53 @@ TestParameters:
   marks: [skip-gfx900, skip-gfx906, skip-gfx1010] # not supported by arch
 
 GlobalParameters:
-  NumElementsToValidate: -1
+  NumElementsToValidate: 65536
   BoundsCheck: True
   KernelTime: True
 
 BenchmarkProblems:
+  ########################################
+  # TN - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: h
+      HighPrecisionAccumulate: True
+      TransposeA: True
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+        - PrefetchLocalRead: [True]
+      ForkParameters:
+        - MatrixInstruction:
+          - [32, 32, 4, 2]
+        - PrefetchGlobalRead: [True]
+        - ThreadTile:
+          - [ 2, 32 ]
+        - WorkGroup:
+          - [ 16, 16, 1 ]
+        - WorkGroupMapping: [8]
+        - TransposeLDS: [0, 1]
+        - LdsPadA: [0, 4]
+        - LdsPadB: [0, 4]
+        - GlobalSplitU: [1]
+        - DepthU: [8]
+        - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [2]
+        - AssertFree0ElementMultiple: [2]
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [ 64, 256, 1, 8 ]
+
   ########################################
   # NT - standard
   ########################################
@@ -35,6 +77,8 @@ BenchmarkProblems:
         - WorkGroup:
           - [ 16, 16, 1 ]
         - WorkGroupMapping: [8]
+        - LdsPadA: [0, 4]
+        - LdsPadB: [0, 4]
         - GlobalSplitU: [1]
         - DepthU: [8]
         - VectorWidth: [-1]

--- a/Tensile/Tests/pre_checkin/mfma/sgemm_asm_mi32x32x1x2.yaml
+++ b/Tensile/Tests/pre_checkin/mfma/sgemm_asm_mi32x32x1x2.yaml
@@ -2,13 +2,13 @@ TestParameters:
   marks: [skip-gfx900, skip-gfx906, skip-gfx1010] # not supported by arch
 
 GlobalParameters:
-  NumElementsToValidate: -1
+  NumElementsToValidate: 65536
   BoundsCheck: True
   KernelTime: True
 
 BenchmarkProblems:
   ########################################
-  # NT - standard
+  # TN - standard
   ########################################
   -
     - # ProblemType
@@ -34,13 +34,53 @@ BenchmarkProblems:
         - WorkGroup:
           - [ 16, 16, 1 ]
         - WorkGroupMapping: [8]
+        - TransposeLDS: [0, 1]
+        - LdsPadA: [0, 1]
+        - LdsPadB: [0, 1]
         - GlobalSplitU: [1]
         - DepthU: [ 8 ]
         - VectorWidth: [1]
       BenchmarkForkParameters:
       JoinParameters:
-        - MacroTile
-        - GlobalSplitU
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [64], [256], [1], [64] ]
+
+  ########################################
+  # NT - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: s
+      TransposeA: False
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+        - PrefetchLocalRead: [True]
+      ForkParameters:
+        - MatrixInstruction:
+          - [32, 32, 1, 2]
+        - PrefetchGlobalRead: [True]
+        - ThreadTile:
+          - [ 2, 32 ]
+        - WorkGroup:
+          - [ 16, 16, 1 ]
+        - WorkGroupMapping: [8]
+        - LdsPadA: [0, 1]
+        - LdsPadB: [0, 1]
+        - GlobalSplitU: [1]
+        - DepthU: [ 8 ]
+        - VectorWidth: [1]
+      BenchmarkForkParameters:
+      JoinParameters:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:

--- a/Tensile/Tests/pre_checkin/mfma/sgemm_asm_mi32x32x2x1.yaml
+++ b/Tensile/Tests/pre_checkin/mfma/sgemm_asm_mi32x32x2x1.yaml
@@ -1,5 +1,6 @@
 TestParameters:
   marks: [skip-gfx900, skip-gfx906, skip-gfx1010] # not supported by arch
+  marks: [xfail] # see PR #871
 
 GlobalParameters:
   NumElementsToValidate: 65536

--- a/Tensile/Tests/pre_checkin/mfma/sgemm_asm_mi32x32x2x1.yaml
+++ b/Tensile/Tests/pre_checkin/mfma/sgemm_asm_mi32x32x2x1.yaml
@@ -2,13 +2,13 @@ TestParameters:
   marks: [skip-gfx900, skip-gfx906, skip-gfx1010] # not supported by arch
 
 GlobalParameters:
-  NumElementsToValidate: -1
+  NumElementsToValidate: 65536
   BoundsCheck: True
   KernelTime: True
 
 BenchmarkProblems:
   ########################################
-  # NT - standard
+  # TN - standard
   ########################################
   -
     - # ProblemType
@@ -34,13 +34,53 @@ BenchmarkProblems:
         - WorkGroup:
           - [ 16, 16, 1 ]
         - WorkGroupMapping: [8]
+        - TransposeLDS: [0, 1]
+        - LdsPadA: [0, 1]
+        - LdsPadB: [0, 1]
         - GlobalSplitU: [1]
         - DepthU: [ 8 ]
         - VectorWidth: [1]
       BenchmarkForkParameters:
       JoinParameters:
-        - MacroTile
-        - GlobalSplitU
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [64], [256], [1], [64] ]
+
+  ########################################
+  # NT - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: s
+      TransposeA: False
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+        - PrefetchLocalRead: [True]
+      ForkParameters:
+        - MatrixInstruction:
+          - [32, 32, 2, 1]
+        - PrefetchGlobalRead: [True]
+        - ThreadTile:
+          - [ 1, 32 ]
+        - WorkGroup:
+          - [ 16, 16, 1 ]
+        - WorkGroupMapping: [8]
+        - LdsPadA: [0, 1]
+        - LdsPadB: [0, 1]
+        - GlobalSplitU: [1]
+        - DepthU: [ 8 ]
+        - VectorWidth: [1]
+      BenchmarkForkParameters:
+      JoinParameters:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:


### PR DESCRIPTION
This should resolve a number of issues found in #853. `half`/`bfloat16` data types are also working. 

~~Though there are known issues regarding odd-k support of `half`/`bfloat16` and is working on it. Once it's complete I will remove the draft status.~~ **Update: odd-k deferred; remove draft status**

Marked MI 32x32x2x1 tests with `xfail` due to #872 

