### PR TITLE
cut run time of top-10 extended tests

### DIFF
--- a/Tensile/Tests/extended/classic_source/test_hgemm_nn.yaml
+++ b/Tensile/Tests/extended/classic_source/test_hgemm_nn.yaml
@@ -8,6 +8,7 @@ GlobalParameters:
   DataInitTypeAB: 1
   DataInitTypeC: 1
   ExitOnFails: 0  # Some solutions fail so just ensure we find one good solution
+  NewClient: 2
 
 BenchmarkProblems:
 
@@ -32,21 +33,21 @@ BenchmarkProblems:
       ForkParameters:
         - ThreadTile:
           - [8, 8]
-          - [7, 4]
-          - [3, 5]
+          ##- [7, 4]
+          ##- [3, 5]
           - [2, 6]
           - [1, 1]
         - WorkGroup:
           - [ 16, 16,  1 ]
           - [  8,  2, 16 ]
-          - [ 16, 12,  1 ]
+          ##- [ 16, 12,  1 ]
         - DepthU: [ 2, 16, 64 ]
         - GlobalSplitU: [1, 4]
         - VectorWidth: [1]
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [   1, 1, 1, 1 ]
-          - Range: [ [127, 1, 129], [127, 1, 129], [1, 2], [63, 1, 65] ]
+          - Range: [ [127, 1, 129], [127, 1, 129], [1, 2], [63, 1, 64] ]
 
 
     - # Non-Tile Sizes
@@ -57,15 +58,15 @@ BenchmarkProblems:
         - ThreadTile: [ [4, 8] ]
         - DepthU: [ 16 ]
       ForkParameters:
-        - GlobalReadCoalesceGroupA: [False, True]
-        - GlobalReadCoalesceGroupB: [False, True]
+        ##- GlobalReadCoalesceGroupA: [False, True]
+        ##- GlobalReadCoalesceGroupB: [False, True]
         - PrefetchGlobalRead: [False, True]
         - PrefetchLocalRead: [False, True]
         - VectorWidth: [1]
         - GlobalSplitU: [1, 4]
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127, 1, 129], [127, 1, 129], [1], [63, 1, 65] ]
+          - Range: [ [127, 1, 129], [127, 1, 129], [1], [63, 1, 64] ]
 
     - # Branches
       BenchmarkCommonParameters:
@@ -82,5 +83,5 @@ BenchmarkProblems:
         - VectorWidth: [1]
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [8, 32, 0, 75], [8, 32, 0, 75], [3], [63, 1, 64] ]
+          - Range: [ [8, 32, 0, 40], [8, 32, 0, 40], [3], [63, 1, 64] ]
 

--- a/Tensile/Tests/extended/classic_source/test_hgemm_tn_tt.yaml
+++ b/Tensile/Tests/extended/classic_source/test_hgemm_tn_tt.yaml
@@ -8,6 +8,7 @@ GlobalParameters:
   DataInitTypeAB: 1
   DataInitTypeC: 1
   ExitOnFails: 0  # Some solutions fail so just ensure we find one good solution
+  NewClient: 2
 
 BenchmarkProblems:
     # Covers TN and TT cases to test combining at at
@@ -33,8 +34,8 @@ BenchmarkProblems:
       ForkParameters:
         - ThreadTile:
           - [8, 8]
-          - [7, 4]
-          - [3, 5]
+          ##- [7, 4]
+          ##- [3, 5]
           - [2, 6]
           - [1, 1]
         - WorkGroup:
@@ -47,7 +48,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [   1,   1,   1 ]
-          - Range: [ [127, 1, 129], [127, 1, 129], [63, 1, 65] ]
+          - Range: [ [127, 1, 129], [127, 1, 129], [63, 1, 64] ]
 
 
     - # Non-Tile Sizes
@@ -58,15 +59,15 @@ BenchmarkProblems:
         - ThreadTile: [ [4, 8] ]
         - DepthU: [ 16 ]
       ForkParameters:
-        - GlobalReadCoalesceGroupA: [False, True]
-        - GlobalReadCoalesceGroupB: [False, True]
+        ##- GlobalReadCoalesceGroupA: [False, True]
+        ##- GlobalReadCoalesceGroupB: [False, True]
         - PrefetchGlobalRead: [False, True]
         - PrefetchLocalRead: [False, True]
         - VectorWidth: [1]
         - GlobalSplitU: [1, 4]
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127, 1, 129], [127, 1, 129], [63, 1, 65] ]
+          - Range: [ [127, 1, 129], [127, 1, 129], [63, 1, 64] ]
 
     - # Branches
       BenchmarkCommonParameters:
@@ -83,7 +84,7 @@ BenchmarkProblems:
         - VectorWidth: [1]
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [8, 32, 0, 75], [8, 32, 0, 75], [63, 1, 64] ]
+          - Range: [ [8, 32, 0, 40], [8, 32, 0, 40], [63, 1, 64] ]
 
 
     ############################################################################
@@ -133,15 +134,15 @@ BenchmarkProblems:
         - ThreadTile: [ [4, 8] ]
         - DepthU: [ 16 ]
       ForkParameters:
