### PR TITLE
Fix kernel segfaults using staggerU with tensor sizes > 2^32

### DIFF
--- a/Tensile/Contractions.py
+++ b/Tensile/Contractions.py
@@ -229,7 +229,7 @@ class ProblemType:
         if includeOperation:
             predicates.append(ProblemPredicate("OperationIdentifierEqual", value=self.operationIdentifier))
             if not self.useBeta:
-                predicates.append(ProblemPredicate("BetaZero"));
+                predicates.append(ProblemPredicate("BetaZero"))
 
         if includeType:
             predicates.append(ProblemPredicate("TypesEqual", value=(self.aType, self.bType, self.cType, self.dType)))

--- a/Tensile/Tests/extended/stagger_u/big_skinny_A_NN.yaml
+++ b/Tensile/Tests/extended/stagger_u/big_skinny_A_NN.yaml
@@ -1,0 +1,100 @@
+GlobalParameters:
+  MinimumRequiredVersion: 4.4.0
+  PrintLevel: 2
+  CMakeBuildType: Release
+  KernelTime: True
+  PinClocks: True
+  SleepPercent: 200
+  DataInitTypeBeta : 0
+  NewClient: 2
+  # Debugging
+  LibraryPrintDebug: True
+  NumElementsToValidate: 1000
+  ValidationMaxToPrint: 10
+  CheckDimOverflow: 1
+  BoundsCheck: True
+  PrintSolutionRejectionReason: True
+
+BenchmarkProblems:
+  ########################################
+  # NN - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: s
+      TransposeA: False
+      TransposeB: False
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+        - AssertMinApproxSize: [0]
+        - AssertStrideBEqual: [ { 0: 1 } ]
+        - BufferLoad: [True] #
+        - GlobalReadVectorWidth: [1]
+        - UseSgprForGRO: [1]
+        - VectorAtomicWidth: [1]
+        - DirectToLds: True
+        - EnableMatrixInstruction: True
+        - VectorWidth: [1]
+        - LoopTail: True
+      BenchmarkCommonParameters:
+        - AssertMinApproxSize: [0]
+        - AssertStrideBEqual: [ { 0: 1 } ]
+        - GlobalReadVectorWidth: [1]
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+        - PrefetchLocalRead: [True]
+        - UseSgprForGRO: [1]
+        - StaggerU: [32] # Non-zero
+        - VectorAtomicWidth: [1]
+      ForkParameters:
+        - ThreadTile:
+          - [ 8, 4 ]
+        - WorkGroup:
+          - [ 16, 16, 1 ]
+        - GlobalSplitU: [1]
+        - DepthU: [8]
+        - VectorWidth: [1]
+      BenchmarkForkParameters:
+      JoinParameters:
+        - MacroTile
+        - GlobalSplitU
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          #- Range: [ [2684355], [1], [1], [400, 10, 790] ]
+          #- Range: [ [405], [1, 1, 2], [1], [2651216] ]
+          - Range: [ [2684355], [1], [1], [250, 11, 790] ]
+
+
+  ########################################
+
+LibraryLogic:
+#   ScheduleName: "vega20"
+#   DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Device 66af", "Vega 20"]
+#   ArchitectureName: "gfx906"
+
+   # ScheduleName: "navi10"
+   # DeviceNames: ["Device 731f"]
+   # ArchitectureName: "gfx1010"
+
+    ScheduleName: "vega10"
+    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860",
+                  "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]",
+                  "Vega [Radeon RX Vega]", "Vega 10 [Radeon Instinct MI25]",
+                  "Vega", "Device 6864", "Device 686c"]
+    ArchitectureName: "gfx900"
+
+#   ScheduleName: "mi25"
+#   DeviceNames: ["Device 6860"]
+#   ArchitectureName: "gfx900"
+
+#   ScheduleName: "r9nano"
+#   DeviceNames: ["Device 7300"]
+#   ArchitectureName: "gfx803"
+
+#   ScheduleName: "hip"
+#   DeviceNames: ["Device 0000"]
+#   ArchitectureName: "fallback"

