### PR TITLE
Try leaving params default due to possible bug in CI

### DIFF
--- a/Tensile/Tests/pre_checkin/sgemm_exact_dict.yaml
+++ b/Tensile/Tests/pre_checkin/sgemm_exact_dict.yaml
@@ -1,8 +1,9 @@
 GlobalParameters:
-  # NumElementsToValidate: 16384 # FIXME: temporarily disable it since CI silently
-                                 # writes bounds-check=true even when this param != -1
+  NumElementsToValidate: 16384
   KernelTime: True
   NewClient: 2
+  BoundsCheck: False # FIXME: temporarily disable it since CI silently
+                     # writes bounds-check=true even when this param != -1
 
 BenchmarkProblems:
   ########################################

--- a/Tensile/Tests/pre_checkin/sgemm_exact_dict.yaml
+++ b/Tensile/Tests/pre_checkin/sgemm_exact_dict.yaml
@@ -1,5 +1,6 @@
 GlobalParameters:
-  NumElementsToValidate: 16384
+  # NumElementsToValidate: 16384 # FIXME: temporarily disable it since CI silently
+                                 # writes bounds-check=true even when this param != -1
   KernelTime: True
   NewClient: 2
 


### PR DESCRIPTION
This is to try getting CI to pass due to misbehavior: incorrectly setting BoundsCheck=true in tensile client parameter when user config clearly states otherwise. Related to #995.

Let's see if CI passes with this one