### PR TITLE
Fix ClientWriter not writing individual co paths to ClientParameters.ini

### DIFF
--- a/Tensile/ClientWriter.py
+++ b/Tensile/ClientWriter.py
@@ -668,6 +668,7 @@ def writeClientParameters(forBenchmark, solutions, problemSizes, stepName, \
       for solution in solutions:
         solutionName = solutionWriter.getSolutionName(solution)
         h += "#include \"" + solutionName + ".h\"\n"
+        h += "#include \"Solutions.h\"\n"
     h += "\n"
   else:
     h += "#include \"Solutions.h\"\n"

--- a/Tensile/Source/SolutionHelper.h
+++ b/Tensile/Source/SolutionHelper.h
@@ -23,6 +23,7 @@
 #define SOLUTION_HELPER_H
 
 #include "TensileTypes.h"
+#include <hip/hip_ext.h>
 #include <map>
 #include <unordered_map>
 #include <string>

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -99,7 +99,7 @@ def getAssemblyCodeObjectFiles(kernels, kernelWriterAssembly, outputPath):
         if globalParameters["PackageLibrary"]:
           newCOFiles = [os.path.join(destDir, archName, k + '.co') for k in assemblyKernelNames]
         else:
-          newCOFiles = [os.path.join(destDir, k + '.co') for k in assemblyKernelNames]
+          newCOFiles = [os.path.join(destDir, k + '_' + archName + '.co') for k in assemblyKernelNames]
 
         for src, dst in Utils.tqdm(zip(origCOFiles, newCOFiles), "Copying code objects"):
           shutil.copyfile(src, dst)


### PR DESCRIPTION
fixed Tensile unable to find code object when `MergeFiles: False` due to recently added name filtering rule based on detected arch

this fix is for some pretty niche use case e.g., when clang is unable to merge 10k+ per-kernel co's into one giant co file

Example error message prior to the fix:
```
Exception occurred: Kernel Cijk_Alik_Bljk_HBH_MT128x256x32_MI32x32x4x2_SE_K1 not found in any loaded module.
```