--- a/Tensile/Tests/extended/stagger_u/big_skinny_A_NT.yaml
+++ b/Tensile/Tests/extended/stagger_u/big_skinny_A_NT.yaml
@@ -1,0 +1,100 @@
+GlobalParameters:
+  MinimumRequiredVersion: 4.4.0
+  PrintLevel: 2
+  CMakeBuildType: Release
+  KernelTime: True
+  PinClocks: True
+  SleepPercent: 200
+  DataInitTypeBeta : 0
+  NewClient: 2
+  # Debugging
+  LibraryPrintDebug: True
+  NumElementsToValidate: 1000
+  ValidationMaxToPrint: 10
+  CheckDimOverflow: 1
+  BoundsCheck: True
+  PrintSolutionRejectionReason: True
+
+BenchmarkProblems:
+  ########################################
+  # NT - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: s
+      TransposeA: False
+      TransposeB: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+        - AssertMinApproxSize: [0]
+        - AssertStrideBEqual: [ { 0: 1 } ]
+        - BufferLoad: [True] #
+        - GlobalReadVectorWidth: [1]
+        - UseSgprForGRO: [1]
+        - VectorAtomicWidth: [1]
+        - DirectToLds: True
+        - EnableMatrixInstruction: True
+        - VectorWidth: [1]
+        - LoopTail: True
+      BenchmarkCommonParameters:
+        - AssertMinApproxSize: [0]
+        - AssertStrideBEqual: [ { 0: 1 } ]
+        - GlobalReadVectorWidth: [1]
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+        - PrefetchLocalRead: [True]
+        - UseSgprForGRO: [1]
+        - StaggerU: [32] # Non-zero
+        - VectorAtomicWidth: [1]
+      ForkParameters:
+        - ThreadTile:
+          - [ 8, 4 ]
+        - WorkGroup:
+          - [ 16, 16, 1 ]
+        - GlobalSplitU: [1]
+        - DepthU: [8]
+        - VectorWidth: [1]
+      BenchmarkForkParameters:
+      JoinParameters:
+        - MacroTile
+        - GlobalSplitU
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          #- Range: [ [2684355], [1], [1], [400, 10, 790] ]
+          #- Range: [ [405], [1, 1, 2], [1], [2651216] ]
+          - Range: [ [2684355], [1], [1], [250, 11, 790] ]
+
+
+  ########################################
+
+LibraryLogic:
+#   ScheduleName: "vega20"
+#   DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Device 66af", "Vega 20"]
+#   ArchitectureName: "gfx906"
+
+   # ScheduleName: "navi10"
+   # DeviceNames: ["Device 731f"]
+   # ArchitectureName: "gfx1010"
+
+    ScheduleName: "vega10"
+    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860",
+                  "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]",
+                  "Vega [Radeon RX Vega]", "Vega 10 [Radeon Instinct MI25]",
+                  "Vega", "Device 6864", "Device 686c"]
+    ArchitectureName: "gfx900"
+
+#   ScheduleName: "mi25"
+#   DeviceNames: ["Device 6860"]
+#   ArchitectureName: "gfx900"
+
+#   ScheduleName: "r9nano"
+#   DeviceNames: ["Device 7300"]
+#   ArchitectureName: "gfx803"
+
+#   ScheduleName: "hip"
+#   DeviceNames: ["Device 0000"]
+#   ArchitectureName: "fallback"