-        - GlobalReadCoalesceGroupA: [False, True]
-        - GlobalReadCoalesceGroupB: [False, True]
+        ##- GlobalReadCoalesceGroupA: [False, True]
+        ##- GlobalReadCoalesceGroupB: [False, True]
         - PrefetchGlobalRead: [False, True]
         - PrefetchLocalRead: [False, True]
         - VectorWidth: [1]
         - GlobalSplitU: [1, 4]
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127, 1, 129], [127, 1, 129], [63, 1, 65] ]
+          - Range: [ [127, 1, 129], [127, 1, 129], [63, 1, 64] ]
 
     - # Branches
       BenchmarkCommonParameters:
@@ -158,7 +159,7 @@ BenchmarkProblems:
         - VectorWidth: [1]
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [8, 32, 0, 75], [8, 32, 0, 75], [63, 1, 64] ]
+          - Range: [ [8, 32, 0, 40], [8, 32, 0, 40], [63, 1, 64] ]
 
 LibraryLogic:
     ScheduleName: "vega10"
@@ -177,4 +178,4 @@ LibraryLogic:
 #   DeviceNames: ["Device 0000"]
 #   ArchitectureName: "fallback"
 
-LibraryClient:
+#LibraryClient:

--- a/Tensile/Tests/extended/classic_source/test_sgemm.yaml
+++ b/Tensile/Tests/extended/classic_source/test_sgemm.yaml
@@ -7,6 +7,7 @@ GlobalParameters:
   ValidationMaxToPrint: 4
   DataInitTypeAB: 1
   DataInitTypeC: 1
+  NewClient: 2
 
 BenchmarkProblems:
 
@@ -31,21 +32,21 @@ BenchmarkProblems:
       ForkParameters:
         - ThreadTile:
           - [8, 8]
-          - [7, 4]
+          ##- [7, 4]
           - [3, 5]
           - [2, 6]
-          - [1, 1]
+          ##- [1, 1]
         - WorkGroup:
           - [ 16, 16,  1 ]
           - [  8,  2, 16 ]
-          - [ 16, 12,  1 ]
+          ##- [ 16, 12,  1 ]
         - DepthU: [ 2, 16, 64 ]
         - GlobalSplitU: [1, 4]
         - VectorWidth: [1]
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [   1, 1, 1, 1 ]
-          - Range: [ [127, 1, 129], [127, 1, 129], [1, 2], [63, 1, 65] ]
+          - Range: [ [127, 1, 129], [127, 1, 129], [1, 2], [63, 1, 64] ]
 
 
     - # Non-Tile Sizes
@@ -56,15 +57,15 @@ BenchmarkProblems:
         - ThreadTile: [ [4, 8] ]
         - DepthU: [ 16 ]
       ForkParameters:
-        - GlobalReadCoalesceGroupA: [False, True]
-        - GlobalReadCoalesceGroupB: [False, True]
+        ##- GlobalReadCoalesceGroupA: [False, True]
+        ##- GlobalReadCoalesceGroupB: [False, True]
         - PrefetchGlobalRead: [False, True]
         - PrefetchLocalRead: [False, True]
         - VectorWidth: [1]
         - GlobalSplitU: [1, 4]
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127, 1, 129], [127, 1, 129], [1], [63, 1, 65] ]
+          - Range: [ [127, 1, 129], [127, 1, 129], [1], [63, 1, 64] ]
 
     - # Branches
       BenchmarkCommonParameters:
@@ -94,13 +95,13 @@ BenchmarkProblems:
         - PrefetchLocalRead: [False]
         - PrefetchGlobalRead: [True]
         - ThreadTile:
-          - [ 3, 3 ]
+          ##- [ 3, 3 ]
           - [ 4, 4 ]
-          - [ 5, 5 ]
+          ##- [ 5, 5 ]
           - [ 8, 8 ]
         - WorkGroup:
           - [ 16, 16,  1 ]
-          - [  8,  8,  1 ]
+          ##- [  8,  8,  1 ]
           - [  4,  4,  4 ]
         - DepthU: [-1]
         - VectorWidth: [-1]
@@ -109,7 +110,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
 
     ############################################################################
     # NT
@@ -131,21 +132,21 @@ BenchmarkProblems:
       ForkParameters:
         - ThreadTile:
           - [8, 8]
-          - [7, 4]
-          - [3, 5]
+          ##- [7, 4]
+          ##- [3, 5]
           - [2, 6]
           - [1, 1]
         - WorkGroup:
           - [ 16, 16,  1 ]
           - [  8,  2, 16 ]
-          - [ 16, 12,  1 ]
+          ##- [ 16, 12,  1 ]
         - DepthU: [ 2, 16, 64 ]
         - GlobalSplitU: [1, 4]
         - VectorWidth: [1]
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [   1,   1,   1 ]
-          - Range: [ [127, 1, 129], [127, 1, 129], [63, 1, 65] ]
+          - Range: [ [127, 1, 129], [127, 1, 129], [63, 1, 64] ]
 
 
     - # Non-Tile Sizes
@@ -156,15 +157,15 @@ BenchmarkProblems:
         - ThreadTile: [ [4, 8] ]
         - DepthU: [ 16 ]
       ForkParameters:
-        - GlobalReadCoalesceGroupA: [False, True]
-        - GlobalReadCoalesceGroupB: [False, True]
+        ##- GlobalReadCoalesceGroupA: [False, True]
+        ##- GlobalReadCoalesceGroupB: [False, True]
         - PrefetchGlobalRead: [False, True]
         - PrefetchLocalRead: [False, True]
         - VectorWidth: [1]
         - GlobalSplitU: [1, 4]
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127, 1, 129], [127, 1, 129], [63, 1, 65] ]
+          - Range: [ [127, 1, 129], [127, 1, 129], [63, 1, 64] ]
 
     - # Branches
       BenchmarkCommonParameters:
@@ -197,8 +198,8 @@ BenchmarkProblems:
         - ThreadTile:
           - [ 3, 3 ]
           - [ 4, 4 ]
-          - [ 5, 5 ]
-          - [ 8, 8 ]
+          ##- [ 5, 5 ]
+          ##- [ 8, 8 ]
         - WorkGroup:
           - [ 16, 16,  1 ]
           - [ 16,  8,  1 ]
@@ -210,7 +211,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
 
 
     ############################################################################
@@ -233,21 +234,21 @@ BenchmarkProblems:
       ForkParameters:
         - ThreadTile:
           - [8, 8]
-          - [7, 4]
-          - [3, 5]
+          ##- [7, 4]
+          ##- [3, 5]
           - [2, 6]
           - [1, 1]
         - WorkGroup:
           - [ 16, 16,  1 ]
           - [  8,  2, 16 ]
-          - [ 16, 12,  1 ]
+          ##- [ 16, 12,  1 ]
         - DepthU: [ 2, 16, 64 ]
         - GlobalSplitU: [1, 4]
         - VectorWidth: [1]
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [   1,   1,   1 ]
-          - Range: [ [127, 1, 129], [127, 1, 129], [63, 1, 65] ]
+          - Range: [ [127, 1, 129], [127, 1, 129], [63, 1, 64] ]
 
 
     - # Non-Tile Sizes
@@ -258,15 +259,15 @@ BenchmarkProblems:
         - ThreadTile: [ [4, 8] ]
         - DepthU: [ 16 ]
       ForkParameters:
-        - GlobalReadCoalesceGroupA: [False, True]
-        - GlobalReadCoalesceGroupB: [False, True]
+        ##- GlobalReadCoalesceGroupA: [False, True]
+        ##- GlobalReadCoalesceGroupB: [False, True]
         - PrefetchGlobalRead: [False, True]
         - PrefetchLocalRead: [False, True]
         - VectorWidth: [1]
         - GlobalSplitU: [1, 4]
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127, 1, 129], [127, 1, 129], [63, 1, 65] ]
+          - Range: [ [127, 1, 129], [127, 1, 129], [63, 1, 64] ]
 
     - # Branches
       BenchmarkCommonParameters:
@@ -298,8 +299,8 @@ BenchmarkProblems:
         - ThreadTile:
           - [ 3, 3 ]
           - [ 4, 4 ]
-          - [ 5, 5 ]
-          - [ 8, 8 ]
+          ##- [ 5, 5 ]
+          ##- [ 8, 8 ]
         - WorkGroup:
           - [ 16, 16,  1 ]
           - [  8,  8,  1 ]
@@ -310,7 +311,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
 
 
     ############################################################################
@@ -333,12 +334,12 @@ BenchmarkProblems:
       ForkParameters:
         - ThreadTile:
           - [8, 8]
-          - [7, 4]
-          - [3, 5]
+          ##- [7, 4]
+          ##- [3, 5]
           - [2, 6]
           - [1, 1]
         - WorkGroup:
-          - [ 16, 16,  1 ]
+          ##- [ 16, 16,  1 ]
           - [  8,  2, 16 ]
           - [ 16, 12,  1 ]
         - DepthU: [ 2, 16, 64 ]
@@ -347,7 +348,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [   1,   1,   1 ]
-          - Range: [ [127, 1, 129], [127, 1, 129], [63, 1, 65] ]
+          - Range: [ [127, 1, 129], [127, 1, 129], [63, 1, 64] ]
 
 
     - # Non-Tile Sizes
@@ -358,15 +359,15 @@ BenchmarkProblems:
         - ThreadTile: [ [4, 8] ]
         - DepthU: [ 16 ]
       ForkParameters:
-        - GlobalReadCoalesceGroupA: [False, True]
-        - GlobalReadCoalesceGroupB: [False, True]
+        ##- GlobalReadCoalesceGroupA: [False, True]
+        ##- GlobalReadCoalesceGroupB: [False, True]
         - PrefetchGlobalRead: [False, True]
         - PrefetchLocalRead: [False, True]
         - VectorWidth: [1]
         - GlobalSplitU: [1, 4]
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127, 1, 129], [127, 1, 129], [63, 1, 65] ]
+          - Range: [ [127, 1, 129], [127, 1, 129], [63, 1, 64] ]
 
     - # Branches
       BenchmarkCommonParameters:
@@ -395,13 +396,13 @@ BenchmarkProblems:
         - PrefetchLocalRead: [False]
         - PrefetchGlobalRead: [False]
         - ThreadTile:
-          - [ 3, 3 ]
+          ##- [ 3, 3 ]
           - [ 4, 4 ]
-          - [ 5, 5 ]
+          ##- [ 5, 5 ]
           - [ 8, 8 ]
         - WorkGroup:
           - [ 16, 16,  1 ]
