### PR TITLE
cut run time of top-5 pre_checkin tests

### DIFF
--- a/Tensile/Tests/pre_checkin/dgemm_asm.yaml
+++ b/Tensile/Tests/pre_checkin/dgemm_asm.yaml
@@ -17,6 +17,7 @@ GlobalParameters:
   DataInitTypeAB: 3
   DataInitTypeC: 3
   KernelTime: True
+  NewClient: 2
 
 BenchmarkProblems:
 
@@ -43,7 +44,7 @@ BenchmarkProblems:
         - ThreadTile:
           - [ 3, 5 ]
           - [ 4, 8 ]
-          - [ 8, 8 ]
+          #- [ 8, 8 ]
         - WorkGroup:
           - [ 32,  4,  1 ]
           - [  8,  8,  1 ]
@@ -54,7 +55,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
 
     - # BenchmarkProblemSizeGroup - Assembly
       InitialSolutionParameters:
@@ -67,10 +68,10 @@ BenchmarkProblems:
         - PrefetchLocalRead: [False]
         - PrefetchGlobalRead: [True]
         - ThreadTile:
-          - [ 3, 3 ]
+          #- [ 3, 3 ]
           - [ 4, 4 ]
           - [ 5, 5 ]
-          - [ 8, 8 ]
+          #- [ 8, 8 ]
         - WorkGroup:
           - [ 16, 16,  1 ]
           - [  8,  8,  1 ]
@@ -81,7 +82,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
 
   - # sgemm NT
     - # ProblemType
@@ -106,7 +107,7 @@ BenchmarkProblems:
         - ThreadTile:
           - [ 3, 5 ]
           - [ 4, 8 ]
-          - [ 8, 8 ]
+          #- [ 8, 8 ]
         - WorkGroup:
           - [ 16, 16,  1 ]
           - [  8, 16,  1 ]
@@ -117,7 +118,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
 
     - # BenchmarkProblemSizeGroup - Assembly
       InitialSolutionParameters:
@@ -132,8 +133,8 @@ BenchmarkProblems:
         - ThreadTile:
           - [ 3, 3 ]
           - [ 4, 4 ]
-          - [ 5, 5 ]
-          - [ 8, 8 ]
+          #- [ 5, 5 ]
+          #- [ 8, 8 ]
         - WorkGroup:
           - [ 16, 16,  1 ]
           - [ 16,  8,  1 ]
@@ -144,7 +145,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
 
   - # sgemm TN
     - # ProblemType
@@ -169,7 +170,7 @@ BenchmarkProblems:
         - ThreadTile:
           - [ 3, 5 ]
           - [ 4, 8 ]
-          - [ 8, 8 ]
+          #- [ 8, 8 ]
         - WorkGroup:
           - [ 16, 16,  1 ]
           - [ 32,  4,  1 ]
@@ -180,7 +181,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
 
     - # BenchmarkProblemSizeGroup - Assembly
       InitialSolutionParameters:
@@ -195,8 +196,8 @@ BenchmarkProblems:
         - ThreadTile:
           - [ 3, 3 ]
           - [ 4, 4 ]
-          - [ 5, 5 ]
-          - [ 8, 8 ]
+          #- [ 5, 5 ]
+          #- [ 8, 8 ]
         - WorkGroup:
           - [ 16, 16,  1 ]
           - [  8,  8,  1 ]
@@ -207,7 +208,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
 
   - # sgemm TT
     - # ProblemType
@@ -231,7 +232,7 @@ BenchmarkProblems:
         - ThreadTile:
           - [ 3, 5 ]
           - [ 4, 8 ]
-          - [ 8, 8 ]
+          #- [ 8, 8 ]
         - WorkGroup:
           - [ 16, 16,  1 ]
           - [  8,  8,  1 ]
@@ -242,7 +243,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
 
     - # BenchmarkProblemSizeGroup - Assembly
       InitialSolutionParameters:
@@ -256,8 +257,8 @@ BenchmarkProblems:
         - ThreadTile:
           - [ 3, 3 ]
           - [ 4, 4 ]
-          - [ 5, 5 ]
-          - [ 8, 8 ]
+          #- [ 5, 5 ]
+          #- [ 8, 8 ]
         - WorkGroup:
           - [ 16, 16,  1 ]
           - [  8,  8,  1 ]
