### PR TITLE
Fix solution state KeyError issue in multi-problem-type

### DIFF
--- a/Tensile/BenchmarkStructs.py
+++ b/Tensile/BenchmarkStructs.py
@@ -163,7 +163,8 @@ class BenchmarkProcess:
     # don't show up in Ccommon/Cfork/CBfork/Cjoin/CBjoin
     # followed by Ccommon
     self.benchmarkCommonParameters = [{"ProblemSizes": currentProblemSizes}]
-    for paramDict in defaultBenchmarkCommonParameters:
+    # need to use deepcopy to prevent default parameters from being washed-out later
+    for paramDict in deepcopy(defaultBenchmarkCommonParameters):  
       for paramName in paramDict:
         if not hasParam( paramName, [ configBenchmarkCommonParameters, \
             configForkParameters, configBenchmarkForkParameters, \
@@ -181,7 +182,8 @@ class BenchmarkProcess:
     # don't show up in Bcommon/Cfork/CBfork/Cjoin/CBjoin
     # followed by Cfork
     self.forkParameters = []
-    for paramDict in defaultForkParameters:
+    # need to use deepcopy to prevent default parameters from being washed-out later
+    for paramDict in deepcopy(defaultForkParameters):
       for paramName in paramDict:
         if not hasParam( paramName, [ self.benchmarkCommonParameters, \
             configForkParameters, configBenchmarkForkParameters, \
@@ -206,7 +208,8 @@ class BenchmarkProcess:
     # don't show up in Bcommon/Bfork/CBfork/Cjoin/CBjoin
     # followed by CBforked
     self.benchmarkForkParameters = [{"ProblemSizes": currentProblemSizes}]
-    for paramDict in defaultBenchmarkForkParameters:
+    # need to use deepcopy to prevent default parameters from being washed-out later
+    for paramDict in deepcopy(defaultBenchmarkForkParameters):
       for paramName in paramDict:
         if not hasParam( paramName, [ self.benchmarkCommonParameters, \
             self.forkParameters, configBenchmarkForkParameters, \
@@ -224,7 +227,8 @@ class BenchmarkProcess:
     # don't show up in Bcommon/Bfork/CBfork/Cjoin/CBjoin
     # followed by CBforked
     self.joinParameters = []
-    for paramName in defaultJoinParameters:
+    # need to use deepcopy to prevent default parameters from being washed-out later
+    for paramName in deepcopy(defaultJoinParameters):
       if not hasParam( paramName, [ self.benchmarkCommonParameters, \
           self.forkParameters, self.benchmarkForkParameters, \
           configJoinParameters, configBenchmarkJoinParameters]) \
@@ -250,7 +254,8 @@ class BenchmarkProcess:
     # don't show up in Bcommon/Bfork/BBfork/Bjoin/CBjoin
     # followed by CBjoin
     self.benchmarkJoinParameters = [{"ProblemSizes": currentProblemSizes}]
-    for paramDict in defaultBenchmarkJoinParameters:
+    # need to use deepcopy to prevent default parameters from being washed-out later
+    for paramDict in deepcopy(defaultBenchmarkJoinParameters):
       for paramName in paramDict:
         if not hasParam( paramName, [ self.benchmarkCommonParameters, \
             self.forkParameters, self.benchmarkForkParameters, \

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -457,7 +457,7 @@ class KernelWriterAssembly(KernelWriter):
     self.initSgprValue    = 0x0  # Value to use for Sgpr Init, if enabled
 
     self.db["InitVgpr"]   = 0x0  # init VGPRs
-    self.initVgprValue    = 0xFFFFFFFF  # Value to use for Sgpr Init, if enabled
+    self.initVgprValue    = 0xFFFFFFFF  # Value to use for Vgpr Init, if enabled
 
     # Debug and Check flags:
     # Check A and B values loaded from memory to ensure they are 1

--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -1750,8 +1750,8 @@ class Solution:
               % (pv, totalVectors, state["NumThreads"]))
           validDepthU = False
         if state["GlobalReadVectorWidth"] % pv != 0:
-          reject(None, "NumThreads %u %% totalVectors %u != 0" \
-              % (state["NumThreads"], totalVectors))
+          reject(None, "GlobalReadVectorWidth %u %% pv %u != 0" \
+              % (state["GlobalReadVectorWidth"], pv))
           validDepthU = False
     else:
       pv = 1 # no partial vector required


### PR DESCRIPTION
Can be re-produced by "Tensile/Configs/rocblas_sgemm_asm_only.yaml"

For a ProblemSizeGroup satisfying: 
1) JoinParameters: MacroTile
2) ForkParameters
3) Is second or later ProblemType

A KeyError 'MatrixInstruction' will triggered when "updating solution database", shown as below:
```
# Updating Solution Database
  File "SolutionStructs.py", line 1656, in assignProblemIndependentDerivedParameters
    if state["MatrixInstruction"]:
KeyError: 'MatrixInstruction'
```
This is due to the defaultXXXXParameters are cleared by the first benchmarkProcess & step.
Fixed by replacing copy with deepcopy