### PR TITLE
Adding useGlobalParameters fixture.

### DIFF
--- a/Tensile/Code.py
+++ b/Tensile/Code.py
@@ -260,7 +260,7 @@ class WaitCnt (Module):
 
     if len(main_args) > 0:
       rv.addInst("s_waitcnt", *main_args, self.comment)
-      if wait_store and self.version == (10,1,0) and self.vmcnt != -1:
+      if wait_store and self.version[0] == 10 and self.vmcnt != -1:
         rv.addInst("s_waitcnt_vscnt", "null", self.vmcnt, "writes")
     else:
       rv.addComment0(self.comment)
@@ -657,7 +657,7 @@ class SrdUpperValue9XX(BitfieldUnion):
   def default(cls):
     return cls(fields=SrdUpperFields9XX.default())
 
-class SrdUpperFields1010(BitfieldStructure):
+class SrdUpperFields10XX(BitfieldStructure):
   _fields_ = [("dst_sel_x",      ctypes.c_uint, 3),
               ("dst_sel_y",      ctypes.c_uint, 3),
               ("dst_sel_z",      ctypes.c_uint, 3),
@@ -678,17 +678,17 @@ class SrdUpperFields1010(BitfieldStructure):
                resource_level = 1,
                oob_select     = 3)
 
-class SrdUpperValue1010(BitfieldUnion):
-  _fields_ = [("fields", SrdUpperFields1010), ("value", ctypes.c_uint32)]
+class SrdUpperValue10XX(BitfieldUnion):
+  _fields_ = [("fields", SrdUpperFields10XX), ("value", ctypes.c_uint32)]
 
   @classmethod
   def default(cls):
-    return cls(fields=SrdUpperFields1010.default())
+    return cls(fields=SrdUpperFields10XX.default())
 
 
 def SrdUpperValue(isa):
-  if isa == (10,1,0):
-    return SrdUpperValue1010.default()
+  if isa[0] == 10:
+    return SrdUpperValue10XX.default()
   else:
     return SrdUpperValue9XX.default()
 

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -1255,21 +1255,25 @@ def locateExe( defaultPath, exeName ): # /opt/rocm/bin, hip-clang
 def GetAsmCaps(isaVersion):
   """ Determine assembler capabilities by testing short instructions sequences """
   rv = {}
-  rv["SupportedISA"]    = tryAssembler(isaVersion, "", "")
-  rv["HasExplicitCO"]   = tryAssembler(isaVersion, "", "v_add_co_u32 v0,vcc,v0,1")
-  rv["HasExplicitNC"]   = tryAssembler(isaVersion, "", "v_add_nc_u32 v0,v0,1")
-  rv["HasDirectToLds"]  = tryAssembler(isaVersion, "", "buffer_load_dword v40, v36, s[24:27], s28 offen offset:0 lds")
-  rv["HasAddLshl"]      = tryAssembler(isaVersion, "", "v_add_lshl_u32 v47, v36, v34, 0x2")
-  rv["HasSMulHi"]       = tryAssembler(isaVersion, "", "s_mul_hi_u32 s47, s36, s34")
-  rv["HasCodeObjectV3"] = tryAssembler(isaVersion, "-mno-code-object-v3", "")
+  rv["SupportedISA"]    = tryAssembler(isaVersion, "")
+  rv["HasExplicitCO"]   = tryAssembler(isaVersion, "v_add_co_u32 v0,vcc,v0,1")
+  rv["HasExplicitNC"]   = tryAssembler(isaVersion, "v_add_nc_u32 v0,v0,1")
 