-          - [  8,  8,  1 ]
+          ##- [  8,  8,  1 ]
         - DepthU: [-1]
         - VectorWidth: [-1]
       BenchmarkForkParameters:
@@ -409,7 +410,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
 
 LibraryLogic:
     ScheduleName: "vega10"
@@ -428,4 +429,4 @@ LibraryLogic:
 #   DeviceNames: ["Device 0000"]
 #   ArchitectureName: "fallback"
 
-LibraryClient:
+#LibraryClient:

--- a/Tensile/Tests/extended/double_complex/zgemm_asm.yaml
+++ b/Tensile/Tests/extended/double_complex/zgemm_asm.yaml
@@ -16,6 +16,7 @@ GlobalParameters:
   DataInitTypeAB: 3
   DataInitTypeC: 3
   KernelTime: True
+  NewClient: 2
 
 BenchmarkProblems:
 
@@ -40,7 +41,7 @@ BenchmarkProblems:
         - PrefetchLocalRead: [False]
         - PrefetchGlobalRead: [True]
         - ThreadTile:
-          - [ 3, 5 ]
+          ##- [ 3, 5 ]
           - [ 4, 8 ]
           - [ 8, 8 ]
         - WorkGroup:
@@ -53,7 +54,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
 
     - # BenchmarkProblemSizeGroup - Assembly
       InitialSolutionParameters:
@@ -66,9 +67,9 @@ BenchmarkProblems:
         - PrefetchLocalRead: [False]
         - PrefetchGlobalRead: [True]
         - ThreadTile:
-          - [ 3, 3 ]
+          ##- [ 3, 3 ]
           - [ 4, 4 ]
-          - [ 5, 5 ]
+          ##- [ 5, 5 ]
           - [ 8, 8 ]
         - WorkGroup:
           - [ 16, 16,  1 ]
@@ -80,7 +81,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
 
   - # zgemm NT
     - # ProblemType
@@ -103,7 +104,7 @@ BenchmarkProblems:
         - PrefetchLocalRead: [True]
         - PrefetchGlobalRead: [True]
         - ThreadTile:
-          - [ 3, 5 ]
+          ##- [ 3, 5 ]
           - [ 4, 8 ]
           - [ 8, 8 ]
         - WorkGroup:
@@ -116,7 +117,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
 
     - # BenchmarkProblemSizeGroup - Assembly
       InitialSolutionParameters:
@@ -129,9 +130,9 @@ BenchmarkProblems:
         - PrefetchLocalRead: [True]
         - PrefetchGlobalRead: [True]
         - ThreadTile:
-          - [ 3, 3 ]
+          ##- [ 3, 3 ]
           - [ 4, 4 ]
-          - [ 5, 5 ]
+          ##- [ 5, 5 ]
           - [ 8, 8 ]
         - WorkGroup:
           - [ 16, 16,  1 ]
@@ -143,7 +144,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
 
   - # zgemm TN
     - # ProblemType
@@ -166,7 +167,7 @@ BenchmarkProblems:
         - PrefetchLocalRead: [True]
         - PrefetchGlobalRead: [False]
         - ThreadTile:
-          - [ 3, 5 ]
+          ##- [ 3, 5 ]
           - [ 4, 8 ]
           - [ 8, 8 ]
         - WorkGroup:
@@ -179,7 +180,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
 
     - # BenchmarkProblemSizeGroup - Assembly
       InitialSolutionParameters:
@@ -192,9 +193,9 @@ BenchmarkProblems:
         - PrefetchLocalRead: [True]
         - PrefetchGlobalRead: [False]
         - ThreadTile:
-          - [ 3, 3 ]
+          ##- [ 3, 3 ]
           - [ 4, 4 ]
-          - [ 5, 5 ]
+          ##- [ 5, 5 ]
           - [ 8, 8 ]
         - WorkGroup:
           - [ 16, 16,  1 ]
@@ -206,7 +207,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
 
   - # zgemm TT
     - # ProblemType
@@ -228,7 +229,7 @@ BenchmarkProblems:
         - PrefetchLocalRead: [False]
         - PrefetchGlobalRead: [False]
         - ThreadTile:
-          - [ 3, 5 ]
+          ##- [ 3, 5 ]
           - [ 4, 8 ]
           - [ 8, 8 ]
         - WorkGroup:
@@ -241,7 +242,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
 
     - # BenchmarkProblemSizeGroup - Assembly
       InitialSolutionParameters:
@@ -253,9 +254,9 @@ BenchmarkProblems:
         - PrefetchLocalRead: [False]
         - PrefetchGlobalRead: [False]
         - ThreadTile:
-          - [ 3, 3 ]
+          ##- [ 3, 3 ]
           - [ 4, 4 ]
-          - [ 5, 5 ]
+          ##- [ 5, 5 ]
           - [ 8, 8 ]
         - WorkGroup:
           - [ 16, 16,  1 ]
@@ -267,7 +268,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
 
   - # zgemm NC
     - # ProblemType
@@ -291,7 +292,7 @@ BenchmarkProblems:
         - PrefetchLocalRead: [True]
         - PrefetchGlobalRead: [True]
         - ThreadTile:
-          - [ 3, 5 ]
+          ##- [ 3, 5 ]
           - [ 4, 8 ]
           - [ 8, 8 ]
         - WorkGroup:
@@ -304,7 +305,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
 
     - # BenchmarkProblemSizeGroup - Assembly
       InitialSolutionParameters:
@@ -317,9 +318,9 @@ BenchmarkProblems:
         - PrefetchLocalRead: [True]
         - PrefetchGlobalRead: [True]
         - ThreadTile:
-          - [ 3, 3 ]
+          ##- [ 3, 3 ]
           - [ 4, 4 ]
-          - [ 5, 5 ]
+          ##- [ 5, 5 ]
           - [ 8, 8 ]
         - WorkGroup:
           - [ 16, 16,  1 ]
@@ -331,7 +332,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
 
   - # zgemm CN
     - # ProblemType
@@ -355,7 +356,7 @@ BenchmarkProblems:
         - PrefetchLocalRead: [True]
         - PrefetchGlobalRead: [False]
         - ThreadTile:
-          - [ 3, 5 ]
+          ##- [ 3, 5 ]
           - [ 4, 8 ]
           - [ 8, 8 ]
         - WorkGroup:
@@ -368,7 +369,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
 
     - # BenchmarkProblemSizeGroup - Assembly
       InitialSolutionParameters:
@@ -381,9 +382,9 @@ BenchmarkProblems:
         - PrefetchLocalRead: [True]
         - PrefetchGlobalRead: [False]
         - ThreadTile:
-          - [ 3, 3 ]
+          ##- [ 3, 3 ]
           - [ 4, 4 ]
-          - [ 5, 5 ]
+          ##- [ 5, 5 ]
           - [ 8, 8 ]
         - WorkGroup:
           - [ 16, 16,  1 ]
@@ -395,7 +396,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
 
   - # zgemm TC
     - # ProblemType
@@ -418,7 +419,7 @@ BenchmarkProblems:
         - PrefetchLocalRead: [False]
         - PrefetchGlobalRead: [False]
         - ThreadTile:
-          - [ 3, 5 ]
+          ##- [ 3, 5 ]
           - [ 4, 8 ]
           - [ 8, 8 ]
         - WorkGroup:
@@ -431,7 +432,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
 
     - # BenchmarkProblemSizeGroup - Assembly
       InitialSolutionParameters:
@@ -443,9 +444,9 @@ BenchmarkProblems:
         - PrefetchLocalRead: [False]
         - PrefetchGlobalRead: [False]
         - ThreadTile:
-          - [ 3, 3 ]
+          ##- [ 3, 3 ]
           - [ 4, 4 ]
-          - [ 5, 5 ]
+          ##- [ 5, 5 ]
           - [ 8, 8 ]
         - WorkGroup:
           - [ 16, 16,  1 ]
@@ -457,7 +458,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
 
 
   - # zgemm CT
@@ -481,7 +482,7 @@ BenchmarkProblems:
         - PrefetchLocalRead: [False]
         - PrefetchGlobalRead: [False]
         - ThreadTile:
-          - [ 3, 5 ]
+          ##- [ 3, 5 ]
           - [ 4, 8 ]
           - [ 8, 8 ]
         - WorkGroup:
@@ -494,7 +495,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
 
     - # BenchmarkProblemSizeGroup - Assembly
       InitialSolutionParameters:
@@ -506,9 +507,9 @@ BenchmarkProblems:
         - PrefetchLocalRead: [False]
         - PrefetchGlobalRead: [False]
         - ThreadTile:
-          - [ 3, 3 ]
+          ##- [ 3, 3 ]
           - [ 4, 4 ]
-          - [ 5, 5 ]
+          ##- [ 5, 5 ]
           - [ 8, 8 ]
         - WorkGroup:
           - [ 16, 16,  1 ]
@@ -520,7 +521,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
 
 
   - # zgemm CC
@@ -545,7 +546,7 @@ BenchmarkProblems:
         - PrefetchLocalRead: [False]
         - PrefetchGlobalRead: [False]
         - ThreadTile:
-          - [ 3, 5 ]
+          ##- [ 3, 5 ]
           - [ 4, 8 ]
           - [ 8, 8 ]
         - WorkGroup:
@@ -558,7 +559,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
 
     - # BenchmarkProblemSizeGroup - Assembly
       InitialSolutionParameters:
@@ -570,9 +571,9 @@ BenchmarkProblems:
         - PrefetchLocalRead: [False]
         - PrefetchGlobalRead: [False]
         - ThreadTile:
-          - [ 3, 3 ]
+          ##- [ 3, 3 ]
           - [ 4, 4 ]
-          - [ 5, 5 ]
+          ##- [ 5, 5 ]
           - [ 8, 8 ]
         - WorkGroup:
           - [ 16, 16,  1 ]
@@ -584,5 +585,5 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
 

--- a/Tensile/Tests/extended/float_complex/cgemm_asm.yaml
+++ b/Tensile/Tests/extended/float_complex/cgemm_asm.yaml
@@ -16,6 +16,7 @@ GlobalParameters:
   DataInitTypeAB: 3
   DataInitTypeC: 3
   KernelTime: True
+  NewClient: 2
 
 BenchmarkProblems:
 
