### PR TITLE
Reduce VGPR count for MI kernels

### DIFF
--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -602,6 +602,16 @@ validParameters = {
     # If empty, do not use these instructions
     "MatrixInstruction":          validMatrixInstructions,
 
+    # Disable overlapping AB-tile vgpr and read/write addr vgprs with C-tile vgprs
+    # Valid only for MatrixInstruction enabled kernels, which by default overlaps
+    # C-tile w/ AB-tile until it's due for v_accvgpr_read before the writeback. Illustrated below:
+    # |<----------------------- valuC ----------------------->|
+    # |<--- valuA/B --->|<-- R/W pointers -->|xxx|<- Spares ->|
+    #                                          ^        ^
+    #         (Reserved by persistent kernels) ^        ^
+    #                       (Utilized by register pool) ^
+    "DisableVgprOverlapping":     [False, True],
+
     # If positive, each switch includes switches <= the specified switch.
     # For example 3 will enable NoPostLoop+NoGlobalRead+NoLocalWrite
     # If negative, setting is precise and will disable only the specified code piece.
@@ -887,6 +897,7 @@ defaultBenchmarkCommonParameters = [
     {"WorkGroupMapping":          [ 8 ] },
     {"ThreadTile":                [ [4,4] ] },
     {"MatrixInstruction":         [ [] ] },
+    {"DisableVgprOverlapping":    [ False ] },
     {"DisableAtomicFail":         [ 0 ] },
     {"DisableKernelPieces":       [ 0 ] },
     {"DepthU":                    [ -1 ] },

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -149,17 +149,18 @@ class RegisterPool:
     oldSize = len(self.pool)
     if newSize > oldSize:
       for i in range(0, newSize-oldSize):
-        self.pool.addInst(self.Register(self.statusUnAvailable,tag))
+        self.pool.append(self.Register(self.statusUnAvailable,tag))
     # mark as available
     for i in range(start, start+size):
       if self.pool[i].status == self.statusUnAvailable:
         self.pool[i].status = self.statusAvailable
+        self.pool[i].tag = tag
       elif self.pool[i].status == self.statusAvailable:
-        warn("RegisterPool::add(%u,%u) pool[%u] already available" % (start, size, i))
+        printWarning("RegisterPool::add(%u,%u) pool[%u](%s) already available" % (start, size, i, self.pool[i].tag))
       elif self.pool[i].status == self.statusInUse:
-        warn("RegisterPool::add(%u,%u) pool[%u] already in use" % (start, size, i))
+        printWarning("RegisterPool::add(%u,%u) pool[%u](%s) already in use" % (start, size, i, self.pool[i].tag))
       else:
-        raise RuntimeError("RegisterPool::add(%u,%u) pool[%u] = %s" % (start, size, i, self.pool[i].status))
+        raise RuntimeError("RegisterPool::add(%u,%u) pool[%u](%s) = %s" % (start, size, i, self.pool[i].tag, self.pool[i].status))
     if self.printRP:
       print(self.state())
   ########################################
@@ -178,11 +179,11 @@ class RegisterPool:
       if  self.pool[i].status == self.statusAvailable:
         self.pool[i].status = self.statusUnAvailable
       elif self.pool[i].status == self.statusUnAvailable:
-        printWarning("RegisterPool::remove(%u,%u) pool[%u] already unavailable" % (start, size, i))
+        printWarning("RegisterPool::remove(%u,%u) pool[%u](%s) already unavailable" % (start, size, i, self.pool[i].tag))
       elif  self.pool[i].status == self.statusInUse:
         printWarning("RegisterPool::remove(%u,%u) pool[%u](%s) still in use" % (start, size, i, self.pool[i].tag))
       else:
-        printExit("RegisterPool::remove(%u,%u) pool[%u] = %s" % (start, size, i, self.pool[i].status))
+        printExit("RegisterPool::remove(%u,%u) pool[%u](%s) = %s" % (start, size, i, self.pool[i].tag, self.pool[i].status))
 
   ########################################
   # Check Out

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -25,7 +25,6 @@ from .KernelWriter import KernelWriter
 from .SolutionStructs import isPackedIndex
 from .Utils import ceil_divide, roundUpToNearestMultiple
 
-from warnings import warn
 from math import log, ceil, trunc, modf
 from copy import deepcopy
 import collections

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -1388,7 +1388,7 @@ class KernelWriterAssembly(KernelWriter):
     vgprIdx = 0
 
     self.startVgprValuC = vgprIdx; vgprIdx += self.numVgprValuC
-    if kernel["MatrixInstruction"]:
+    if kernel["MatrixInstruction"] and not kernel["DisableVgprOverlapping"]:
       # MI kernels can overlap C-tile w/ AB-tile up until writeback. Illustrated below:
       # |<-------------- valuC -------------->|
       # |------------|-----------|xx|---------|
@@ -11453,8 +11453,6 @@ class KernelWriterAssembly(KernelWriter):
       #                             lastValuC ^
       kStr += self.comment("remove the rest of C-tile %u-%u from pool"%(self.startVgprReuse, self.startVgprValuC+self.numVgprValuC))
       self.vgprPool.remove(self.startVgprReuse, max(0, self.numVgprValuC-self.startVgprReuse), "ValuC")
-    else:
-      assert(False) # shouldn't be here 
 
     if kernel["MatrixInstM"] == 4:
       for i in range(0, kernel["MIOutputVectorWidth"] * kernel["MIWaveTile"][0] * kernel["MIWaveTile"][1]):

--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -2100,6 +2100,8 @@ class Solution:
     if "LoopUnroll" in state:
       state["LoopIters"] = state["LoopUnroll"]
 
+    if state["DisableVgprOverlapping"] is True and state["EnableMatrixInstruction"] is not True:
+      reject(state, "Non-MI kernels are already non-overlapping in pre-allocated registers")
 
     if state["EnableMatrixInstruction"]:
       if not (state["ProblemType"]["DataType"].isSingle() \

--- a/Tensile/Tests/pre_checkin/regression/persistent_kernel.yaml
+++ b/Tensile/Tests/pre_checkin/regression/persistent_kernel.yaml
@@ -1,0 +1,35 @@
+GlobalParameters:
+  NumElementsToValidate: 16384
+  DataInitTypeBeta: 2 # the bug is in the non-OptNLL code path of persitent kernel
+  NewClient: 2
+
+BenchmarkProblems:
+  - # sgemm NN
+    - # ProblemType
+      OperationType: GEMM
+      DataType: s
+      TransposeA: False
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Assembly
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - LoopTail: [True]
+        - EdgeType: ["ShiftPtr"]
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - GlobalSplitU: [1]
+        - ThreadTile:
+          - [ 4, 4 ] 
+        - WorkGroup:
+          - [ 8, 8, 1 ]
+        - DepthU: [8]
+        - PersistentKernel: [1,2]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [ 1872, 2000, 1, 128, 2000, 2000, 2000, 2000] # make sure each WG can run at least 2 MTs 

--- a/pytest.ini
+++ b/pytest.ini
@@ -16,6 +16,7 @@ markers =
  weekly: directory
  yaml_only: directory, all tests which simply run a YAML file.
  disabled: Disabled tests.
+ regression: directory; tests for some bug hotspots
 
  validate: All tests which validate the results.
  validateAll: All tests which validate all data points.


### PR DESCRIPTION
This patch reduces VGPR usage when MI kernel is enabled, through overlapping C-tile registers with AB-tile & RW pointers



`rocblas-test` run with success against this PR
```
Query device success: there are 1 devices
-------------------------------------------------------------------------------
Device ID 0 : Device ____
with ____ memory, clock rate ____ MHz @ computing capability ___
maxGridDimX 2147483647, sharedMemPerBlock 65.5 KB, maxThreadsPerBlock 1024, warpSize 64
-------------------------------------------------------------------------------
Note: Google Test filter = -*known_bug*
[==========] Running 1082902 tests from 491 test cases.
... 
[----------] Global test environment tear-down
[==========] 1082902 tests from 491 test cases ran. (19557158 ms total)
[  PASSED  ] 1082902 tests.
rocBLAS version: 2.23.0.2339-5b34ddf2
```

VGPR count before/after for selected kernels

Kernels (NT fp16) | This patch | Original
:-- | -- | --
MT128x256x32_IU1 | 141 | 197
MT128x256x32_IU2 | 141 | 213
MT128x256x32_IU4 | 181 | 245
MT64x128x32_IU1 | 48 | 69
MT64x128x32_IU2 | 61 | 77
MT64x128x32_IU4 | 93 | 93
MT64x128x64_IU1 | 72 | 93
MT64x128x64_IU2 | 85 | 101
MT64x128x64_IU4 | 117 | 117
MT64x128x64_IU8 | 181 | 181


Kernels (TN fp16) | This patch | Original
:-- | -- | --
MT128x256x32_IU1 | 141 | 175
MT128x256x32_IU2 | 141 | 191
MT128x256x32_IU4 | 141 | 223
MT64x128x32_IU1 | 45 | 59
MT64x128x32_IU2 | 46 | 67
MT64x128x32_IU4 | 62 | 83
MT64x128x64_IU1 | 50 | 71
MT64x128x64_IU2 | 58 | 79
MT64x128x64_IU4 | 74 | 95
MT64x128x64_IU8 | 106 | 127