--- a/Tensile/Tests/extended/stagger_u/big_skinny_A_TN.yaml
+++ b/Tensile/Tests/extended/stagger_u/big_skinny_A_TN.yaml
@@ -1,0 +1,100 @@
+GlobalParameters:
+  MinimumRequiredVersion: 4.4.0
+  PrintLevel: 2
+  CMakeBuildType: Release
+  KernelTime: True
+  PinClocks: True
+  SleepPercent: 200
+  DataInitTypeBeta : 0
+  NewClient: 2
+  # Debugging
+  LibraryPrintDebug: True
+  NumElementsToValidate: 1000
+  ValidationMaxToPrint: 10
+  CheckDimOverflow: 1
+  BoundsCheck: True
+  PrintSolutionRejectionReason: True
+
+BenchmarkProblems:
+  ########################################
+  # TN - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: s
+      TransposeA: True
+      TransposeB: False
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+        - AssertMinApproxSize: [0]
+        - AssertStrideBEqual: [ { 0: 1 } ]
+        - BufferLoad: [True] #
+        - GlobalReadVectorWidth: [1]
+        - UseSgprForGRO: [1]
+        - VectorAtomicWidth: [1]
+        - DirectToLds: True
+        - EnableMatrixInstruction: True
+        - VectorWidth: [1]
+        - LoopTail: True
+      BenchmarkCommonParameters:
+        - AssertMinApproxSize: [0]
+        - AssertStrideBEqual: [ { 0: 1 } ]
+        - GlobalReadVectorWidth: [1]
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+        - PrefetchLocalRead: [True]
+        - UseSgprForGRO: [1]
+        - StaggerU: [32] # Non-zero
+        - VectorAtomicWidth: [1]
+      ForkParameters:
+        - ThreadTile:
+          - [ 8, 4 ]
+        - WorkGroup:
+          - [ 16, 16, 1 ]
+        - GlobalSplitU: [1]
+        - DepthU: [8]
+        - VectorWidth: [1]
+      BenchmarkForkParameters:
+      JoinParameters:
+        - MacroTile
+        - GlobalSplitU
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          #- Range: [ [2684355], [1], [1], [400, 10, 790] ]
+          #- Range: [ [405], [1, 1, 2], [1], [2651216] ]
+          - Range: [ [2684355], [1], [1], [250, 11, 790] ]
+
+
+  ########################################
+
+LibraryLogic:
+#   ScheduleName: "vega20"
+#   DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Device 66af", "Vega 20"]
+#   ArchitectureName: "gfx906"
+
+   # ScheduleName: "navi10"
+   # DeviceNames: ["Device 731f"]
+   # ArchitectureName: "gfx1010"
+
+    ScheduleName: "vega10"
+    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860",
+                  "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]",
+                  "Vega [Radeon RX Vega]", "Vega 10 [Radeon Instinct MI25]",
+                  "Vega", "Device 6864", "Device 686c"]
+    ArchitectureName: "gfx900"
+
+#   ScheduleName: "mi25"
+#   DeviceNames: ["Device 6860"]
+#   ArchitectureName: "gfx900"
+
+#   ScheduleName: "r9nano"
+#   DeviceNames: ["Device 7300"]
+#   ArchitectureName: "gfx803"
+
+#   ScheduleName: "hip"
+#   DeviceNames: ["Device 0000"]
+#   ArchitectureName: "fallback"