@@ -40,7 +41,7 @@ BenchmarkProblems:
         - PrefetchLocalRead: [False]
         - PrefetchGlobalRead: [True]
         - ThreadTile:
-          - [ 3, 5 ]
+          ##- [ 3, 5 ]
           - [ 4, 8 ]
           - [ 8, 8 ]
         - WorkGroup:
@@ -53,7 +54,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
 
     - # BenchmarkProblemSizeGroup - Assembly
       InitialSolutionParameters:
@@ -66,9 +67,9 @@ BenchmarkProblems:
         - PrefetchLocalRead: [False]
         - PrefetchGlobalRead: [True]
         - ThreadTile:
-          - [ 3, 3 ]
+          ##- [ 3, 3 ]
           - [ 4, 4 ]
-          - [ 5, 5 ]
+          ##- [ 5, 5 ]
           - [ 8, 8 ]
         - WorkGroup:
           - [ 16, 16,  1 ]
@@ -80,7 +81,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
 
   - # cgemm NT
     - # ProblemType
@@ -103,7 +104,7 @@ BenchmarkProblems:
         - PrefetchLocalRead: [True]
         - PrefetchGlobalRead: [True]
         - ThreadTile:
-          - [ 3, 5 ]
+          ##- [ 3, 5 ]
           - [ 4, 8 ]
           - [ 8, 8 ]
         - WorkGroup:
@@ -116,7 +117,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
 
     - # BenchmarkProblemSizeGroup - Assembly
       InitialSolutionParameters:
@@ -129,9 +130,9 @@ BenchmarkProblems:
         - PrefetchLocalRead: [True]
         - PrefetchGlobalRead: [True]
         - ThreadTile:
-          - [ 3, 3 ]
+          ##- [ 3, 3 ]
           - [ 4, 4 ]
-          - [ 5, 5 ]
+          ##- [ 5, 5 ]
           - [ 8, 8 ]
         - WorkGroup:
           - [ 16, 16,  1 ]
@@ -143,7 +144,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
 
   - # cgemm TN
     - # ProblemType
@@ -166,7 +167,7 @@ BenchmarkProblems:
         - PrefetchLocalRead: [True]
         - PrefetchGlobalRead: [False]
         - ThreadTile:
-          - [ 3, 5 ]
+          ##- [ 3, 5 ]
           - [ 4, 8 ]
           - [ 8, 8 ]
         - WorkGroup:
@@ -179,7 +180,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
 
     - # BenchmarkProblemSizeGroup - Assembly
       InitialSolutionParameters:
@@ -192,9 +193,9 @@ BenchmarkProblems:
         - PrefetchLocalRead: [True]
         - PrefetchGlobalRead: [False]
         - ThreadTile:
-          - [ 3, 3 ]
+          ##- [ 3, 3 ]
           - [ 4, 4 ]
-          - [ 5, 5 ]
+          ##- [ 5, 5 ]
           - [ 8, 8 ]
         - WorkGroup:
           - [ 16, 16,  1 ]
@@ -206,7 +207,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
 
   - # cgemm TT
     - # ProblemType
@@ -228,7 +229,7 @@ BenchmarkProblems:
         - PrefetchLocalRead: [False]
         - PrefetchGlobalRead: [False]
         - ThreadTile:
-          - [ 3, 5 ]
+          ##- [ 3, 5 ]
           - [ 4, 8 ]
           - [ 8, 8 ]
         - WorkGroup:
@@ -241,7 +242,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
 
     - # BenchmarkProblemSizeGroup - Assembly
       InitialSolutionParameters:
@@ -253,9 +254,9 @@ BenchmarkProblems:
         - PrefetchLocalRead: [False]
         - PrefetchGlobalRead: [False]
         - ThreadTile:
-          - [ 3, 3 ]
+          ##- [ 3, 3 ]
           - [ 4, 4 ]
-          - [ 5, 5 ]
+          ##- [ 5, 5 ]
           - [ 8, 8 ]
         - WorkGroup:
           - [ 16, 16,  1 ]
@@ -267,7 +268,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
 
   - # cgemm NC
     - # ProblemType
@@ -291,7 +292,7 @@ BenchmarkProblems:
         - PrefetchLocalRead: [True]
         - PrefetchGlobalRead: [True]
         - ThreadTile:
-          - [ 3, 5 ]
+          ##- [ 3, 5 ]
           - [ 4, 8 ]
           - [ 8, 8 ]
         - WorkGroup:
@@ -304,7 +305,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
 
     - # BenchmarkProblemSizeGroup - Assembly
       InitialSolutionParameters:
@@ -317,9 +318,9 @@ BenchmarkProblems:
         - PrefetchLocalRead: [True]
         - PrefetchGlobalRead: [True]
         - ThreadTile:
-          - [ 3, 3 ]
+          ##- [ 3, 3 ]
           - [ 4, 4 ]
-          - [ 5, 5 ]
+          ##- [ 5, 5 ]
           - [ 8, 8 ]
         - WorkGroup:
           - [ 16, 16,  1 ]
@@ -331,7 +332,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
 
   - # cgemm CN
     - # ProblemType
@@ -355,7 +356,7 @@ BenchmarkProblems:
         - PrefetchLocalRead: [True]
         - PrefetchGlobalRead: [False]
         - ThreadTile:
-          - [ 3, 5 ]
+          ##- [ 3, 5 ]
           - [ 4, 8 ]
           - [ 8, 8 ]
         - WorkGroup:
@@ -368,7 +369,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
 
     - # BenchmarkProblemSizeGroup - Assembly
       InitialSolutionParameters:
@@ -381,9 +382,9 @@ BenchmarkProblems:
         - PrefetchLocalRead: [True]
         - PrefetchGlobalRead: [False]
         - ThreadTile:
-          - [ 3, 3 ]
+          ##- [ 3, 3 ]
           - [ 4, 4 ]
-          - [ 5, 5 ]
+          ##- [ 5, 5 ]
           - [ 8, 8 ]
         - WorkGroup:
           - [ 16, 16,  1 ]
@@ -395,7 +396,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
 
   - # cgemm TC
     - # ProblemType
@@ -418,7 +419,7 @@ BenchmarkProblems:
         - PrefetchLocalRead: [False]
         - PrefetchGlobalRead: [False]
         - ThreadTile:
-          - [ 3, 5 ]
+          ##- [ 3, 5 ]
           - [ 4, 8 ]
           - [ 8, 8 ]
         - WorkGroup:
@@ -431,7 +432,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
 
     - # BenchmarkProblemSizeGroup - Assembly
       InitialSolutionParameters:
@@ -443,9 +444,9 @@ BenchmarkProblems:
         - PrefetchLocalRead: [False]
         - PrefetchGlobalRead: [False]
         - ThreadTile:
-          - [ 3, 3 ]
+          ##- [ 3, 3 ]
           - [ 4, 4 ]
-          - [ 5, 5 ]
+          ##- [ 5, 5 ]
           - [ 8, 8 ]
         - WorkGroup:
           - [ 16, 16,  1 ]
@@ -457,7 +458,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
 
 
   - # cgemm CT
@@ -481,7 +482,7 @@ BenchmarkProblems:
         - PrefetchLocalRead: [False]
         - PrefetchGlobalRead: [False]
         - ThreadTile:
-          - [ 3, 5 ]
+          ##- [ 3, 5 ]
           - [ 4, 8 ]
           - [ 8, 8 ]
         - WorkGroup:
@@ -494,7 +495,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
 
     - # BenchmarkProblemSizeGroup - Assembly
       InitialSolutionParameters:
@@ -506,9 +507,9 @@ BenchmarkProblems:
         - PrefetchLocalRead: [False]
         - PrefetchGlobalRead: [False]
         - ThreadTile:
-          - [ 3, 3 ]
+          ##- [ 3, 3 ]
           - [ 4, 4 ]
-          - [ 5, 5 ]
+          ##- [ 5, 5 ]
           - [ 8, 8 ]
         - WorkGroup:
           - [ 16, 16,  1 ]
@@ -520,7 +521,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
 
 
   - # cgemm CC
@@ -545,7 +546,7 @@ BenchmarkProblems:
         - PrefetchLocalRead: [False]
         - PrefetchGlobalRead: [False]
         - ThreadTile:
-          - [ 3, 5 ]
+          ##- [ 3, 5 ]
           - [ 4, 8 ]
           - [ 8, 8 ]
         - WorkGroup:
@@ -558,7 +559,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
 
     - # BenchmarkProblemSizeGroup - Assembly
       InitialSolutionParameters:
@@ -570,9 +571,9 @@ BenchmarkProblems:
         - PrefetchLocalRead: [False]
         - PrefetchGlobalRead: [False]
         - ThreadTile:
-          - [ 3, 3 ]
+          ##- [ 3, 3 ]
           - [ 4, 4 ]
-          - [ 5, 5 ]
+          ##- [ 5, 5 ]
           - [ 8, 8 ]
         - WorkGroup:
           - [ 16, 16,  1 ]
@@ -584,5 +585,5 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
 

--- a/Tensile/Tests/extended/fractional/test_sgemm_fractional_tile_sweep.yaml
+++ b/Tensile/Tests/extended/fractional/test_sgemm_fractional_tile_sweep.yaml
@@ -17,6 +17,7 @@ GlobalParameters:
   DataInitTypeC: 3
   KernelTime: True
   CodeFromFiles: True
+  NewClient: 2
 
 BenchmarkProblems:
 
@@ -95,4 +96,5 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [60,1,70] ]
+          ##- Range: [ [127,1,129], 0, [2], [60,1,70] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,65] ]

--- a/Tensile/Tests/extended/global_split_u/hgemm_gsu.yaml
+++ b/Tensile/Tests/extended/global_split_u/hgemm_gsu.yaml
@@ -27,6 +27,7 @@ GlobalParameters:
   PrintTensorA: 0
   PrintTensorB: 0
   PrintSolutionRejectionReason: 0
+  NewClient: 2
 
 
 BenchmarkProblems:
@@ -78,5 +79,7 @@ BenchmarkProblems:
         - ProblemSizes:
           # Note for K>1024 the operation order change with LSU doesn't consistently match CPU
           #- Range: [[64,8,64], [64,8,64], [1,1,2], [64, 64, 64, 1024]]