@@ -268,27 +269,4 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
-
-LibraryLogic:
-    SolutionImportanceMin: 0
-    ScheduleName: "vega20"
-    DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Vega 20"]
-    ArchitectureName: "gfx906"
-
-    #ScheduleName: "vega10"
-    #DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860", "Device 6861", "Vega 10 [Radeon Instinct MI25]"]
-    #ArchitectureName: "gfx900"
-
-#   ScheduleName: "mi25"
-#   DeviceNames: ["Device 6860"]
-#   ArchitectureName: "gfx900"
-
-#   ScheduleName: "r9nano"
-#   DeviceNames: ["Device 7300"]
-#   ArchitectureName: "gfx803"
-
-#   ScheduleName: "hip"
-#   DeviceNames: ["Device 0000"]
-#   ArchitectureName: "fallback"
-LibraryClient:
+          - Range: [ [127,1,129], 0, [2], [63,1,64] ]

--- a/Tensile/Tests/pre_checkin/hgemm_hpa_asm_nn.yaml
+++ b/Tensile/Tests/pre_checkin/hgemm_hpa_asm_nn.yaml
@@ -4,6 +4,7 @@ GlobalParameters:
   NumElementsToValidate: -1
   BoundsCheck: True
   KernelTime: True
+  NewClient: 2
 
 BenchmarkProblems:
 

--- a/Tensile/Tests/pre_checkin/igemm_hpa_hip_nt.yaml
+++ b/Tensile/Tests/pre_checkin/igemm_hpa_hip_nt.yaml
@@ -47,31 +47,31 @@ BenchmarkProblems:
         - ProblemSizes:
           - Range: [ [127,1,129], 0, [2], [63,1,65] ]
 
-    - # BenchmarkProblemSizeGroup - Source
-      InitialSolutionParameters:
-      BenchmarkCommonParameters:
-        - LoopTail: [True]
-        - EdgeType: ["ShiftPtr"]
-        - KernelLanguage: ["Source"]
-      ForkParameters:
-        - GlobalSplitU: [1, 3]
-        - PrefetchLocalRead: [True]
-        - PrefetchGlobalRead: [False]
-        - ThreadTile:
-          - [ 8, 2 ]
-          - [ 2, 8 ]
-          - [ 16, 2 ]
-          - [ 2, 16 ]
-        - WorkGroup:
-          - [ 16, 16,  1 ]
-          - [  8,  8,  1 ]
-        - DepthU: [16]
-        - VectorWidth: [-1]
-        - AssertSummationElementMultiple: [1,2]
-        - AssertFree0ElementMultiple: [1,2]
-      BenchmarkForkParameters:
-      JoinParameters:
-      BenchmarkJoinParameters:
-      BenchmarkFinalParameters:
-        - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+##    - # BenchmarkProblemSizeGroup - Source
+##      InitialSolutionParameters:
+##      BenchmarkCommonParameters:
+##        - LoopTail: [True]
+##        - EdgeType: ["ShiftPtr"]
+##        - KernelLanguage: ["Source"]
+##      ForkParameters:
+##        - GlobalSplitU: [1, 3]
+##        - PrefetchLocalRead: [True]
+##        - PrefetchGlobalRead: [False]
+##        - ThreadTile:
+##          - [ 8, 2 ]
+##          - [ 2, 8 ]
+##          - [ 16, 2 ]
+##          - [ 2, 16 ]
+##        - WorkGroup:
+##          - [ 16, 16,  1 ]
+##          - [  8,  8,  1 ]
+##        - DepthU: [16]
+##        - VectorWidth: [-1]
+##        - AssertSummationElementMultiple: [1,2]
+##        - AssertFree0ElementMultiple: [1,2]
+##      BenchmarkForkParameters:
+##      JoinParameters:
+##      BenchmarkJoinParameters:
+##      BenchmarkFinalParameters:
+##        - ProblemSizes:
+##          - Range: [ [127,1,129], 0, [2], [63,1,65] ]

--- a/Tensile/Tests/pre_checkin/igemm_hpa_hip_tn.yaml
+++ b/Tensile/Tests/pre_checkin/igemm_hpa_hip_tn.yaml
@@ -48,32 +48,32 @@ BenchmarkProblems:
         - ProblemSizes:
           - Range: [ [127,1,129], 0, [2], [63,1,65] ]
 
