### PR TITLE
Pr fp16 optimize

### DIFF
--- a/Tensile/Code.py
+++ b/Tensile/Code.py
@@ -201,6 +201,7 @@ class TextBlock(Item):
   def __init__(self,text):
     assert(isinstance(text, str))
     self.text = text
+    self.name = text
 
   def __str__(self):
     return self.text

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -322,7 +322,7 @@ validParameters = {
     # Scheduling algorithm to use for each iteration:
     # 0 = minimal/no scheduling.  Global Read and increments, followed by local reads,
     # followed by local writes, followed by MACs
-    "ScheduleIterAlg":             [0, 1, 2],
+    "ScheduleIterAlg":             [0, 1, 2, 3],
 
     # LDD Support
     # Allow LDD and StrideD to != LDC and StrideC for LDD <= LDC and LDD == M

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -6002,15 +6002,79 @@ class KernelWriterAssembly(KernelWriter):
   ##############################################################################
 
   def mfmaIter(self, kernel, m, innerUnroll):
+    imod = Code.Module("mi")
+    shiftK = Code.Module("shiftK")
+    
+    # constants 
     numVgprsPerMfmaInput = 2 if kernel["ProblemType"]["DataType"].isHalf() else 1
-    imod = Code.Module("mfmaCode")
-    if kernel["ProblemType"]["DataType"].isBFloat16() or kernel["ProblemType"]["DataType"].isHalf():
-      # a must; for VALU packing writes to be consumed by matrix instruction
-      # this can be removed once the vregs are directly loaded via ds_read 
-      # transposeLDS=1 no packing needed
-      if not kernel["TransposeLDS"]:
-        imod.addInst("s_nop ","1","VALU packing writes to be consumed by matrix instruction")  
+    loopChar = self.indexChars[kernel["ProblemType"]["IndicesSummation"][self.unrollIdx]]
+    numElementsPerMfmaInput = 1
+    if kernel["ProblemType"]["DataType"].isBFloat16():
+      numElementsPerMfmaInput*=2
+    if kernel["ProblemType"]["DataType"].isHalf():
+      numElementsPerMfmaInput*=4
+    mfmaInputWidth = numVgprsPerMfmaInput*32
 
+    # states
+    kIdx = None 
+    tailHasOOB = False
+    numElemShift = None
+
+    # zeroing out-of-bound data from the mfma input
+    if kernel["MatrixInstruction"] and \
+       kernel["AssertSummationElementMultiple"] % kernel["MatrixInstK"] != 0 and \
+       self.inTailLoop:
+      tailHasOOB = True
+      shiftK.addComment0("Check if sum dim is not divisible by MatrixInstK")
+      shiftK.addInst("s_cmp_lt_u32", sgpr("LoopCounter%s" % loopChar), kernel["MatrixInstK"], "check if last iter in tail loop")
+      shiftK.addInst("s_cbranch_scc0", "label_tail_mfma", "")
+      shiftK.addInst("s_cmp_eq_u32", sgpr("NumRemainderSumElements%s"%loopChar), "0", "check if sum dim is divisible by MatrixInstK")
+      shiftK.addInst("s_cbranch_scc1", "label_tail_mfma", "")
+      kIdx = self.vgprPool.checkOut(1, "kIdx")
+      if kernel["MatrixInstB"] == 1:
+        shiftK.addInst("v_and_b32", vgpr(kIdx), hex(globalParameters["WavefrontWidth"] - 1), vgpr("Serial"), "laneId (0-63)")
+        shiftK.addInst("v_lshrrev_b32", vgpr(kIdx), log2(kernel["MatrixInstM"]/numElementsPerMfmaInput), vgpr(kIdx), \
+          "kIdx = laneId/MatrixInstM*numMfmaInputPerThread = laneId>>log2(%u/%u)"%(kernel["MatrixInstM"], numElementsPerMfmaInput))
+      else:
+        shiftK.addInst("v_mov_b32", vgpr(kIdx), 0, "kIdx = 0")
+      shiftK.addComment1("Zero out elements in case where sum dim is not divisible by MatrixInstK")
+      numElemShift = self.vgprPool.checkOut(1, "numElemShift")
+      shiftK.addInst("v_add_i32", vgpr(kIdx), vgpr(kIdx), numElementsPerMfmaInput, "kEnd = kIdx + numMfmaInputPerThread")
+      shiftK.addInst("v_sub_i32", vgpr(numElemShift), vgpr(kIdx), sgpr("NumRemainderSumElements%s" % loopChar), "kShift = kEnd - numRemainderElements")
+      shiftK.addInst("v_max_i32", vgpr(numElemShift), vgpr(numElemShift), 0, "kShift = max(kShift, 0); clamp to prevent wrap around")
+      bitPerElem = int(32*kernel["ProblemType"]["DataType"].numRegisters())
+      shiftK.addInst("v_lshlrev_b32", vgpr(numElemShift), log2(bitPerElem), vgpr(numElemShift), "scale by bitPerElem; kShift now in bits")
+      shiftK.addInst("v_min_u32", vgpr(numElemShift), vgpr(numElemShift), mfmaInputWidth-1, "kShift = min(kShift, %u); clamp to prevent wrap around"%(mfmaInputWidth-1))
+      imod.addText("label_tail_mfma:%s" % (self.endLine))
+
+    if not kernel["TransposeLDS"] and \
+      (kernel["ProblemType"]["DataType"].isBFloat16() or kernel["ProblemType"]["DataType"].isHalf()):
+      if tailHasOOB:
+        # in tail loop with possible OOB data, there is enough headroom between VALU and MFMA
+        pass 
+      else:
+        # MFMA preceded immediately by VALU ops as a result of register packing
+        imod.addInst("s_nop ", "1", "VALU packing writes to be consumed by matrix instruction")
+
+    if tailHasOOB:
+      mfmaInputs = []
+      for iui in range(0, innerUnroll):
+        for a in range(0, self.numRowInsts):
+          aStr = vgpr("ValuA_X%u_I%u+%u" % (m, iui, a*numVgprsPerMfmaInput), numVgprsPerMfmaInput)
+          mfmaInputs.append(aStr) 
+        for b in range(0, self.numColInsts):
+          bStr = vgpr("ValuB_X%u_I%u+%u" % (m, iui, b*numVgprsPerMfmaInput), numVgprsPerMfmaInput)
+          mfmaInputs.append(bStr)
+
+      for mfmaInput in mfmaInputs:
+        shiftK.addInst("v_lshlrev_b%u"%(mfmaInputWidth), mfmaInput, vgpr(numElemShift), mfmaInput, "shift out bits to create 0's")
+      
+      shiftK.addInst("v_cmpx_eq_u32", "vcc", vgpr(numElemShift), mfmaInputWidth-1, "if kShift == %u"%(mfmaInputWidth-1))
+      for mfmaInput in mfmaInputs:
+        shiftK.addInst("v_lshlrev_b%u"%(mfmaInputWidth), mfmaInput, "1", mfmaInput, "shift last bit")
+      shiftK.addInst("s_mov_b64", "exec", "0xffffffffffffffff", "end if kShift == %u"%(mfmaInputWidth-1))
+
+    # matrix instructions
     for iui in range(0, innerUnroll):
       for a in range(0, self.numRowInsts):
         for b in range(0, self.numColInsts):
@@ -6024,7 +6088,16 @@ class KernelWriterAssembly(KernelWriter):
           # TODO Broadcast code
           #kStr += "v_mfma_f32_%ux%ux%uf32 a[%u:%u], %s, %s, a[%u:%u] blgp:%u%s" \
           #  % (kernel["MatrixInstM"], kernel["MatrixInstN"], kernel["MatrixInstK"], accStart, accEnd, bStr, aStr, accStart, accEnd, a, self.endLine)
-    return imod
+
+    if kIdx != None:
+      self.vgprPool.checkIn(kIdx)
+    if numElemShift != None:
+      self.vgprPool.checkIn(numElemShift)
+
+    mfmaMod = Code.Module("mfmaCode")
+    mfmaMod.addCode(shiftK)
+    mfmaMod.addCode(imod)
+    return mfmaMod
 
   ##############################################################################
   # MAC Iteration
@@ -7588,7 +7661,6 @@ class KernelWriterAssembly(KernelWriter):
   # epsi = expand pointer swap index. Only used for PAP
   ##############################################################################
   def localReadDo(self, kernel, bufferIdx, iui, epsi, uIdx, tP):
-
     tc=tP["tensorChar"]
     if not self.do["LocalRead%s"%tc]: return ""
     imod = Code.Module("LocalReadDo%s"%tc)
@@ -7621,15 +7693,11 @@ class KernelWriterAssembly(KernelWriter):
       if kernel["TransposeLDS"] == 1:
         numReadsAlongK =1
 
-    loopIdx = self.unrollIdx
-    loopDim = kernel["ProblemType"]["IndicesSummation"][loopIdx]
-    loopChar = self.indexChars[loopDim]
     # mfma: for AB tile in NT layout
     # TODO need to break this if into multi if -else if - else 
     # for code readability
     if kernel["MatrixInstruction"] and (kernel["ProblemType"]["DataType"].isHalf() or kernel["ProblemType"]["DataType"].isBFloat16()) and numReadsAlongK > 1 and not kernel["TransposeLDS"]:
       pack = Code.Module("pack%s_I%s"%(tc,iui))
-      isTailRemainderLoop = self.getTmpSgpr(2)
       tmpVgprIdx = self.vgprPool.checkOut(self.numVgprValuAPerBlock if tc == 'A' else self.numVgprValuBPerBlock)
       packCode = pack.addCode (Code.Module("packCode"))
       packCode.addTempVgpr(tmpVgprIdx)
@@ -7673,21 +7741,6 @@ class KernelWriterAssembly(KernelWriter):
 
             if kIdx % 2 == 1:
               # pack 2 half-dword into one
-              if kernel["MatrixInstruction"] and \
-                 kernel["AssertSummationElementMultiple"] % kernel["MatrixInstK"] != 0 and \
-                 self.inTailLoop:
-                packCode.addInst("v_cmp_lt_u32", sgpr(isTailRemainderLoop, 2), sgpr("LoopCounter%s"%loopChar), kernel["MatrixInstK"], "check if last iter in tail loop")
-                packCode.addInst("s_cmp_eq_u32", sgpr("NumRemainderSumElements%s"%loopChar), "0", "check if sum dim is divisible by k")
-                packCode.addInst("s_cselect_b64", sgpr(isTailRemainderLoop, 2), "0x0", sgpr(isTailRemainderLoop, 2), "zero-fill only if last iter AND sum dim not divisible by k")
-                
-                packCode.addInst("v_cmp_le_u32", "vcc", sgpr("NumRemainderSumElements%s"%loopChar), kIdx-1, "OOB = NumRemainderSumElements <= kIdx")
-                packCode.addInst("s_and_b64", "vcc", "vcc", sgpr(isTailRemainderLoop, 2), "OOB &= isLastProduct")
-                packCode.addInst("v_cndmask_b32", destVgpr, destVgpr, "0", "vcc", "vgpr = OOB ? 0 : vgpr")
-
-                packCode.addInst("v_cmp_le_u32", "vcc", sgpr("NumRemainderSumElements%s"%loopChar), kIdx-0, "OOB = NumRemainderSumElements <= kIdx")
-                packCode.addInst("s_and_b64", "vcc", "vcc", sgpr(isTailRemainderLoop, 2), "OOB &= isLastProduct")
-                packCode.addInst("v_cndmask_b32", tmpVgpr, tmpVgpr, "0", "vcc", "vgpr = OOB ? 0 : vgpr")
-
               packCode.addInst("v_or_b32", destVgpr, destVgpr, tmpVgpr, "pack")
 
             valuIdx += blockWidth

--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -1664,11 +1664,6 @@ class Solution:
           state["MatrixInstN"] = state["MatrixInstruction"][1]
           state["MatrixInstK"] = state["MatrixInstruction"][2]
           state["MatrixInstB"] = state["MatrixInstruction"][3]
-      if not state["ProblemType"]["HighPrecisionAccumulate"] and \
-         not state["ProblemType"]["DataType"].isSingle() :
-        reject(state, "Matrix instructions for half types are natively accumulated" + \
-         " in fp32 precision. Please add the following config:" + \
-         "\n - HighPrecisionAccumulate: True")
     else:
       if state["ThreadTile"][0] > 16 or state["ThreadTile"][1] > 16:
         reject(state, "Invalid value for ThreadTile")
@@ -2066,6 +2061,11 @@ class Solution:
       if not (state["ProblemType"]["DataType"].toChar() in validMFMA and \
         state["MatrixInstruction"] in validMFMA[state["ProblemType"]["DataType"].toChar()]):
         reject(state, "MatrixInstruction %s not valid for DataType %s" % (state["MatrixInstruction"], state["ProblemType"]["DataType"]))
+      if not state["ProblemType"]["HighPrecisionAccumulate"] and \
+         not state["ProblemType"]["DataType"].isSingle() :
+        reject(state, "Matrix instructions for half types are natively accumulated" + \
+         " in fp32 precision. Please add the following config:" + \
+         "\n - HighPrecisionAccumulate: True")
 
     if state["ProblemType"]["Tensor0"]==0:
       state["ThreadTileA"] = state["ThreadTile0"]

--- a/Tensile/Tests/pre_checkin/mfma/hpa_bfloat16_gemm_asm_mi32x32x2x2.yaml
+++ b/Tensile/Tests/pre_checkin/mfma/hpa_bfloat16_gemm_asm_mi32x32x2x2.yaml
@@ -2,7 +2,7 @@ TestParameters:
   marks: [skip-gfx900, skip-gfx906, skip-gfx1010] # not supported by arch
 
 GlobalParameters:
-  NumElementsToValidate: -1
+  NumElementsToValidate: 16384
   BoundsCheck: True
   KernelTime: True
 
@@ -27,23 +27,65 @@ BenchmarkProblems:
       BenchmarkCommonParameters:
         - KernelLanguage: ["Assembly"]
         - EdgeType: ["ShiftPtr"]
-        - PrefetchLocalRead: [True]
       ForkParameters:
         - MatrixInstruction:
           - [32, 32, 2, 2]
+        - PrefetchLocalRead: [0, 1, 3]
         - PrefetchGlobalRead: [True]
         - ThreadTile:
           - [ 2, 32 ]
         - WorkGroup:
-          - [ 16, 16, 1 ]
+          - [ 64, 4, 1 ]
         - WorkGroupMapping: [8]
         - GlobalSplitU: [1]
+        - InnerUnroll: [2]
         - DepthU: [8]
         - VectorWidth: [-1]
-        - AssertSummationElementMultiple: [2]
-        - AssertFree0ElementMultiple: [2]
+        - AssertSummationElementMultiple: [1, 2]
       JoinParameters:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [ 64, 256, 1, 8 ]
+          - Range: [ [64], [256], [1], [31, 33, 130] ]
+
+  ########################################
+  # TN - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: B
+      DestDataType: B
+      ComputeDataType: s
+      HighPrecisionAccumulate: True
+      TransposeA: True
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - TransposeLDS: [0, 1]
+        - MatrixInstruction:
+          - [32, 32, 2, 2]
+        - PrefetchLocalRead: [0, 1, 3]
+        - PrefetchGlobalRead: [True]
+        - ThreadTile:
+          - [ 2, 32 ]
+        - WorkGroup:
+          - [ 64, 4, 1 ]
+        - WorkGroupMapping: [8]
+        - GlobalSplitU: [1]
+        - InnerUnroll: [2]
+        - DepthU: [8]
+        - VectorWidth: [-1]
+        - AssertSummationElementMultiple: [1, 2]
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [64], [256], [1], [31, 33, 130] ]

