### PR TITLE
allow even longer timeout for extended CI run

### DIFF
--- a/.jenkins/extended.groovy
+++ b/.jenkins/extended.groovy
@@ -20,7 +20,7 @@ def runCI =
 
     boolean formatCheck = false
 
-    prj.timeout.test = 900
+    prj.timeout.test = 1440
 
     def commonGroovy
 


### PR DESCRIPTION
At least one extended CI run hit 15-hour timeout last night.  Increase it to 24 hours for now.