-    - # BenchmarkProblemSizeGroup - Source
-      InitialSolutionParameters:
-      BenchmarkCommonParameters:
-        - LoopTail: [True]
-        - EdgeType: ["ShiftPtr"]
-        - KernelLanguage: ["Source"]
-      ForkParameters:
-        - GlobalSplitU: [1, 3]
-        - PrefetchLocalRead: [True]
-        - PrefetchGlobalRead: [False]
-        - ThreadTile:
-          - [ 8, 2 ]
-          - [ 2, 8 ]
-          - [ 16, 2 ]
-          - [ 2, 16 ]
-        - WorkGroup:
-          - [ 16, 16,  1 ]
-          - [  8,  8,  1 ]
-        - DepthU: [16]
-        - VectorWidth: [-1]
-        - AssertSummationElementMultiple: [1,2]
-        - AssertFree0ElementMultiple: [1,2]
-      BenchmarkForkParameters:
-      JoinParameters:
-      BenchmarkJoinParameters:
-      BenchmarkFinalParameters:
-        - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+##    - # BenchmarkProblemSizeGroup - Source
+##      InitialSolutionParameters:
+##      BenchmarkCommonParameters:
+##        - LoopTail: [True]
+##        - EdgeType: ["ShiftPtr"]
+##        - KernelLanguage: ["Source"]
+##      ForkParameters:
+##        - GlobalSplitU: [1, 3]
+##        - PrefetchLocalRead: [True]
+##        - PrefetchGlobalRead: [False]
+##        - ThreadTile:
+##          - [ 8, 2 ]
+##          - [ 2, 8 ]
+##          - [ 16, 2 ]
+##          - [ 2, 16 ]
+##        - WorkGroup:
+##          - [ 16, 16,  1 ]
+##          - [  8,  8,  1 ]
+##        - DepthU: [16]
+##        - VectorWidth: [-1]
+##        - AssertSummationElementMultiple: [1,2]
+##        - AssertFree0ElementMultiple: [1,2]
+##      BenchmarkForkParameters:
+##      JoinParameters:
+##      BenchmarkJoinParameters:
+##      BenchmarkFinalParameters:
+##        - ProblemSizes:
+##          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
 

--- a/Tensile/Tests/pre_checkin/igemm_hpa_hip_tt.yaml
+++ b/Tensile/Tests/pre_checkin/igemm_hpa_hip_tt.yaml
@@ -47,30 +47,30 @@ BenchmarkProblems:
         - ProblemSizes:
           - Range: [ [127,1,129], 0, [2], [63,1,65] ]
 
-    - # BenchmarkProblemSizeGroup - Source
-      InitialSolutionParameters:
-      BenchmarkCommonParameters:
-        - LoopTail: [True]
-        - EdgeType: ["ShiftPtr"]
-        - KernelLanguage: ["Source"]
-      ForkParameters:
-        - GlobalSplitU: [1, 3]
-        - PrefetchLocalRead: [True]
-        - PrefetchGlobalRead: [False]
-        - ThreadTile:
-          - [ 8, 8 ]
-          - [ 8, 2 ]
-          - [ 4, 8 ]
-        - WorkGroup:
-          - [ 16, 16,  1 ]
-          - [  8,  8,  1 ]
-        - DepthU: [16]
-        - VectorWidth: [-1]
-        - AssertSummationElementMultiple: [1,2]
-        - AssertFree0ElementMultiple: [1,2]
-      BenchmarkForkParameters:
-      JoinParameters:
-      BenchmarkJoinParameters:
-      BenchmarkFinalParameters:
-        - ProblemSizes:
-          - Range: [ [127,1,129], 0, [2], [63,1,65] ]
+##    - # BenchmarkProblemSizeGroup - Source
+##      InitialSolutionParameters:
+##      BenchmarkCommonParameters:
+##        - LoopTail: [True]
+##        - EdgeType: ["ShiftPtr"]
+##        - KernelLanguage: ["Source"]
+##      ForkParameters:
+##        - GlobalSplitU: [1, 3]
+##        - PrefetchLocalRead: [True]
+##        - PrefetchGlobalRead: [False]
+##        - ThreadTile:
+##          - [ 8, 8 ]
+##          - [ 8, 2 ]
+##          - [ 4, 8 ]
+##        - WorkGroup:
+##          - [ 16, 16,  1 ]
+##          - [  8,  8,  1 ]
+##        - DepthU: [16]
+##        - VectorWidth: [-1]
+##        - AssertSummationElementMultiple: [1,2]
+##        - AssertFree0ElementMultiple: [1,2]
+##      BenchmarkForkParameters:
+##      JoinParameters:
+##      BenchmarkJoinParameters:
+##      BenchmarkFinalParameters:
+##        - ProblemSizes:
+##          - Range: [ [127,1,129], 0, [2], [63,1,65] ]

--- a/pytest.ini
+++ b/pytest.ini
@@ -11,6 +11,7 @@ markers =
  unit: Unit tests
  no_load_loop: Directory, tests for the OptNoLoadLoop option.
  use_initial_strides: directory
+ use_initial_strides_cd: directory
  vega_20: directory
  weekly: directory
  yaml_only: directory, all tests which simply run a YAML file.


### PR DESCRIPTION
Comparisons between new and old pre_checkin run time (in hours) on standalone test desktops:
gfx900 1.15 vs. 1.75 (32GB/16 cores, scvega1)
gfx906 1.10 vs. 1.40 (64GB/64 cores, scvega2)
gfx908 1.67 vs. 2.30 (64GB/28 cores, 151.48)