### PR TITLE
Temporarily revert pre_checkin tests to old client pending hipclang updates

### DIFF
--- a/Tensile/Tests/pre_checkin/bfloat16/bfloat16_hpa_source_nn.yaml
+++ b/Tensile/Tests/pre_checkin/bfloat16/bfloat16_hpa_source_nn.yaml
@@ -3,6 +3,7 @@ GlobalParameters:
   MinimumRequiredVersion: 4.2.0
   NumElementsToValidate: -1
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
 

--- a/Tensile/Tests/pre_checkin/bfloat16/bfloat16_hpa_source_nt.yaml
+++ b/Tensile/Tests/pre_checkin/bfloat16/bfloat16_hpa_source_nt.yaml
@@ -3,6 +3,7 @@ GlobalParameters:
   MinimumRequiredVersion: 4.2.0
   NumElementsToValidate: -1
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
   - # hgemm TN

--- a/Tensile/Tests/pre_checkin/bfloat16/bfloat16_hpa_source_tn.yaml
+++ b/Tensile/Tests/pre_checkin/bfloat16/bfloat16_hpa_source_tn.yaml
@@ -3,6 +3,7 @@ GlobalParameters:
   MinimumRequiredVersion: 4.2.0
   NumElementsToValidate: -1
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
 

--- a/Tensile/Tests/pre_checkin/bfloat16/bfloat16_hpa_source_tt.yaml
+++ b/Tensile/Tests/pre_checkin/bfloat16/bfloat16_hpa_source_tt.yaml
@@ -2,6 +2,7 @@ GlobalParameters:
   MinimumRequiredVersion: 4.2.0
   NumElementsToValidate: -1
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
   - # hgemm TT

--- a/Tensile/Tests/pre_checkin/dgemm_asm.yaml
+++ b/Tensile/Tests/pre_checkin/dgemm_asm.yaml
@@ -17,7 +17,8 @@ GlobalParameters:
   DataInitTypeAB: 3
   DataInitTypeC: 3
   KernelTime: True
-  NewClient: 2
+  # NewClient: 2
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
 

--- a/Tensile/Tests/pre_checkin/direct_to_lds/hgemm_asm_nn.yaml
+++ b/Tensile/Tests/pre_checkin/direct_to_lds/hgemm_asm_nn.yaml
@@ -4,6 +4,7 @@ GlobalParameters:
   NumElementsToValidate: -1
   KernelTime: True
   PrintSolutionRejectionReason: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
 

--- a/Tensile/Tests/pre_checkin/double_complex/double_complex_asm_cc.yaml
+++ b/Tensile/Tests/pre_checkin/double_complex/double_complex_asm_cc.yaml
@@ -2,6 +2,7 @@ GlobalParameters:
   MinimumRequiredVersion: 4.2.0
   NumElementsToValidate: 128
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
   - # zgemm CC

--- a/Tensile/Tests/pre_checkin/double_complex/double_complex_asm_cn.yaml
+++ b/Tensile/Tests/pre_checkin/double_complex/double_complex_asm_cn.yaml
@@ -2,6 +2,7 @@ GlobalParameters:
   MinimumRequiredVersion: 4.2.0
   NumElementsToValidate: 128
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
   - # zgemm CN

--- a/Tensile/Tests/pre_checkin/double_complex/double_complex_asm_ct.yaml
+++ b/Tensile/Tests/pre_checkin/double_complex/double_complex_asm_ct.yaml
@@ -2,6 +2,7 @@ GlobalParameters:
   MinimumRequiredVersion: 4.2.0
   NumElementsToValidate: 128
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
   - # zgemm CT

--- a/Tensile/Tests/pre_checkin/double_complex/double_complex_asm_nc.yaml
+++ b/Tensile/Tests/pre_checkin/double_complex/double_complex_asm_nc.yaml
@@ -2,6 +2,7 @@ GlobalParameters:
   MinimumRequiredVersion: 4.2.0
   NumElementsToValidate: 128
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
   - # zgemm NC

--- a/Tensile/Tests/pre_checkin/double_complex/double_complex_asm_nn.yaml
+++ b/Tensile/Tests/pre_checkin/double_complex/double_complex_asm_nn.yaml
@@ -2,6 +2,7 @@ GlobalParameters:
   MinimumRequiredVersion: 4.2.0
   NumElementsToValidate: 128
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
   - # zgemm NN

