### PR TITLE
host-side assertion to check bufferload/bufferstore offset limit

### DIFF
--- a/Tensile/Configs/rocblas_dgemm_bufferload_limit.yaml
+++ b/Tensile/Configs/rocblas_dgemm_bufferload_limit.yaml
@@ -179,7 +179,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Range: [ [32], [32], [1], [33554432] ]  # strideA = 33554432, should fail on MT0 >= 16 (For tensorA-T)
-          - Range: [ [32], [32], [1], [16777216] ]  # strideA = 16777216, should fail on MT0 >= 32 (For tensorA-T)
+          # - Range: [ [32], [32], [1], [16777216] ]  # strideA = 16777216, should fail on MT0 >= 32 (For tensorA-T)  # TODO - this randomly causes a segfault, Skip for now
           - Range: [ [32], [33554432], [1], [32] ]  # strideB = 33554432, should fail on DU >= 16 (For tensorB-T)
           - Range: [ [32], [16777216], [1], [32] ]  # strideB = 16777216, should fail on DU >= 32 (For tensorB-T)
 

--- a/Tensile/Configs/rocblas_dgemm_bufferload_limit.yaml
+++ b/Tensile/Configs/rocblas_dgemm_bufferload_limit.yaml
@@ -1,0 +1,195 @@
+GlobalParameters:
+  BoundsCheck: False
+  KernelTime: True
+  NewClient: 2
+  # PrintSolutionRejectionReason: True
+  # NumElementsToValidate: 65535
+  # CMakeBuildType: Debug
+  
+BenchmarkProblems:
+
+  ########################################
+  # NN
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: d
+      TransposeA: False
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - BufferLoad: [True]
+        - BufferStore: [True]
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - WorkGroupMapping: [8]
+      ForkParameters:
+        - VectorWidth: [2]          # 4 never wins
+        - ThreadTile:
+          - [ 2, 4 ]
+        - WorkGroup:
+          - [ 32, 2, 1 ]  # 64x8
+          - [ 16, 4, 1 ]  # 32x16
+          - [ 16, 8, 1 ]  # 32x32
+        - DepthU: [8,16,32]
+        # - DepthU: [8]
+        - StaggerU: [0]
+        - StaggerUStride: [256]
+        - StaggerUMapping: [0]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [33554432], [32], [1], [32] ]  # strideA = 33554432, should fail on DU >= 16 (For tensorA-N) # MT32x32x8: PassBufferLoadAssert but FailBufferStoreAssert
+          - Range: [ [16777216], [32], [1], [32] ]  # strideA = 16777216, should fail on DU >= 32 (For tensorA-N) # MT32x32x8/MT32x32x16: PassBufferLoadAssert but FailBufferStoreAssert
+          - Range: [ [32], [32], [1], [33554432] ]  # strideB = 33554432, should fail on MT1 >= 16 (For tensorB-N)
+          - Range: [ [32], [32], [1], [16777216] ]  # strideB = 16777216, should fail on MT1 >= 32 (For tensorB-N)
+
+  ########################################
+  # NT
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: d
+      TransposeA: False
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - BufferLoad: [True]
+        - BufferStore: [True]
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - WorkGroupMapping: [8]
+      ForkParameters:
+        - VectorWidth: [2]          # 4 never wins
+        - ThreadTile:
+          - [ 2, 2 ]
+        - WorkGroup:
+          - [ 8, 8, 1 ]  # 16x16
+          - [ 8, 16, 1 ]  # 16x32
+          - [ 16, 8, 1 ]  # 32x16
+        - DepthU: [8,16,32]
+        # - DepthU: [8,16]
+        - StaggerU: [0]
+        - StaggerUStride: [256]
+        - StaggerUMapping: [0]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [33554432], [32], [1], [32] ]  # strideA = 33554432, should fail on DU >= 16 (For tensorA-N) # DU8: PassBufferLoadAssert but FailBufferStoreAssert
+          - Range: [ [16777216], [32], [1], [32] ]  # strideA = 16777216, should fail on DU >= 32 (For tensorA-N) # MT16x32x8 / MT16x32x16: PassBufferLoadAssert but FailBufferStoreAssert
+          - Range: [ [32], [33554432], [1], [32] ]  # strideB = 33554432, should fail on DU >= 16 (For tensorB-T)
+          - Range: [ [32], [16777216], [1], [32] ]  # strideB = 16777216, should fail on DU >= 32 (For tensorB-T)
+
+  ########################################
+  # TN
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: d
+      TransposeA: True
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - BufferLoad: [True]
+        - BufferStore: [True]
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - WorkGroupMapping: [8]
+      ForkParameters:
+        - VectorWidth: [2]          # 4 never wins
+        - ThreadTile:
+          - [ 2, 2 ]
+        - WorkGroup:
+          - [ 4, 4, 4 ]   # 8x8x4
+          - [ 4, 8, 2 ]   # 8x16x2
+          - [ 8, 4, 2 ]   # 16x8x2
+          - [ 8, 8, 1 ]   # 16x16
+          - [ 8, 16, 1 ]  # 16x32
+          - [ 16, 8, 1 ]  # 32x16
+        - DepthU: [16]      # DU doesn't affect bufferload limit in TN
+        - StaggerU: [0]
+        - StaggerUStride: [256]
+        - StaggerUMapping: [0]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [32], [32], [1], [33554432] ]  # strideA = 33554432, should fail on MT0 >= 16 (For tensorA-T)  # strideB = 33554432, should fail on MT1 >= 16 (For tensorB-N)
+          - Range: [ [32], [32], [1], [16777216] ]  # strideA = 16777216, should fail on MT0 >= 32 (For tensorA-T)  # strideB = 16777216, should fail on MT1 >= 32 (For tensorB-N)
+
+  ########################################
+  # TT
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: d
+      TransposeA: True
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - BufferLoad: [True]
+        - BufferStore: [True]
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - WorkGroupMapping: [8]
+      ForkParameters:
+        - VectorWidth: [2]          # 4 never wins
+        - ThreadTile:
+          - [ 2, 2 ]
+        - WorkGroup:
+          - [ 4, 4, 4 ]   # 8x8
+          - [ 8, 4, 2 ]   # 16x8
+          - [ 16, 4, 1 ]  # 32x8
+        - DepthU: [8,16,32]
+        - StaggerU: [0]
+        - StaggerUStride: [256]
+        - StaggerUMapping: [0]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [32], [32], [1], [33554432] ]  # strideA = 33554432, should fail on MT0 >= 16 (For tensorA-T)
+          - Range: [ [32], [32], [1], [16777216] ]  # strideA = 16777216, should fail on MT0 >= 32 (For tensorA-T)
+          - Range: [ [32], [33554432], [1], [32] ]  # strideB = 33554432, should fail on DU >= 16 (For tensorB-T)
+          - Range: [ [32], [16777216], [1], [32] ]  # strideB = 16777216, should fail on DU >= 32 (For tensorB-T)
+
+LibraryLogic:
+    ScheduleName: "vega20"
+    DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Device 66af", "Vega 20"]
+    ArchitectureName: "gfx906"
+
+    ScheduleName: "arcturus"
+    DeviceNames: ["Device 7380", "Device 7388", "Device 738c", "Device 7390"]
+    ArchitectureName: "gfx908"
+
+LibraryClient:

--- a/Tensile/Configs/rocblas_hgemm_bufferload_limit.yaml
+++ b/Tensile/Configs/rocblas_hgemm_bufferload_limit.yaml
@@ -1,0 +1,194 @@
+GlobalParameters:
+  BoundsCheck: False
+  KernelTime: True
+  NewClient: 2
+  PrintSolutionRejectionReason: True
+  # NumElementsToValidate: 65535
+  # CMakeBuildType: Debug
+  
+BenchmarkProblems:
+
+  ########################################
+  # NN / TLUA = 1, TLUB = 0
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: h
+      TransposeA: False
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - BufferLoad: [True]
+        - BufferStore: [True]
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - WorkGroupMapping: [8]
+        - AssertFree0ElementMultiple: [2]
+        - AssertFree1ElementMultiple: [2]
+      ForkParameters:
+        - VectorWidth: [2]
+        - ThreadTile:
+          - [ 2, 8 ]
+        - WorkGroup:
+          - [ 32, 2, 1 ]  # 64x16
+          - [ 16, 4, 1 ]  # 32x32
+          - [ 16, 8, 1 ]  # 32x64
+        - DepthU: [32,64]
+        - StaggerU: [0]
+        - StaggerUStride: [256]
+        - StaggerUMapping: [0]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        # - ProblemSizes:
+        #   - Range: [ [67108864], [32], [1], [32] ]  # strideA = 67108864, should fail on DU >= 32 (For tensorA-N)
+        #   - Range: [ [33554432], [64], [1], [64] ]  # strideA = 33554432, should fail on DU >= 64 (For tensorA-N)
+        #   - Range: [ [32], [32], [1], [67108864] ]  # strideB = 33554432, should fail on MT1 >= 32 (For tensorB-N)  # TODO - check MT32x32x32/MT32x64x32/MT32x32x64/MT32x64x64: FailAssert but PassValidate
+        #   - Range: [ [64], [64], [1], [33554432] ]  # strideB = 33554432, should fail on MT1 >= 64 (For tensorB-N)  # TODO - check            MT32x64x32/           MT32x64x64: FailAssert but PassValidate
+
+  # ########################################
+  # # NT / TLUA = 1, TLUB = 1 # Pass
+  # ########################################
+  # -
+  #   - # ProblemType
+  #     OperationType: GEMM
+  #     DataType: h
+  #     TransposeA: False
+  #     TransposeB: True
+  #     UseBeta: True
+  #     Batched: True
+
+  #   - # BenchmarkProblemSizeGroup
+  #     InitialSolutionParameters:
+  #     BenchmarkCommonParameters:
+  #       - BufferLoad: [True]
+  #       - BufferStore: [True]
+  #       - KernelLanguage: ["Assembly"]
+  #       - EdgeType: ["ShiftPtr"]
+  #       - LoopTail: [True]
+  #       - WorkGroupMapping: [8]
+  #       - AssertFree0ElementMultiple: [2]
+  #       - AssertFree1ElementMultiple: [2]
+  #     ForkParameters:
+  #       - VectorWidth: [2]
+  #       - ThreadTile:
+  #         - [ 2, 2 ]
+  #       - WorkGroup:
+  #         - [ 16, 16, 1 ]  # 32x32
+  #         - [ 16, 32, 1 ]  # 32x64
+  #         - [ 32, 16, 1 ]  # 64x32
+  #       - DepthU: [16,32,64]
+  #       - StaggerU: [0]
+  #       - StaggerUStride: [256]
+  #       - StaggerUMapping: [0]
+  #     BenchmarkForkParameters:
+  #     JoinParameters:
+  #     BenchmarkJoinParameters:
+  #     BenchmarkFinalParameters:
+  #       - ProblemSizes:
+  #         - Range: [ [67108864], [32], [1], [32] ]  # strideA = 67108864, should fail on DU >= 32 (For tensorA-N)
+  #         - Range: [ [33554432], [64], [1], [64] ]  # strideA = 33554432, should fail on DU >= 64 (For tensorA-N)
+  #         - Range: [ [32], [67108864], [1], [32] ]  # strideB = 67108864, should fail on DU >= 32 (For tensorB-T)
+  #         - Range: [ [64], [33554432], [1], [64] ]  # strideB = 33554432, should fail on DU >= 64 (For tensorB-T)
+
+  # ########################################
+  # # TN / TLUA = 0, TLUB = 0 TODO - seems all incorrect
+  # ########################################
+  # -
+  #   - # ProblemType
+  #     OperationType: GEMM
+  #     DataType: h
+  #     TransposeA: True
+  #     TransposeB: False
+  #     UseBeta: True
+  #     Batched: True
+
+  #   - # BenchmarkProblemSizeGroup
+  #     InitialSolutionParameters:
+  #     BenchmarkCommonParameters:
+  #       - BufferLoad: [True]
+  #       - BufferStore: [True]
+  #       - KernelLanguage: ["Assembly"]
+  #       - EdgeType: ["ShiftPtr"]
+  #       - LoopTail: [True]
+  #       - WorkGroupMapping: [8]
+  #       - AssertFree0ElementMultiple: [2]
+  #       - AssertFree1ElementMultiple: [2]
+  #     ForkParameters:
+  #       - VectorWidth: [2]
+  #       - ThreadTile:
+  #         - [ 2, 2 ]
+  #       - WorkGroup:
+  #         - [ 8, 8, 1 ]   # 16x16
+  #         - [ 8, 16, 1 ]  # 16x32
+  #         - [ 16, 8, 1 ]  # 32x16
+  #         - [ 16, 16, 1 ] # 32x32
+  #         - [ 16, 32, 1 ] # 32x64
+  #         - [ 32, 16, 1 ] # 64x32
+  #       - DepthU: [16]      # DU doesn't affect bufferload limit in TN
+  #     BenchmarkForkParameters:
+  #     JoinParameters:
+  #     BenchmarkJoinParameters:
+  #     BenchmarkFinalParameters:
+  #       - ProblemSizes:
+  #         - Range: [ [32], [32], [1], [67108864] ]  # strideA = 67108864, should fail on MT0 >= 32 (For tensorA-T)  # strideB = 67108864, should fail on MT1 >= 32 (For tensorB-N)
+  #         - Range: [ [64], [64], [1], [33554432] ]  # strideA = 33554432, should fail on MT0 >= 64 (For tensorA-T)  # strideB = 33554432, should fail on MT1 >= 64 (For tensorB-N)
+
+  # ########################################
+  # # TT / TLUA = 0, TLUB = 1
+  # ########################################
+  # -
+  #   - # ProblemType
+  #     OperationType: GEMM
+  #     DataType: h
+  #     TransposeA: True
+  #     TransposeB: True
+  #     UseBeta: True
+  #     Batched: True
+
+  #   - # BenchmarkProblemSizeGroup
+  #     InitialSolutionParameters:
+  #     BenchmarkCommonParameters:
+  #       - BufferLoad: [True]
+  #       - BufferStore: [True]
+  #       - KernelLanguage: ["Assembly"]
+  #       - EdgeType: ["ShiftPtr"]
+  #       - LoopTail: [True]
+  #       - WorkGroupMapping: [8]
+  #       - AssertFree0ElementMultiple: [2]
+  #     ForkParameters:
+  #       - VectorWidth: [2]
+  #       - ThreadTile:
+  #         - [ 2, 2 ]
+  #       - WorkGroup:
+  #         - [ 8, 8, 1 ]   # 16x16
+  #         - [ 16, 8, 1 ]  # 32x16
+  #         - [ 32, 8, 1 ]  # 64x16
+  #       - DepthU: [16,32,64]
+  #     BenchmarkForkParameters:
+  #     JoinParameters:
+  #     BenchmarkJoinParameters:
+  #     BenchmarkFinalParameters:
+  #       - ProblemSizes:
+  #         - Range: [ [32], [32], [1], [67108864] ]  # strideA = 67108864, should fail on MT0 >= 32 (For tensorA-T)
+  #         - Range: [ [64], [64], [1], [33554432] ]  # strideA = 33554432, should fail on MT0 >= 64 (For tensorA-T)  # TODO - check MT64x16x32: FailAssert but PassValidate
+  #         - Range: [ [32], [67108864], [1], [32] ]  # strideB = 67108864, should fail on DU >= 32 (For tensorB-T)
+  #         - Range: [ [64], [33554432], [1], [64] ]  # strideB = 33554432, should fail on DU >= 64 (For tensorB-T)
+
+LibraryLogic:
+    ScheduleName: "vega20"
+    DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Device 66af", "Vega 20"]
+    ArchitectureName: "gfx906"
+
+    ScheduleName: "arcturus"
+    DeviceNames: ["Device 7380", "Device 7388", "Device 738c", "Device 7390"]
+    ArchitectureName: "gfx908"
+
+LibraryClient:

--- a/Tensile/Configs/rocblas_sgemm_bufferload_limit.yaml
+++ b/Tensile/Configs/rocblas_sgemm_bufferload_limit.yaml
@@ -1,0 +1,194 @@
+GlobalParameters:
+  BoundsCheck: False
+  KernelTime: True
+  NewClient: 2
+  # PrintSolutionRejectionReason: True
+  # NumElementsToValidate: 65535
+  # CMakeBuildType: Debug
+  
+BenchmarkProblems:
+
+  ########################################
+  # NN / TLUA = 1, TLUB = 0
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: s
+      TransposeA: False
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - BufferLoad: [True]
+        - BufferStore: [True]
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - WorkGroupMapping: [8]
+      ForkParameters:
+        - VectorWidth: [2]
+        - ThreadTile:
+          - [ 2, 8 ]
+        - WorkGroup:
+          - [ 32, 2, 1 ]  # 64x16
+          - [ 16, 4, 1 ]  # 32x32
+          - [ 16, 8, 1 ]  # 32x64
+        - DepthU: [16,32,64]
+        - StaggerU: [0]
+        - StaggerUStride: [256]
+        - StaggerUMapping: [0]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [33554432], [64], [1], [64] ]  # strideA = 33554432, should fail on DU >= 32 (For tensorA-N)
+          - Range: [ [16777216], [64], [1], [64] ]  # strideA = 16777216, should fail on DU >= 64 (For tensorA-N)
+          - Range: [ [64], [64], [1], [33554432] ]  # strideB = 33554432, should fail on MT1 >= 32 (For tensorB-N)
+          - Range: [ [64], [64], [1], [16777216] ]  # strideB = 16777216, should fail on MT1 >= 64 (For tensorB-N)
+
+  ########################################
+  # NT / TLUA = 1, TLUB = 1
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: s
+      TransposeA: False
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - BufferLoad: [True]
+        - BufferStore: [True]
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - WorkGroupMapping: [8]
+      ForkParameters:
+        - VectorWidth: [2]
+        - ThreadTile:
+          - [ 2, 2 ]
+        - WorkGroup:
+          - [ 8, 8, 1 ]  # 16x16
+          - [ 8, 16, 1 ]  # 16x32
+          - [ 16, 8, 1 ]  # 32x16
+        - DepthU: [16,32,64]
+        # - DepthU: [16]
+        - StaggerU: [0]
+        - StaggerUStride: [256]
+        - StaggerUMapping: [0]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [33554432], [64], [1], [64] ]  # strideA = 33554432, should fail on DU >= 32 (For tensorA-N) # MT16x32x16: PassBufferLoadAssert but FailBufferStoreAssert
+          - Range: [ [16777216], [64], [1], [64] ]  # strideA = 16777216, should fail on DU >= 64 (For tensorA-N)
+          - Range: [ [64], [33554432], [1], [64] ]  # strideB = 33554432, should fail on DU >= 32 (For tensorB-T)
+          - Range: [ [64], [16777216], [1], [64] ]  # strideB = 16777216, should fail on DU >= 64 (For tensorB-T)
+
+  ########################################
+  # TN / TLUA = 0, TLUB = 0
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: s
+      TransposeA: True
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - BufferLoad: [True]
+        - BufferStore: [True]
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - WorkGroupMapping: [8]
+      ForkParameters:
+        - VectorWidth: [2]
+        - ThreadTile:
+          - [ 2, 2 ]
+        - WorkGroup:
+          - [ 8, 8, 1 ]   # 16x16
+          - [ 8, 16, 1 ]  # 16x32
+          - [ 16, 8, 1 ]  # 32x16
+          - [ 16, 16, 1 ] # 32x32
+          - [ 16, 32, 1 ] # 32x64
+          - [ 32, 16, 1 ] # 64x32
+        - DepthU: [16]      # DU doesn't affect bufferload limit in TN
+        - StaggerU: [0]
+        - StaggerUStride: [256]
+        - StaggerUMapping: [0]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [64], [64], [1], [33554432] ]  # strideA = 33554432, should fail on MT0 >= 32 (For tensorA-T)  # strideB = 33554432, should fail on MT1 >= 32 (For tensorB-N)
+          - Range: [ [64], [64], [1], [16777216] ]  # strideA = 16777216, should fail on MT0 >= 64 (For tensorA-T)  # strideB = 16777216, should fail on MT1 >= 64 (For tensorB-N)
+
+  ########################################
+  # TT / TLUA = 0, TLUB = 1
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: s
+      TransposeA: True
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - BufferLoad: [True]
+        - BufferStore: [True]
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - WorkGroupMapping: [8]
+      ForkParameters:
+        - VectorWidth: [2]
+        - ThreadTile:
+          - [ 2, 2 ]
+        - WorkGroup:
+          - [ 8, 8, 1 ]   # 16x16
+          - [ 16, 8, 1 ]  # 32x16
+          - [ 32, 8, 1 ]  # 64x16
+        - DepthU: [16,32,64]
+        - StaggerU: [0]
+        - StaggerUStride: [256]
+        - StaggerUMapping: [0]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [64], [64], [1], [33554432] ]  # strideA = 33554432, should fail on MT0 >= 32 (For tensorA-T)
+          - Range: [ [64], [64], [1], [16777216] ]  # strideA = 16777216, should fail on MT0 >= 64 (For tensorA-T)
+          - Range: [ [64], [33554432], [1], [64] ]  # strideB = 33554432, should fail on DU >= 32 (For tensorB-T)
+          - Range: [ [64], [16777216], [1], [64] ]  # strideB = 16777216, should fail on DU >= 64 (For tensorB-T)
+
+LibraryLogic:
+    ScheduleName: "vega20"
+    DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Device 66af", "Vega 20"]
+    ArchitectureName: "gfx906"
+
+    ScheduleName: "arcturus"
+    DeviceNames: ["Device 7380", "Device 7388", "Device 738c", "Device 7390"]
+    ArchitectureName: "gfx908"
+
+LibraryClient:

--- a/Tensile/Configs/rocblas_sgemm_bufferload_limit.yaml
+++ b/Tensile/Configs/rocblas_sgemm_bufferload_limit.yaml
@@ -49,7 +49,7 @@ BenchmarkProblems:
           - Range: [ [33554432], [64], [1], [64] ]  # strideA = 33554432, should fail on DU >= 32 (For tensorA-N)
           - Range: [ [16777216], [64], [1], [64] ]  # strideA = 16777216, should fail on DU >= 64 (For tensorA-N)
           - Range: [ [64], [64], [1], [33554432] ]  # strideB = 33554432, should fail on MT1 >= 32 (For tensorB-N)
-          - Range: [ [64], [64], [1], [16777216] ]  # strideB = 16777216, should fail on MT1 >= 64 (For tensorB-N)
+          # - Range: [ [64], [64], [1], [16777216] ]  # strideB = 16777216, should fail on MT1 >= 64 (For tensorB-N)  # TODO - this randomly causes a segfault, Skip for now
 
   ########################################
   # NT / TLUA = 1, TLUB = 1
@@ -178,7 +178,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Range: [ [64], [64], [1], [33554432] ]  # strideA = 33554432, should fail on MT0 >= 32 (For tensorA-T)
-          - Range: [ [64], [64], [1], [16777216] ]  # strideA = 16777216, should fail on MT0 >= 64 (For tensorA-T)
+          # - Range: [ [64], [64], [1], [16777216] ]  # strideA = 16777216, should fail on MT0 >= 64 (For tensorA-T)  # TODO - this randomly causes a segfault, Skip for now
           - Range: [ [64], [33554432], [1], [64] ]  # strideB = 33554432, should fail on DU >= 32 (For tensorB-T)
           - Range: [ [64], [16777216], [1], [64] ]  # strideB = 16777216, should fail on DU >= 64 (For tensorB-T)
 