--- a/Tensile/Tests/extended/stagger_u/big_skinny_A_TT.yaml
+++ b/Tensile/Tests/extended/stagger_u/big_skinny_A_TT.yaml
@@ -1,0 +1,100 @@
+GlobalParameters:
+  MinimumRequiredVersion: 4.4.0
+  PrintLevel: 2
+  CMakeBuildType: Release
+  KernelTime: True
+  PinClocks: True
+  SleepPercent: 200
+  DataInitTypeBeta : 0
+  NewClient: 2
+  # Debugging
+  LibraryPrintDebug: True
+  NumElementsToValidate: 1000
+  ValidationMaxToPrint: 10
+  CheckDimOverflow: 1
+  BoundsCheck: True
+  PrintSolutionRejectionReason: True
+
+BenchmarkProblems:
+  ########################################
+  # TT - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: s
+      TransposeA: True
+      TransposeB: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+        - AssertMinApproxSize: [0]
+        - AssertStrideBEqual: [ { 0: 1 } ]
+        - BufferLoad: [True] #
+        - GlobalReadVectorWidth: [1]
+        - UseSgprForGRO: [1]
+        - VectorAtomicWidth: [1]
+        - DirectToLds: True
+        - EnableMatrixInstruction: True
+        - VectorWidth: [1]
+        - LoopTail: True
+      BenchmarkCommonParameters:
+        - AssertMinApproxSize: [0]
+        - AssertStrideBEqual: [ { 0: 1 } ]
+        - GlobalReadVectorWidth: [1]
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+        - PrefetchLocalRead: [True]
+        - UseSgprForGRO: [1]
+        - StaggerU: [32] # Non-zero
+        - VectorAtomicWidth: [1]
+      ForkParameters:
+        - ThreadTile:
+          - [ 8, 4 ]
+        - WorkGroup:
+          - [ 16, 16, 1 ]
+        - GlobalSplitU: [1]
+        - DepthU: [8]
+        - VectorWidth: [1]
+      BenchmarkForkParameters:
+      JoinParameters:
+        - MacroTile
+        - GlobalSplitU
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          #- Range: [ [2684355], [1], [1], [400, 10, 790] ]
+          #- Range: [ [405], [1, 1, 2], [1], [2651216] ]
+          - Range: [ [2684355], [1], [1], [250, 11, 790] ]
+
+
+  ########################################
+
+LibraryLogic:
+#   ScheduleName: "vega20"
+#   DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Device 66af", "Vega 20"]
+#   ArchitectureName: "gfx906"
+
+   # ScheduleName: "navi10"
+   # DeviceNames: ["Device 731f"]
+   # ArchitectureName: "gfx1010"
+
+    ScheduleName: "vega10"
+    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860",
+                  "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]",
+                  "Vega [Radeon RX Vega]", "Vega 10 [Radeon Instinct MI25]",
+                  "Vega", "Device 6864", "Device 686c"]
+    ArchitectureName: "gfx900"
+
+#   ScheduleName: "mi25"
+#   DeviceNames: ["Device 6860"]
+#   ArchitectureName: "gfx900"
+
+#   ScheduleName: "r9nano"
+#   DeviceNames: ["Device 7300"]
+#   ArchitectureName: "gfx803"
+
+#   ScheduleName: "hip"
+#   DeviceNames: ["Device 0000"]
+#   ArchitectureName: "fallback"

--- a/Tensile/Tests/extended/stagger_u/big_skinny_B_NN.yaml
+++ b/Tensile/Tests/extended/stagger_u/big_skinny_B_NN.yaml
@@ -1,0 +1,100 @@
+GlobalParameters:
+  MinimumRequiredVersion: 4.4.0
+  PrintLevel: 2
+  CMakeBuildType: Release
+  KernelTime: True
+  PinClocks: True
+  SleepPercent: 200
+  DataInitTypeBeta : 0
+  NewClient: 2
+  # Debugging
+  LibraryPrintDebug: True
+  NumElementsToValidate: 1000
+  ValidationMaxToPrint: 10
+  CheckDimOverflow: 1
+  BoundsCheck: True
+  PrintSolutionRejectionReason: True
+
+BenchmarkProblems:
+  ########################################
+  # NN - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: s
+      TransposeA: False
+      TransposeB: False
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+        - AssertMinApproxSize: [0]
+        - AssertStrideBEqual: [ { 0: 1 } ]
+        - BufferLoad: [True] #
+        - GlobalReadVectorWidth: [1]
+        - UseSgprForGRO: [1]
+        - VectorAtomicWidth: [1]
+        - DirectToLds: True
+        - EnableMatrixInstruction: True
+        - VectorWidth: [1]
+        - LoopTail: True
+      BenchmarkCommonParameters:
+        - AssertMinApproxSize: [0]
+        - AssertStrideBEqual: [ { 0: 1 } ]
+        - GlobalReadVectorWidth: [1]
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+        - PrefetchLocalRead: [True]
+        - UseSgprForGRO: [1]
+        - StaggerU: [32] # Non-zero
+        - VectorAtomicWidth: [1]
+      ForkParameters:
+        - ThreadTile:
+          - [ 8, 4 ]
+        - WorkGroup:
+          - [ 16, 16, 1 ]
+        - GlobalSplitU: [1]
+        - DepthU: [8]
+        - VectorWidth: [1]
+      BenchmarkForkParameters:
+      JoinParameters:
+        - MacroTile
+        - GlobalSplitU
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          #- Range: [ [2684355], [1], [1], [400, 10, 790] ]
+          #- Range: [ [405], [1, 1, 2], [1], [2651216] ]
+          - Range: [ [1], [2684355], [1], [250, 11, 790] ]
+
+
+  ########################################
+
+LibraryLogic:
+#   ScheduleName: "vega20"
+#   DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Device 66af", "Vega 20"]
+#   ArchitectureName: "gfx906"
+
+   # ScheduleName: "navi10"
+   # DeviceNames: ["Device 731f"]
+   # ArchitectureName: "gfx1010"
+
+    ScheduleName: "vega10"
+    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860",
+                  "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]",
+                  "Vega [Radeon RX Vega]", "Vega 10 [Radeon Instinct MI25]",
+                  "Vega", "Device 6864", "Device 686c"]
+    ArchitectureName: "gfx900"
+
+#   ScheduleName: "mi25"
+#   DeviceNames: ["Device 6860"]
+#   ArchitectureName: "gfx900"
+
+#   ScheduleName: "r9nano"
+#   DeviceNames: ["Device 7300"]
+#   ArchitectureName: "gfx803"
+
+#   ScheduleName: "hip"
+#   DeviceNames: ["Device 0000"]
+#   ArchitectureName: "fallback"