--- a/Tensile/Tests/pre_checkin/double_complex/double_complex_asm_nt.yaml
+++ b/Tensile/Tests/pre_checkin/double_complex/double_complex_asm_nt.yaml
@@ -2,6 +2,7 @@ GlobalParameters:
   MinimumRequiredVersion: 4.2.0
   NumElementsToValidate: 128
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
   - # zgemm TN

--- a/Tensile/Tests/pre_checkin/double_complex/double_complex_asm_tc.yaml
+++ b/Tensile/Tests/pre_checkin/double_complex/double_complex_asm_tc.yaml
@@ -2,6 +2,7 @@ GlobalParameters:
   MinimumRequiredVersion: 4.2.0
   NumElementsToValidate: 128
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
   - # zgemm TC

--- a/Tensile/Tests/pre_checkin/double_complex/double_complex_asm_tn.yaml
+++ b/Tensile/Tests/pre_checkin/double_complex/double_complex_asm_tn.yaml
@@ -2,6 +2,7 @@ GlobalParameters:
   MinimumRequiredVersion: 4.2.0
   NumElementsToValidate: 128
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
   - # zgemm TN

--- a/Tensile/Tests/pre_checkin/double_complex/double_complex_asm_tt.yaml
+++ b/Tensile/Tests/pre_checkin/double_complex/double_complex_asm_tt.yaml
@@ -2,6 +2,7 @@ GlobalParameters:
   MinimumRequiredVersion: 4.2.0
   NumElementsToValidate: 128
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
   - # zgemm TT

--- a/Tensile/Tests/pre_checkin/double_complex/double_complex_hip_cc.yaml
+++ b/Tensile/Tests/pre_checkin/double_complex/double_complex_hip_cc.yaml
@@ -2,6 +2,7 @@ GlobalParameters:
   MinimumRequiredVersion: 4.2.0
   NumElementsToValidate: 128
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
   - # zgemm CC

--- a/Tensile/Tests/pre_checkin/double_complex/double_complex_hip_cn.yaml
+++ b/Tensile/Tests/pre_checkin/double_complex/double_complex_hip_cn.yaml
@@ -2,6 +2,7 @@ GlobalParameters:
   MinimumRequiredVersion: 4.2.0
   NumElementsToValidate: 128
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
   - # zgemm CN

--- a/Tensile/Tests/pre_checkin/double_complex/double_complex_hip_ct.yaml
+++ b/Tensile/Tests/pre_checkin/double_complex/double_complex_hip_ct.yaml
@@ -2,6 +2,7 @@ GlobalParameters:
   MinimumRequiredVersion: 4.2.0
   NumElementsToValidate: 128
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
   - # zgemm CT

--- a/Tensile/Tests/pre_checkin/double_complex/double_complex_hip_nc.yaml
+++ b/Tensile/Tests/pre_checkin/double_complex/double_complex_hip_nc.yaml
@@ -2,6 +2,7 @@ GlobalParameters:
   MinimumRequiredVersion: 4.2.0
   NumElementsToValidate: 128
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
   - # zgemm NC

--- a/Tensile/Tests/pre_checkin/double_complex/double_complex_hip_nn.yaml
+++ b/Tensile/Tests/pre_checkin/double_complex/double_complex_hip_nn.yaml
@@ -2,6 +2,7 @@ GlobalParameters:
   MinimumRequiredVersion: 4.2.0
   NumElementsToValidate: 128
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
   - # zgemm NN

--- a/Tensile/Tests/pre_checkin/double_complex/double_complex_hip_nt.yaml
+++ b/Tensile/Tests/pre_checkin/double_complex/double_complex_hip_nt.yaml
@@ -2,6 +2,7 @@ GlobalParameters:
   MinimumRequiredVersion: 4.2.0
   NumElementsToValidate: 128
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
   - # zgemm TN

--- a/Tensile/Tests/pre_checkin/double_complex/double_complex_hip_tc.yaml
+++ b/Tensile/Tests/pre_checkin/double_complex/double_complex_hip_tc.yaml
@@ -2,6 +2,7 @@ GlobalParameters:
   MinimumRequiredVersion: 4.2.0
   NumElementsToValidate: 128
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
   - # zgemm TC

