### PR TITLE
Hot fix to PR #949 

### DIFF
--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -5402,7 +5402,7 @@ class KernelWriterAssembly(KernelWriter):
   def declareStaggerParms(self, kernel):
 
     kStr=""
-    tmpSgpr = self.getTmpSgpr(2)
+    tmpSgpr = self.getTmpSgpr(2).idx()
     if self.staggerU:
       # this coud be dynamic?
       if kernel["StaggerUMapping"] == 0:


### PR DESCRIPTION
usage requirement of getTmpSgpr() has changed after #934 is merged. this quick fix for #949 reflects that new usage