### PR TITLE
Including entire path to YAML file in test name.

### DIFF
--- a/Tensile/Tests/yaml_only/test_config.py
+++ b/Tensile/Tests/yaml_only/test_config.py
@@ -147,8 +147,7 @@ def findConfigs(rootDir=None):
             if filename.endswith('.yaml'):
                 filepath = os.path.join(rootDir, dirpath, filename)
                 marks = configMarks(filepath, rootDir, availableArchs)
-                testname = os.path.splitext(filename)[0]
-                params.append(pytest.param(filepath, marks=marks, id=testname))
+                params.append(pytest.param(filepath, marks=marks, id=filepath))
     return params
 
 @pytest.mark.parametrize("config", findConfigs())

--- a/Tensile/Tests/yaml_only/test_config.py
+++ b/Tensile/Tests/yaml_only/test_config.py
@@ -138,6 +138,9 @@ def findConfigs(rootDir=None):
     """
     if rootDir ==  None:
         rootDir = os.path.dirname(os.path.dirname(__file__))
+        printRoot = os.path.dirname(os.path.dirname(rootDir))
+    else:
+        printRoot = rootDir
     
     availableArchs = findAvailableArchs()
 
@@ -147,7 +150,8 @@ def findConfigs(rootDir=None):
             if filename.endswith('.yaml'):
                 filepath = os.path.join(rootDir, dirpath, filename)
                 marks = configMarks(filepath, rootDir, availableArchs)
-                params.append(pytest.param(filepath, marks=marks, id=filepath))
+                relpath = os.path.relpath(filepath, printRoot)
+                params.append(pytest.param(filepath, marks=marks, id=relpath))
     return params
 
 @pytest.mark.parametrize("config", findConfigs())


### PR DESCRIPTION
Tests show up as `test_config[Tensile/Tests/pre_checkin/igemm_hpa_hip_tt.yaml]` instead of `test_config[igemm_hpa_hip_tt]` which should reduce confusion when people look at failing tests.