--- a/Tensile/Tests/pre_checkin/double_complex/double_complex_hip_tn.yaml
+++ b/Tensile/Tests/pre_checkin/double_complex/double_complex_hip_tn.yaml
@@ -2,6 +2,7 @@ GlobalParameters:
   MinimumRequiredVersion: 4.2.0
   NumElementsToValidate: 128
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
   - # zgemm TN

--- a/Tensile/Tests/pre_checkin/double_complex/double_complex_hip_tt.yaml
+++ b/Tensile/Tests/pre_checkin/double_complex/double_complex_hip_tt.yaml
@@ -2,6 +2,7 @@ GlobalParameters:
   MinimumRequiredVersion: 4.2.0
   NumElementsToValidate: 128
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
   - # zgemm TT

--- a/Tensile/Tests/pre_checkin/float_complex/float_complex_asm_cc.yaml
+++ b/Tensile/Tests/pre_checkin/float_complex/float_complex_asm_cc.yaml
@@ -2,6 +2,7 @@ GlobalParameters:
   MinimumRequiredVersion: 4.2.0
   NumElementsToValidate: 128
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
   - # cgemm CC

--- a/Tensile/Tests/pre_checkin/float_complex/float_complex_asm_cn.yaml
+++ b/Tensile/Tests/pre_checkin/float_complex/float_complex_asm_cn.yaml
@@ -2,6 +2,7 @@ GlobalParameters:
   MinimumRequiredVersion: 4.2.0
   NumElementsToValidate: 128
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
   - # cgemm CN

--- a/Tensile/Tests/pre_checkin/float_complex/float_complex_asm_ct.yaml
+++ b/Tensile/Tests/pre_checkin/float_complex/float_complex_asm_ct.yaml
@@ -2,6 +2,7 @@ GlobalParameters:
   MinimumRequiredVersion: 4.2.0
   NumElementsToValidate: 128
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
   - # cgemm CT

--- a/Tensile/Tests/pre_checkin/float_complex/float_complex_asm_nc.yaml
+++ b/Tensile/Tests/pre_checkin/float_complex/float_complex_asm_nc.yaml
@@ -2,6 +2,7 @@ GlobalParameters:
   MinimumRequiredVersion: 4.2.0
   NumElementsToValidate: 128
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
   - # cgemm NC

--- a/Tensile/Tests/pre_checkin/float_complex/float_complex_asm_nn.yaml
+++ b/Tensile/Tests/pre_checkin/float_complex/float_complex_asm_nn.yaml
@@ -2,6 +2,7 @@ GlobalParameters:
   MinimumRequiredVersion: 4.2.0
   NumElementsToValidate: 128
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
   - # cgemm NN

--- a/Tensile/Tests/pre_checkin/float_complex/float_complex_asm_nt.yaml
+++ b/Tensile/Tests/pre_checkin/float_complex/float_complex_asm_nt.yaml
@@ -2,6 +2,7 @@ GlobalParameters:
   MinimumRequiredVersion: 4.2.0
   NumElementsToValidate: 128
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
   - # cgemm TN

--- a/Tensile/Tests/pre_checkin/float_complex/float_complex_asm_tc.yaml
+++ b/Tensile/Tests/pre_checkin/float_complex/float_complex_asm_tc.yaml
@@ -2,6 +2,7 @@ GlobalParameters:
   MinimumRequiredVersion: 4.2.0
   NumElementsToValidate: 128
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
   - # cgemm TC

--- a/Tensile/Tests/pre_checkin/float_complex/float_complex_asm_tn.yaml
+++ b/Tensile/Tests/pre_checkin/float_complex/float_complex_asm_tn.yaml
@@ -2,6 +2,7 @@ GlobalParameters:
   MinimumRequiredVersion: 4.2.0
   NumElementsToValidate: 128
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
   - # cgemm TN

--- a/Tensile/Tests/pre_checkin/float_complex/float_complex_asm_tt.yaml
+++ b/Tensile/Tests/pre_checkin/float_complex/float_complex_asm_tt.yaml
@@ -2,6 +2,7 @@ GlobalParameters:
   MinimumRequiredVersion: 4.2.0
   NumElementsToValidate: 128
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
   - # cgemm TT