--- a/Tensile/Contractions.py
+++ b/Tensile/Contractions.py
@@ -331,8 +331,8 @@ class ProblemPredicate(Properties.Predicate):
         # to prevent from some extremely large problems from launching and causing bufferload offset limit < 2^32
         # thoses cases will not satisfy the assertion thus won't use the kernel.
         # See Common.py for more details, we will need four values: 
-        # TODO - haven't been fully tested for FP16 and BF16, so we consider single and double only so far.
-        if 'BufferLoad' in state and state['BufferLoad'] == True and (problemType.aType.isSingle() or problemType.aType.isDouble()):
+        # TODO - haven't been fully tested for FP16 and BF, need to verify the false-positive
+        if 'BufferLoad' in state and state['BufferLoad'] == True:
             TLUA = state['ProblemType']['TLUA']
             TLUB = state['ProblemType']['TLUB']            
             MayShiftA = TLUA and state['AssertFree0ElementMultiple'] < state['GlobalLoadVectorWidthA']
@@ -348,7 +348,7 @@ class ProblemPredicate(Properties.Predicate):
         # similiar check is applied for bufferstore,
         # for bufferstore offset, test if the bot-right offset < 2^32, 
         # it should be StrideA*MT1, so we need to output MT1 and use the StrideA of problem in host-side for predication
-        if 'BufferStore' in state and state['BufferStore'] == True and (problemType.cType.isSingle() or problemType.aType.isDouble()):       
+        if 'BufferStore' in state and state['BufferStore'] == True:
             rv += [cls('BufferStoreOffsetLimitCheck', value=state['MacroTile1'])]            
 
         return rv

--- a/Tensile/Contractions.py
+++ b/Tensile/Contractions.py
@@ -330,20 +330,20 @@ class ProblemPredicate(Properties.Predicate):
         # if bufferload is performed, we output some predication info for host side,
         # to prevent from some extremely large problems from launching and causing bufferload offset limit < 2^32
         # thoses cases will not satisfy the assertion thus won't use the kernel.
+        # See Common.py for more details, we will need four values: 
         # TODO - haven't been fully tested for FP16 and BF16, so we consider single and double only so far.
         if 'BufferLoad' in state and state['BufferLoad'] == True and (problemType.aType.isSingle() or problemType.aType.isDouble()):
             TLUA = state['ProblemType']['TLUA']
             TLUB = state['ProblemType']['TLUB']            
             MayShiftA = TLUA and state['AssertFree0ElementMultiple'] < state['GlobalLoadVectorWidthA']
             MayShiftB = TLUB and state['AssertFree1ElementMultiple'] < state['GlobalLoadVectorWidthB']
-            # See Common.py for more details, we pack the possible needed info in one value: 
-            # for the later two fields, using DU or MT depends on the TLU value
-            # |-- (ShiftPtrElemB) 4-bit --|--(ShiftPtrElemA) 4-bit--|--(DU/MT0 elem) 11-bit--|--(DU/MT1 elem)11-bit--|
-            encodedValue = ((state['GlobalLoadVectorWidthB'] << 26) if MayShiftB else 0 ) | \
-                           ((state['GlobalLoadVectorWidthA'] << 22) if MayShiftA else 0 ) | \
-                           ((state['DepthU'] if TLUB else state['MacroTile1']) << 11) | \
-                           (state['DepthU'] if TLUA else state['MacroTile0'])            
-            rv += [cls('BufferLoadOffsetLimitCheck', value=encodedValue)]
+            subrv={}
+            subrv['ShiftPtrElemB'] = state['GlobalLoadVectorWidthB'] if MayShiftB else 0
+            subrv['ShiftPtrElemA'] = state['GlobalLoadVectorWidthA'] if MayShiftA else 0
+            subrv['DUorMT1'] = state['DepthU'] if TLUB else state['MacroTile1']
+            subrv['DUorMT0'] = state['DepthU'] if TLUA else state['MacroTile0']
+            # value is also a dict for better readibility, client side need to handel the serialization
+            rv += [cls('BufferLoadOffsetLimitCheck', value=subrv)]
 
         # similiar check is applied for bufferstore,
         # for bufferstore offset, test if the bot-right offset < 2^32, 

--- a/Tensile/Source/lib/include/Tensile/ContractionSolution.hpp
+++ b/Tensile/Source/lib/include/Tensile/ContractionSolution.hpp
@@ -52,6 +52,14 @@ namespace Tensile
 
     extern PerfModel perf;
 
