### PR TITLE
fix Old Client build error

### DIFF
--- a/Tensile/ClientWriter.py
+++ b/Tensile/ClientWriter.py
@@ -669,6 +669,7 @@ def writeClientParameters(forBenchmark, solutions, problemSizes, stepName, \
         solutionName = solutionWriter.getSolutionName(solution)
         h += "#include \"" + solutionName + ".h\"\n"
         h += "#include \"Solutions.h\"\n"
+    h += "#include \"ReferenceCPU.h\"\n"
     h += "\n"
   else:
     h += "#include \"Solutions.h\"\n"


### PR DESCRIPTION
ClientParameter.h miss to include referenceCPU header and cause build fail.