--- a/Tensile/Tests/pre_checkin/float_complex/float_complex_hip_cc.yaml
+++ b/Tensile/Tests/pre_checkin/float_complex/float_complex_hip_cc.yaml
@@ -2,6 +2,7 @@ GlobalParameters:
   MinimumRequiredVersion: 4.2.0
   NumElementsToValidate: 128
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
   - # cgemm CC

--- a/Tensile/Tests/pre_checkin/float_complex/float_complex_hip_cn.yaml
+++ b/Tensile/Tests/pre_checkin/float_complex/float_complex_hip_cn.yaml
@@ -2,6 +2,7 @@ GlobalParameters:
   MinimumRequiredVersion: 4.2.0
   NumElementsToValidate: 128
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
   - # cgemm CN

--- a/Tensile/Tests/pre_checkin/float_complex/float_complex_hip_ct.yaml
+++ b/Tensile/Tests/pre_checkin/float_complex/float_complex_hip_ct.yaml
@@ -2,6 +2,7 @@ GlobalParameters:
   MinimumRequiredVersion: 4.2.0
   NumElementsToValidate: 128
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
   - # cgemm CT

--- a/Tensile/Tests/pre_checkin/float_complex/float_complex_hip_nc.yaml
+++ b/Tensile/Tests/pre_checkin/float_complex/float_complex_hip_nc.yaml
@@ -2,6 +2,7 @@ GlobalParameters:
   MinimumRequiredVersion: 4.2.0
   NumElementsToValidate: 128
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
   - # cgemm NC

--- a/Tensile/Tests/pre_checkin/float_complex/float_complex_hip_nn.yaml
+++ b/Tensile/Tests/pre_checkin/float_complex/float_complex_hip_nn.yaml
@@ -2,6 +2,7 @@ GlobalParameters:
   MinimumRequiredVersion: 4.2.0
   NumElementsToValidate: 128
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
   - # cgemm NN

--- a/Tensile/Tests/pre_checkin/float_complex/float_complex_hip_nt.yaml
+++ b/Tensile/Tests/pre_checkin/float_complex/float_complex_hip_nt.yaml
@@ -2,6 +2,7 @@ GlobalParameters:
   MinimumRequiredVersion: 4.2.0
   NumElementsToValidate: 128
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
   - # cgemm TN

--- a/Tensile/Tests/pre_checkin/float_complex/float_complex_hip_tc.yaml
+++ b/Tensile/Tests/pre_checkin/float_complex/float_complex_hip_tc.yaml
@@ -2,6 +2,7 @@ GlobalParameters:
   MinimumRequiredVersion: 4.2.0
   NumElementsToValidate: 128
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
   - # cgemm TC

--- a/Tensile/Tests/pre_checkin/float_complex/float_complex_hip_tn.yaml
+++ b/Tensile/Tests/pre_checkin/float_complex/float_complex_hip_tn.yaml
@@ -2,6 +2,7 @@ GlobalParameters:
   MinimumRequiredVersion: 4.2.0
   NumElementsToValidate: 128
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
   - # cgemm TN

--- a/Tensile/Tests/pre_checkin/float_complex/float_complex_hip_tt.yaml
+++ b/Tensile/Tests/pre_checkin/float_complex/float_complex_hip_tt.yaml
@@ -2,6 +2,7 @@ GlobalParameters:
   MinimumRequiredVersion: 4.2.0
   NumElementsToValidate: 128
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
   - # cgemm TT

--- a/Tensile/Tests/pre_checkin/hgemm_asm_nn.yaml
+++ b/Tensile/Tests/pre_checkin/hgemm_asm_nn.yaml
@@ -6,6 +6,7 @@ GlobalParameters:
   ValidationPrintValids: True
   KernelTime: True
   PrintSolutionRejectionReason: 1
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
 

--- a/Tensile/Tests/pre_checkin/hgemm_asm_nt.yaml
+++ b/Tensile/Tests/pre_checkin/hgemm_asm_nt.yaml
@@ -4,6 +4,7 @@ GlobalParameters:
   NumElementsToValidate: -1
   BoundsCheck: True
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
   - # hgemm TN