-  rv["v_fma_f16"]       = tryAssembler(isaVersion, "", "v_fma_f16 v47, v36, v34, v47, op_sel:[0,0,0,0]")
-  rv["v_pk_fma_f16"]    = tryAssembler(isaVersion, "", "v_pk_fma_f16 v47, v36, v34, v47, op_sel:[0,0,0]")
-  rv["v_mad_mix_f32"]   = tryAssembler(isaVersion, "", "v_mad_mix_f32 v47, v36, v34, v47, op_sel:[0,0,0] op_sel_hi:[1,1,0]")
+  rv["HasDirectToLds"]  = tryAssembler(isaVersion, "buffer_load_dword v40, v36, s[24:27], s28 offen offset:0 lds")
+  rv["HasAddLshl"]      = tryAssembler(isaVersion, "v_add_lshl_u32 v47, v36, v34, 0x2")
+  rv["HasSMulHi"]       = tryAssembler(isaVersion, "s_mul_hi_u32 s47, s36, s34")
+  rv["HasCodeObjectV3"] = tryAssembler(isaVersion, "", False, "-mno-code-object-v3")
 
-  if tryAssembler(isaVersion, "", "s_waitcnt vmcnt(63)"):
+  rv["v_fma_f16"]       = tryAssembler(isaVersion, "v_fma_f16 v47, v36, v34, v47, op_sel:[0,0,0,0]")
+  rv["v_pk_fma_f16"]    = tryAssembler(isaVersion, "v_pk_fma_f16 v47, v36, v34, v47, op_sel:[0,0,0]")
+  rv["v_mad_mix_f32"]   = tryAssembler(isaVersion, "v_mad_mix_f32 v47, v36, v34, v47, op_sel:[0,0,0] op_sel_hi:[1,1,0]")
+  rv["v_fma_mix_f32"]   = tryAssembler(isaVersion, "v_fma_mix_f32 v47, v36, v34, v47, op_sel:[0,0,0] op_sel_hi:[1,1,0]")
+
+  rv["v_dot2c_f32_f16"] = tryAssembler(isaVersion, "v_dot2c_f32_f16 v47, v36, v34")
+
+  if tryAssembler(isaVersion, "s_waitcnt vmcnt(63)"):
     rv["MaxVmcnt"] = 63
-  elif tryAssembler(isaVersion, "", "s_waitcnt vmcnt(15)"):
+  elif tryAssembler(isaVersion, "s_waitcnt vmcnt(15)"):
     rv["MaxVmcnt"] = 15
   else:
     rv["MaxVmcnt"] = 0
@@ -1291,33 +1295,36 @@ def GetArchCaps(isaVersion):
 
   return rv
 
-def tryAssembler(isaVersion, options, asmString, debug=False):
+def tryAssembler(isaVersion, asmString, debug=False, *options):
   """
   Try to assemble the asmString for the specified target processor
   Success is defined as assembler returning no error code or stderr/stdout
   """
+  options = list(options)
+  if globalParameters["PrintLevel"] >= 2:
+    debug = True
+
   if isaVersion[0] == 10:
-    options += ' -mwavefrontsize64'
+    options += ['-mwavefrontsize64']
 
-  asmCmd = "%s -x assembler -target amdgcn-amdhsa -mcpu=%s %s -" \
-             % (globalParameters["AssemblerPath"], gfxName(isaVersion), options)
+  args = [globalParameters["AssemblerPath"], '-x', 'assembler',
+          '-target', 'amdgcn-amdhsa',
+          '-mcpu='+gfxName(isaVersion),
+          *options,
+          '-']
 
