### PR TITLE
Lower timeout for test stage for extended and precheckin tests

### DIFF
--- a/.jenkins/extended.groovy
+++ b/.jenkins/extended.groovy
@@ -20,7 +20,7 @@ def runCI =
 
     boolean formatCheck = false
 
-    prj.timeout.test = 1440
+    prj.timeout.test = 420
 
     def commonGroovy
 

--- a/.jenkins/precheckin.groovy
+++ b/.jenkins/precheckin.groovy
@@ -20,8 +20,7 @@ def runCI =
 
     boolean formatCheck = false
 
-    // temporarily increase timeout from 5 hours to 8 hours
-    prj.timeout.test = 480
+    prj.timeout.test = 120
 
     def commonGroovy
 


### PR DESCRIPTION
Extended lowered from 24 hours to 7 hours (hcc takes 5hrs 40 mins)
PreCheckin lowered from 8 hours to 2 hours (hcc takes 56 mins)

Temporary measure to manage CI load