### PR TITLE
fix tensor refer to wrong sizefree index when calculate gro

### DIFF
--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -3968,7 +3968,7 @@ class KernelWriterAssembly(KernelWriter):
 
           for l in range(0, tP["nrt"]):
             lastGroVgpr = vgpr(v+l)
-            lastGroIdx = 0
+            lastGroIdx = tP["PackedIndices"][0]
             kStr += "\n"
             for p in range(0, numExtraPackedOffsetsPerTile):
               groIdx  = tP["PackedIndices"][p+1]


### PR DESCRIPTION
this PR fix multi_free2 test failures
Tensile/Tests/extended/pack_tensor_dims/multi_free2.yaml