--- a/Tensile/Tests/pre_checkin/hgemm_asm_tn.yaml
+++ b/Tensile/Tests/pre_checkin/hgemm_asm_tn.yaml
@@ -4,6 +4,7 @@ GlobalParameters:
   NumElementsToValidate: -1
   BoundsCheck: True
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
 

--- a/Tensile/Tests/pre_checkin/hgemm_asm_tt.yaml
+++ b/Tensile/Tests/pre_checkin/hgemm_asm_tt.yaml
@@ -3,6 +3,7 @@ GlobalParameters:
   NumElementsToValidate: -1
   BoundsCheck: True
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
   - # hgemm TT

--- a/Tensile/Tests/pre_checkin/hgemm_hpa_asm_nn.yaml
+++ b/Tensile/Tests/pre_checkin/hgemm_hpa_asm_nn.yaml
@@ -4,7 +4,8 @@ GlobalParameters:
   NumElementsToValidate: -1
   BoundsCheck: True
   KernelTime: True
-  NewClient: 2
+  # NewClient: 2
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
 

--- a/Tensile/Tests/pre_checkin/hgemm_hpa_asm_nt.yaml
+++ b/Tensile/Tests/pre_checkin/hgemm_hpa_asm_nt.yaml
@@ -4,6 +4,7 @@ GlobalParameters:
   NumElementsToValidate: -1
   BoundsCheck: True
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
   - # hgemm TN

--- a/Tensile/Tests/pre_checkin/hgemm_hpa_asm_tn.yaml
+++ b/Tensile/Tests/pre_checkin/hgemm_hpa_asm_tn.yaml
@@ -4,6 +4,7 @@ GlobalParameters:
   NumElementsToValidate: -1
   BoundsCheck: True
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
 

--- a/Tensile/Tests/pre_checkin/hgemm_hpa_asm_tt.yaml
+++ b/Tensile/Tests/pre_checkin/hgemm_hpa_asm_tt.yaml
@@ -3,6 +3,7 @@ GlobalParameters:
   NumElementsToValidate: -1
   BoundsCheck: True
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
   - # hgemm TT

--- a/Tensile/Tests/pre_checkin/hgemm_hpa_iu2_asm_nn.yaml
+++ b/Tensile/Tests/pre_checkin/hgemm_hpa_iu2_asm_nn.yaml
@@ -4,6 +4,7 @@ GlobalParameters:
   NumElementsToValidate: -1
   BoundsCheck: True
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
 

--- a/Tensile/Tests/pre_checkin/hgemm_hpa_iu2_asm_nt.yaml
+++ b/Tensile/Tests/pre_checkin/hgemm_hpa_iu2_asm_nt.yaml
@@ -4,6 +4,7 @@ GlobalParameters:
   NumElementsToValidate: -1
   BoundsCheck: True
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
   - # hgemm NT

--- a/Tensile/Tests/pre_checkin/hgemm_hpa_iu2_asm_tn.yaml
+++ b/Tensile/Tests/pre_checkin/hgemm_hpa_iu2_asm_tn.yaml
@@ -4,6 +4,7 @@ GlobalParameters:
   NumElementsToValidate: -1
   BoundsCheck: True
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
 

--- a/Tensile/Tests/pre_checkin/hgemm_hpa_iu2_asm_tt.yaml
+++ b/Tensile/Tests/pre_checkin/hgemm_hpa_iu2_asm_tt.yaml
@@ -3,6 +3,7 @@ GlobalParameters:
   NumElementsToValidate: -1
   BoundsCheck: True
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
   - # hgemm TT

--- a/Tensile/Tests/pre_checkin/igemm_hpa_hip_nn.yaml
+++ b/Tensile/Tests/pre_checkin/igemm_hpa_hip_nn.yaml
@@ -3,7 +3,8 @@ GlobalParameters:
   NumElementsToValidate: -1
   BoundsCheck: True
   KernelTime: True
-  NewClient: 2
+  # NewClient: 2
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
   MergeFiles: False
 
 BenchmarkProblems:

--- a/Tensile/Tests/pre_checkin/igemm_hpa_hip_nt.yaml
+++ b/Tensile/Tests/pre_checkin/igemm_hpa_hip_nt.yaml
@@ -4,7 +4,8 @@ GlobalParameters:
   NumElementsToValidate: -1
   BoundsCheck: True
   KernelTime: True
