### PR TITLE
Capture timing incrementally as test progresses.

### DIFF
--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -27,7 +27,7 @@ def runCompileCommand(platform, project, jobName, boolean debug=false)
             tox --version
             tox -v --workdir /tmp/.tensile-tox -e lint
             #### temporarily enable --no-merge-files until hipclang update is posted
-            tox -v --workdir /tmp/.tensile-tox -e py35 -- ${test_dir} -m "${test_marks}" --junit-xml=\$(pwd)/python_unit_tests.xml --tensile-options="--no-merge-files"
+            tox -v --workdir /tmp/.tensile-tox -e py35 -- ${test_dir} -m "${test_marks}" --junit-xml=\$(pwd)/python_unit_tests.xml --tensile-options="--no-merge-files" --timing-file=\$(pwd)/timing.csv
 
             mkdir build
             pushd build
@@ -83,7 +83,7 @@ def runTestCommand (platform, project, test_marks)
                 ####
                 tox --version
                 #### temporarily enable --no-merge-files until hipclang update is posted
-                tox -v --workdir /tmp/.tensile-tox -e py35 -- ${test_dir} -m "${test_marks}" --tensile-options="--no-merge-files"
+                tox -v --workdir /tmp/.tensile-tox -e py35 -- ${test_dir} -m "${test_marks}" --tensile-options="--no-merge-files" --timing-file=\$(pwd)/timing.csv
                 PY_ERR=\$?
                 date
 
@@ -103,6 +103,7 @@ def runTestCommand (platform, project, test_marks)
     {
         try
         {
+            archiveArtifacts "${project.paths.project_build_prefix}/timing.csv"
             junit "${project.paths.project_build_prefix}/build/host_test_output.xml"
         }
         finally

--- a/Tensile/Tests/conftest.py
+++ b/Tensile/Tests/conftest.py
@@ -60,7 +60,6 @@ def worker_lock_instance(worker_lock_path):
 def tensile_args(pytestconfig, builddir, worker_lock_path):
     rv = []
     if worker_lock_path:
-        lockPath = tmp_path_factory.getbasetemp().parent / "client_execution.lock"
         rv += ["--client-lock", str(worker_lock_path)]
 
     extraOptions = pytestconfig.getoption("--tensile-options")

--- a/Tensile/Tests/conftest.py
+++ b/Tensile/Tests/conftest.py
@@ -11,6 +11,28 @@ def pytest_addoption(parser):
     parser.addoption("--tensile-options")
     parser.addoption("--no-common-build", action="store_true")
     parser.addoption("--builddir", "--client-dir")
+    parser.addoption("--timing-file")
+
+@pytest.fixture
+def timing_path(pytestconfig, tmpdir_factory):
+    userDir = pytestconfig.getoption("--timing-file")
+    if userDir is not None:
+        return userDir
+    return str(tmpdir_factory.mktemp("results") / "timing.csv")
+
+@pytest.fixture(autouse=True)
+def incremental_timer(request, worker_lock_instance, timing_path):
+    #import pdb
+    #pdb.set_trace()
+    import datetime
+    start = datetime.datetime.now()
+    yield
+    stop = datetime.datetime.now()
+
+    testtime = stop - start
+    with worker_lock_instance:
+        with open(timing_path, "a") as f:
+            f.write("{},{}\n".format(request.node.name, testtime.total_seconds()))
 
 @pytest.fixture(scope="session")
 def builddir(pytestconfig, tmpdir_factory):
@@ -19,12 +41,27 @@ def builddir(pytestconfig, tmpdir_factory):
         return userDir
     return str(tmpdir_factory.mktemp("0_Build"))
 
+@pytest.fixture(scope="session")
+def worker_lock_path(worker_id, tmp_path_factory):
+    if not worker_id:
+        return None
+    
+    return tmp_path_factory.getbasetemp().parent / "client_execution.lock"
+
 @pytest.fixture
-def tensile_args(pytestconfig, builddir, worker_id, tmp_path_factory):
+def worker_lock_instance(worker_lock_path):
+    if not worker_lock_path:
+        return open(os.devnull)
+
+    import filelock
+    return filelock.FileLock(str(worker_lock_path))
+
+@pytest.fixture
+def tensile_args(pytestconfig, builddir, worker_lock_path):
     rv = []
-    if worker_id:
+    if worker_lock_path:
         lockPath = tmp_path_factory.getbasetemp().parent / "client_execution.lock"
-        rv += ["--client-lock", str(lockPath)]
+        rv += ["--client-lock", str(worker_lock_path)]
 
     extraOptions = pytestconfig.getoption("--tensile-options")
     if extraOptions is not None:


### PR DESCRIPTION
Timing is recorded to `timing.csv` which should be archived to Jenkins.