-  sysCmd = "echo \"%s\" | %s" % (asmString, asmCmd)
+  result = subprocess.run(args, input=asmString.encode(), stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+  output = result.stdout.decode()
 
-  try:
-    result = subprocess.check_output([sysCmd], shell=True,  stderr=subprocess.STDOUT).decode()
-    if debug or globalParameters["PrintLevel"] >=2:
-        print("isaVersion: ", isaVersion)
-        print("asm_cmd: ", asmCmd)
-        print("output :", result)
-    if result != "":
-      return 0 # stdout and stderr must be empty
-  except subprocess.CalledProcessError as e:
-    if debug or globalParameters["PrintLevel"] >=2:
-        print("CalledProcessError", e)
-    return 0 # error, not supported
+  if debug:
+    print("isaVersion: ", isaVersion)
+    print("asm_cmd:", ' '.join(args))
+    print("output: ", output)
+    print("return code: ", result.returncode)
 
-  return 1 # syntax works
+  if output != "" or result.returncode != 0:
+    return False
+  return True
 
 def gfxArch(name):
     import re
@@ -1341,12 +1348,56 @@ def gfxArch(name):
 def gfxName(arch):
     return 'gfx' + ''.join(map(str,arch))
 
+def restoreDefaultGlobalParameters():
+  """
+  Restores `globalParameters` back to defaults.
+  """
+  global globalParameters
+  global defaultGlobalParameters
+  # Can't just assign globalParameters = deepcopy(defaultGlobalParameters) because that would
+  # result in dangling references, specifically in Tensile.Tensile().
+  globalParameters.clear()
+  for key, value in deepcopy(defaultGlobalParameters).items():
+    globalParameters[key] = value
+
+def printTable(rows):
+  rows = list([[str(cell) for cell in row] for row in rows])
+  colWidths = list([max([len(cell) for cell in col]) for col in zip(*rows)])
+
+  for row in rows:
+    for (width, cell) in zip(colWidths, row):
+      pad = ' ' * (width - len(cell))
+      print(pad, cell, sep='', end=' ')
+    print()
+
+def printCapTable(parameters):
+  import itertools
+  archs = [(0,0,0)] + parameters["SupportedISA"]
+  gfxNames = list(map(gfxName, archs))
+
+  headerRow = ['cap'] + gfxNames
+
+  def capRow(caps, cap):
+    return [cap] + [('1' if cap in caps[arch] and caps[arch][cap] else '0') for arch in archs]
+
+  allAsmCaps = set(itertools.chain(*[caps.keys() for arch, caps in parameters["AsmCaps"].items()]))
+  allAsmCaps = sorted(allAsmCaps)
+  asmCapRows = [capRow(parameters["AsmCaps"], cap) for cap in allAsmCaps]
+
+  allArchCaps = set(itertools.chain(*[caps.keys() for arch, caps in parameters["ArchCaps"].items()]))
+  allArchCaps = sorted(allArchCaps)
+  archCapRows = [capRow(parameters["ArchCaps"], cap) for cap in allArchCaps]
+
+  printTable([headerRow] + asmCapRows + archCapRows)
+
 ################################################################################
-# Assign Global Parameters
-# each global parameter has a default parameter, and the user
-# can override them, those overridings happen here
 ################################################################################
 def assignGlobalParameters( config ):
+  """
+  Assign Global Parameters
+  Each global parameter has a default parameter, and the user
+  can override them, those overridings happen here
+  """
 
   global globalParameters
 
@@ -1409,17 +1460,13 @@ def assignGlobalParameters( config ):
 
   globalParameters["AsmCaps"] = {}
   globalParameters["ArchCaps"] = {}
+
   for v in globalParameters["SupportedISA"] + [(0,0,0)]:
     globalParameters["AsmCaps"][v] = GetAsmCaps(v)
     globalParameters["ArchCaps"][v] = GetArchCaps(v)
 
-    asmCaps = " ".join(["%s=%u"%(k,v) for k,v in globalParameters["AsmCaps"][v].items()])
-    archCaps = " ".join(["%s=%u"%(k,v) for k,v in globalParameters["ArchCaps"][v].items()])
-
-    #print("# Asm caps for %s:%s" % (gfxName(v), asmCaps))
-
-    print1 ("# Asm caps for %s:%s" % (gfxName(v), asmCaps))
-    print1 ("# Arch caps for %s:%s" % (gfxName(v), archCaps))
+  if globalParameters["PrintLevel"] >= 1:
+    printCapTable(globalParameters)
 
   globalParameters["SupportedISA"] = list([i for i in globalParameters["SupportedISA"] if globalParameters["AsmCaps"][i]["SupportedISA"]])
 

--- a/Tensile/Properties.py
+++ b/Tensile/Properties.py
@@ -53,7 +53,8 @@ class Property:
 
 class Predicate(Property):
     @classmethod
-    def FromOriginalState(cls, d, morePreds=[]):
+    def FromOriginalState(cls, d, morePreds=None):
+        if morePreds is None: morePreds = []
         predicates = [p for p in map(cls.FromOriginalKeyPair, d.items()) if p is not None] + morePreds
         return cls.And(predicates)
 

--- a/Tensile/Tensile.py
+++ b/Tensile/Tensile.py
@@ -27,7 +27,7 @@ import os
 import sys
 import argparse
 from .Common import globalParameters, print1, ensurePath, \
-    assignGlobalParameters, defaultGlobalParameters, HR
+    assignGlobalParameters, restoreDefaultGlobalParameters, HR
 from . import BenchmarkProblems
 from . import ClientWriter
 from . import LibraryLogic
@@ -85,18 +85,12 @@ def executeStepsInConfig( config ):
     ClientWriter.main( libraryClientConfig )
     print1("")
 
+def addCommonArguments(argParser):
+  """
+  Add a common set of arguments to `argParser`.
 
-################################################################################
-# Tensile
-# - below entry points call here
-################################################################################
-def Tensile(userArgs):
-  # 1st half of splash
-  print1("")
-  print1(HR)
-  print1("#")
-  print1("#  Tensile v%s" % (__version__) )
-
+  Currently used by the main Tensile script and the unit tests but could also be used for TensileCreateLibrary.
+  """
   def splitExtraParameters(par):
     """
     Allows the --global-parameters option to specify any parameters from the command line.
@@ -106,14 +100,6 @@ def Tensile(userArgs):
     value = eval(value)
     return (key, value)
 
-  # setup argument parser
-  argParser = argparse.ArgumentParser()
-  argParser.add_argument("config_file", \
-      help="benchmark config.yaml file")
-  argParser.add_argument("output_path", \
-      help="path where to conduct benchmark")
-  argParser.add_argument("--version", action="version", \
-      version="%(prog)s {version}".format(version=__version__))
   argParser.add_argument("-d", "--device", dest="device", type=int, \
       help="override which device to benchmark")
   argParser.add_argument("-p", "--platform", dest="platform", type=int, \
@@ -136,12 +122,79 @@ def Tensile(userArgs):
   argParser.add_argument("--client-lock", default=None)
 
   argParser.add_argument("--global-parameters", nargs="+", type=splitExtraParameters, default=[])
+
+def argUpdatedGlobalParameters(args):
+  """
+  Returns a dictionary with `globalParameters` keys that should be updated based on `args`.
+  """
+  rv = {}
+  # override config with command-line options
+  if args.device:
+    print1("# Command-line override: Device")
+    rv["Device"] = args.device
+  if args.platform:
+    print1("# Command-line override: Platform")
+    rv["Platform"] = args.platform
+  if args.RuntimeLanguage:
+    print1("# Command-line override: RuntimeLanguage")
+    rv["RuntimeLanguage"] = args.RuntimeLanguage
+  if args.CodeObjectVersion:
+    print1("# Command-line override: CodeObjectVersion")
+    rv["CodeObjectVersion"] = args.CodeObjectVersion
+  if args.verbose:
+    print1("# Command-line override: PrintLevel")
+    rv["PrintLevel"] = 2
+  if args.debug:
+    print1("# Command-line override: Debug")
+    rv["PrintLevel"] = 2
+    rv["CMakeBuildType"] = "Debug"
+  if args.shortNames:
+    rv["ShortNames"] = True
+  if args.noMergeFiles:
+    rv["MergeFiles"] = False
+  if args.CxxCompiler:
+    rv['CxxCompiler'] = args.CxxCompiler
+    if rv['CxxCompiler'] == "hipcc" and not args.CodeObjectVersion:
+      rv["CodeObjectVersion"] = "V3"
+  print1("")
+  if args.client_build_path:
+    rv["ClientBuildPath"] = args.client_build_path
+  if args.client_lock:
+    rv["ClientExecutionLockPath"] = args.client_lock
+
+  for key, value in args.global_parameters:
+    rv[key] = value
+
+  return rv
+
+################################################################################
+# Tensile
+# - below entry points call here
+################################################################################
+def Tensile(userArgs):
+  global globalParameters
+
+  # 1st half of splash
+  print1("")
+  print1(HR)
+  print1("#")
+  print1("#  Tensile v%s" % (__version__) )
+
+  # setup argument parser
+  argParser = argparse.ArgumentParser()
+  argParser.add_argument("config_file", type=os.path.realpath, help="benchmark config.yaml file")
+  argParser.add_argument("output_path", \
+      help="path where to conduct benchmark")
+  argParser.add_argument("--version", action="version", \
+      version="%(prog)s {version}".format(version=__version__))
   # argParser.add_argument("--hcc-version", dest="HccVersion", \
   #     help="This can affect what opcodes are emitted by the assembler")
+  addCommonArguments(argParser)
 
   # parse arguments
   args = argParser.parse_args(userArgs)
-  configPath = os.path.realpath( args.config_file)
+
+  configPath = args.config_file
 
   # 2nd half of splash
   print1("#  Config: %s" % (configPath) )
@@ -150,11 +203,11 @@ def Tensile(userArgs):
   print1("")
 
   print1("# Restoring default globalParameters")
-  for key in defaultGlobalParameters:
-    if args.CxxCompiler:
-      globalParameters['CxxCompiler'] = args.CxxCompiler
-    else:
-      globalParameters[key] = defaultGlobalParameters[key]
+  restoreDefaultGlobalParameters()
+
+  # CxxCompiler needs to be updated before assignGlobalParameters.
+  if args.CxxCompiler:
+    globalParameters['CxxCompiler'] = args.CxxCompiler
 
   # read config
   config = LibraryIO.readConfig( configPath )
@@ -169,41 +222,9 @@ def Tensile(userArgs):
   globalParameters["OutputPath"] = ensurePath(os.path.abspath(args.output_path))
   globalParameters["WorkingPath"] = globalParameters["OutputPath"]
 
-  # override config with command-line options
-  if args.device:
-    print1("# Command-line override: Device")
-    globalParameters["Device"] = args.device
-  if args.platform:
-    print1("# Command-line override: Platform")
-    globalParameters["Platform"] = args.platform
-  if args.RuntimeLanguage:
-    print1("# Command-line override: RuntimeLanguage")
-    globalParameters["RuntimeLanguage"] = args.RuntimeLanguage
-  if args.CodeObjectVersion:
-    print1("# Command-line override: CodeObjectVersion")
-    globalParameters["CodeObjectVersion"] = args.CodeObjectVersion
-  if args.verbose:
-    print1("# Command-line override: PrintLevel")
-    globalParameters["PrintLevel"] = 2
-  if args.debug:
-    print1("# Command-line override: Debug")
-    globalParameters["PrintLevel"] = 2
-    globalParameters["CMakeBuildType"] = "Debug"
-  if args.shortNames:
-    globalParameters["ShortNames"] = True
-  if args.noMergeFiles:
-    globalParameters["MergeFiles"] = False
-  if args.CxxCompiler:
-    globalParameters['CxxCompiler'] = args.CxxCompiler
-    if globalParameters['CxxCompiler'] == "hipcc" and not args.CodeObjectVersion:
-      globalParameters["CodeObjectVersion"] = "V3"
-  print1("")
-  if args.client_build_path:
-    globalParameters["ClientBuildPath"] = args.client_build_path
-  if args.client_lock:
-    globalParameters["ClientExecutionLockPath"] = args.client_lock
+  overrideParameters = argUpdatedGlobalParameters(args)
 
-  for key, value in args.global_parameters:
+  for key, value in overrideParameters.items():
     print("Overriding {0}={1}".format(key, value))
     globalParameters[key] = value
 
@@ -211,7 +232,7 @@ def Tensile(userArgs):
   #globalParameters["PrintCodeCommands"] = True
 
   # Execute Steps in the config script
-  executeStepsInConfig( config )
+  executeStepsInConfig(config)
 
 
 def TensileConfigPath(*args):

--- a/Tensile/Tests/unit/test_tryAssembler.py
+++ b/Tensile/Tests/unit/test_tryAssembler.py
@@ -1,0 +1,57 @@
+################################################################################
+# Copyright 2020 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell cop-
+# ies of the Software, and to permit persons to whom the Software is furnished
+# to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM-
+# PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNE-
+# CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+################################################################################
+
+from Tensile.Common import tryAssembler
+
+def test_Simple(useGlobalParameters):
+    with useGlobalParameters():
+        assert tryAssembler((9,0,0), "")
+        assert not tryAssembler((20,0,0), "")
+
+def test_Options(useGlobalParameters):
+    with useGlobalParameters():
+        assert tryAssembler((9,0,6), "", False, "-mno-code-object-v3")
+
+def test_Macro(useGlobalParameters):
+    """
+    Test a multi-line kernel that defines a macro.
+    """
+    with useGlobalParameters():
+
+        thekernel = r"""
+            .text
+            .macro _v_add_co_u32 dst:req, cc:req, src0:req, src1:req, dpp=
+            v_add_co_u32 \dst, \cc, \src0, \src1 \dpp
+            .endm
+
+            .set vgprLocalReadAddrB, 93
+
+            _v_add_co_u32 v[vgprLocalReadAddrB+0], vcc, 0x400, v[vgprLocalReadAddrB+0]
+            a_label:
+
+            v_add_co_u32 v[vgprLocalReadAddrB+0], vcc, 0x400, v[vgprLocalReadAddrB+0]
+            _v_add_co_u32 v[vgprLocalReadAddrB+0], vcc, 0x400, v[vgprLocalReadAddrB+0]
+
+            """
+
+        assert tryAssembler((10,1,0), thekernel.format(arch="gfx1010"), True, '-mcode-object-v3')
+        assert tryAssembler((10,1,1), thekernel.format(arch="gfx1011"))
+        assert not tryAssembler((8,0,3), thekernel.format(arch="gfx803"))

--- a/Tensile/Tests/unit/test_useGlobalParameters.py
+++ b/Tensile/Tests/unit/test_useGlobalParameters.py
@@ -1,0 +1,37 @@
+################################################################################
+# Copyright 2020 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell cop-
+# ies of the Software, and to permit persons to whom the Software is furnished
+# to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM-
+# PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNE-
+# CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+################################################################################
+
+from Tensile.Common import globalParameters
+
+def test_Simple(useGlobalParameters):
+    with useGlobalParameters():
+        assert not globalParameters["PinClocks"]
+
+        globalParameters["PinClocks"] = True
+
+    # outside the with statement, changes should be reverted.
+    assert not globalParameters["PinClocks"]
+
+def test_Args(useGlobalParameters):
+    with useGlobalParameters(PinClocks=True):
+        assert globalParameters["PinClocks"]
+
+    assert not globalParameters["PinClocks"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,7 @@
 [pytest]
 junit_family = xunit2
+junit_logging = all
+junit_log_passing_tests = False
 xfail_strict = True
 markers =
  bugs: directory


### PR DESCRIPTION
`useGlobalParameters` fixture allows unit testing of components that use `globalParameters`.

Adding unit test of `tryAssembler` function, and refactoring it to handle multi-line inputs.