### PR TITLE
temporarily allow longer timeout even for precheckin CI run

### DIFF
--- a/.jenkins/precheckin.groovy
+++ b/.jenkins/precheckin.groovy
@@ -20,6 +20,9 @@ def runCI =
 
     boolean formatCheck = false
 
+    // temporarily increase timeout from 5 hours to 8 hours
+    prj.timeout.test = 480
+
     def commonGroovy
 
     def compileCommand =


### PR DESCRIPTION
We'll assess the test base and reduce overall run time for both precheckin and extended soon.