--- a/Tensile/Tests/pre_checkin/mfma/hpa_hgemm_asm_mi32x32x4x2.yaml
+++ b/Tensile/Tests/pre_checkin/mfma/hpa_hgemm_asm_mi32x32x4x2.yaml
@@ -2,7 +2,7 @@ TestParameters:
   marks: [skip-gfx900, skip-gfx906, skip-gfx1010] # not supported by arch
 
 GlobalParameters:
-  NumElementsToValidate: -1
+  NumElementsToValidate: 16384
   BoundsCheck: True
   KernelTime: True
 
@@ -25,23 +25,63 @@ BenchmarkProblems:
       BenchmarkCommonParameters:
         - KernelLanguage: ["Assembly"]
         - EdgeType: ["ShiftPtr"]
-        - PrefetchLocalRead: [True]
       ForkParameters:
         - MatrixInstruction:
           - [32, 32, 4, 2]
+        - PrefetchLocalRead: [0, 1, 3]
         - PrefetchGlobalRead: [True]
         - ThreadTile:
           - [ 2, 32 ]
         - WorkGroup:
-          - [ 16, 16, 1 ]
+          - [ 64, 4, 1 ]
         - WorkGroupMapping: [8]
         - GlobalSplitU: [1]
+        - InnerUnroll: [2]
         - DepthU: [8]
