### PR TITLE
Fix problem predicates

### DIFF
--- a/Tensile/Contractions.py
+++ b/Tensile/Contractions.py
@@ -296,9 +296,9 @@ class ProblemPredicate(Properties.Predicate):
     def CompoundPredicates(cls, state, problemType):
         rv = []
 
-        if 'VectorWidth' in state and state['VectorWidth'] > 1:
+        if 'GlobalReadVectorWidth' in state and state['GlobalReadVectorWidth'] > 1:
             if not problemType.aType.isInt8x4():
-                rv += [cls('LeadingFreeSizesGreaterOrEqual', value=state['VectorWidth'])]
+                rv += [cls('LeadingFreeSizesGreaterOrEqual', value=state['GlobalReadVectorWidth'])]
 
         if "LdcEqualsLdd" not in state or state["LdcEqualsLdd"] == True:
             rv += [cls("CDStridesEqual")]

--- a/Tensile/Source/lib/include/Tensile/ContractionProblemPredicates.hpp
+++ b/Tensile/Source/lib/include/Tensile/ContractionProblemPredicates.hpp
@@ -98,7 +98,7 @@ namespace Tensile
 
                 virtual bool operator()(ContractionProblem const& problem) const override
                 {
-                    return problem.freeSizeA(index) % value == 0;
+                    return problem.freeSizeB(index) % value == 0;
                 }
             };
 


### PR DESCRIPTION
This should fix some issue with kernel-problem matching, which was potentially causing validation failures or even segfault. Namely:
- SizeN assertion due to a typo in problem predicate; fixes #915
- Leading dimension size should be >= kernel's global read width