-  NewClient: 2
+  # NewClient: 2
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
   MergeFiles: False
 
 BenchmarkProblems:

--- a/Tensile/Tests/pre_checkin/igemm_hpa_hip_tn.yaml
+++ b/Tensile/Tests/pre_checkin/igemm_hpa_hip_tn.yaml
@@ -4,7 +4,8 @@ GlobalParameters:
   NumElementsToValidate: -1
   BoundsCheck: True
   KernelTime: True
-  NewClient: 2
+  # NewClient: 2
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
   MergeFiles: False
 
 BenchmarkProblems:

--- a/Tensile/Tests/pre_checkin/igemm_hpa_hip_tt.yaml
+++ b/Tensile/Tests/pre_checkin/igemm_hpa_hip_tt.yaml
@@ -4,7 +4,8 @@ GlobalParameters:
   NumElementsToValidate: -1
   BoundsCheck: True
   KernelTime: True
-  NewClient: 2
+  # NewClient: 2
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
   MergeFiles: False
 
 BenchmarkProblems:

--- a/Tensile/Tests/pre_checkin/mfma/c-tile-reuse-no-nll.yaml
+++ b/Tensile/Tests/pre_checkin/mfma/c-tile-reuse-no-nll.yaml
@@ -6,6 +6,7 @@ GlobalParameters:
   NumElementsToValidate: 16384
   BoundsCheck: True
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
   ########################################

--- a/Tensile/Tests/pre_checkin/mfma/hpa_bfloat16_gemm_asm_mi32x32x2x2.yaml
+++ b/Tensile/Tests/pre_checkin/mfma/hpa_bfloat16_gemm_asm_mi32x32x2x2.yaml
@@ -5,6 +5,7 @@ GlobalParameters:
   NumElementsToValidate: 16384
   BoundsCheck: True
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
   ########################################

--- a/Tensile/Tests/pre_checkin/mfma/hpa_hgemm_asm_mi32x32x4x2.yaml
+++ b/Tensile/Tests/pre_checkin/mfma/hpa_hgemm_asm_mi32x32x4x2.yaml
@@ -5,6 +5,7 @@ GlobalParameters:
   NumElementsToValidate: 16384
   BoundsCheck: True
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
   ########################################

--- a/Tensile/Tests/pre_checkin/mfma/sgemm_asm_mi32x32x1x2.yaml
+++ b/Tensile/Tests/pre_checkin/mfma/sgemm_asm_mi32x32x1x2.yaml
@@ -5,6 +5,7 @@ GlobalParameters:
   NumElementsToValidate: 16384
   BoundsCheck: True
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
   ########################################

--- a/Tensile/Tests/pre_checkin/mfma/sgemm_asm_mi32x32x2x1.yaml
+++ b/Tensile/Tests/pre_checkin/mfma/sgemm_asm_mi32x32x2x1.yaml
@@ -5,6 +5,7 @@ GlobalParameters:
   NumElementsToValidate: 16384
   BoundsCheck: True
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
   ########################################

--- a/Tensile/Tests/pre_checkin/no_load_loop/nll_reproduce_bug.yaml
+++ b/Tensile/Tests/pre_checkin/no_load_loop/nll_reproduce_bug.yaml
@@ -19,7 +19,8 @@ GlobalParameters:
   DataInitTypeAlpha: 1
   DataInitTypeBeta: 0
   KernelTime: True
-  NewClient: 2
+  # NewClient: 2
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
 

--- a/Tensile/Tests/pre_checkin/no_load_loop/sgemm_nll_asm_nn.yaml
+++ b/Tensile/Tests/pre_checkin/no_load_loop/sgemm_nll_asm_nn.yaml
@@ -19,7 +19,8 @@ GlobalParameters:
   DataInitTypeAlpha: 1
   DataInitTypeBeta: 0
   KernelTime: True
-  NewClient: 2
+  # NewClient: 2
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
 