--- a/Tensile/Tests/extended/stagger_u/big_skinny_B_NT.yaml
+++ b/Tensile/Tests/extended/stagger_u/big_skinny_B_NT.yaml
@@ -1,0 +1,100 @@
+GlobalParameters:
+  MinimumRequiredVersion: 4.4.0
+  PrintLevel: 2
+  CMakeBuildType: Release
+  KernelTime: True
+  PinClocks: True
+  SleepPercent: 200
+  DataInitTypeBeta : 0
+  NewClient: 2
+  # Debugging
+  LibraryPrintDebug: True
+  NumElementsToValidate: 1000
+  ValidationMaxToPrint: 10
+  CheckDimOverflow: 1
+  BoundsCheck: True
+  PrintSolutionRejectionReason: True
+
+BenchmarkProblems:
+  ########################################
+  # NT - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: s
+      TransposeA: False
+      TransposeB: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+        - AssertMinApproxSize: [0]
+        - AssertStrideBEqual: [ { 0: 1 } ]
+        - BufferLoad: [True] #
+        - GlobalReadVectorWidth: [1]
+        - UseSgprForGRO: [1]
+        - VectorAtomicWidth: [1]
+        - DirectToLds: True
+        - EnableMatrixInstruction: True
+        - VectorWidth: [1]
+        - LoopTail: True
+      BenchmarkCommonParameters:
+        - AssertMinApproxSize: [0]
+        - AssertStrideBEqual: [ { 0: 1 } ]
+        - GlobalReadVectorWidth: [1]
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+        - PrefetchLocalRead: [True]
+        - UseSgprForGRO: [1]
+        - StaggerU: [32] # Non-zero
+        - VectorAtomicWidth: [1]
+      ForkParameters:
+        - ThreadTile:
+          - [ 8, 4 ]
+        - WorkGroup:
+          - [ 16, 16, 1 ]
+        - GlobalSplitU: [1]
+        - DepthU: [8]
+        - VectorWidth: [1]
+      BenchmarkForkParameters:
+      JoinParameters:
+        - MacroTile
+        - GlobalSplitU
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          #- Range: [ [2684355], [1], [1], [400, 10, 790] ]
+          #- Range: [ [405], [1, 1, 2], [1], [2651216] ]
+          - Range: [ [1], [2684355], [1], [250, 11, 790] ]
+
+
+  ########################################
+
+LibraryLogic:
+#   ScheduleName: "vega20"
+#   DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Device 66af", "Vega 20"]
+#   ArchitectureName: "gfx906"
+
+   # ScheduleName: "navi10"
+   # DeviceNames: ["Device 731f"]
+   # ArchitectureName: "gfx1010"
+
+    ScheduleName: "vega10"
+    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860",
+                  "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]",
+                  "Vega [Radeon RX Vega]", "Vega 10 [Radeon Instinct MI25]",
+                  "Vega", "Device 6864", "Device 686c"]
+    ArchitectureName: "gfx900"
+
+#   ScheduleName: "mi25"
+#   DeviceNames: ["Device 6860"]
+#   ArchitectureName: "gfx900"
+
+#   ScheduleName: "r9nano"
+#   DeviceNames: ["Device 7300"]
+#   ArchitectureName: "gfx803"
+
+#   ScheduleName: "hip"
+#   DeviceNames: ["Device 0000"]
+#   ArchitectureName: "fallback"

