### PR TITLE
implement WaveSeperateGlobalRead feature

### DIFF
--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -271,6 +271,13 @@ validParameters = {
     "GlobalReadCoalesceVectorA":  [        True ], # FIXME =False worked before the vector refactor; fixing requires re-ordering load/store indices; but they aren't the faster option so not worth time right now
     "GlobalReadCoalesceVectorB":  [        True ],
 
+    # original global read to lds is interlace, [w0,w1,w2,w3,w0,w1,w2,w3,w0,w1,w2,w3,w0,w1,w2,w3]
+    # when WaveSeparateGlobalRead is enabled, LDS is divided to number of waves part.
+    # each wave load a block memory to lds,     [w0,w0,w0,w0,w1,w1,w1,w1,w2,w2,w2,w2,w3,w3,w3,w3]
+    # -1 is selected by logic, 0 disable, 1 enable.
+    "WaveSeparateGlobalReadA":    [ 0, 1 ],
+    "WaveSeparateGlobalReadB":    [ 0, 1 ],
+
     "PrefetchGlobalRead":         [ False, True ], # prefetch / double-buffer reads from global memory -> vgprs -> lds. Requires 2X LDS space, and VGPRs for buffering data on way into LDS
     "PrefetchLocalRead":          [ 0,1,2,3], # prefetch / double-buffer reads from lds (or 2 for triple-buffer, 3 for quad-buffer).  Increases size of ValuA/ValuB registers.
 
@@ -831,6 +838,8 @@ defaultBenchmarkCommonParameters = [
     {"LocalReadVectorWidth":      [ -1 ] },
     {"GlobalReadCoalesceVectorA": [ True ] },
     {"GlobalReadCoalesceVectorB": [ True ] },
+    {"WaveSeparateGlobalReadA":    [ 0 ] },
+    {"WaveSeparateGlobalReadB":    [ 0 ] },
     {"GlobalReadCoalesceGroupA":  [ True ] },
     {"GlobalReadCoalesceGroupB":  [ True ] },
     {"PrefetchGlobalRead":        [ True ] },


### PR DESCRIPTION
sync previous global memory pattern when transposeLDS is enabled.
This feature ask each wave to load separate region.
Original global read pattern is [w0,w1,w2,w3,w0,w1,w2,w3,w0,w1,w2,w3,w0,w1,w2,w3].
When this feature is enabled, read pattern becomes [w0,w0,w0,w0,w1,w1,w1,w1,w2,w2,w2,w2,w3,w3,w3,w3].