### PR TITLE
modify logic of ldsPad=-1

### DIFF
--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -769,6 +769,7 @@ validParameters = {
     # integer ammount of padding to put into LDS, in 2016 this didn't seem to help performance, profilers were showing that channel conflicts weren't really hurting
     # performance so this has been deprecated and probably doesn't work
     # -1 means use same padding as the VectorWidth if TLU=0 else 0.  (Padding only helps when transpose is required)
+    # With MatrixInstruciton: -1 means max(GRVW,MIInput) if TLU=0
     "LdsPadA":                     [ -1, 0, 1, 2, 3, 4, 8],
     "LdsPadB":                     [ -1, 0, 1, 2, 3, 4, 8],
 

--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -2657,10 +2657,22 @@ class Solution:
       return
 
     if state["LdsPadA"] == -1:
-      state["LdsPadA"] = 0 if state["ProblemType"]["TLUA"] else state["VectorWidth"]
+      if state["ProblemType"]["TLUA"]:
+        state["LdsPadA"] = 0
+      else:
+        if state["MatrixInstruction"] and state["TransposeLDS"]:
+          state["LdsPadA"] = max(state["GlobalReadVectorWidth"],state["ProblemType"]["DataType"].numMIInput())
+        else:
+          state["LdsPadA"] = state["VectorWidth"]
       assert(state["LdsPadA"] >= 0)
     if state["LdsPadB"] == -1:
-      state["LdsPadB"] = 0 if state["ProblemType"]["TLUB"] else state["VectorWidth"]
+      if state["ProblemType"]["TLUB"]:
+        state["LdsPadB"] = 0
+      else:
+        if state["MatrixInstruction"] and state["TransposeLDS"]:
+          state["LdsPadB"] = max(state["GlobalReadVectorWidth"],state["ProblemType"]["DataType"].numMIInput())
+        else:
+          state["LdsPadB"] = state["VectorWidth"]
       assert(state["LdsPadB"] >= 0)
 
     if (state["UnrollMajorLDSA"] or state["UnrollMajorLDSB"]) and (not state["EnableMatrixInstruction"]):


### PR DESCRIPTION
we need to pad lds to avoid bank conflict on both ds_read and ds_write
In MatrixInstruction and TLDS,
we'll have MIInput element per ds_read and GRVW element per ds_write