--- a/Tensile/Tests/extended/stagger_u/big_skinny_B_TN.yaml
+++ b/Tensile/Tests/extended/stagger_u/big_skinny_B_TN.yaml
@@ -1,0 +1,100 @@
+GlobalParameters:
+  MinimumRequiredVersion: 4.4.0
+  PrintLevel: 2
+  CMakeBuildType: Release
+  KernelTime: True
+  PinClocks: True
+  SleepPercent: 200
+  DataInitTypeBeta : 0
+  NewClient: 2
+  # Debugging
+  LibraryPrintDebug: True
+  NumElementsToValidate: 1000
+  ValidationMaxToPrint: 10
+  CheckDimOverflow: 1
+  BoundsCheck: True
+  PrintSolutionRejectionReason: True
+
+BenchmarkProblems:
+  ########################################
+  # TN - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: s
+      TransposeA: True
+      TransposeB: False
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+        - AssertMinApproxSize: [0]
+        - AssertStrideBEqual: [ { 0: 1 } ]
+        - BufferLoad: [True] #
+        - GlobalReadVectorWidth: [1]
+        - UseSgprForGRO: [1]
+        - VectorAtomicWidth: [1]
+        - DirectToLds: True
+        - EnableMatrixInstruction: True
+        - VectorWidth: [1]
+        - LoopTail: True
+      BenchmarkCommonParameters:
+        - AssertMinApproxSize: [0]
+        - AssertStrideBEqual: [ { 0: 1 } ]
+        - GlobalReadVectorWidth: [1]
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+        - PrefetchLocalRead: [True]
+        - UseSgprForGRO: [1]
+        - StaggerU: [32] # Non-zero
+        - VectorAtomicWidth: [1]
+      ForkParameters:
+        - ThreadTile:
+          - [ 8, 4 ]
+        - WorkGroup:
+          - [ 16, 16, 1 ]
+        - GlobalSplitU: [1]
+        - DepthU: [8]
+        - VectorWidth: [1]
+      BenchmarkForkParameters:
+      JoinParameters:
+        - MacroTile
+        - GlobalSplitU
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          #- Range: [ [2684355], [1], [1], [400, 10, 790] ]
+          #- Range: [ [405], [1, 1, 2], [1], [2651216] ]
+          - Range: [ [1], [2684355], [1], [250, 11, 790] ]
+
+
+  ########################################
+
+LibraryLogic:
+#   ScheduleName: "vega20"
+#   DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Device 66af", "Vega 20"]
+#   ArchitectureName: "gfx906"
+
+   # ScheduleName: "navi10"
+   # DeviceNames: ["Device 731f"]
+   # ArchitectureName: "gfx1010"
+
+    ScheduleName: "vega10"
+    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860",
+                  "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]",
+                  "Vega [Radeon RX Vega]", "Vega 10 [Radeon Instinct MI25]",
+                  "Vega", "Device 6864", "Device 686c"]
+    ArchitectureName: "gfx900"
+
+#   ScheduleName: "mi25"
+#   DeviceNames: ["Device 6860"]
+#   ArchitectureName: "gfx900"
+
+#   ScheduleName: "r9nano"
+#   DeviceNames: ["Device 7300"]
+#   ArchitectureName: "gfx803"
+
+#   ScheduleName: "hip"
+#   DeviceNames: ["Device 0000"]
+#   ArchitectureName: "fallback"

