### PR TITLE
Partial support of tuning strided batched GEMMs

### DIFF
--- a/Tensile/ClientWriter.py
+++ b/Tensile/ClientWriter.py
@@ -471,13 +471,13 @@ def problemSizeParams(solution, problem):
         # should just set problem.stride* appropriately when reading the Yaml and not deal with extra fields here
         if astrides[1] == -1:
           astrides[1] = problem.sizes[numIndices+2]
-        else:
+        elif astrides[1] != problem.sizes[numIndices+2]:
           raise RuntimeError("problem-specified lda(%u) conflicts with setConstStrideA(%u)" % \
               (astrides[1], problem.sizes[numIndices+2]))
 
         if bstrides[1] == -1:
           bstrides[1] = problem.sizes[numIndices+3]
-        else:
+        elif bstrides[1] != problem.sizes[numIndices+3]:
           raise RuntimeError("problem-specified ldb(%u) conflicts with setConstStrideB(%u)" % \
               (bstrides[1], problem.sizes[numIndices+3]))
 

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -20,7 +20,7 @@
 ################################################################################
 
 from . import Code
-from .Common import globalParameters, printExit, printWarning, roundUp
+from .Common import globalParameters, printExit, printWarning, roundUp, print2
 from .KernelWriter import KernelWriter
 from .SolutionStructs import isPackedIndex
 from .Utils import ceil_divide, roundUpToNearestMultiple
@@ -10128,20 +10128,20 @@ class KernelWriterAssembly(KernelWriter):
           elif gwvw != gwvwOrig:
             self.ss.gwvw = gwvw # make both representations consistent
             if shrinkDb:
-              print("info: %s shrank gwvw from %u to %u but kept occupancy same=%u." \
+              print2("info: %s shrank gwvw from %u to %u but kept occupancy same=%u." \
                   % (self.kernelName, gwvwOrig, gwvw, currentOccupancy))
 
           if numVgprAvailable < minElements*numVgprsPerElement:
-            print("info: growing pool += %d * %d for GlobalWrite\n" \
+            print2("info: growing pool += %d * %d for GlobalWrite\n" \
                 % (minElements,numVgprsPerElement))
-            print(self.vgprPool.state())
+            print2(self.vgprPool.state())
             tl = []
             for i in range(0,minElements):
               tl.append(self.vgprPool.checkOut(numVgprsPerElement, "grow-pool for GlobalWrite"))
             for t in tl:
               self.vgprPool.checkIn(t)
             numVgprAvailable = self.vgprPool.available()
-            print(self.vgprPool.state())
+            print2(self.vgprPool.state())
 
         # set atomicW after we potentially resize GWVW
         atomicW = min(gwvw, kernel["VectorAtomicWidth"])

--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -24,7 +24,7 @@ import operator
 from collections import namedtuple,OrderedDict
 from warnings import warn
 from functools import reduce
-from .Common import globalParameters, defaultProblemType, assignParameterWithDefault, printExit, assignParameterRequired, defaultSolution, validParameters, print1
+from .Common import globalParameters, defaultProblemType, assignParameterWithDefault, printExit, assignParameterRequired, defaultSolution, validParameters, print2
 from .Common import validActivationFormats, validWeightFormats, validConvolutionConfig, validMFMA
 from copy import deepcopy
 import math
@@ -2119,7 +2119,7 @@ class Solution:
 
     ProblemType.assignDerivedParameters(state["ProblemType"])
     if not state["Valid"]:
-      print1("in assignDerivedParameters, state['Valid'] = False")
+      print2("in assignDerivedParameters, state['Valid'] = False")
       return
 
     # Init LoopIters parameter in case of early exit

--- a/Tensile/Tests/pre_checkin/sgemm_exact_dict.yaml
+++ b/Tensile/Tests/pre_checkin/sgemm_exact_dict.yaml
@@ -41,11 +41,10 @@ BenchmarkProblems:
           - Exact: {sizes: [31, 31, 2048, 64]}  # Exact dict with default strides
           - Exact: {sizes: [31, 31, 2048, 64], stridesA: [-1, -1, -1], stridesB: [-1, -1, -1], stridesC: [-1, -1, -1], stridesD: [-1, -1, -1] } # exact dict with explicitly specified default strides
           - Exact: [31, 31, 2048, 64] # classic format
-
-      # strideA/B/C/D format in GEMM context: [element_stride, ld, stride]
-      # for example
-      #   m=31, n=31, batch=2048, k=64,
-      #   lda=ldb=131072, ldc=ldd=31,
-      #   stride_a=stride_b=64, stride_c=stride_d=961
-      # is represented as
-      # - Exact: { sizes: [31, 31, 2048, 64], stridesA: [-1, 131072, 64], stridesB: [-1, 131072, 64], stridesC: [-1, 31, 961], stridesD: [-1, 31, 961] }
+          # strideA/B/C/D format in GEMM context: [element_stride, ld, stride]
+          # for example
+          #   m=31, n=31, batch=2048, k=64,
+          #   lda=ldb=131072, ldc=ldd=31,
+          #   stride_a=stride_b=64, stride_c=stride_d=961
+          # is represented as
+          - Exact: { sizes: [31, 31, 2048, 64], stridesA: [-1, 131072, 64], stridesB: [-1, 131072, 64], stridesC: [-1, 31, 961], stridesD: [-1, 31, 961] }

--- a/Tensile/Tests/pre_checkin/sgemm_exact_dict.yaml
+++ b/Tensile/Tests/pre_checkin/sgemm_exact_dict.yaml
@@ -41,3 +41,11 @@ BenchmarkProblems:
           - Exact: {sizes: [31, 31, 2048, 64]}  # Exact dict with default strides
           - Exact: {sizes: [31, 31, 2048, 64], stridesA: [-1, -1, -1], stridesB: [-1, -1, -1], stridesC: [-1, -1, -1], stridesD: [-1, -1, -1] } # exact dict with explicitly specified default strides
           - Exact: [31, 31, 2048, 64] # classic format
+
+      # strideA/B/C/D format in GEMM context: [element_stride, ld, stride]
+      # for example
+      #   m=31, n=31, batch=2048, k=64,
+      #   lda=ldb=131072, ldc=ldd=31,
+      #   stride_a=stride_b=64, stride_c=stride_d=961
+      # is represented as
+      # - Exact: { sizes: [31, 31, 2048, 64], stridesA: [-1, 131072, 64], stridesB: [-1, 131072, 64], stridesC: [-1, 31, 961], stridesD: [-1, 31, 961] }

--- a/Tensile/Tests/pre_checkin/sgemm_exact_dict.yaml
+++ b/Tensile/Tests/pre_checkin/sgemm_exact_dict.yaml
@@ -1,0 +1,43 @@
+GlobalParameters:
+  NumElementsToValidate: 16384
+  KernelTime: True
+  NewClient: 2
+
+BenchmarkProblems:
+  ########################################
+  # TN - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: s
+      TransposeA: True
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - ThreadTile:
+          - [ 4, 4 ]
+        - WorkGroup:
+          - [ 8, 8, 1 ]
+        - DepthU:
+          - 16
+        - VectorWidth: [2]
+        - LdsPadA: [4]
+        - LdsPadB: [4]
+        - PrefetchLocalRead: [0,1]
+        - PrefetchGlobalRead: [0,1]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: {sizes: [31, 31, 2048, 64]}  # Exact dict with default strides
+          - Exact: {sizes: [31, 31, 2048, 64], stridesA: [-1, -1, -1], stridesB: [-1, -1, -1], stridesC: [-1, -1, -1], stridesD: [-1, -1, -1] } # exact dict with explicitly specified default strides
+          - Exact: [31, 31, 2048, 64] # classic format

--- a/Tensile/YAMLIO.py
+++ b/Tensile/YAMLIO.py
@@ -77,7 +77,7 @@ def writeSolutions( filename, problemSizes, solutions ):
     stream.write("  - Range: %s\n" % sizeRange)
   for problemExact in problemSizes.exacts:
     #FIXME-problem, this ignores strides:
-    stream.write("  - Exact: %s\n" % list(problemExact.sizes))
+    stream.write("  - Exact: %s\n" % str(problemExact))
   yaml.dump(solutionStates, stream, default_flow_style=None)
   stream.close()
 


### PR DESCRIPTION
**Update May 18: remove draft status. Defer some of the tasks till next PR**

'Partial' means as far as solution library is concerned, it will treat the same 8-tuple gemm problem size descriptor (mnbk + ld's) as identical no matter how different their strides are.

Need discussion on how the strides information should conveyed in logic yaml (edit: exact dict format preferred) and benchmark csv. 


**To-dos**
* [ ] (Deferred) ~~library logic: both the logic parser and logic merge script should preserve LD & strides~~
* [ ] (Deffered) ~~write additional strides information in intermediate benchmark outputs (those CSV files)~~