-          - Range: [[56,8,72], [56,8,72], [1,1,2], [64, 64, 34, 1024]]
-          - Range: [[56,8,72], [56,8,72], [1,1,2], [66, 64, 34, 1024]]
+          ##- Range: [[56,8,72], [56,8,72], [1,1,2], [64, 64, 34, 1024]]
+          ##- Range: [[56,8,72], [56,8,72], [1,1,2], [66, 64, 34, 1024]]
+          - Range: [[56,8,72], 0, [1,1,2], [64, 64, 34, 1024]]
+          - Range: [[56,8,72], 0, [1,1,2], [66, 64, 34, 1024]]

--- a/Tensile/Tests/extended/global_split_u/sgemm_gsu_beta0.yaml
+++ b/Tensile/Tests/extended/global_split_u/sgemm_gsu_beta0.yaml
@@ -27,6 +27,7 @@ GlobalParameters:
   PrintTensorA: 0
   PrintTensorB: 0
   PrintSolutionRejectionReason: 0
+  NewClient: 2
 
 BenchmarkProblems:
   ########################################
@@ -55,12 +56,12 @@ BenchmarkProblems:
         - PrefetchGlobalRead: [ False]
         - PrefetchLocalRead: [ False]
         - ThreadTile:
-          - [ 2, 2 ]
+          ##- [ 2, 2 ]
           - [ 4, 8 ]
           - [ 8, 8 ]
         - WorkGroup:
           - [ 8, 8, 1 ]
-          - [ 8, 16, 1 ]
+          ##- [ 8, 16, 1 ]
           - [ 8, 4, 4 ] # LSU case
         - GlobalSplitU: [1,2,3,4,5,7,8,16,32,64]
         - WorkGroupMapping: [64]
@@ -75,5 +76,5 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           # Use step=4 so many GRVW work OK
-          - Range: [[60,4,66], [60,4,66], [1,1,2], [64, 64, 33, 4096]]
-          - Range: [[508,4,516], [256,4,256], [2], [64, 64, 128, 1024]]
+          - Range: [[60,4,66], [60,4,66], [1,1,2], [64, 64, 33, 1024]]
+          - Range: [[508,4,512], [256,4,256], [2], [64, 64, 128, 1024]]

--- a/Tensile/Tests/extended/hpa_source/test_hgemm_hpa_src_nn.yaml
+++ b/Tensile/Tests/extended/hpa_source/test_hgemm_hpa_src_nn.yaml
@@ -30,7 +30,7 @@ BenchmarkProblems:
         - PrefetchLocalRead: [False]
         - PrefetchGlobalRead: [True]
         - ThreadTile:
-          - [ 2, 4 ]
+          ##- [ 2, 4 ]
           - [ 4, 8 ]
           - [ 16, 8 ]
         - WorkGroup:
@@ -43,7 +43,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
 
     - # BenchmarkProblemSizeGroup - Source
       InitialSolutionParameters:
@@ -56,7 +56,7 @@ BenchmarkProblems:
         - PrefetchLocalRead: [False]
         - PrefetchGlobalRead: [True]
         - ThreadTile:
-          - [ 4, 2 ]
+          ##- [ 4, 2 ]
           - [ 4, 8 ]
           - [ 16, 16 ]
           - [ 8, 8 ]
@@ -70,7 +70,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
 
   - # hgemm NT
     - # ProblemType
@@ -94,7 +94,7 @@ BenchmarkProblems:
         - PrefetchLocalRead: [True]
         - PrefetchGlobalRead: [True]
         - ThreadTile:
-          - [ 2, 2 ]
+          ##- [ 2, 2 ]
           - [ 4, 4 ]
           - [ 8, 16 ]
         - WorkGroup:
@@ -107,7 +107,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
 
     - # BenchmarkProblemSizeGroup - Source
       InitialSolutionParameters:
@@ -120,7 +120,7 @@ BenchmarkProblems:
         - PrefetchLocalRead: [True]
         - PrefetchGlobalRead: [True]
         - ThreadTile:
-          - [ 4, 2 ]
+          ##- [ 4, 2 ]
           - [ 8, 8 ]
           - [ 8, 4 ]
         - WorkGroup:
@@ -133,4 +133,4 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]

--- a/Tensile/Tests/extended/local_split_u/hgemm_lsu.yaml
+++ b/Tensile/Tests/extended/local_split_u/hgemm_lsu.yaml
@@ -27,6 +27,7 @@ GlobalParameters:
   PrintTensorA: 0
   PrintTensorB: 0
   PrintSolutionRejectionReason: 0
+  NewClient: 2
 
 
 BenchmarkProblems:
@@ -78,4 +79,5 @@ BenchmarkProblems:
         - ProblemSizes:
           # Note for K>1024 the operation order change with LSU doesn't consistently match CPU
           #- Range: [[64,8,64], [64,8,64], [1,1,2], [64, 64, 64, 1024]]
-          - Range: [[56,8,72], [56,8,72], [1,1,2], [64, 64, 34, 1024]]
+          ##- Range: [[56,8,64], [56,8,72], [1,1,2], [64, 64, 34, 1024]]
+          - Range: [[56,8,72], 0, [1,1,2], [64, 64, 34, 1024]]


### PR DESCRIPTION
In a standalone arcturus environment (64GB main memory with 28 cores), pytest portion of an extended run now lasted about 5.7 hours as opposed to the old 7.3 hours.