-        - VectorWidth: [-1]
-        - AssertSummationElementMultiple: [2]
-        - AssertFree0ElementMultiple: [2]
+        - VectorWidth: [2, 4]
+        - AssertSummationElementMultiple: [1, 2]
       JoinParameters:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [ 64, 256, 1, 8 ]
+          - Range: [ [64], [256], [1], [31, 33, 130] ]
+
+  ########################################
+  # TN - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: h
+      HighPrecisionAccumulate: True
+      TransposeA: True
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - TransposeLDS: [0, 1]
+        - MatrixInstruction:
+          - [32, 32, 4, 2]
+        - PrefetchLocalRead: [0, 1, 3]
+        - PrefetchGlobalRead: [True]
+        - ThreadTile:
+          - [ 2, 32 ]
+        - WorkGroup:
+          - [ 64, 4, 1 ]
+        - WorkGroupMapping: [8]
+        - GlobalSplitU: [1]
+        - InnerUnroll: [2]
+        - DepthU: [8]
+        - VectorWidth: [2, 4]
+        - AssertSummationElementMultiple: [1, 2]
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [64], [256], [1], [31, 33, 130] ]

--- a/Tensile/Tests/pre_checkin/mfma/sgemm_asm_mi32x32x1x2.yaml
+++ b/Tensile/Tests/pre_checkin/mfma/sgemm_asm_mi32x32x1x2.yaml
@@ -2,13 +2,51 @@ TestParameters:
   marks: [skip-gfx900, skip-gfx906, skip-gfx1010] # not supported by arch
 
 GlobalParameters:
-  NumElementsToValidate: -1
+  NumElementsToValidate: 16384
   BoundsCheck: True
   KernelTime: True
 
 BenchmarkProblems:
   ########################################
   # NT - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: s
+      TransposeA: False
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [32, 32, 1, 2]
+        - PrefetchLocalRead: [0, 1, 3]
+        - PrefetchGlobalRead: [True]
+        - ThreadTile:
+          - [ 2, 32 ]
+        - WorkGroup:
+          - [ 64, 4, 1 ]
+        - WorkGroupMapping: [8]
+        - GlobalSplitU: [1]
+        - InnerUnroll: [2]
+        - DepthU: [ 8 ]
+        - VectorWidth: [1]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [64], [256], [1], [31, 33, 130] ]
+
+  ########################################
+  # TN - standard
   ########################################
   -
     - # ProblemType
@@ -24,26 +62,25 @@ BenchmarkProblems:
       BenchmarkCommonParameters:
         - KernelLanguage: ["Assembly"]
         - EdgeType: ["ShiftPtr"]
-        - PrefetchLocalRead: [True]
       ForkParameters:
+        - TransposeLDS: [0, 1]
         - MatrixInstruction:
           - [32, 32, 1, 2]
+        - PrefetchLocalRead: [0, 1, 3]
         - PrefetchGlobalRead: [True]
         - ThreadTile:
           - [ 2, 32 ]
         - WorkGroup:
-          - [ 16, 16, 1 ]
+          - [ 64, 4, 1 ]
         - WorkGroupMapping: [8]
         - GlobalSplitU: [1]
+        - InnerUnroll: [2]
         - DepthU: [ 8 ]
         - VectorWidth: [1]
       BenchmarkForkParameters:
       JoinParameters:
-        - MacroTile
-        - GlobalSplitU
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [64], [256], [1], [64] ]
-
+          - Range: [ [64], [256], [1], [31, 33, 130] ]
   ########################################

--- a/Tensile/Tests/pre_checkin/mfma/sgemm_asm_mi32x32x2x1.yaml
+++ b/Tensile/Tests/pre_checkin/mfma/sgemm_asm_mi32x32x2x1.yaml
@@ -2,13 +2,52 @@ TestParameters:
   marks: [skip-gfx900, skip-gfx906, skip-gfx1010] # not supported by arch
 
 GlobalParameters:
-  NumElementsToValidate: -1
+  NumElementsToValidate: 16384
   BoundsCheck: True
   KernelTime: True
 
 BenchmarkProblems:
   ########################################
   # NT - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: s
+      TransposeA: False
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [32, 32, 2, 1]
+        - PrefetchLocalRead: [0, 1, 3]
+        - PrefetchGlobalRead: [True]
+        - ThreadTile:
+          - [ 1, 32 ]
+        - WorkGroup:
+          - [ 32, 8, 1 ]
+        - WorkGroupMapping: [8]
+        - GlobalSplitU: [1]
+        - InnerUnroll: [2]
+        - DepthU: [ 16 ]
+        - VectorWidth: [1, 2]
+        - AssertSummationElementMultiple: [1, 2]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [64], [256], [1], [31, 33, 130] ]
+
+  ########################################
+  # TN - standard
   ########################################
   -
     - # ProblemType
