### PR TITLE
new feature StoreRemap to optimize MatrixInstruction store performance

### DIFF
--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -609,6 +609,21 @@ validParameters = {
     # If empty, do not use these instructions
     "MatrixInstruction":          validMatrixInstructions,
 
+    # StoreRemap: Optimize MatrixInstruction store patterns to enhance performance.
+    #             MI output data between each threads are along N dims.
+    #             But global memory is along M dim continous.
+    #             That mean global write between each threads are not continous.
+    #             Therefore, store performance for MI instruction is poor.
+    # How StoreRemap works in final store stage:
+    #             1. Put all thread output data into LDS.
+    #             2. All thread read data from LDS along M dims.
+    #                (match global Memory continous direction)
+    #             3. All thread write out data into global memory.
+    # 0:   Disable StoreRemap (default)
+    # 1~8: Enable StoreRemap and set the global write vector width
+    # Suggest optimum value: fp32 = [2,4], fp16 or bf16 = [4,8] (dwordx2 and dowrdx4)
+    "StoreRemapVectorWidth":      [0,1,2,4,8],
+
     # Disable overlapping AB-tile vgpr and read/write addr vgprs with C-tile vgprs
     # Valid only for MatrixInstruction enabled kernels, which by default overlaps
     # C-tile w/ AB-tile until it's due for v_accvgpr_read before the writeback. Illustrated below:
@@ -919,6 +934,7 @@ defaultBenchmarkCommonParameters = [
     {"ReplacementKernel":         [ False ] },
     {"MinVgprNumber":             [0]},
     {"MaxVgprNumber":             [256]},
+    {"StoreRemapVectorWidth":     [ 0 ] },
     ]
 # benchmark these solution independently
 defaultForkParameters = []

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -6413,7 +6413,10 @@ class KernelWriterAssembly(KernelWriter):
         # TODO - maybe this should be encapulated in the SS setup code
         tmpSgpr = self.getTmpSgpr(2).idx()
         if ss.optSingleColVgpr:
-          tmpVgpr= None # don't need tmps for other uses?
+          if not kernel["StoreRemapVectorWidth"]:
+            tmpVgpr= None # don't need tmps for other uses?
+          else:
+            tmpVgpr= self.vgprPool.checkOut(1, "NLL store remap tmps")
         else:
           tmpVgpr= self.vgprPool.checkOut(3, "NLL address tmps")
         assert(len(kernel["PackedC1IndicesX"]) == 1)
@@ -6438,6 +6441,22 @@ class KernelWriterAssembly(KernelWriter):
 
         for elementIdx in range(0, len(elements)):
           kStr += self.comment("store element %d : %s" % (elementIdx, str(elements[elementIdx])))
+          addrCalc = ss.elementAddr[elementIdx]
+          sumIdx = ss.elementSumIdx[elementIdx]
+
+          if kernel["StoreRemapVectorWidth"] and elementIdx == 0:
+            self.storeRemapStartSumIdx = sumIdx
+
+          if ss.optSrdIncForRow and addrCalc.rowInc and kernel["StoreRemapVectorWidth"]:
+            kStr += self.comment("StoreRemap: handle local read and global write")
+            self.storeRemapEndSumIdx = sumIdx
+            kStr += self.storeRemapAddStore(kernel, ss, addrCalc, tmpVgpr, tmpSgpr, edge=False)
+            kStr += addrCalc.incrementToNextRow(kernel, "D", ss, tmpSgpr)
+            kStr += inst("v_mov_b32", vgpr(tmpVgpr), addrCalc.rowInc, "set shift rows")
+            kStr += inst("v_add_u32", vgpr(self.storeRemapCoord1), vgpr(self.storeRemapCoord1), vgpr(tmpVgpr), \
+                "shift storeRemap coord1")
+            self.storeRemapStartSumIdx = sumIdx
+
           # pack stores, beta and non-beta reach here:
           for vi in range(0, fullVw):
             sumIdxV = ss.elementSumIdx[elementIdx] + vi
@@ -6459,12 +6478,17 @@ class KernelWriterAssembly(KernelWriter):
                 d = ss.elementSumIdx[elementIdx] + vi//2
                 kStr += inst("v_and_or_b32", vgpr(d), vgpr("ValuC+%u"%sumIdxV), vgpr(vgprBf16Mask), vgpr("ValuC+%u"%(sumIdxV-1)), "pack two bf16 to dword")
 
-          addrCalc = ss.elementAddr[elementIdx]
-          sumIdx = ss.elementSumIdx[elementIdx]
-
           kStr += addrCalc.emitAddressSetupCode(kernel, ss, tmpVgpr01=tmpVgpr, tmpS01=tmpSgpr, \
                               edge=False, beta=False, atomic=False, mask=None, elementIdx=elementIdx)
-          kStr += self.addStore(kernel, ss, addrCalc, sumIdx, tmpSgpr, edge=False)
+
+          if not kernel["StoreRemapVectorWidth"]:
+            kStr += self.addStore(kernel, ss, addrCalc, sumIdx, tmpSgpr, edge=False)
+          else:
+            kStr += self.storeRemapAddLocalWrite(kernel, ss, addrCalc, sumIdx)
+            if elementIdx == (len(elements)-1):
+              kStr += self.comment("StoreRemap: last local read and global write")
+              self.storeRemapEndSumIdx = sumIdx+fullVw
+              kStr += self.storeRemapAddStore(kernel, ss, addrCalc, tmpVgpr, tmpSgpr, edge=False)
 
         if kernel["ProblemType"]["DataType"].isBFloat16() and kernel["ProblemType"]["HighPrecisionAccumulate"]:
           self.vgprPool.checkIn(vgprBf16Temp)
@@ -8850,6 +8874,13 @@ class KernelWriterAssembly(KernelWriter):
     self.vgprPool.checkIn(tmpVgpr0)
     self.vgprPool.checkIn(wave_id)
 
+    # StoreRemap: calculate
+    # 1. local read address
+    # 2. local write address
+    # 3. global write coord0 and coord1
+    if kernel["StoreRemapVectorWidth"]:
+      kStr += self.storeRemapComputeStoreVgprs(kernel)
+
     self.coord0 = tid0
     self.coord1 = tid1
 
@@ -8984,6 +9015,12 @@ class KernelWriterAssembly(KernelWriter):
     self.vgprPool.checkIn(self.coord0)
     self.vgprPool.checkIn(self.coord1)
 
+    if kernel["StoreRemapVectorWidth"]:
+      self.vgprPool.checkIn(self.storeRemapLW)
+      self.vgprPool.checkIn(self.storeRemapLR)
+      self.vgprPool.checkIn(self.storeRemapCoord0)
+      self.vgprPool.checkIn(self.storeRemapCoord1)
+      self.vgprPool.checkIn(self.storeRemapOffsetCoord1)
     if kernel["BufferStore"]:
       self.vgprPool.checkIn(self.cinRowPtr)
       if not kernel["LdcEqualsLdd"]:
@@ -9048,7 +9085,7 @@ class KernelWriterAssembly(KernelWriter):
     elements    = []
     vectorwidth = 0
 
-    if edge:
+    if edge and not kernel["StoreRemapVectorWidth"]:
       vectorwidth = kernel["StoreVectorWidth"] if kernel["_VectorStore"] else 1
       vectorwidth = min(vectorwidth, self.maxGwvw(kernel), kernel["AssertFree0ElementMultiple"])
     else:
@@ -9085,6 +9122,267 @@ class KernelWriterAssembly(KernelWriter):
         return self.notLocalFullTileElementsMFMA(kernel, edge)
     else:
         return self.notLocalFullTileElementsVALU(kernel, edge)
+  ##############################################################################
+  # Store Remap: Local Write
+  ##############################################################################
+  def storeRemapAddLocalWrite(self, kernel, ss, addrCalc, sumIdx):
+    """
+    Add localWrite for the element with addrCalc and sumIdx.
+    """
+    kStr = ""
+
+    bps = kernel["ProblemType"]["DataType"].numBytes() * ss.cfg.gwvw
+    rpv = kernel["ProblemType"]["DataType"].numRegisters() * ss.cfg.gwvw
+
+    addr0 = vgpr(self.storeRemapLW)
+    offset =  addrCalc.globalOffset
+
+    # only consider store with vector4
+    # bps==8 is for bf16 and fp16
+    # bps==16 is for fp32
+    if bps==8:
+      kStr += inst("ds_write_b64", addr0, vgpr(sumIdx, rpv), \
+                 "offset:%u"%offset, "storeRemap lw")
+    elif bps==16:
+      kStr += inst("ds_write_b128", addr0, vgpr(sumIdx, rpv), \
+                 "offset:%u"%offset, "storeRemap lw")
+    else:
+       assert ("StoreRemap: bad bps! only support vector4 local write")
+
+    return kStr
+
+  ##############################################################################
+  # Store Remap: Local Read and Global Write
+  ##############################################################################
+  def storeRemapAddStore(self, kernel, ss, addrCalc, tmpVgpr, tmpS01, edge):
+    kStr = ""
+
+    kStr += inst("s_waitcnt", "lgkmcnt(0)", "wait for LDS write" )
+    kStr += "\n"
+
+    gwvw = kernel["StoreRemapVectorWidth"]
+    startIdx = self.storeRemapStartSumIdx
+    endIdx = self.storeRemapEndSumIdx
+    bpe = kernel["ProblemType"]["DataType"].numBytes()
+    bps = kernel["ProblemType"]["DataType"].numBytes() * gwvw
+    rpe = kernel["ProblemType"]["DataType"].numRegisters()
+    rpv = kernel["ProblemType"]["DataType"].numRegisters() * gwvw
+
+    src = vgpr(self.storeRemapLR)
+    for i in range (startIdx, endIdx, gwvw):
+      offset = self.storeRemapLrOffset * kernel["ProblemType"]["DataType"].numBytes() \
+          * ((i-startIdx)//gwvw)
+      dst = vgpr((i-startIdx), rpv)
+      if bps==4:
+        kStr += inst("ds_read_b32", dst, src, "offset:%u"%offset, "storeRemap lr")
+      elif bps==8:
+        kStr += inst("ds_read_b64", dst, src, "offset:%u"%offset, "storeRemap lr")
+      elif bps==16:
+        kStr += inst("ds_read_b128", dst, src, "offset:%u"%offset, "storeRemap lr")
+
+    kStr += "\n"
+
+    # Global Write
+    ntStr = ""
+    if kernel["NonTemporalC"]%2==1:
+      ntStr += " glc"
+    if kernel["NonTemporalC"]//2==1:
+      ntStr += " slc"
+
+    addr1 = sgpr("SrdD", 4)
+    packedC1 = kernel["PackedC1IndicesX"]
+    strideC1 = "StrideC%s" % (self.indexChars[packedC1[0]])
+
+    vTmp = self.vgprPool.checkOut(1, "SR Store temp addr0")
+    addr0 = vgpr(vTmp)
+
+    if not edge:
+      for i in range (startIdx, endIdx, gwvw):
+        if i == startIdx:
+          kStr += inst("v_mov_b32", addr0, vgpr(self.storeRemapOffsetCoord1), "coord1")
+        else:
+          currentStep = (i-startIdx)//gwvw
+          kStr += inst("v_add_u32", addr0, vgpr(self.storeRemapOffsetCoord1), self.storeRemapNCPL * currentStep , "coord1 += nColPerLoad")
+
+        kStr += inst("v_mul_lo_u32", addr0, addr0, sgpr(strideC1), "coord1 offset =  coord1 * StrideC")
+        kStr += inst("_v_add_lshl_u32", addr0, addr0,  vgpr(self.storeRemapCoord0), hex(log2(bpe)), "global write C address")
+
+        lgkmcnt = min((endIdx-i)//gwvw - 1, 15)
+        kStr += inst("s_waitcnt", "lgkmcnt(%u)"% lgkmcnt, "wait for LDS read" )
+
+        kStr += self.chooseGlobalWrite(True, bps, (i-startIdx), rpv, addr0, addr1, 0, ntStr)
+    else:
+      tmpS23 = tmpS01+2
+      coord0 = tmpVgpr
+      coord1 = coord0+1
+      for i in range (startIdx, endIdx, gwvw):
+        for vi in range (0,gwvw):
+
+          if vi == 0:
+            lgkmcnt = min((endIdx-i)//gwvw - 1, 15)
+            kStr += inst("s_waitcnt", "lgkmcnt(%u)"% lgkmcnt, "wait for LDS read" )
+
+          sizeBoundary = [0,0]
+          sizeBoundary[0] = \
+              sgpr("PackedSize0") if len(kernel["PackedC0IndicesX"]) > 1 \
+              else self.sizeRef(kernel["ProblemType"]["Index0"])
+          sizeBoundary[1] = \
+              sgpr("PackedSize1") if len(kernel["PackedC1IndicesX"]) > 1 \
+              else self.sizeRef(kernel["ProblemType"]["Index1"])
+          currentStep = (i-startIdx)//gwvw
+
+          # calculate global coordination
+          kStr += inst("v_add_u32", vgpr(coord1), vgpr(self.storeRemapCoord1), self.storeRemapNCPL * currentStep , "coord1 += nColPerLoad")
+          kStr += inst("v_add_u32",vgpr(coord0), vgpr(self.storeRemapCoord0), vi , "coord0 += element index of storeVector")
+          kStr += inst("v_add_u32", addr0, vgpr(self.storeRemapOffsetCoord1), self.storeRemapNCPL * currentStep , \
+                        "offset coord1 += nColPerLoad")
+
+          kStr += inst("v_cmp_lt_u32",  sgpr(tmpS01,2), vgpr(coord0), sizeBoundary[0], "coord0 < size0" )
+          kStr += inst("v_cmp_lt_u32",  sgpr(tmpS23,2), vgpr(coord1), sizeBoundary[1], "coord1 < size1" )
+          kStr += inst("s_and_b64",  sgpr(tmpS23,2), sgpr(tmpS01,2), sgpr(tmpS23,2), "in0 && in1" )
+
+          kStr += inst("v_mul_lo_u32", addr0, addr0, sgpr(strideC1), "coord1 element offset =  coord1 * StrideC")
+          kStr += inst("_v_add_lshl_u32", addr0, addr0,  vgpr(coord0), hex(log2(bpe)), "scale to BPE")
+          kStr += inst("v_cndmask_b32", addr0, -1, addr0, sgpr(tmpS23,2), "clip if OOB. offset" )
+
+          sumIdx = (i-startIdx)+ int(vi*rpe)
+          kStr += self.chooseGlobalWrite(True, bpe, sumIdx, rpe, addr0, addr1, 0, ntStr, hi16=vi%2)
+
+    kStr += "\n"
+    self.vgprPool.checkIn(vTmp)
+
+    return kStr
+
+  ##############################################################################
+  # Store remap compute vgprs:
+  ##############################################################################
+  def storeRemapComputeStoreVgprs(self, kernel):
+    kStr = ""
+    kStr += self.comment1("Store Remap Local Write adderss")
+
+    tmpS0 = self.getTmpSgpr(2).idx()
+    wgMT1 = tmpS0+1
+
+    wg0="WorkGroup0"
+    wg1="WorkGroup1"
+
+    tid0 = self.vgprPool.checkOut(1, "SR coord0")
+    tid1 = self.vgprPool.checkOut(1, "SR coord1")
+    coord1Offset = self.vgprPool.checkOut(1, "SR coord1 offset")
+    storeRemapLW = self.vgprPool.checkOut(1, "SR local write")
+    storeRemapLR = self.vgprPool.checkOut(1, "SR local read")
+
+    tmpV0 = self.vgprPool.checkOut(5, "tmpV0")
+    tmpV1 = tmpV0+1
+    ldsStride = tmpV0+2
+    coord0 = tmpV0+3
+    waveCoord1 = tmpV0+4
+
+    gwvw = kernel["StoreRemapVectorWidth"]
+    ldsPad = max(kernel["StoreRemapVectorWidth"],kernel["MIOutputVectorWidth"])
+
+    #calculate local write Address: v[vgprLocalWriteAddrC]
+    kStr += vectorStaticDivideAndRemainder(tid1, tid0, "Serial", globalParameters["WavefrontWidth"], \
+      tmpV0, tmpS0)
+
+    kStr += inst("v_mul_lo_u32", vgpr(waveCoord1),
+                  hex(kernel["MatrixInstN"]), vgpr(tid1), "coord1 offset of LDS for each Wave")
+    kStr += inst("v_and_b32", vgpr(tid1),
+                  hex(kernel["MatrixInstN"]-1), vgpr("Serial"), "coord1 offset of LDS for each thread")
+    kStr += inst("v_add_u32", vgpr(tid1), vgpr(waveCoord1),vgpr(tid1),"coord1 offset in MacroTile")
+    kStr += inst("v_mov_b32", vgpr(ldsStride), hex(kernel["MacroTile0"]+ldsPad), \
+                    "lds stride = MT0 + PAD")
+    kStr += inst("v_mul_lo_u32", vgpr(tmpV0), vgpr(tid1), vgpr(ldsStride), \
+                  "lds coord1 offset = Col-id* lds stride")
+    kStr += inst("v_lshrrev_b32", vgpr(coord0),
+                hex(log2(kernel["MatrixInstM"])), vgpr(tid0), \
+                "tid / matrixInstM")
+    kStr += inst("v_lshlrev_b32", vgpr(coord0), hex(log2(kernel["MIOutputVectorWidth"])), vgpr(coord0), \
+                  "lds coord0 offset *= 4 (each thread hold 4 element)")
+
+    kStr += inst("_v_add_lshl_u32", \
+      vgpr(storeRemapLW), \
+      vgpr(tmpV0), \
+      vgpr(coord0), \
+      hex(log2(self.bpeCexternal)), \
+      "local write C address")
+
+    kStr += "\n"
+    # calculate local read address : v[vgprLocalReadAddrC]
+
+    kStr += self.comment1("Store Remap Local Read address")
+    nThreadPerCol = kernel["MacroTile0"] // gwvw
+    nColPerLoad = globalParameters["WavefrontWidth"] // nThreadPerCol
+    self.storeRemapLrOffset = (kernel["MacroTile0"]+ldsPad) * nColPerLoad
+    self.storeRemapNCPL = nColPerLoad
+    kStr += inst("v_lshrrev_b32", vgpr(tid1),\
+                hex(log2(nThreadPerCol)), vgpr(tid0), \
+                "tid / nThreadPerCol")
+    kStr += inst("v_add_u32", vgpr(coord1Offset), vgpr(waveCoord1),vgpr(tid1),"coord1 offset in MacroTile")
+    kStr += inst("v_mov_b32", vgpr(ldsStride), hex(kernel["MacroTile0"]+ldsPad), \
+                    "lds stride = MT0 + PAD")
+    kStr += inst("v_mul_lo_u32", vgpr(tmpV0), vgpr(coord1Offset), vgpr(ldsStride), \
+                  "lds coord1 offset = Col-id* lds stride")
+
+    kStr += inst("v_and_b32", vgpr(coord0),
+                  hex(nThreadPerCol-1), vgpr(tid0), "coord0 offset of LDS for each thread")
+    kStr += inst("v_lshlrev_b32", vgpr(coord0), hex(log2(gwvw)), vgpr(coord0), \
+                  "lds coord0 offset *= gwvw (each thread hold gwvw element)")
+
+    kStr += inst("_v_add_lshl_u32", \
+      vgpr(storeRemapLR), \
+      vgpr(tmpV0), \
+      vgpr(coord0), \
+      hex(log2(self.bpeCexternal)), \
+      "local read C address")
+    kStr += "\n"
+
+    # calculate global write coord0 and coord1
+    kStr += self.comment1("Store Remap global write coord0 and coord1")
+    kStr += vectorStaticDivideAndRemainder(waveCoord1, tmpV1, "Serial", globalParameters["WavefrontWidth"], \
+      tmpV0, tmpS0)
+
+    ColsPerWave = kernel["MatrixInstN"] * kernel["MatrixInstBN"]
+    kStr += inst("v_mul_lo_u32", vgpr(waveCoord1),
+                  hex(ColsPerWave), vgpr(waveCoord1), "coord1 offset of global memory for each Wave")
+    kStr += inst("v_lshrrev_b32", vgpr(tmpV1),\
+                hex(log2(nThreadPerCol)), vgpr(tmpV1), \
+                "tid / nThreadPerCol")
+    kStr += inst("v_add_u32", vgpr(coord1Offset), vgpr(waveCoord1),vgpr(tmpV1),"coord1 offset in MacroTile")
+
+    kStr += inst("s_mul_i32", \
+        sgpr(tmpS0), \
+        hex(kernel["MacroTile0"]), \
+        sgpr(wg0), \
+        "%s = wg0*MT0"%sgpr(tmpS0))
+
+    kStr += inst("v_add_co_u32", vgpr(tid0), "vcc", sgpr(tmpS0), vgpr(coord0), "coord0 = coord0 + wg0 * MT0")
+
+    kStr += inst("s_mul_i32", \
+        sgpr(wgMT1), \
+        "MT1", \
+        sgpr(wg1), \
+        "<- wg1*MT1")
+    kStr += inst("_v_add_co_u32", \
+        vgpr(tid1), \
+        "vcc", \
+        sgpr(wgMT1), \
+        vgpr(coord1Offset), \
+        "coord1 = tid1*VW + wg1*MT1")
+
+    kStr += "\n"
+
+    kStr += self.syncThreads(kernel, "StoreRemap Start")
+
+    self.storeRemapLW = storeRemapLW  #local write
+    self.storeRemapLR = storeRemapLR  #local read
+    self.storeRemapCoord0 = tid0      #global coord0
+    self.storeRemapCoord1 = tid1      #global coord1
+    self.storeRemapOffsetCoord1 = coord1Offset #offset coord1
+
+    self.vgprPool.checkIn(tmpV0)
+
+    return kStr
 
 
   ##############################################################################
@@ -9262,6 +9560,10 @@ class KernelWriterAssembly(KernelWriter):
 
         if not atomic and len(kernel["PackedC1IndicesX"]) == 1:
           self.optSrdIncForRow = 1
+
+      if kernel["StoreRemapVectorWidth"]:
+        self.optSingleColVgpr = 1
+        self.optSrdIncForRow = 1
 
       if kernel["ProblemType"]["UseInitialStridesCD"]:
         self.optSingleColVgpr = 0 # BOZO, hack to disable this
@@ -9523,6 +9825,17 @@ class KernelWriterAssembly(KernelWriter):
           % (d1,vc1,d0,vc0))
       if ss.optSingleColVgpr:
         self.coord0Vgpr = kw.coord0
+        # StoreRemap: even in SignalColVgpr, increasing coord1 is neccesary for shiftPtr correction
+        if kernel["StoreRemapVectorWidth"] and edge and self.newCoord1 and self.rowInc:
+          if self.rowInc <= 64:
+            kStr += inst("_v_add_co_u32", vgpr(self.coord1Vgpr), "vcc", \
+                      vgpr(self.kernelWriter.coord1), self.rowInc, \
+                      "coord1.1: coord1Vgpr += d1*sg1*VW + vc1")
+          else:
+            kStr += inst("s_mov_b32", sgpr(tmpS01), self.rowInc, "rowInc d1=%u vc1=%u"%(d0, vc0))
+            kStr += inst("_v_add_co_u32", vgpr(self.coord1Vgpr), "vcc", \
+                      vgpr(self.kernelWriter.coord1), sgpr(tmpS01), \
+                      "coord1.2: coord1 += d1*sg1*VW + vc1")
       elif not ss.optSharedColVgpr or (d1 == vc1 == 0):
         # not share mode or first row always does the address calc math:
 
@@ -9759,16 +10072,24 @@ class KernelWriterAssembly(KernelWriter):
           kStr += inst("v_sub_i32", vgpr(vTmp2), vgpr(vTmp1), vgpr(self.coord1Vgpr), "shift how many column")
           kStr += inst("v_cndmask_b32", vgpr(self.coord1Vgpr), vgpr(self.coord1Vgpr), vgpr(vTmp1), \
                         sgpr(sTmp1,2), "set new coord1 if meet conditions" )
-          kStr += inst("v_mul_i32_i24", vgpr(vTmp2), vgpr(vTmp2), sgpr(strideC1), "shift column *  StridesC")
-          kStr += inst("v_add_i32", vgpr(vTmp1), vgpr(kw.cinRowPtr), vgpr(vTmp2), "new rowStart address")
+          kStr += inst("v_mad_i32_i24", vgpr(vTmp1), sgpr(strideC1), vgpr(vTmp2), vgpr(kw.cinRowPtr), \
+                      "new rowStart address += shift column * StridesC")
           kStr += inst("v_cndmask_b32", vgpr(kw.cinRowPtr), vgpr(kw.cinRowPtr), vgpr(vTmp1), \
                         sgpr(sTmp1,2), "set new rowStart if meet conditions" )
+          if kernel["StoreRemapVectorWidth"]:
+            ldsPad = max(kernel["StoreRemapVectorWidth"],kernel["MIOutputVectorWidth"])
+            kStr += inst("v_mov_b32", vgpr(vTmp1), hex((kernel["MacroTile0"]+ldsPad)*kw.bpeCexternal), \
+                        "lds byte stride = (MT0 + PAD) * bpe")
+            kStr += inst("v_mad_i32_i24", vgpr(vTmp1), vgpr(vTmp1), vgpr(vTmp2), vgpr(kw.storeRemapLW), \
+                        "new lds write address += shift column * Lds byte Stride")
+            kStr += inst("v_cndmask_b32", vgpr(kw.storeRemapLW), vgpr(kw.storeRemapLW), vgpr(vTmp1), \
+                          sgpr(sTmp1,2), "set new rowStart if meet conditions" )
           kStr += "\n"
 
 
       # Now do the edge check and compute the address in bytes:
       if kernel["BufferStore"]:
-        if edge:
+        if edge and not kernel["StoreRemapVectorWidth"]:
           # Set address to -1 if OOB on either dimension
           # and only check the x/coord0 index here, save a couple inst
           sizeBoundary = [0,0]
@@ -10184,6 +10505,16 @@ class KernelWriterAssembly(KernelWriter):
           firstRow = [e for e in elements[edgeI] if e[0]==0 and e[2]==0]
           numElementsPerBatch=min(len(firstRow),numElementsPerBatch)
 
+        # hack to avoid modifing local write address across rows to support shiftPtr in storeRemap
+        if kernel["StoreRemapVectorWidth"] and edge and not kernel["GuaranteeNoPartialB"] and self.readTileDimVectorB:
+          firstRow = [e for e in elements[edgeI] if e[0]==0 and e[2]==0]
+          # find the largest factor and smaller than numElementPerBatch
+          for d in range(1, len(firstRow)+1):
+            largestFactor = len(firstRow)//d
+            if len(firstRow)%d == 0 and largestFactor <= numElementsPerBatch:
+              numElementsPerBatch = largestFactor
+              break
+
         # if no atomics and no edge, then write whole vectors
         #if not atomic and not edge:
         #  numVectorsPerBatch = numElementsPerBatch / kernel["GlobalWriteVectorWidth"]
@@ -10215,12 +10546,20 @@ class KernelWriterAssembly(KernelWriter):
           # elementVgprs can be large and should be perfectly tuned to the number of available
           # VGPRS.  We do not want to accidentally overflow and grow the pool here:
 
+          if kernel["StoreRemapVectorWidth"]:
+            #Indication if this batch last batch
+            self.StoreRemapLastBatch = 1 if batchIdx == (numBatches-1) else 0
+            #Reset Start Sum index when first batch
+            if batchIdx == 0:
+              self.storeRemapStartSumIdx = 0
+
           kStr += self.globalWriteBatch(kernel, self.ss, batchIdx, beta, edge, atomic, gwvw, atomicW, \
               elementsThisBatch, self.coord0, self.coord1, self.addrD, self.addrC, \
               tmpVgpr, \
               elementSgprs, tmpSgpr)
         # TODO - if this is the last tile, don't need to jump to next instruction
         kStr += inst("s_branch", "label_%04u"%endLabel, "jump to end")
+        del self.ss
 
     # End label
     kStr += "label_%04u:%s"%(endLabel, self.endLine)
@@ -10901,11 +11240,24 @@ class KernelWriterAssembly(KernelWriter):
         element = batchElements[elementIdx]
         addr = ss.elementAddr[elementIdx].addrVgpr
         mask = ss.elementMask[elementIdx]
+        addrCalc = ss.elementAddr[elementIdx]
         d1 = element[0]
         d0 = element[1]
         vc1 = element[2]
         vc0 = element[3]
         sumIdx = ss.elementSumIdx[elementIdx]
+
+        # Already write wave column block into LDS
+        # Now read lds data back to registers and write to global memroy
+        if ss.optSrdIncForRow and addrCalc.rowInc and kernel["StoreRemapVectorWidth"] > 0:
+          kStr += self.comment("StoreRemap: process local read and global write")
+          self.storeRemapEndSumIdx = sumIdx
+          kStr += self.storeRemapAddStore(kernel, ss, addrCalc, tmpVgpr, tmpS01, edge)
+          kStr += addrCalc.incrementToNextRow(kernel, "D", ss, tmpS01)
+          kStr += inst("v_mov_b32", vgpr(tmpVgpr), addrCalc.rowInc, "set shift rows")
+          kStr += inst("v_add_u32", vgpr(self.storeRemapCoord1), vgpr(self.storeRemapCoord1), vgpr(tmpVgpr), "shift storeRemap coord1")
+          self.storeRemapStartSumIdx = sumIdx
+          storesIssued += 1
 
         # apply in-bounds exec mask
         if edge and not kernel["BufferStore"]:
@@ -10961,7 +11313,6 @@ class KernelWriterAssembly(KernelWriter):
                 # src0 = beta = f32 = opsel 00
                 # src1 = dataV = f16.lo = opsel 10 or 11 depending on even/odd
                 # src2 = sumIdxV = f32 = opsel 00
-                tmpVgpr = self.vgprPool.checkOut(1)
                 dataCExternal = ss.elementData[elementIdx] + vi//2
                 if (vi%2) == 1:
                   kStr += inst("v_and_b32", vgpr(tmpVgpr), vgpr(dataCExternal), vgpr(vgprBf16Mask), "convert bf16 to fp32")
@@ -10969,7 +11320,6 @@ class KernelWriterAssembly(KernelWriter):
                   kStr += inst("v_lshlrev_b32", vgpr(tmpVgpr), "16", vgpr(dataCExternal), "convert bf16 to fp32" )
                 kStr += inst("v_mac_f32", vgpr("ValuC+%u"%sumIdxV), vgpr(tmpVgpr), sgpr("Beta"), \
                     "finalSum = sum*alpha + C*beta")
-                self.vgprPool.checkIn(tmpVgpr)
 
             elif kernel["ProblemType"]["DataType"].isSingle():
               kStr += inst("v_mac_f32", vgpr("ValuC+%u"%sumIdxV), vgpr(dataV+0), sgpr("Beta"), \
@@ -11032,9 +11382,17 @@ class KernelWriterAssembly(KernelWriter):
                 d = ss.elementSumIdx[elementIdx] + vi//2
                 kStr += inst("v_and_or_b32", vgpr(d), vgpr("ValuC+%u"%sumIdxV), vgpr(vgprBf16Mask), vgpr("ValuC+%u"%(sumIdxV-1)), "pack two bf16 to dword")
 
-        addrCalc = ss.elementAddr[elementIdx]
-        kStr += self.addStore(kernel, ss, addrCalc, sumIdx, tmpS01, edge)
-        storesIssued += 1
+        if not kernel["StoreRemapVectorWidth"]:
+          kStr += self.addStore(kernel, ss, addrCalc, sumIdx, tmpS01, edge)
+          storesIssued += 1
+        else:
+          kStr += self.storeRemapAddLocalWrite(kernel, ss, addrCalc, sumIdx)
+          # Handle last wave column block
+          if self.StoreRemapLastBatch == 1 and (elementIdx == len(batchElements)-1):
+            kStr += self.comment("last local read and global write")
+            self.storeRemapEndSumIdx = sumIdx+gwvw
+            kStr += self.storeRemapAddStore(kernel, ss, addrCalc, tmpVgpr, tmpS01, edge)
+            storesIssued += 1
 
       if kernel["ProblemType"]["DataType"].isBFloat16() and kernel["ProblemType"]["HighPrecisionAccumulate"]:
         self.vgprPool.checkIn(vgprBf16Temp)

--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -2736,6 +2736,40 @@ class Solution:
 
     # lds size is the greater of the two
     ldsNumElements = max(ldsNumElementsAB, ldsNumElementsReduction, ldsNumElementsOccupancy)
+
+    #check not support cases and calculate lds resources
+    if state["StoreRemapVectorWidth"]:
+      if not state["EnableMatrixInstruction"]:
+        reject(state, "storeRemap only support MaxtrixInstruction kernel")
+      if state["PersistentKernel"]:
+        reject(state, "storeRemap doesn't support persist kernel yet")
+      if state["GlobalSplitU"] > 1:
+        reject(state, "storeRemap doesn't support GlobalSplitU yet")
+      if packedC0 or packedC1:
+        reject(state, "storeRemap doesn't support packedC0 and packedC1 yet")
+      if state["MIWaveGroup"][0] > 1:
+        reject(state, "storeRemap doesn't support MI wave group in M direction yet")
+      if state["MatrixInstBN"] > 1 and state["MatrixInstN"] == 4:
+        reject(state, "storeRemap doesn't support MI4x4 multi blocks in N direction yet")
+
+      srMinVw = 1
+      srMaxVw = 8
+      if state["ProblemType"]["DataType"].isSingle():
+        srMaxVw = 4
+      elif state["ProblemType"]["DataType"].isHalf() or state["ProblemType"]["DataType"].isBFloat16():
+        srMinVw = 2
+      if srMinVw > state["StoreRemapVectorWidth"] or srMaxVw < state["StoreRemapVectorWidth"]:
+        reject(state, "StoreRemapVectorWidth %u is not allowed for this data type" % state["StoreRemapVectorWidth"])
+
+      if state["MacroTile0"]*state["MatrixInstN"] < state["StoreRemapVectorWidth"]*globalParameters["WavefrontWidth"]:
+        reject(state, "storeRemap: number of lds elements less than per wave local read elements. Please use smaller StoreRemapVectorWidth")
+      wavefronts = state["NumThreads"] // globalParameters["WavefrontWidth"]
+      ldsRemapPad = max(state["StoreRemapVectorWidth"],state["MIOutputVectorWidth"])
+      ldsNumElementsPerWave = (state["MacroTile0"]+ldsRemapPad)* state["MatrixInstN"]
+      ldsNumElementsRemapC = ldsNumElementsPerWave * wavefronts
+      #print("ldsNumElementsRemapC=%u" % ldsNumElementsRemapC)
+      ldsNumElements = max(ldsNumElements, ldsNumElementsRemapC)
+
     state["LdsNumElements"] = ldsNumElements
     ldsSize = ldsNumElements * state["ProblemType"]["DataType"].numBytes()
     if ldsSize > globalParameters["MaxLDS"]:


### PR DESCRIPTION
This new feature is used to optimize MatrixInstruction store patterns to enhance performance.
MI output data between each threads are along N dims. But global memory is along M dim continous. That mean global write between each threads are not continous. Therefore, store performance for MI instruction is poor.

How StoreRemap works in final store stage:
1. Put all thread output data into LDS.
2. All thread read data from LDS along M dims. (match global Memory continous direction)
3. All thread write out data into global memory.

"StoreRemapVectorWidth":      [0,1,2,4,8]
0:   Disable StoreRemap (default)
1~8: Enable StoreRemap and set the global write vector width