--- a/Tensile/Tests/extended/stagger_u/big_skinny_B_TT.yaml
+++ b/Tensile/Tests/extended/stagger_u/big_skinny_B_TT.yaml
@@ -1,0 +1,100 @@
+GlobalParameters:
+  MinimumRequiredVersion: 4.4.0
+  PrintLevel: 2
+  CMakeBuildType: Release
+  KernelTime: True
+  PinClocks: True
+  SleepPercent: 200
+  DataInitTypeBeta : 0
+  NewClient: 2
+  # Debugging
+  LibraryPrintDebug: True
+  NumElementsToValidate: 1000
+  ValidationMaxToPrint: 10
+  CheckDimOverflow: 1
+  BoundsCheck: True
+  PrintSolutionRejectionReason: True
+
+BenchmarkProblems:
+  ########################################
+  # TT - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: s
+      TransposeA: True
+      TransposeB: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+        - AssertMinApproxSize: [0]
+        - AssertStrideBEqual: [ { 0: 1 } ]
+        - BufferLoad: [True] #
+        - GlobalReadVectorWidth: [1]
+        - UseSgprForGRO: [1]
+        - VectorAtomicWidth: [1]
+        - DirectToLds: True
+        - EnableMatrixInstruction: True
+        - VectorWidth: [1]
+        - LoopTail: True
+      BenchmarkCommonParameters:
+        - AssertMinApproxSize: [0]
+        - AssertStrideBEqual: [ { 0: 1 } ]
+        - GlobalReadVectorWidth: [1]
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+        - PrefetchLocalRead: [True]
+        - UseSgprForGRO: [1]
+        - StaggerU: [32] # Non-zero
+        - VectorAtomicWidth: [1]
+      ForkParameters:
+        - ThreadTile:
+          - [ 8, 4 ]
+        - WorkGroup:
+          - [ 16, 16, 1 ]
+        - GlobalSplitU: [1]
+        - DepthU: [8]
+        - VectorWidth: [1]
+      BenchmarkForkParameters:
+      JoinParameters:
+        - MacroTile
+        - GlobalSplitU
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          #- Range: [ [2684355], [1], [1], [400, 10, 790] ]
+          #- Range: [ [405], [1, 1, 2], [1], [2651216] ]
+          - Range: [ [1], [2684355], [1], [250, 11, 790] ]
+
+
+  ########################################
+
+LibraryLogic:
+#   ScheduleName: "vega20"
+#   DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Device 66af", "Vega 20"]
+#   ArchitectureName: "gfx906"
+
+   # ScheduleName: "navi10"
+   # DeviceNames: ["Device 731f"]
+   # ArchitectureName: "gfx1010"
+
+    ScheduleName: "vega10"
+    DeviceNames: ["Device 6863", "Device 6862", "Device 687f", "Device 6860",
+                  "Device 6861", "Vega 10 XTX [Radeon Vega Frontier Edition]",
+                  "Vega [Radeon RX Vega]", "Vega 10 [Radeon Instinct MI25]",
+                  "Vega", "Device 6864", "Device 686c"]
+    ArchitectureName: "gfx900"
+
+#   ScheduleName: "mi25"
+#   DeviceNames: ["Device 6860"]
+#   ArchitectureName: "gfx900"
+
+#   ScheduleName: "r9nano"
+#   DeviceNames: ["Device 7300"]
+#   ArchitectureName: "gfx803"
+
+#   ScheduleName: "hip"
+#   DeviceNames: ["Device 0000"]
+#   ArchitectureName: "fallback"


### PR DESCRIPTION
For these kernels, the calculation of the stagger offsets need to be augmented to 64 bit calculations to ensure that tensors in col-major format (N) with sizes > 2^32 can be handled.

This PR will address the 64 bit calculations in both unroll loop and tail section addressing updates of the kernels. Will also add tests for regression covering these cases where skinny tensors can get > 2^32 in size.