@@ -24,26 +63,26 @@ BenchmarkProblems:
       BenchmarkCommonParameters:
         - KernelLanguage: ["Assembly"]
         - EdgeType: ["ShiftPtr"]
-        - PrefetchLocalRead: [True]
       ForkParameters:
+        - TransposeLDS: [0, 1]
         - MatrixInstruction:
           - [32, 32, 2, 1]
+        - PrefetchLocalRead: [0, 1, 3]
         - PrefetchGlobalRead: [True]
         - ThreadTile:
           - [ 1, 32 ]
         - WorkGroup:
-          - [ 16, 16, 1 ]
+          - [ 32, 8, 1 ]
         - WorkGroupMapping: [8]
         - GlobalSplitU: [1]
-        - DepthU: [ 8 ]
+        - InnerUnroll: [2]
+        - DepthU: [ 16 ]
         - VectorWidth: [1]
+        - AssertSummationElementMultiple: [1, 2]
       BenchmarkForkParameters:
       JoinParameters:
-        - MacroTile
-        - GlobalSplitU
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [64], [256], [1], [64] ]
-
+          - Range: [ [64], [256], [1], [31, 33, 130] ]
   ########################################


### PR DESCRIPTION
1. fix fp16 tlds=0 localRead address calculation
2. fix waitcnt calculation when schedule localwrite
3. fix PLR>1 in order to optimize smaller latency MI
4. mfma interleave
  schedule localread, localwrite and globalread based on number of mfma instructions per iteration
<strike>5. wider load kernel argument
  original design takes too much time to issue instruction, wider load can save about 3 us.</strike>
6. arbitrary K-size support enabled for when TransposeLDS=1
  redesigned tail loop zero-filling method via bit shifting; should work for multi-k MI variants
7. fixed local read vector width mapping to wrong unit in internal representation; temporarily commented out a few lines related to LocalReadVectorWidth as it seems redundant in VW/GRVW/StoreVectorWidth-spanned parameter space