+    struct BufferLoadCheckPacket
+    {
+        size_t shiftPtrElemA;
+        size_t shiftPtrElemB;
+        size_t depthUorMT0;
+        size_t depthUorMT1;
+    };    
+
     /**
  * Represents a single kernel or set of kernels that can perform a single
  * tensor contraction.
@@ -228,4 +236,5 @@ namespace Tensile
                              ContractionSolution::StaticPerformanceModel const& spm);
     std::ostream& operator<<(std::ostream&                                    stream,
                              ContractionSolution::ProjectedPerformance const& spm);
+    std::ostream& operator<<(std::ostream& stream, BufferLoadCheckPacket const& st);
 } // namespace Tensile

--- a/Tensile/Source/lib/include/Tensile/Serialization/ContractionPredicates.hpp
+++ b/Tensile/Source/lib/include/Tensile/Serialization/ContractionPredicates.hpp
@@ -78,6 +78,8 @@ namespace Tensile
                     Base::template Pair<Predicates::Contraction::ArithmeticUnitEqual>(),
                     Base::template Pair<Predicates::Contraction::TypesEqual>(),
                     Base::template Pair<Predicates::Contraction::OperationIdentifierEqual>(),
+                    Base::template Pair<Predicates::Contraction::BufferLoadOffsetLimitCheck>(),
+                    Base::template Pair<Predicates::Contraction::BufferStoreOffsetLimitCheck>(),
                 });
 
                 auto gmap = Generic::GetSubclasses();
@@ -225,6 +227,18 @@ namespace Tensile
         template <typename IO>
         struct MappingTraits<Predicates::Contraction::OperationIdentifierEqual, IO>
             : public AutoMappingTraits<Predicates::Contraction::OperationIdentifierEqual, IO>
+        {
+        };
+
+        template <typename IO>
+        struct MappingTraits<Predicates::Contraction::BufferLoadOffsetLimitCheck, IO>
+            : public AutoMappingTraits<Predicates::Contraction::BufferLoadOffsetLimitCheck, IO>
+        {
+        };
+
+        template <typename IO>
+        struct MappingTraits<Predicates::Contraction::BufferStoreOffsetLimitCheck, IO>
+            : public AutoMappingTraits<Predicates::Contraction::BufferStoreOffsetLimitCheck, IO>
         {
         };
     } // namespace Serialization

--- a/Tensile/Source/lib/include/Tensile/Serialization/ContractionSolution.hpp
+++ b/Tensile/Source/lib/include/Tensile/Serialization/ContractionSolution.hpp
@@ -115,5 +115,20 @@ namespace Tensile
 
             const static bool flow = false;
         };
+
+        template <typename IO>
+        struct MappingTraits<BufferLoadCheckPacket, IO>
+        {
+            using iot = IOTraits<IO>;
+            static void mapping(IO& io, BufferLoadCheckPacket& s)
+            {
+                iot::mapRequired(io, "ShiftPtrElemA", s.shiftPtrElemA);
+                iot::mapRequired(io, "ShiftPtrElemB", s.shiftPtrElemB);
+                iot::mapRequired(io, "DUorMT0", s.depthUorMT0);
+                iot::mapRequired(io, "DUorMT1", s.depthUorMT1);
+            }
+
+            const static bool flow = false;
+        };
     } // namespace Serialization
 } // namespace Tensile

--- a/Tensile/Source/lib/source/ContractionSolution.cpp
+++ b/Tensile/Source/lib/source/ContractionSolution.cpp
@@ -880,4 +880,13 @@ namespace Tensile
                       << " staticModel=[ " << pp.staticModel << " ]";
     }
 
+    std::ostream& operator<<(std::ostream& stream, BufferLoadCheckPacket const& st)
+    {
+        return stream << " shiftPtrElemA=" << st.shiftPtrElemA
+                      << " shiftPtrElemB=" << st.shiftPtrElemB
+                      << " depthUorMT0=" << st.depthUorMT0
+                      << " depthUorMT1=" << st.depthUorMT1;
+    }
+
+
 } // namespace Tensile

--- a/Tensile/Tests/extended/bufferload_offset/rocblas_dgemm_bufferload_limit.yaml
+++ b/Tensile/Tests/extended/bufferload_offset/rocblas_dgemm_bufferload_limit.yaml
@@ -158,7 +158,6 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Range: [ [32], [32], [1], [33554432] ]  # strideA = 33554432, should fail on MT0 >= 16 (For tensorA-T)
-          - Range: [ [32], [32], [1], [16777216] ]  # strideA = 16777216, should fail on MT0 >= 32 (For tensorA-T)
           - Range: [ [32], [33554432], [1], [32] ]  # strideB = 33554432, should fail on DU >= 16 (For tensorB-T)
           - Range: [ [32], [16777216], [1], [32] ]  # strideB = 16777216, should fail on DU >= 32 (For tensorB-T)
 

--- a/Tensile/Tests/extended/bufferload_offset/rocblas_dgemm_bufferload_limit.yaml
+++ b/Tensile/Tests/extended/bufferload_offset/rocblas_dgemm_bufferload_limit.yaml
@@ -1,0 +1,174 @@
+GlobalParameters:
+  BoundsCheck: False
+  KernelTime: True
+  NewClient: 2
+  PrintSolutionRejectionReason: True
+  
+BenchmarkProblems:
+
+  ########################################
+  # NN / TLUA = 1, TLUB = 0
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: d
+      TransposeA: False
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - BufferLoad: [True]
+        - BufferStore: [True]
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - WorkGroupMapping: [8]
+      ForkParameters:
+        - VectorWidth: [2]
+        - ThreadTile:
+          - [ 2, 4 ]
+        - WorkGroup:
+          - [ 16, 4, 1 ]  # 32x16
+          - [ 16, 8, 1 ]  # 32x32
+        - DepthU: [16,32]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [33554432], [32], [1], [32] ]  # strideA = 33554432, should fail on DU >= 16 (For tensorA-N)
+          - Range: [ [16777216], [32], [1], [32] ]  # strideA = 16777216, should fail on DU >= 32 (For tensorA-N)
+          - Range: [ [32], [32], [1], [33554432] ]  # strideB = 33554432, should fail on MT1 >= 16 (For tensorB-N)
+          - Range: [ [32], [32], [1], [16777216] ]  # strideB = 16777216, should fail on MT1 >= 32 (For tensorB-N)
+
+  ########################################
+  # NT / TLUA = 1, TLUB = 1
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: d
+      TransposeA: False
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - BufferLoad: [True]
+        - BufferStore: [True]
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - WorkGroupMapping: [8]
+      ForkParameters:
+        - VectorWidth: [2]          # 4 never wins
+        - ThreadTile:
+          - [ 2, 2 ]
+        - WorkGroup:
+          - [ 16, 16, 1 ]  # 32x32
+        - DepthU: [16,32]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [33554432], [32], [1], [32] ]  # strideA = 33554432, should fail on DU >= 16 (For tensorA-N)
+          - Range: [ [16777216], [32], [1], [32] ]  # strideA = 16777216, should fail on DU >= 32 (For tensorA-N)
+          - Range: [ [32], [33554432], [1], [32] ]  # strideB = 33554432, should fail on DU >= 16 (For tensorB-T)
+          - Range: [ [32], [16777216], [1], [32] ]  # strideB = 16777216, should fail on DU >= 32 (For tensorB-T)
+
+  ########################################
+  # TN / TLUA = 0, TLUB = 0
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: d
+      TransposeA: True
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - BufferLoad: [True]
+        - BufferStore: [True]
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - WorkGroupMapping: [8]
+      ForkParameters:
+        - VectorWidth: [2]          # 4 never wins
+        - ThreadTile:
+          - [ 2, 2 ]
+        - WorkGroup:
+          - [ 4, 8, 2 ]   # 8x16x2
+          - [ 8, 4, 2 ]   # 16x8x2
+          - [ 8, 8, 1 ]   # 16x16
+          - [ 8, 16, 1 ]  # 16x32
+          - [ 16, 8, 1 ]  # 32x16
+        - DepthU: [16]      # DU doesn't affect bufferload limit in TN
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [32], [32], [1], [33554432] ]  # strideA = 33554432, should fail on MT0 >= 16 (For tensorA-T)  # strideB = 33554432, should fail on MT1 >= 16 (For tensorB-N)
+          - Range: [ [32], [32], [1], [16777216] ]  # strideA = 16777216, should fail on MT0 >= 32 (For tensorA-T)  # strideB = 16777216, should fail on MT1 >= 32 (For tensorB-N)
+
+  ########################################
+  # TT / TLUA = 0, TLUB = 1
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: d
+      TransposeA: True
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - BufferLoad: [True]
+        - BufferStore: [True]
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - WorkGroupMapping: [8]
+      ForkParameters:
+        - VectorWidth: [2]          # 4 never wins
+        - ThreadTile:
+          - [ 2, 2 ]
+        - WorkGroup:
+          - [ 8, 4, 2 ]   # 16x8
+          - [ 16, 4, 1 ]  # 32x8
+        - DepthU: [16,32]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [32], [32], [1], [33554432] ]  # strideA = 33554432, should fail on MT0 >= 16 (For tensorA-T)
+          - Range: [ [32], [32], [1], [16777216] ]  # strideA = 16777216, should fail on MT0 >= 32 (For tensorA-T)
+          - Range: [ [32], [33554432], [1], [32] ]  # strideB = 33554432, should fail on DU >= 16 (For tensorB-T)
+          - Range: [ [32], [16777216], [1], [32] ]  # strideB = 16777216, should fail on DU >= 32 (For tensorB-T)
+
+LibraryLogic:
+    ScheduleName: "vega20"
+    DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Device 66af", "Vega 20"]
+    ArchitectureName: "gfx906"
+
+    ScheduleName: "arcturus"
+    DeviceNames: ["Device 7380", "Device 7388", "Device 738c", "Device 7390"]
+    ArchitectureName: "gfx908"
+
+LibraryClient:

--- a/Tensile/Tests/extended/bufferload_offset/rocblas_sgemm_bufferload_limit.yaml
+++ b/Tensile/Tests/extended/bufferload_offset/rocblas_sgemm_bufferload_limit.yaml
@@ -1,0 +1,174 @@
+GlobalParameters:
+  BoundsCheck: False
+  KernelTime: True
+  NewClient: 2
+  PrintSolutionRejectionReason: True
+  
+BenchmarkProblems:
+
+  ########################################
+  # NN / TLUA = 1, TLUB = 0
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: s
+      TransposeA: False
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - BufferLoad: [True]
+        - BufferStore: [True]
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - WorkGroupMapping: [8]
+      ForkParameters:
+        - VectorWidth: [2]
+        - ThreadTile:
+          - [ 2, 8 ]
+        - WorkGroup:
+          - [ 16, 4, 1 ]  # 32x32
+          - [ 16, 8, 1 ]  # 32x64
+        - DepthU: [32,64]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [33554432], [64], [1], [64] ]  # strideA = 33554432, should fail on DU >= 32 (For tensorA-N)
+          - Range: [ [16777216], [64], [1], [64] ]  # strideA = 16777216, should fail on DU >= 64 (For tensorA-N)
+          - Range: [ [64], [64], [1], [33554432] ]  # strideB = 33554432, should fail on MT1 >= 32 (For tensorB-N)
+          - Range: [ [64], [64], [1], [16777216] ]  # strideB = 16777216, should fail on MT1 >= 64 (For tensorB-N)
+
+  ########################################
+  # NT / TLUA = 1, TLUB = 1
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: s
+      TransposeA: False
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - BufferLoad: [True]
+        - BufferStore: [True]
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - WorkGroupMapping: [8]
+      ForkParameters:
+        - VectorWidth: [2]
+        - ThreadTile:
+          - [ 2, 2 ]
+        - WorkGroup:
+          - [ 16, 16, 1 ]  # 32x32
+        - DepthU: [32,64]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [33554432], [64], [1], [64] ]  # strideA = 33554432, should fail on DU >= 32 (For tensorA-N)
+          - Range: [ [16777216], [64], [1], [64] ]  # strideA = 16777216, should fail on DU >= 64 (For tensorA-N)
+          - Range: [ [64], [33554432], [1], [64] ]  # strideB = 33554432, should fail on DU >= 32 (For tensorB-T)
+          - Range: [ [64], [16777216], [1], [64] ]  # strideB = 16777216, should fail on DU >= 64 (For tensorB-T)
+
+  ########################################
+  # TN / TLUA = 0, TLUB = 0
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: s
+      TransposeA: True
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - BufferLoad: [True]
+        - BufferStore: [True]
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - WorkGroupMapping: [8]
+      ForkParameters:
+        - VectorWidth: [2]
+        - ThreadTile:
+          - [ 2, 2 ]
+        - WorkGroup:
+          - [ 8, 16, 1 ]  # 16x32
+          - [ 16, 8, 1 ]  # 32x16
+          - [ 16, 16, 1 ] # 32x32
+          - [ 16, 32, 1 ] # 32x64
+          - [ 32, 16, 1 ] # 64x32
+        - DepthU: [16]      # DU doesn't affect bufferload limit in TN
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [64], [64], [1], [33554432] ]  # strideA = 33554432, should fail on MT0 >= 32 (For tensorA-T)  # strideB = 33554432, should fail on MT1 >= 32 (For tensorB-N)
+          - Range: [ [64], [64], [1], [16777216] ]  # strideA = 16777216, should fail on MT0 >= 64 (For tensorA-T)  # strideB = 16777216, should fail on MT1 >= 64 (For tensorB-N)
+
+  ########################################
+  # TT / TLUA = 0, TLUB = 1
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: s
+      TransposeA: True
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - BufferLoad: [True]
+        - BufferStore: [True]
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - WorkGroupMapping: [8]
+      ForkParameters:
+        - VectorWidth: [2]
+        - ThreadTile:
+          - [ 2, 2 ]
+        - WorkGroup:
+          - [ 16, 8, 1 ]  # 32x16
+          - [ 32, 8, 1 ]  # 64x16
+        - DepthU: [32,64]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [64], [64], [1], [33554432] ]  # strideA = 33554432, should fail on MT0 >= 32 (For tensorA-T)
+          - Range: [ [64], [64], [1], [16777216] ]  # strideA = 16777216, should fail on MT0 >= 64 (For tensorA-T)
+          - Range: [ [64], [33554432], [1], [64] ]  # strideB = 33554432, should fail on DU >= 32 (For tensorB-T)
+          - Range: [ [64], [16777216], [1], [64] ]  # strideB = 16777216, should fail on DU >= 64 (For tensorB-T)
+
+LibraryLogic:
+    ScheduleName: "vega20"
+    DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Device 66af", "Vega 20"]
+    ArchitectureName: "gfx906"
+
+    ScheduleName: "arcturus"
+    DeviceNames: ["Device 7380", "Device 7388", "Device 738c", "Device 7390"]
+    ArchitectureName: "gfx908"
+
+LibraryClient:

--- a/Tensile/Tests/extended/bufferload_offset/rocblas_sgemm_bufferload_limit.yaml
+++ b/Tensile/Tests/extended/bufferload_offset/rocblas_sgemm_bufferload_limit.yaml
@@ -43,7 +43,6 @@ BenchmarkProblems:
           - Range: [ [33554432], [64], [1], [64] ]  # strideA = 33554432, should fail on DU >= 32 (For tensorA-N)
           - Range: [ [16777216], [64], [1], [64] ]  # strideA = 16777216, should fail on DU >= 64 (For tensorA-N)
           - Range: [ [64], [64], [1], [33554432] ]  # strideB = 33554432, should fail on MT1 >= 32 (For tensorB-N)
-          - Range: [ [64], [64], [1], [16777216] ]  # strideB = 16777216, should fail on MT1 >= 64 (For tensorB-N)
 
   ########################################
   # NT / TLUA = 1, TLUB = 1
@@ -158,7 +157,6 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Range: [ [64], [64], [1], [33554432] ]  # strideA = 33554432, should fail on MT0 >= 32 (For tensorA-T)
-          - Range: [ [64], [64], [1], [16777216] ]  # strideA = 16777216, should fail on MT0 >= 64 (For tensorA-T)
           - Range: [ [64], [33554432], [1], [64] ]  # strideB = 33554432, should fail on DU >= 32 (For tensorB-T)
           - Range: [ [64], [16777216], [1], [64] ]  # strideB = 16777216, should fail on DU >= 64 (For tensorB-T)
 


### PR DESCRIPTION
Add new predicates to check if a problem will cause bufferload offset >= 2^32 for a kernel. 
if DID_NOT_SATISFY_ASSERTS, then the kernel will not be used for the problem to avoid incorrect gemm result.
The yamls under Tests/extended/bufflerload_limit show these kind of problems. 