--- a/Tensile/Tests/pre_checkin/no_load_loop/sgemm_nll_asm_nt.yaml
+++ b/Tensile/Tests/pre_checkin/no_load_loop/sgemm_nll_asm_nt.yaml
@@ -19,7 +19,8 @@ GlobalParameters:
   DataTypeInitAlpha: 1
   DataTypeInitBeta: 0
   KernelTime: True
-  NewClient: 2
+  # NewClient: 2
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
 

--- a/Tensile/Tests/pre_checkin/no_load_loop/sgemm_nll_asm_tn.yaml
+++ b/Tensile/Tests/pre_checkin/no_load_loop/sgemm_nll_asm_tn.yaml
@@ -19,7 +19,8 @@ GlobalParameters:
   DataTypeInitAlpha: 1
   DataTypeInitBeta: 0
   KernelTime: True
-  NewClient: 2
+  # NewClient: 2
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
 

--- a/Tensile/Tests/pre_checkin/no_load_loop/sgemm_nll_asm_tt.yaml
+++ b/Tensile/Tests/pre_checkin/no_load_loop/sgemm_nll_asm_tt.yaml
@@ -19,7 +19,8 @@ GlobalParameters:
   DataInitTypeAlpha: 1
   DataInitTypeBeta: 0
   KernelTime: True
-  NewClient: 2
+  # NewClient: 2
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
 

--- a/Tensile/Tests/pre_checkin/sgemm_asm_nn.yaml
+++ b/Tensile/Tests/pre_checkin/sgemm_asm_nn.yaml
@@ -17,6 +17,7 @@ GlobalParameters:
   DataInitTypeAB: 3
   DataInitTypeC: 3
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
 

--- a/Tensile/Tests/pre_checkin/sgemm_asm_nt.yaml
+++ b/Tensile/Tests/pre_checkin/sgemm_asm_nt.yaml
@@ -17,7 +17,8 @@ GlobalParameters:
   DataInitTypeAB: 3
   DataInitTypeC: 3
   KernelTime: True
-  NewClient: 2
+  # NewClient: 2
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
 

--- a/Tensile/Tests/pre_checkin/sgemm_asm_tn.yaml
+++ b/Tensile/Tests/pre_checkin/sgemm_asm_tn.yaml
@@ -17,6 +17,7 @@ GlobalParameters:
   DataInitTypeAB: 3
   DataInitTypeC: 3
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
 

--- a/Tensile/Tests/pre_checkin/sgemm_asm_tn_bigk.yaml
+++ b/Tensile/Tests/pre_checkin/sgemm_asm_tn_bigk.yaml
@@ -3,6 +3,7 @@ GlobalParameters:
   MinimumRequiredVersion: 4.2.0
   NumElementsToValidate: 1000
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
 

--- a/Tensile/Tests/pre_checkin/sgemm_asm_tt.yaml
+++ b/Tensile/Tests/pre_checkin/sgemm_asm_tt.yaml
@@ -17,6 +17,7 @@ GlobalParameters:
   DataInitTypeAB: 3
   DataInitTypeC: 3
   KernelTime: True
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
 
 BenchmarkProblems:
 

--- a/Tensile/Tests/pre_checkin/source/test_dgemm_defaults.yaml
+++ b/Tensile/Tests/pre_checkin/source/test_dgemm_defaults.yaml
@@ -1,3 +1,6 @@
+GlobalParameters:
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
+
 BenchmarkProblems:
   - # dgemm NT
     - # ProblemType

--- a/Tensile/Tests/pre_checkin/source/test_hgemm_defaults.yaml
+++ b/Tensile/Tests/pre_checkin/source/test_hgemm_defaults.yaml
@@ -1,3 +1,6 @@
+GlobalParameters:
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
+
 BenchmarkProblems:
   - # sgemm NT
     - # ProblemType

--- a/Tensile/Tests/pre_checkin/source/test_sgemm_defaults.yaml
+++ b/Tensile/Tests/pre_checkin/source/test_sgemm_defaults.yaml
@@ -1,3 +1,6 @@
+GlobalParameters:
+  NewClient: 0 # Temporarily revert pre_checkin tests to old client pending hipclang udpates
+
 BenchmarkProblems:
   - # sgemm NT
     - # ProblemType


### PR DESCRIPTION
Run pre_checkin tests using old client for now so we can run CI on new PRs in hipclang until a new build is available.