### PR TITLE
fix sync issue in one DB replacement kernel; add replacement kernel support for NewClient:2

### DIFF
--- a/Tensile/ReplacementKernels-cov3/Cijk_Ailk_Bjlk_DB_MT48x64x4_AF0EM1_ASEM1_FL1_GRVW2_ISA906_MDA2_PGR1_PLR0_SU0_TT6_4_VAW1_VW2_WG8_16_1_WGM4.s.txt
+++ b/Tensile/ReplacementKernels-cov3/Cijk_Ailk_Bjlk_DB_MT48x64x4_AF0EM1_ASEM1_FL1_GRVW2_ISA906_MDA2_PGR1_PLR0_SU0_TT6_4_VAW1_VW2_WG8_16_1_WGM4.s.txt
@@ -1,0 +1,3886 @@
+
+
+/******************************************/
+/* Function Prefix                        */
+/******************************************/
+
+
+
+/******************************************/
+/* Begin Kernel                           */
+/******************************************/
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx906"
+.text
+.protected Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA906_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM4
+.globl Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA906_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM4
+.p2align 8
+.type Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA906_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM4,@function
+.section .rodata,#alloc
+.p2align 6
+.amdhsa_kernel Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA906_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM4
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_next_free_vgpr 84 // vgprs
+  .amdhsa_next_free_sgpr 98 // sgprs
+  .amdhsa_group_segment_fixed_size 7680 // lds bytes
+  .amdhsa_private_segment_fixed_size 0
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+.text
+
+.amdgpu_metadata
+---
+amdhsa.version:
+  - 1
+  - 0
+amdhsa.kernels:
+  - .name: Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA906_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM4
+    .symbol: 'Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA906_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM4.kd'
+    .group_segment_fixed_size:   7680
+    .language:                   OpenCL C
+    .language_version:
+      - 2
+      - 0
+    .max_flat_workgroup_size: 128
+    .private_segment_fixed_size: 0
+    .sgpr_count:                 98
+    .sgpr_spill_count:           0
+    .vgpr_count:                 84
+    .vgpr_spill_count:           0
+    .wavefront_size:             64
+    .args:
+      - .name:            sizeC
+        .size:            8
+        .offset:          0
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            sizeA
+        .size:            8
+        .offset:          8
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            sizeB
+        .size:            8
+        .offset:          16
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            D
+        .size:            8
+        .offset:          24
+        .value_kind:      global_buffer
+        .value_type:      f64
+        .address_space:   generic
+      - .name:            C
+        .size:            8
+        .offset:          32
+        .value_kind:      global_buffer
+        .value_type:      f64
+        .address_space:   generic
+      - .name:            A
+        .size:            8
+        .offset:          40
+        .value_kind:      global_buffer
+        .value_type:      f64
+        .address_space:   generic
+      - .name:            B
+        .size:            8
+        .offset:          48
+        .value_kind:      global_buffer
+        .value_type:      f64
+        .address_space:   generic
+      - .name:            alpha
+        .size:            8
+        .offset:          56
+        .value_kind:      by_value
+        .value_type:      f64
+      - .name:            beta
+        .size:            8
+        .offset:          64
+        .value_kind:      by_value
+        .value_type:      f64
+      - .name:            strideD0
+        .size:            4
+        .offset:          72
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideD1
+        .size:            4
+        .offset:          76
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideC0
+        .size:            4
+        .offset:          80
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideC1
+        .size:            4
+        .offset:          84
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideA0
+        .size:            4
+        .offset:          88
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideA1
+        .size:            4
+        .offset:          92
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideB0
+        .size:            4
+        .offset:          96
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideB1
+        .size:            4
+        .offset:          100
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree0
+        .size:            4
+        .offset:          104
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree1
+        .size:            4
+        .offset:          108
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree2
+        .size:            4
+        .offset:          112
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesSum0
+        .size:            4
+        .offset:          116
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            OrigStaggerUIter
+        .size:            4
+        .offset:          120
+        .value_kind:      by_value
+        .value_type:      i32
+      - .name:            NumWorkGroups0
+        .size:            4
+        .offset:          124
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            NumWorkGroups1
+        .size:            4
+        .offset:          128
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            MagicNumberProblemNumGroupTiles0
+        .size:            4
+        .offset:          132
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            GridNumWorkGroups0
+        .size:            4
+        .offset:          136
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            NumFullBlocks
+        .size:            4
+        .offset:          140
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            WgmRemainder1
+        .size:            4
+        .offset:          144
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            MagicNumberWgmRemainder1
+        .size:            4
+        .offset:          148
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            padding
+        .size:            4
+        .offset:          152
+        .value_kind:      by_value
+        .value_type:      u32
+    .kernarg_segment_align:      8
+    .kernarg_segment_size:       160
+...
+.end_amdgpu_metadata
+Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA906_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM4:
+
+/******************************************/
+/* Optimizations and Config:              */
+/******************************************/
+/* ThreadTile= 6 x 4 */
+/* SubGroup= 8 x 16 */
+/* VectorWidth=2 */
+/* GlobalLoadVectorWidthA=2, GlobalLoadVectorWidthB=2 */
+/* DirectToLdsA=False */
+/* DirectToLdsB=False */
+/* UseSgprForGRO=False */
+
+/******************************************/
+/* Asm syntax workarounds                 */
+/******************************************/
+.macro _v_add_co_u32 dst, cc, src0, src1, dpp=
+   v_add_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+.macro _v_sub_co_u32 dst, cc, src0, src1, dpp=
+   v_sub_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+.macro _v_addc_co_u32 dst, ccOut, src0, ccIn, src1, dpp=
+   v_addc_co_u32 \dst, \ccOut, \src0, \ccIn, \src1 \dpp
+.endm
+.macro _v_add_lshl_u32 dst, src0, src1, shiftCnt
+    v_add_lshl_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+.macro _v_lshl_add_u32 dst, src0, src1, shiftCnt
+    v_lshl_add_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+/******************************************/
+/* Magic div and mod functions            */
+/******************************************/
+.macro V_MAGIC_DIV dstIdx, dividend, magicNumber, magicShift
+    v_mul_lo_u32 v[\dstIdx+0], \dividend, \magicNumber
+    v_mul_hi_u32 v[\dstIdx+1], \dividend, \magicNumber
+    v_lshrrev_b64 v[\dstIdx:\dstIdx+1], \magicShift, v[\dstIdx:\dstIdx+1]
+.endm
+
+/******************************************/
+/* VGPR Assignments                       */
+/******************************************/
+.set vgprValuC, 0
+/* ValuA/B   Xn=PLR buffer idx,  In=InnerUnroll idx */
+.set vgprValuA_X0_I0, 48
+.set vgprG2LA, 60
+.set vgprValuB_X0_I0, 64
+.set vgprG2LB, 72
+.set vgprLocalWriteAddrA, 76
+.set vgprLocalWriteAddrB, 77
+.set vgprGlobalReadOffsetA, 78
+.set vgprGlobalReadOffsetB, 79
+.set vgprLocalReadAddrA, 80
+.set vgprLocalReadAddrB, 81
+.set vgprSerial, 82
+/* Num VGPR=83 */
+
+/******************************************/
+/* SGPR Assignments                       */
+/******************************************/
+.set sgprKernArgAddress, 0
+.set sgprWorkGroup0, 2
+.set sgprWorkGroup1, 3
+.set sgprWorkGroup2, 4
+.set sgprNumWorkGroups0, 5
+.set sgprNumWorkGroups1, 6
+.set sgprSrdA, 8
+.set sgprSrdB, 12
+.set sgprSrdD, 16
+.set sgprSrdC, 20
+.set sgprTensor2dSizeC, 24
+.set sgprTensor2dSizeA, 26
+.set sgprTensor2dSizeB, 28
+.set sgprSaveExecMask, 30
+.set sgprAddressD, 32
+.set sgprAddressC, 34
+.set sgprStridesC, 36
+.set sgprAlpha, 38
+.set sgprBeta, 40
+.set sgprSizesFree, 42
+.set sgprSizesSum, 45
+.set sgprLoopCounters, 46
+.set sgprOrigLoopCounter, 47
+.set sgprStridesA, 48
+.set sgprStridesB, 50
+.set sgprAddressA, 52
+.set sgprAddressB, 54
+.set sgprShadowLimitA, 56
+.set sgprShadowLimitB, 58
+.set sgprNumFullBlocks, 60
+.set sgprWgmRemainder1, 61
+.set sgprMagicNumberWgmRemainder1, 62
+.set sgprGlobalReadIncsA, 63
+.set sgprGlobalReadIncsB, 64
+.set sgprStridesD, 74
+.set sgprTMP0, 90
+.set sgprTMP1, 91
+.set sgprEdgeSelMask0, 93
+.set sgprEdgeSelMask1, 94
+/* max SGPR=98 */
+
+/******************************************/
+/* 2GB limit - set offsets to -1 to exceed this and clamp */
+/******************************************/
+.set BufferLimit, 0x80000000
+
+/******************************************/
+/* Bits 127:96 of SRD.  Set DataFormat = 32 bit */
+/******************************************/
+.set Srd127_96, 0x0020000
+.set BufferOOB, 0x80000000
+
+/* Global Offset A */
+.macro GLOBAL_OFFSET_A vgprAddr vgprOffset0I vgprOffsetL vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStridesA+0], v[\vgprOffsetL] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprTmp+0], v[\vgprOffset0I] // accumulate d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, 0x2, v[\vgprAddr+0] // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x3, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/* Global Offset B */
+.macro GLOBAL_OFFSET_B vgprAddr vgprOffset1J vgprOffsetL vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStridesB+0], v[\vgprOffsetL] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprTmp+0], v[\vgprOffset1J] // accumulate d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, 0x2, v[\vgprAddr+0] // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x3, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/******************************************/
+/* Dynamic Scalar Divide: vQuotient=vDividend/vDivisor; vRemainder=vDividend%vDivisor; */
+/******************************************/
+.macro DYNAMIC_VECTOR_DIVIDE vQuotient vRemainder vDividend vDivisor vTmp0 vTmp1 sTmp
+v_cvt_f32_u32 v[\vQuotient], v[\vDivisor]          //
+v_rcp_f32 v[\vQuotient], v[\vQuotient]             //
+v_mul_f32 v[\vQuotient], 0x4f800000, v[\vQuotient] //
+v_cvt_u32_f32 v[\vQuotient], v[\vQuotient]         //
+v_mul_lo_u32 v[\vRemainder], v[\vDivisor], v[\vQuotient] //
+v_mul_hi_u32 v[\vTmp0], v[\vDivisor], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp1], vcc, 0x0, v[\vRemainder]  //
+v_cmp_ne_i32 s[\sTmp:\sTmp+1], 0x0, v[\vTmp0]      //
+v_cndmask_b32 v[\vRemainder], v[\vTmp1], v[\vRemainder], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vRemainder], v[\vRemainder], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vQuotient], v[\vRemainder] //
+_v_add_co_u32 v[\vQuotient], vcc, v[\vQuotient], v[\vRemainder] //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vTmp0], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vQuotient], v[\vQuotient], v[\vDividend] //
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vDividend], v[\vRemainder] //
+v_cmp_ge_u32 s[\sTmp:\sTmp+1], v[\vDividend], v[\vRemainder] //
+_v_add_co_u32 v[\vRemainder], vcc, 0x1, v[\vQuotient] //
+_v_add_co_u32 v[\vTmp1], vcc, -1, v[\vQuotient]    //
+v_cmp_le_u32 vcc, v[\vDivisor], v[\vTmp0]          //
+s_and_b64 vcc, s[\sTmp:\sTmp+1], vcc               //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vRemainder], vcc //
+v_cndmask_b32 v[\vQuotient], v[\vTmp1], v[\vQuotient], s[\sTmp:\sTmp+1] //
+v_cmp_ne_i32 vcc, 0x0, v[\vDivisor]                //
+v_cndmask_b32 v[\vQuotient], -1, v[\vQuotient], vcc // final result
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vRemainder], vcc, v[\vDividend], v[\vRemainder] // final result
+.endm
+
+/******************************************/
+/* 6x4 thread-tile                        */
+/******************************************/
+.macro MAC_6x4_X0
+v_fma_f64 v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1]
+s_setprio 1 // Raise priority while processing macs
+v_fma_f64 v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1]
+s_setprio 0 // Reset priority after macs
+.endm
+
+.macro MAC_6x4_X0_part_1
+v_fma_f64 v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1]
+s_setprio 1 // Raise priority while processing macs
+v_fma_f64 v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1]
+.endm
+
+.macro MAC_6x4_X0_part_2
+.endm
+
+.macro MAC_6x4_X0_part_3
+v_fma_f64 v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1]
+s_setprio 0 // Reset Priority
+.endm
+
+.macro MAC_6x4_X0_unprio_0
+v_fma_f64 v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1]
+s_setprio 1 // Raise priority while processing macs
+v_fma_f64 v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1]
+.endm
+
+
+.macro MAC_6x4_X0_part1
+v_fma_f64 v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1]
+s_setprio 1
+v_fma_f64 v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1]
+s_setprio 0
+.endm
+
+
+.macro MAC_6x4_X0_part2
+v_fma_f64 v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1]
+s_setprio 1
+v_fma_f64 v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1]
+s_setprio 0
+.endm
+.macro MAC_6x4_X0_part3
+v_fma_f64 v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1]
+s_setprio 1
+v_fma_f64 v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1]
+s_setprio 0
+.endm
+.macro MAC_6x4_X0_part4
+v_fma_f64 v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1]
+s_setprio 1
+v_fma_f64 v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1]
+//vnop_4
+s_setprio 0
+.endm
+.macro MAC_6x4_X0_part5
+v_fma_f64 v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1]
+s_setprio 1
+v_fma_f64 v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1]
+//vnop_4
+s_setprio 0
+.endm
+.macro MAC_6x4_X0_part6
+v_fma_f64 v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1]
+s_setprio 1
+v_fma_f64 v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1]
+s_setprio 0
+.endm
+
+/******************************************/
+/* Allocate Resources                     */
+/******************************************/
+
+s_mov_b32 m0, 0x1e00                               // LDS clamp at 7680 bytes
+v_mov_b32 v[vgprSerial], v0                        // thread serial id
+
+/* Load Kernel Args */
+s_load_dword s[sgprTensor2dSizeC+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x0 //
+s_load_dword s[sgprTensor2dSizeC+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x4 //
+s_load_dword s[sgprTensor2dSizeA+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x8 //
+s_load_dword s[sgprTensor2dSizeA+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0xc //
+s_load_dword s[sgprTensor2dSizeB+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x10 //
+s_load_dword s[sgprTensor2dSizeB+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x14 //
+s_load_dword s[sgprAddressD], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x18 //
+s_load_dword s[sgprAddressD+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x1c //
+s_load_dword s[sgprAddressC], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x20 //
+s_load_dword s[sgprAddressC+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x24 //
+s_load_dword s[sgprAddressA], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x28 //
+s_load_dword s[sgprAddressA+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x2c //
+s_load_dword s[sgprAddressB], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x30 //
+s_load_dword s[sgprAddressB+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x34 //
+s_load_dword s[sgprAlpha+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x38 //
+s_load_dword s[sgprAlpha+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x3c //
+s_load_dword s[sgprBeta+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x40 //
+s_load_dword s[sgprBeta+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x44 //
+s_load_dword s[sgprStridesD+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x48 //
+s_load_dword s[sgprStridesD+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x4c //
+s_load_dword s[sgprStridesC+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x50 //
+s_load_dword s[sgprStridesC+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x54 //
+s_load_dword s[sgprStridesA+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x58 //
+s_load_dword s[sgprStridesA+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x5c //
+s_load_dword s[sgprStridesB+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x60 //
+s_load_dword s[sgprStridesB+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x64 //
+s_load_dword s[sgprSizesFree+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x68 //
+s_load_dword s[sgprSizesFree+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x6c //
+s_load_dword s[sgprSizesFree+2], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x70 //
+s_load_dword s[sgprSizesSum+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x74 //
+s_load_dword s[sgprNumWorkGroups0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x7c //
+s_load_dword s[sgprNumWorkGroups1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x80 //
+s_load_dword s[sgprNumFullBlocks], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x8c //
+s_load_dword s[sgprWgmRemainder1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x90 //
+s_load_dword s[sgprMagicNumberWgmRemainder1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x94 //
+s_waitcnt lgkmcnt(0)                               // wait for 144 bytes of kern args
+
+
+/******************************************/
+/* Local Read Addresses                   */
+/******************************************/
+
+
+/* local read addresses: tile assignments a */
+
+/*lr0I = serial % SG0I*/
+v_lshrrev_b32 v0, 3, v[vgprSerial]                 // vectorStaticDiv: v0 = v[vgprSerial] / 8
+v_and_b32 v1, 7, v[vgprSerial]                     // vectorStaticDiv: v1 = v[vgprSerial] % 8
+
+
+/* local read addresses: tile assignments b */
+
+/*lr1J = (serial / SG1J) % SG1J*/
+v_lshrrev_b32 v2, 4, v0                            // vectorStaticDiv: v2 = v0 / 16
+v_and_b32 v3, 15, v0                               // vectorStaticDiv: v3 = v0 % 16
+
+
+/* local read addresses: final offsets a */
+
+v_lshrrev_b32 v0, 7, v[vgprSerial]                 // vectorStaticDiv: v0 = v[vgprSerial] / 128
+v_and_b32 v2, 127, v[vgprSerial]                   // vectorStaticDiv: v2 = v[vgprSerial] % 128
+s_mov_b32 s65, 0x30                                // MT0+PAD
+v_mul_lo_u32 v0, s65, v0                           // sgid=sgid*(MT0+PAD)
+v_lshlrev_b32 v1, 1, v1                            // staticMultiply: v1 = v1 * 2
+_v_add_lshl_u32 v[vgprLocalReadAddrA], v0, v1, 0x3 // o = (lroA*VW+sgid*MT0)*bpe
+
+
+/* local read addresses: final offsets b */
+
+v_lshrrev_b32 v0, 7, v[vgprSerial]                 // vectorStaticDiv: v0 = v[vgprSerial] / 128
+v_and_b32 v1, 127, v[vgprSerial]                   // vectorStaticDiv: v1 = v[vgprSerial] % 128
+s_mov_b32 s65, 0x40                                // MT1+PAD
+v_mul_lo_u32 v0, s65, v0                           // sgid=sgid*(MT1+PAD)
+v_lshlrev_b32 v3, 1, v3                            // staticMultiply: v3 = v3 * 2
+_v_add_lshl_u32 v[vgprLocalReadAddrB], v0, v3, 0x3 // o = (lroB*VW+sgid*MT1)*bpe
+
+
+/* local read addresses: declare addresses a */
+
+/* N/A */
+
+
+/* local read addresses: declare addresses b */
+
+_v_add_co_u32 v[vgprLocalReadAddrB+0], vcc, 0x600, v[vgprLocalReadAddrB+0] //  += LdsOffsetB (lower)
+
+
+s_load_dword s[sgprNumWorkGroups1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x80 //
+s_load_dword s[sgprNumFullBlocks], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x8c //
+s_load_dword s[sgprWgmRemainder1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x90 //
+s_load_dword s[sgprMagicNumberWgmRemainder1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x94 //
+/******************************************/
+/* Global Read Addresses                  */
+/******************************************/
+
+
+/* global read addresses: work-group */
+
+/* graWorkGroup mapping */
+s_mov_b32 s69, 0x20000001L                         // magic number for WGM==4
+s_mul_hi_u32 s67, s[sgprWorkGroup1], s69           // s_magic mul
+s_mul_i32 s66, s[sgprWorkGroup1], s69              // s_magic mul
+s_lshr_b64 s[66:67], s[66:67], 31                  // sMagicDiv
+s_mul_i32 s67, s66, 4                              // quotient * non-magic divisor
+s_sub_u32 s67, s[sgprWorkGroup1], s67              // WorkGroup1=remainder
+s_mul_i32 s67, s67, s[sgprNumWorkGroups0]          // (wg1 % WGM)*nwg0
+s_add_u32 s67, s67, s[sgprWorkGroup0]              // wgSerial = wg0 + (wg1 % WGM)*nwg0
+s_cmp_ge_u32 s66, s[sgprNumFullBlocks]             // blockId >= numFullBlocks ?
+s_cmov_b32 s69, s[sgprMagicNumberWgmRemainder1]    //
+s_cselect_b32 s68, s[sgprWgmRemainder1], 4         //
+s_mul_hi_u32 s3, s67, s69                          // s_magic mul
+s_mul_i32 s2, s67, s69                             // s_magic mul
+s_lshr_b64 s[2:3], s[2:3], 31                      // sMagicDiv
+s_mul_i32 s[sgprWorkGroup1], s[sgprWorkGroup0], s68 // quotient * non-magic divisor
+s_sub_u32 s[sgprWorkGroup1], s67, s[sgprWorkGroup1] // WorkGroup1=remainder
+s_mul_i32 s66, s66, 4                              // blockId * WGM
+s_add_u32 s[sgprWorkGroup1], s[sgprWorkGroup1], s66 // wg1 += blockId * WGM
+
+
+/* global read addresses: tile offset assignment a */
+
+/* LVCA = 24 */
+/* v0 = (local)groA-tile = serial%LVCA (note (wgA*MTA) will be added to SRD) */
+/* v1 = groA-unroll = serial/LVCA */
+s_mov_b32 s65, 0x15555556                          //
+v_mul_hi_u32 v3, v[vgprSerial], s65                //
+v_mul_lo_u32 v2, v[vgprSerial], s65                //
+v_lshrrev_b64 v[2:3], 0x21, v[2:3]                 //
+v_mov_b32 v1, v2                                   // vectorStaticDiv: quotient
+s_mov_b32 s65, 0x18                                // divisor
+v_mul_lo_u32 v2, v1, s65                           // vectorStaticDiv: product = quotient * divisor
+_v_sub_co_u32 v0, vcc, v[vgprSerial], v2           // vectorStaticDiv: remainder = dividend - product
+/* gro-tile *= glvw */
+v_lshlrev_b32 v0, 1, v0                            // staticMultiply: v0 = v0 * 2
+
+
+/* global read addresses: tile offset assignment b */
+
+/* LVCB = 32 */
+/* v2 = (local)groB-tile = serial%LVCB (note (wgB*MTB) will be added to SRD) */
+/* v3 = groB-unroll = serial/LVCB */
+v_lshrrev_b32 v3, 5, v[vgprSerial]                 // vectorStaticDiv: v3 = v[vgprSerial] / 32
+v_and_b32 v2, 31, v[vgprSerial]                    // vectorStaticDiv: v2 = v[vgprSerial] % 32
+/* gro-tile *= glvw */
+v_lshlrev_b32 v2, 1, v2                            // staticMultiply: v2 = v2 * 2
+
+
+/* global read addresses: unroll assignment a */
+
+/* v1 */
+
+
+/* global read addresses: unroll assignment b */
+
+/* v3 */
+
+
+/* global read addresses: other free assignments */
+
+/* s[sgprWorkGroup2] */
+
+
+/* global read addresses: tile offsets a */
+
+v_mov_b32 v4, v0                                   // groA0I_0
+
+
+/* global read addresses: tile offsets b */
+
+v_mov_b32 v5, v2                                   // groB1J_0
+
+
+/* global read addresses: unroll offsets a */
+
+v_mov_b32 v6, v1                                   // groAL_0
+
+
+/* global read addresses: unroll offsets b */
+
+v_mov_b32 v7, v3                                   // groBL_0
+
+
+/* global read addresses: shift a */
+
+s_mul_i32 s65, s[sgprWorkGroup0], 48               // WorkGroup[01] * MT
+s_sub_u32 s65, s[sgprSizesFree+0], s65             // edge = Size0I - WG*MT
+s_sub_u32 s65, s65, 2                              // edge -= margin
+v_mov_b32 v8, s65                                  // edge vgpr = Size0I-2
+_v_add_co_u32 v9, vcc, v8, 2                       // add srdShiftLift
+_v_add_co_u32 v10, vcc, v4, 2                      //
+v_cmp_lt_u32 s[66:67], v10, v9                     // offset < edge
+v_cndmask_b32 v4, v8, v4, s[66:67]                 // offset = (offset < edge) ? offset : edge
+
+
+/* global read addresses: shift b */
+
+s_mul_i32 s65, s[sgprWorkGroup1], 64               // WorkGroup[01] * MT
+s_sub_u32 s65, s[sgprSizesFree+1], s65             // edge = Size1J - WG*MT
+s_sub_u32 s65, s65, 2                              // edge -= margin
+v_mov_b32 v8, s65                                  // edge vgpr = Size1J-2
+_v_add_co_u32 v9, vcc, v8, 2                       // add srdShiftLift
+_v_add_co_u32 v10, vcc, v5, 2                      //
+v_cmp_lt_u32 s[66:67], v10, v9                     // offset < edge
+v_cndmask_b32 v5, v8, v5, s[66:67]                 // offset = (offset < edge) ? offset : edge
+
+
+/* global read addresses: final offsets a */
+
+GLOBAL_OFFSET_A vgprGlobalReadOffsetA+0,  4,  6, 8 // gROA_0_0_0_0
+// Offset only valid for 96/128 threads inside the PerLoadTile
+s_mov_b32 s66, 96                                  //
+v_cmp_lt_u32 vcc, v[vgprSerial], s66               // tid < valid-tid
+s_mov_b32 s66, BufferOOB                           //
+v_mov_b32 v11, s66                                 //
+v_cndmask_b32 v[vgprGlobalReadOffsetA+0], v11, v[vgprGlobalReadOffsetA+0], vcc // Mask load so OOB will return 0
+
+
+/* global read addresses: final offsets b */
+
+GLOBAL_OFFSET_B vgprGlobalReadOffsetB+0,  5,  7, 8 // gROB_0_0_0_0
+
+
+/* global read addresses: addresses a */
+
+/* max read offset = size[n] * stride[n-1] */
+s_mul_hi_u32 s69, s[sgprWorkGroup0], 48            // WorkGroup[01] * MT
+s_mul_i32 s68, s[sgprWorkGroup0], 48               // WorkGroup[01] * MT
+s_sub_u32 s[sgprShadowLimitA+0], s[sgprTensor2dSizeA], s68 // sub tileStart
+s_subb_u32 s[sgprShadowLimitA+1], s[sgprTensor2dSizeA+1], s69 // sub tileStart
+s_lshl_b64 s[sgprShadowLimitA:sgprShadowLimitA+1], s[sgprShadowLimitA:sgprShadowLimitA+1], 0x3 // Set limit to use bytes
+s_add_u32 s[sgprShadowLimitA+0], s[sgprShadowLimitA+0], 16 // extend limit for pre-pad
+s_addc_u32 s[sgprShadowLimitA+1], s[sgprShadowLimitA+1], 0 // extend limit for pre-pad
+s_cmp_eq_u32 s[sgprShadowLimitA+1], 0              // are we within 2^32?
+s_cselect_b32 s[sgprSrdA+2], s[sgprShadowLimitA+0], BufferLimit // Move shadow to real if we are within 2^32
+s_mul_hi_u32 s67, s[sgprStridesA+1], s[sgprWorkGroup2] // Stride*WG
+s_mul_i32 s66, s[sgprStridesA+1], s[sgprWorkGroup2] // Stride*WG
+s_add_u32 s68, s68, s66                            // accum wg term to tilestart
+s_addc_u32 s69, s69, s67                           // accum wg term to tilestart
+s_lshl_b64 s[68:69], s[68:69], 3                   // tileStart *= BPE
+s_add_u32 s[sgprSrdA+0], s[sgprAddressA+0], s68    // SRD base = Address+ tileStart0
+s_addc_u32 s[sgprSrdA+1], s[sgprAddressA+1], s69   // SRD base = Address+ tileStart1
+s_sub_u32 s[sgprSrdA+0], s[sgprSrdA+0], 16         // pre-pad to make room for possible pointer shift
+s_subb_u32 s[sgprSrdA+1], s[sgprSrdA+1], 0         // pre-pad to make room for possible pointer shift
+s_mov_b32 s[sgprSrdA+3], Srd127_96                 // Set bits 127_96 in SRD
+
+
+/* global read addresses: addresses b */
+
+/* max read offset = size[n] * stride[n-1] */
+s_mul_hi_u32 s69, s[sgprWorkGroup1], 64            // WorkGroup[01] * MT
+s_mul_i32 s68, s[sgprWorkGroup1], 64               // WorkGroup[01] * MT
+s_sub_u32 s[sgprShadowLimitB+0], s[sgprTensor2dSizeB], s68 // sub tileStart
+s_subb_u32 s[sgprShadowLimitB+1], s[sgprTensor2dSizeB+1], s69 // sub tileStart
+s_lshl_b64 s[sgprShadowLimitB:sgprShadowLimitB+1], s[sgprShadowLimitB:sgprShadowLimitB+1], 0x3 // Set limit to use bytes
+s_add_u32 s[sgprShadowLimitB+0], s[sgprShadowLimitB+0], 16 // extend limit for pre-pad
+s_addc_u32 s[sgprShadowLimitB+1], s[sgprShadowLimitB+1], 0 // extend limit for pre-pad
+s_cmp_eq_u32 s[sgprShadowLimitB+1], 0              // are we within 2^32?
+s_cselect_b32 s[sgprSrdB+2], s[sgprShadowLimitB+0], BufferLimit // Move shadow to real if we are within 2^32
+s_mul_hi_u32 s67, s[sgprStridesB+1], s[sgprWorkGroup2] // Stride*WG
+s_mul_i32 s66, s[sgprStridesB+1], s[sgprWorkGroup2] // Stride*WG
+s_add_u32 s68, s68, s66                            // accum wg term to tilestart
+s_addc_u32 s69, s69, s67                           // accum wg term to tilestart
+s_lshl_b64 s[68:69], s[68:69], 3                   // tileStart *= BPE
+s_add_u32 s[sgprSrdB+0], s[sgprAddressB+0], s68    // SRD base = Address+ tileStart0
+s_addc_u32 s[sgprSrdB+1], s[sgprAddressB+1], s69   // SRD base = Address+ tileStart1
+s_sub_u32 s[sgprSrdB+0], s[sgprSrdB+0], 16         // pre-pad to make room for possible pointer shift
+s_subb_u32 s[sgprSrdB+1], s[sgprSrdB+1], 0         // pre-pad to make room for possible pointer shift
+s_mov_b32 s[sgprSrdB+3], Srd127_96                 // Set bits 127_96 in SRD
+
+
+/* global read addresses: increments a */
+
+s_mul_i32 s[sgprGlobalReadIncsA+0], 0x20, s[sgprStridesA] // incr = stride*4*bytes
+
+
+/* global read addresses: increments b */
+
+s_mul_i32 s[sgprGlobalReadIncsB+0], 0x20, s[sgprStridesB] // incr = stride*4*bytes
+
+
+/******************************************/
+/* Local Write Addresses                  */
+/******************************************/
+
+
+/* local write addresses: tile assignment a */
+
+/* lwaTileA = v0 */
+
+
+/* local write addresses: tile assignment b */
+
+/* lwaTileB = v2 */
+
+
+/* local write addresses: unroll assignment a */
+
+/* lwaUnrollA = v1 */
+
+
+/* local write addresses: unroll assignment b */
+
+/* lwaUnrollB = v3 */
+
+
+/* local write addresses: first offset a */
+
+v_mul_u32_u24 v[vgprLocalWriteAddrA], 0x30, v1     // lwAL**(MTA + PAD)
+_v_add_lshl_u32 v[vgprLocalWriteAddrA], v0, v[vgprLocalWriteAddrA], 0x3 // lwFOA = (lwAA + lwAL*(MT0I+PAD))*bpe
+s_mov_b32 s65, 96                                  // lsc*lsp=48*4
+v_cmp_lt_u32 vcc, v[vgprSerial], s65               // fractional: ensure tid < global read tile elements
+v_mov_b32 v0, 0xf00000                             //
+v_cndmask_b32 v[vgprLocalWriteAddrA], v0, v[vgprLocalWriteAddrA], vcc // Mask load so out-of-gr-tile bounds returns 0
+
+
+/* local write addresses: first offset b */
+
+v_mul_u32_u24 v[vgprLocalWriteAddrB], 0x40, v3     // lwBL**(MTB + PAD)
+_v_add_lshl_u32 v[vgprLocalWriteAddrB], v2, v[vgprLocalWriteAddrB], 0x3 // lwFOB = (lwBB + lwBL*(MT1J+PAD))*bpe
+_v_add_co_u32 v[vgprLocalWriteAddrB], vcc, 0x600, v[vgprLocalWriteAddrB] // lwFOB = lwB1J + lwBL*MT1J + LDS_OFFSET_B=192*8
+
+
+/* local write addresses: final offsets a */
+
+
+/* N/A */
+
+
+/* local write addresses: final offsets b */
+
+
+/* N/A */
+
+
+/* local write addresses: declare addresses a */
+
+/* N/A */
+
+
+/* local write addresses: declare addresses b */
+
+/* N/A */
+
+
+/* local write addresses: init pointers a */
+
+/* N/A */
+
+
+/* local write addresses: init pointers b */
+
+/* N/A */
+
+
+/* declare loop num iterations */
+
+
+s_lshr_b32 s[sgprLoopCounters+0], s[sgprSizesSum+0], 2 // s[sgprLoopCounters+0] = s[sgprSizesSum+0] / 4
+s_mov_b32 s[sgprOrigLoopCounter], s[sgprLoopCounters+0] // copy loop counter
+s_sub_u32 s[sgprLoopCounters+0], 0x0, s[sgprLoopCounters+0] // counterL = -sizeL
+
+
+/* local read addresses: init pointers a */
+
+
+
+/* local read addresses: init pointers b */
+
+
+
+/* TODO-packed- compare against product of all packed C0 sizes not just SizesFree+0 */
+s_mov_b32 s91, 0x0                                 // STATIC_DIV: divisior=48
+s_mul_i32 s90, 0xaaa, s[sgprSizesFree+0]           // tmp1 = dividend * magic hi
+s_lshl_b64 s[90:91], s[90:91], 0x10                // left shift 16 bits
+s_mul_i32 s82, s[sgprSizesFree+0], 0xaaab          // tmp0 = dividend * magic lo
+s_add_u32 s90, s82, s90                            // add lo
+s_addc_u32 s91, s91, 0x0                           // add hi
+s_lshr_b64 s[90:91], s[90:91], 0x21                // tmp1 = (dividend * magic) << shift
+s_mov_b32 s82, s90                                 // quotient
+s_mul_i32 s90, s82, 0x30                           // quotient*divisor
+s_sub_u32 s[sgprEdgeSelMask0], s[sgprSizesFree+0], s90             // rReg = dividend - quotient*divisor
+s_lshr_b32 s82, s[sgprSizesFree+1], 6              // s58 = s[sgprSizesFree+1] / 64
+s_and_b32 s[sgprEdgeSelMask1], 63, s[sgprSizesFree+1]
+
+
+/* prefetch: global -> local */
+
+s_cmp_eq_u32 s[sgprLoopCounters+0], 0x0            // numIter0I == 0
+s_cbranch_scc1 label_0008                          // skip to ShadowInitStart iter b/c numIter==0
+
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+
+
+/* global read inc A */
+s_add_u32  s[sgprSrdA+0], s[sgprSrdA+0], s[sgprGlobalReadIncsA] // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdA+1], s[sgprSrdA+1], 0        // gra SRD += inc(upper)
+s_sub_u32 s[sgprShadowLimitA+0], s[sgprShadowLimitA+0], s[sgprGlobalReadIncsA] // limit -= inc)
+s_subb_u32 s[sgprShadowLimitA+1], s[sgprShadowLimitA+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitA+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdA+2], s[sgprShadowLimitA+0]    // Move shadow to real if we are within 2^32
+
+
+/* global read inc B */
+s_add_u32  s[sgprSrdB+0], s[sgprSrdB+0], s[sgprGlobalReadIncsB] // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdB+1], s[sgprSrdB+1], 0        // gra SRD += inc(upper)
+s_sub_u32 s[sgprShadowLimitB+0], s[sgprShadowLimitB+0], s[sgprGlobalReadIncsB] // limit -= inc)
+s_subb_u32 s[sgprShadowLimitB+1], s[sgprShadowLimitB+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitB+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdB+2], s[sgprShadowLimitB+0]    // Move shadow to real if we are within 2^32
+
+label_0008: // ShadowInitStart
+
+s_mov_b32 s[sgprSrdD+0], s[sgprAddressD+0]         // init SRD base address (lower)
+s_mov_b32 s[sgprSrdD+1], s[sgprAddressD+1]         // init SRD base address (upper) + other fields
+s_mov_b32 s[sgprSrdD+2], 0x80000000                //
+s_mov_b32 s[sgprSrdD+3], Srd127_96                 // Set bits 127_96 in SRD
+s_mov_b32 s[sgprSrdC+0], s[sgprAddressC+0]         // init SRD base address (lower)
+s_mov_b32 s[sgprSrdC+1], s[sgprAddressC+1]         // init SRD base address (upper) + other fields
+s_mov_b32 s[sgprSrdC+2], 0x80000000                //
+s_mov_b32 s[sgprSrdC+3], Srd127_96                 // Set bits 127_96 in SRD
+
+s_mul_i32 s[sgprTMP1], 0x40, s[sgprWorkGroup1]             // <- wg1*MT1
+s_mul_i32 s[sgprTMP0], 0x30, s[sgprWorkGroup1]             // <- wg1*MT1
+s_mul_hi_u32 s67, s[sgprTMP1], s[sgprStridesC+0]           // Scale s68 by Stride
+s_mul_i32 s66, s[sgprTMP1], s[sgprStridesC+0]              // Scale s68 by Stride
+s_lshl_b64 s[66:67], s[66:67], 3                   // scale by bpe
+s_add_u32 s[sgprSrdD+0], s[sgprSrdD+0], s66        // add lo to SRD
+s_addc_u32 s[sgprSrdD+1], s[sgprSrdD+1], s67       // add hi to SRD
+s_add_u32 s[sgprSrdC+0], s[sgprSrdC+0], s66        // add lo to SRD
+s_addc_u32 s[sgprSrdC+1], s[sgprSrdC+1], s67       // add hi to SRD
+
+s_mul_hi_u32 s67, s[sgprWorkGroup2], s[sgprStridesC+1] // Scale s[sgprWorkGroup2] by Stride
+s_mul_i32 s66, s[sgprWorkGroup2], s[sgprStridesC+1] // Scale s[sgprWorkGroup2] by Stride
+s_lshl_b64 s[66:67], s[66:67], 3                   // scale by bpe
+s_add_u32 s[sgprSrdD+0], s[sgprSrdD+0], s66        // add lo to SRD
+s_addc_u32 s[sgprSrdD+1], s[sgprSrdD+1], s67       // add hi to SRD
+s_add_u32 s[sgprSrdC+0], s[sgprSrdC+0], s66        // add lo to SRD
+s_addc_u32 s[sgprSrdC+1], s[sgprSrdC+1], s67       // add hi to SRD
+
+
+v_mov_b32 v[vgprValuC+0], 0x0                      // initC
+v_mov_b32 v[vgprValuC+1], 0x0                      // initC
+v_mov_b32 v[vgprValuC+2], 0x0                      // initC
+v_mov_b32 v[vgprValuC+3], 0x0                      // initC
+v_mov_b32 v[vgprValuC+4], 0x0                      // initC
+v_mov_b32 v[vgprValuC+5], 0x0                      // initC
+v_mov_b32 v[vgprValuC+6], 0x0                      // initC
+v_mov_b32 v[vgprValuC+7], 0x0                      // initC
+v_mov_b32 v[vgprValuC+8], 0x0                      // initC
+v_mov_b32 v[vgprValuC+9], 0x0                      // initC
+v_mov_b32 v[vgprValuC+10], 0x0                     // initC
+v_mov_b32 v[vgprValuC+11], 0x0                     // initC
+v_mov_b32 v[vgprValuC+12], 0x0                     // initC
+v_mov_b32 v[vgprValuC+13], 0x0                     // initC
+v_mov_b32 v[vgprValuC+14], 0x0                     // initC
+v_mov_b32 v[vgprValuC+15], 0x0                     // initC
+v_mov_b32 v[vgprValuC+16], 0x0                     // initC
+v_mov_b32 v[vgprValuC+17], 0x0                     // initC
+v_mov_b32 v[vgprValuC+18], 0x0                     // initC
+v_mov_b32 v[vgprValuC+19], 0x0                     // initC
+v_mov_b32 v[vgprValuC+20], 0x0                     // initC
+v_mov_b32 v[vgprValuC+21], 0x0                     // initC
+v_mov_b32 v[vgprValuC+22], 0x0                     // initC
+v_mov_b32 v[vgprValuC+23], 0x0                     // initC
+v_mov_b32 v[vgprValuC+24], 0x0                     // initC
+v_mov_b32 v[vgprValuC+25], 0x0                     // initC
+v_mov_b32 v[vgprValuC+26], 0x0                     // initC
+v_mov_b32 v[vgprValuC+27], 0x0                     // initC
+v_mov_b32 v[vgprValuC+28], 0x0                     // initC
+v_mov_b32 v[vgprValuC+29], 0x0                     // initC
+v_mov_b32 v[vgprValuC+30], 0x0                     // initC
+v_mov_b32 v[vgprValuC+31], 0x0                     // initC
+v_mov_b32 v[vgprValuC+32], 0x0                     // initC
+v_mov_b32 v[vgprValuC+33], 0x0                     // initC
+v_mov_b32 v[vgprValuC+34], 0x0                     // initC
+v_mov_b32 v[vgprValuC+35], 0x0                     // initC
+v_mov_b32 v[vgprValuC+36], 0x0                     // initC
+v_mov_b32 v[vgprValuC+37], 0x0                     // initC
+v_mov_b32 v[vgprValuC+38], 0x0                     // initC
+v_mov_b32 v[vgprValuC+39], 0x0                     // initC
+v_mov_b32 v[vgprValuC+40], 0x0                     // initC
+v_mov_b32 v[vgprValuC+41], 0x0                     // initC
+v_mov_b32 v[vgprValuC+42], 0x0                     // initC
+v_mov_b32 v[vgprValuC+43], 0x0                     // initC
+v_mov_b32 v[vgprValuC+44], 0x0                     // initC
+v_mov_b32 v[vgprValuC+45], 0x0                     // initC
+v_mov_b32 v[vgprValuC+46], 0x0                     // initC
+v_mov_b32 v[vgprValuC+47], 0x0                     // initC
+s_cmp_eq_u32 s[sgprLoopCounters+0], 0x0            // numIter0I == 0
+s_cbranch_scc1 label_0004                          // after InitC, skip to end of prefetch last iter b/c numIter==0
+
+s_waitcnt vmcnt(0)                                 // 8wait for global read
+
+
+/* local write a */
+
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:0 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 0
+
+
+/* local write b */
+
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:0 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 0
+
+
+/* local write swap a */
+
+
+
+/* local write swap b */
+
+
+
+/* local write init pointers a */
+
+/* N/A */
+
+
+/* local write init pointers b */
+
+/* N/A */
+
+/******************************************/
+/* Unrolled Loop(s) - Begin               */
+/******************************************/
+
+s_cmp_ge_i32 s[sgprLoopCounters+0], 0x0            // LoopCounterL < EndCounter
+s_cbranch_scc1 label_0004                          // don't enter LoopL
+label_0001:
+
+
+/******************************************/
+/* Unroll Loop 1/2 - Begin                */
+/******************************************/
+
+s_barrier //4sync for global read
+
+s_cmp_eq_i32 s[sgprLoopCounters+0], -1             // is this the last iteration
+s_cmov_b32 s[sgprSrdA+2], 0                        // Set limit to 0 for last iteration
+s_cmov_b32 s[sgprSrdB+2], 0                        // Set limit to 0 for last iteration
+
+s_waitcnt lgkmcnt(0)                               // 1wait for local write
+
+
+
+
+/* iter 0 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(2)                               // wait for prior local read old=0 new=0
+//MAC_6x4_X0
+MAC_6x4_X0_part_1
+
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:384 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:512 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* global read inc A */
+s_add_u32  s[sgprSrdA+0], s[sgprSrdA+0], s[sgprGlobalReadIncsA] // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdA+1], s[sgprSrdA+1], 0        // gra SRD += inc(upper)
+s_sub_u32 s[sgprShadowLimitA+0], s[sgprShadowLimitA+0], s[sgprGlobalReadIncsA] // limit -= inc)
+s_subb_u32 s[sgprShadowLimitA+1], s[sgprShadowLimitA+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitA+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdA+2], s[sgprShadowLimitA+0]    // Move shadow to real if we are within 2^32
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:640 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(2)                               // wait for prior local read old=0 new=0
+//MAC_6x4_X0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:768 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* global read inc B */
+s_add_u32  s[sgprSrdB+0], s[sgprSrdB+0], s[sgprGlobalReadIncsB] // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdB+1], s[sgprSrdB+1], 0        // gra SRD += inc(upper)
+s_sub_u32 s[sgprShadowLimitB+0], s[sgprShadowLimitB+0], s[sgprGlobalReadIncsB] // limit -= inc)
+s_subb_u32 s[sgprShadowLimitB+1], s[sgprShadowLimitB+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitB+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdB+2], s[sgprShadowLimitB+0]    // Move shadow to real if we are within 2^32
+
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:896 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1024 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 2 writesPerItem=1 */
+s_waitcnt vmcnt(1)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:4096 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 4096
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(3)                               // wait for prior local read old=0 new=0
+//MAC_6x4_X0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(1)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+/* iter 3 (last) */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:1152 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1280 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1408 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 3 writesPerItem=1 */
+s_waitcnt vmcnt(0)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:4096 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 4096
+
+/* local write swap offsets a */
+
+/* local write swap offsets b */
+
+/* local write init pointers a */
+/* N/A */
+
+/* local write init pointers b */
+/* N/A */
+
+/* local read swap offsets a */
+
+/* local read swap internal offset -> 4096 */
+
+/* local read swap offsets b */
+
+/* local read swap internal offset -> 4096 */
+
+/* local read init pointers a */
+
+/* local read init pointers b */
+s_waitcnt lgkmcnt(3)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(1)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0_part_3
+
+/******************************************/
+/* Unrolled Loop - End 1/2                */
+/******************************************/
+
+s_add_u32 s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+s_cmp_eq_i32 s[sgprLoopCounters+0],  -2            // counterL==0
+s_cbranch_scc1 label_0003                          // exit LoopL
+
+
+/******************************************/
+/* Unroll Loop 2/2 - Begin                */
+/******************************************/
+
+s_barrier //4sync for global read
+
+s_cmp_eq_i32 s[sgprLoopCounters+0], -1             // is this the last iteration
+s_cmov_b32 s[sgprSrdA+2], 0                        // Set limit to 0 for last iteration
+s_cmov_b32 s[sgprSrdB+2], 0                        // Set limit to 0 for last iteration
+
+s_waitcnt lgkmcnt(0)                               // 1wait for local write
+
+
+
+
+/* iter 0 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4096 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4224 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4352 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(2)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4480 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4608 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* global read inc A */
+s_add_u32  s[sgprSrdA+0], s[sgprSrdA+0], s[sgprGlobalReadIncsA] // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdA+1], s[sgprSrdA+1], 0        // gra SRD += inc(upper)
+s_sub_u32 s[sgprShadowLimitA+0], s[sgprShadowLimitA+0], s[sgprGlobalReadIncsA] // limit -= inc)
+s_subb_u32 s[sgprShadowLimitA+1], s[sgprShadowLimitA+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitA+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdA+2], s[sgprShadowLimitA+0]    // Move shadow to real if we are within 2^32
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4736 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(2)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4864 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* global read inc B */
+s_add_u32  s[sgprSrdB+0], s[sgprSrdB+0], s[sgprGlobalReadIncsB] // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdB+1], s[sgprSrdB+1], 0        // gra SRD += inc(upper)
+s_sub_u32 s[sgprShadowLimitB+0], s[sgprShadowLimitB+0], s[sgprGlobalReadIncsB] // limit -= inc)
+s_subb_u32 s[sgprShadowLimitB+1], s[sgprShadowLimitB+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitB+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdB+2], s[sgprShadowLimitB+0]    // Move shadow to real if we are within 2^32
+
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4992 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5120 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 2 writesPerItem=1 */
+s_waitcnt vmcnt(1)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:0 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 0
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(3)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(1)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:5248 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=192 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=192 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5376 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5504 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 3 writesPerItem=1 */
+s_waitcnt vmcnt(0)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:0 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 0
+
+/* local write swap offsets a */
+
+/* local write swap offsets b */
+
+/* local write init pointers a */
+/* N/A */
+
+/* local write init pointers b */
+/* N/A */
+
+/* local read swap offsets a */
+
+/* local read swap internal offset -> 0 */
+
+/* local read swap offsets b */
+
+/* local read swap internal offset -> 0 */
+
+/* local read init pointers a */
+
+/* local read init pointers b */
+s_waitcnt lgkmcnt(3)                               // 6wait for local read old=3 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(1)                               // 6wait for local read old=1 new=0
+MAC_6x4_X0_part_3
+
+/******************************************/
+/* Unrolled Loop - End 2/2 (final)        */
+/******************************************/
+
+s_add_u32 s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+s_cmp_eq_i32 s[sgprLoopCounters+0], -2              // counterL==0
+s_cbranch_scc0 label_0001                          // restart LoopL
+s_cbranch_scc1 label_0002                          // restart LoopL
+
+label_0003: // unroll loop odditer exit
+
+//check edge Batch calculation needed
+//for Batch edge jump to different beta loop optimization code
+s_add_u32      s83,-0x1, s[sgprNumWorkGroups0]       //
+s_cmp_lt_u32   s[sgprWorkGroup0], s83                // wg0 < nwg0-1
+s_cmov_b32     s[sgprEdgeSelMask0], 0x0
+s_cmpk_gt_u32  s[sgprEdgeSelMask0], 0x0
+s_cbranch_scc1 label_1003                            // wg1 < nwg1-1 so skip rMT1 = Size1 % MT1
+s_add_u32      s83, -0x1, s[sgprNumWorkGroups1]      //
+s_cmp_lt_u32   s[sgprWorkGroup1], s83                // wg1 < nwg1-1
+s_cmov_b32     s[sgprEdgeSelMask1], 0x0
+s_cmpk_gt_u32  s[sgprEdgeSelMask1], 0x0
+s_cbranch_scc1 label_1003                            // wg1 < nwg1-1 so skip rMT1 = Size1 % MT1
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4224 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4480 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4608 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4736 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4864 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4992 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5120 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:0 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 4096
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(1)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:5248 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5376 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5504 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_mul_i32 s56, 0x30, s[sgprWorkGroup0]             // s56 = wg0*MT0
+s_mul_i32 s58, 0x40, s[sgprWorkGroup1]             // s56 = wg0*MT0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 3 writesPerItem=1 */
+s_waitcnt vmcnt(0)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:0 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 4096
+
+s_waitcnt lgkmcnt(1)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0_unprio_0
+v_lshrrev_b32 v[vgprLocalWriteAddrB], 3, v[vgprSerial]                // vectorStaticDiv: v49 = v[vgprSerial] / 8
+v_and_b32 v[vgprLocalWriteAddrA], 7, v[vgprSerial]                    // vectorStaticDiv: v48 = v[vgprSerial] % 8
+v_lshlrev_b32 v[vgprLocalWriteAddrA], 1, v[vgprLocalWriteAddrA]       // staticMultiply: v48 = v48 * 2
+v_lshlrev_b32 v[vgprLocalWriteAddrB], 1, v[vgprLocalWriteAddrB]       // staticMultiply: v49 = v49 * 2
+v_mul_lo_u32 v[vgprGlobalReadOffsetB], v[vgprLocalWriteAddrB], s[sgprStridesC+0]           // rowStart vgpr
+_v_add_co_u32 v[vgprLocalWriteAddrA], vcc, s56, v[vgprLocalWriteAddrA]                   // coord0 = tid0*VW + wg0*MT0
+_v_add_lshl_u32 v[vgprGlobalReadOffsetA], v[vgprGlobalReadOffsetB], v[vgprLocalWriteAddrA], 0x3                 // init cb addr <-  rowStart + coord0, scaled by BPE
+s_setprio 0
+
+s_add_u32       s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+s_cmp_eq_i32    s[sgprLoopCounters+0], -1             // is this the last iteration
+s_cmov_b32 	s[sgprSrdA+2], 0                        // Set limit to 0 for last iteration
+s_cmov_b32 	s[sgprSrdB+2], 0                        // Set limit to 0 for last iteration
+s_mov_b32 	s85, s[sgprSrdC+0]
+s_mov_b32 	s86, s[sgprSrdC+1]
+s_mov_b32       s87, s[sgprSrdD+0]
+s_mov_b32       s88, s[sgprSrdD+1]
+
+
+s_waitcnt lgkmcnt(0)                               // 1wait for local write
+s_barrier //4sync for global read
+
+/* iter 0,1 */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:384 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part1
+
+/* iter 1 */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:768  // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1152 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part1
+
+
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:512 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+0:vgprValuC+0+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+0:vgprValuC+0+1] // *= alpha
+v_mul_f64 v[vgprValuC+2:vgprValuC+2+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+2:vgprValuC+2+1] // *= alpha
+v_fma_f64 v[vgprValuC+0:vgprValuC+0+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+0:vgprValuC+0+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+2:vgprValuC+2+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+2:vgprValuC+2+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[0:3], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+12:vgprValuC+12+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+12:vgprValuC+12+1] // *= alpha
+v_mul_f64 v[vgprValuC+14:vgprValuC+14+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+14:vgprValuC+14+1] // *= alpha
+v_fma_f64 v[vgprValuC+12:vgprValuC+12+1], v[vgprG2LB+0:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+12:vgprValuC+12+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+14:vgprValuC+14+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+14:vgprValuC+14+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[12:15], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part2
+
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:896 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1280 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part2
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:640 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+4:vgprValuC+4+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+4:vgprValuC+4+1] // *= alpha
+v_mul_f64 v[vgprValuC+6:vgprValuC+6+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+6:vgprValuC+6+1] // *= alpha
+v_fma_f64 v[vgprValuC+4:vgprValuC+4+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+4:vgprValuC+4+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+6:vgprValuC+6+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+6:vgprValuC+6+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[4:7], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+16:vgprValuC+16+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+16:vgprValuC+16+1] // *= alpha
+v_mul_f64 v[vgprValuC+18:vgprValuC+18+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+18:vgprValuC+18+1] // *= alpha
+v_fma_f64 v[vgprValuC+16:vgprValuC+16+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+16:vgprValuC+16+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+18:vgprValuC+18+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+18:vgprValuC+18+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[16:19], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part3
+
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1024 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:1408 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part3
+
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:384 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+8:vgprValuC+8+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+8:vgprValuC+8+1] // *= alpha
+v_mul_f64 v[vgprValuC+10:vgprValuC+10+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+10:vgprValuC+10+1] // *= alpha
+v_fma_f64 v[vgprValuC+8:vgprValuC+8+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+8:vgprValuC+8+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+10:vgprValuC+10+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+10:vgprValuC+10+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[8:11], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+20:vgprValuC+20+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+20:vgprValuC+20+1] // *= alpha
+v_mul_f64 v[vgprValuC+22:vgprValuC+22+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+22:vgprValuC+22+1] // *= alpha
+v_fma_f64 v[vgprValuC+20:vgprValuC+20+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+20:vgprValuC+20+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+22:vgprValuC+22+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+22:vgprValuC+22+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[20:23], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_mul_i32  s56, s[sgprStridesC+0], 248              // Scale by BPE
+s_add_u32   s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+s_mov_b32   s85, s[sgprSrdC+0]
+s_mov_b32   s86, s[sgprSrdC+1]                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part4
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:768 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+s_lshl_b32   s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32   s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1152 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part4
+
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+s_mul_i32   s56, s[sgprStridesD+0], 248              // Scale by BPE
+s_add_u32   s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:512 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+24:vgprValuC+24+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+24:vgprValuC+24+1] // *= alpha
+v_mul_f64 v[vgprValuC+26:vgprValuC+26+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+26:vgprValuC+26+1] // *= alpha
+v_fma_f64 v[vgprValuC+24:vgprValuC+24+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+24:vgprValuC+24+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+26:vgprValuC+26+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+26:vgprValuC+26+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[24:27], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_mov_b32       s87, s[sgprSrdD+0]
+s_mov_b32       s88, s[sgprSrdD+1]                 /* local read init pointers b */
+s_lshl_b32      s56, s[sgprStridesD+0], 3         // Scale     s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_add_u32       s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32      s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+36:vgprValuC+36+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+36:vgprValuC+36+1] // *= alpha
+v_mul_f64 v[vgprValuC+38:vgprValuC+38+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+38:vgprValuC+38+1] // *= alpha
+v_fma_f64 v[vgprValuC+36:vgprValuC+36+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+36:vgprValuC+36+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+38:vgprValuC+38+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+38:vgprValuC+38+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[36:39], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0_part5
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:896 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1280 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part5
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:640 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+28:vgprValuC+28+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+28:vgprValuC+28+1] // *= alpha
+v_mul_f64 v[vgprValuC+30:vgprValuC+30+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+30:vgprValuC+30+1] // *= alpha
+v_fma_f64 v[vgprValuC+28:vgprValuC+28+1], v[vgprG2LA+0:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+28:vgprValuC+28+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+30:vgprValuC+30+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+30:vgprValuC+30+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[28:31], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+40:vgprValuC+40+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+40:vgprValuC+40+1] // *= alpha
+v_mul_f64 v[vgprValuC+42:vgprValuC+42+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+42:vgprValuC+42+1] // *= alpha
+v_fma_f64 v[vgprValuC+40:vgprValuC+40+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+40:vgprValuC+40+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+42:vgprValuC+42+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+42:vgprValuC+42+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[40:43], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part6
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1024 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1408 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part6
+
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+32:vgprValuC+32+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+32:vgprValuC+32+1] // *= alpha
+v_mul_f64 v[vgprValuC+34:vgprValuC+34+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+34:vgprValuC+34+1] // *= alpha
+v_fma_f64 v[vgprValuC+32:vgprValuC+32+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+32:vgprValuC+32+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+34:vgprValuC+34+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+34:vgprValuC+34+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[32:35], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_lshl_b32  s56, 	   s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32   s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+
+v_mul_f64 v[vgprValuC+44:vgprValuC+44+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+44:vgprValuC+44+1] // *= alpha
+v_mul_f64 v[vgprValuC+46:vgprValuC+46+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+46:vgprValuC+46+1] // *= alpha
+v_fma_f64 v[vgprValuC+44:vgprValuC+44+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+44:vgprValuC+44+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+46:vgprValuC+46+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+46:vgprValuC+46+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[44:47], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_add_u32            s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+
+
+s_endpgm
+
+label_0002:
+
+/* TODO-packed- compare against product of all packed C0 sizes not just SizesFree+0 */
+//s_mov_b32 s91, 0x0                                 // STATIC_DIV: divisior=48
+//s_mul_i32 s90, 0xaaa, s[sgprSizesFree+0]           // tmp1 = dividend * magic hi
+//s_lshl_b64 s[90:91], s[90:91], 0x10                // left shift 16 bits
+//s_mul_i32 s82, s[sgprSizesFree+0], 0xaaab          // tmp0 = dividend * magic lo
+//s_add_u32 s90, s82, s90                            // add lo
+//s_addc_u32 s91, s91, 0x0                           // add hi
+//s_lshr_b64 s[90:91], s[90:91], 0x21                // tmp1 = (dividend * magic) << shift
+//s_mov_b32 s82, s90                                 // quotient
+//s_mul_i32 s90, s82, 0x30                           // quotient*divisor
+//s_sub_u32 s[sgprEdgeSelMask0], s[sgprSizesFree+0], s90             // rReg = dividend - quotient*divisor
+//s_lshr_b32 s82, s[sgprSizesFree+1], 6              // s58 = s[sgprSizesFree+1] / 64
+//s_and_b32 s[sgprEdgeSelMask1], 63, s[sgprSizesFree+1]
+
+//check edge Batch calculation needed
+//for Batch edge jump to different beta loop optimization code
+s_add_u32      s83,-0x1, s[sgprNumWorkGroups0]       //
+s_cmp_lt_u32   s[sgprWorkGroup0], s83                // wg0 < nwg0-1
+s_cmov_b32     s[sgprEdgeSelMask0], 0x0
+s_cmpk_gt_u32  s[sgprEdgeSelMask0], 0x0
+s_cbranch_scc1 label_1002                            // wg1 < nwg1-1 so skip rMT1 = Size1 % MT1
+s_add_u32      s83, -0x1, s[sgprNumWorkGroups1]      //
+s_cmp_lt_u32   s[sgprWorkGroup1], s83                // wg1 < nwg1-1
+s_cmov_b32     s[sgprEdgeSelMask1], 0x0
+s_cmpk_gt_u32  s[sgprEdgeSelMask1], 0x0
+s_cbranch_scc1 label_1002                            // wg1 < nwg1-1 so skip rMT1 = Size1 % MT1
+
+/******************************************/
+
+s_waitcnt lgkmcnt(0)                                 // 1wait for local write
+s_barrier //4sync for global read
+
+/* iter 0 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(2)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:384 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:512 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:640 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(2)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:768 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:896 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1024 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:4096 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 4096
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(3)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(1)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:1152 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1280 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+s_mul_i32 s56, 0x30, s[sgprWorkGroup0]             // s56 = wg0*MT0
+s_mul_i32 s58, 0x40, s[sgprWorkGroup1]             // s56 = wg0*MT0
+/* sched write - iter 3 writesPerItem=1 */
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1408 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(0)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:4096 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 4096
+
+s_waitcnt lgkmcnt(1)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0_unprio_0
+v_lshrrev_b32 v[vgprLocalWriteAddrB], 3, v[vgprSerial]                // vectorStaticDiv: v49 = v[vgprSerial] / 8
+v_and_b32 v[vgprLocalWriteAddrA], 7, v[vgprSerial]                    // vectorStaticDiv: v48 = v[vgprSerial] % 8
+v_lshlrev_b32 v[vgprLocalWriteAddrA], 1, v[vgprLocalWriteAddrA]       // staticMultiply: v48 = v48 * 2
+v_lshlrev_b32 v[vgprLocalWriteAddrB], 1, v[vgprLocalWriteAddrB]       // staticMultiply: v49 = v49 * 2
+v_mul_lo_u32 v[vgprGlobalReadOffsetB], v[vgprLocalWriteAddrB], s[sgprStridesC+0]           // rowStart vgpr
+_v_add_co_u32 v[vgprLocalWriteAddrA], vcc, s56, v[vgprLocalWriteAddrA]                   // coord0 = tid0*VW + wg0*MT0
+_v_add_lshl_u32 v[vgprGlobalReadOffsetA], v[vgprGlobalReadOffsetB], v[vgprLocalWriteAddrA], 0x3                 // init cb addr <-  rowStart + coord0, scaled by BPE
+s_setprio 0
+
+s_add_u32       s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+s_cmp_eq_i32    s[sgprLoopCounters+0], -1             // is this the last iteration
+s_cmov_b32 	s[sgprSrdA+2], 0                        // Set limit to 0 for last iteration
+s_cmov_b32 	s[sgprSrdB+2], 0                        // Set limit to 0 for last iteration
+s_mov_b32 	s85, s[sgprSrdC+0]
+s_mov_b32 	s86, s[sgprSrdC+1]
+s_mov_b32       s87, s[sgprSrdD+0]
+s_mov_b32       s88, s[sgprSrdD+1]
+
+
+s_waitcnt lgkmcnt(0)                               // 1wait for local write
+s_barrier //4sync for global read
+
+/* iter 0,1 */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4480 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part1
+
+/* iter 1 */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4864 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5248 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part1
+
+
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4224 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4608 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+0:vgprValuC+0+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+0:vgprValuC+0+1] // *= alpha
+v_mul_f64 v[vgprValuC+2:vgprValuC+2+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+2:vgprValuC+2+1] // *= alpha
+v_fma_f64 v[vgprValuC+0:vgprValuC+0+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+0:vgprValuC+0+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+2:vgprValuC+2+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+2:vgprValuC+2+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[0:3], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+12:vgprValuC+12+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+12:vgprValuC+12+1] // *= alpha
+v_mul_f64 v[vgprValuC+14:vgprValuC+14+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+14:vgprValuC+14+1] // *= alpha
+v_fma_f64 v[vgprValuC+12:vgprValuC+12+1], v[vgprG2LB+0:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+12:vgprValuC+12+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+14:vgprValuC+14+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+14:vgprValuC+14+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[12:15], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part2
+
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4992 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5376 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part2
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4736 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+4:vgprValuC+4+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+4:vgprValuC+4+1] // *= alpha
+v_mul_f64 v[vgprValuC+6:vgprValuC+6+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+6:vgprValuC+6+1] // *= alpha
+v_fma_f64 v[vgprValuC+4:vgprValuC+4+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+4:vgprValuC+4+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+6:vgprValuC+6+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+6:vgprValuC+6+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[4:7], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+16:vgprValuC+16+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+16:vgprValuC+16+1] // *= alpha
+v_mul_f64 v[vgprValuC+18:vgprValuC+18+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+18:vgprValuC+18+1] // *= alpha
+v_fma_f64 v[vgprValuC+16:vgprValuC+16+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+16:vgprValuC+16+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+18:vgprValuC+18+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+18:vgprValuC+18+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[16:19], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part3
+
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5120 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:5504 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part3
+
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4480 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+8:vgprValuC+8+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+8:vgprValuC+8+1] // *= alpha
+v_mul_f64 v[vgprValuC+10:vgprValuC+10+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+10:vgprValuC+10+1] // *= alpha
+v_fma_f64 v[vgprValuC+8:vgprValuC+8+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+8:vgprValuC+8+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+10:vgprValuC+10+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+10:vgprValuC+10+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[8:11], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+20:vgprValuC+20+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+20:vgprValuC+20+1] // *= alpha
+v_mul_f64 v[vgprValuC+22:vgprValuC+22+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+22:vgprValuC+22+1] // *= alpha
+v_fma_f64 v[vgprValuC+20:vgprValuC+20+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+20:vgprValuC+20+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+22:vgprValuC+22+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+22:vgprValuC+22+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[20:23], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_mul_i32  s56, s[sgprStridesC+0], 248              // Scale by BPE
+s_add_u32   s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+s_mov_b32   s85, s[sgprSrdC+0]
+s_mov_b32   s86, s[sgprSrdC+1]                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part4
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4864 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+s_lshl_b32   s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32   s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5248 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part4
+
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4224 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+s_mul_i32   s56, s[sgprStridesD+0], 248              // Scale by BPE
+s_add_u32   s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4608 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+24:vgprValuC+24+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+24:vgprValuC+24+1] // *= alpha
+v_mul_f64 v[vgprValuC+26:vgprValuC+26+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+26:vgprValuC+26+1] // *= alpha
+v_fma_f64 v[vgprValuC+24:vgprValuC+24+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+24:vgprValuC+24+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+26:vgprValuC+26+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+26:vgprValuC+26+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[24:27], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_mov_b32       s87, s[sgprSrdD+0]
+s_mov_b32       s88, s[sgprSrdD+1]                 /* local read init pointers b */
+s_lshl_b32      s56, s[sgprStridesD+0], 3         // Scale     s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_add_u32       s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32      s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+36:vgprValuC+36+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+36:vgprValuC+36+1] // *= alpha
+v_mul_f64 v[vgprValuC+38:vgprValuC+38+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+38:vgprValuC+38+1] // *= alpha
+v_fma_f64 v[vgprValuC+36:vgprValuC+36+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+36:vgprValuC+36+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+38:vgprValuC+38+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+38:vgprValuC+38+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[36:39], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0_part5
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4992 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5376 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part5
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4736 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+28:vgprValuC+28+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+28:vgprValuC+28+1] // *= alpha
+v_mul_f64 v[vgprValuC+30:vgprValuC+30+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+30:vgprValuC+30+1] // *= alpha
+v_fma_f64 v[vgprValuC+28:vgprValuC+28+1], v[vgprG2LA+0:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+28:vgprValuC+28+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+30:vgprValuC+30+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+30:vgprValuC+30+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[28:31], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+40:vgprValuC+40+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+40:vgprValuC+40+1] // *= alpha
+v_mul_f64 v[vgprValuC+42:vgprValuC+42+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+42:vgprValuC+42+1] // *= alpha
+v_fma_f64 v[vgprValuC+40:vgprValuC+40+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+40:vgprValuC+40+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+42:vgprValuC+42+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+42:vgprValuC+42+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[40:43], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part6
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5120 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5504 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part6
+
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+32:vgprValuC+32+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+32:vgprValuC+32+1] // *= alpha
+v_mul_f64 v[vgprValuC+34:vgprValuC+34+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+34:vgprValuC+34+1] // *= alpha
+v_fma_f64 v[vgprValuC+32:vgprValuC+32+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+32:vgprValuC+32+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+34:vgprValuC+34+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+34:vgprValuC+34+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[32:35], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_lshl_b32  s56, 	   s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32   s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+
+v_mul_f64 v[vgprValuC+44:vgprValuC+44+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+44:vgprValuC+44+1] // *= alpha
+v_mul_f64 v[vgprValuC+46:vgprValuC+46+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+46:vgprValuC+46+1] // *= alpha
+v_fma_f64 v[vgprValuC+44:vgprValuC+44+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+44:vgprValuC+44+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+46:vgprValuC+46+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+46:vgprValuC+46+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[44:47], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_add_u32            s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+
+
+s_endpgm
+
+label_1002:
+
+/******************************************/
+//branch logic gets executed for edge MT to use legacy alph_beta code
+
+s_waitcnt lgkmcnt(0)                                 // 1wait for local write
+s_barrier //4sync for global read
+
+/* iter 0 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:384 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:512 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:640 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:768 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:896 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt vmcnt(1)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:4096 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 4096
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1024 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:1152 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1280 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 3 writesPerItem=1 */
+s_waitcnt vmcnt(0)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:4096 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 4096
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1408 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0
+
+
+s_waitcnt lgkmcnt(0)                               // 1wait for local write
+s_barrier //4sync for global read
+
+
+/* iter 0 */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4096 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4224 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4352 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4480 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4608 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4736 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4864 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4992 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5120 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:5248 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5376 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5504 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=192 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=192 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0
+s_add_u32 s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+
+s_branch label_0004
+
+label_1003:
+
+s_waitcnt lgkmcnt(0)                               // 1wait for local write
+s_barrier //4sync for global read
+
+
+/* iter 0 */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4096 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4224 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4352 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4480 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4608 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4736 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4864 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4992 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* sched write - iter 2 writesPerItem=1 */
+s_waitcnt vmcnt(1)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:0 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5120 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:5248 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5376 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 3 writesPerItem=1 */
+s_waitcnt vmcnt(0)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:0 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5504 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=192 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=192 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+
+/* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0
+
+s_add_u32 s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+s_cmp_eq_i32 s[sgprLoopCounters+0], -1             // is this the last iteration
+s_cmov_b32 s[sgprSrdA+2], 0                        // Set limit to 0 for last iteration
+s_cmov_b32 s[sgprSrdB+2], 0                        // Set limit to 0 for last iteration
+
+s_waitcnt lgkmcnt(0)                               // 1wait for local write
+
+s_barrier //4sync for global read
+
+/* iter 0 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:384 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:512 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:640 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:768 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:896 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1024 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:1152 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1280 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1408 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0
+s_add_u32 s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+
+label_0004:
+
+
+/******************************************/
+/* Tail Loop                              */
+/******************************************/
+
+
+/* local write reset offsets a */
+
+
+
+/* local write reset offsets b */
+
+
+
+s_cmp_eq_u32 s[sgprOrigLoopCounter], 0             // completely skipped unroll loop?
+s_cselect_b32 s66, 0, s[sgprGlobalReadIncsA]       // force to 0?
+s_cselect_b32 s67, 0, s[sgprGlobalReadIncsB]       // force to 0?
+s_sub_u32  s[sgprSrdA+0], s[sgprSrdA+0], s66       // gra SRD -= inc(lower)
+s_subb_u32  s[sgprSrdA+1], s[sgprSrdA+1], 0        // gra SRD -= inc(upper)
+s_add_u32 s[sgprShadowLimitA+0], s[sgprShadowLimitA+0], s66 // limit -= inc)
+s_addc_u32 s[sgprShadowLimitA+1], s[sgprShadowLimitA+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitA+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdA+2], s[sgprShadowLimitA+0]    // Move shadow to real if we are within 2^32
+
+s_sub_u32  s[sgprSrdB+0], s[sgprSrdB+0], s67       // gra SRD -= inc(lower)
+s_subb_u32  s[sgprSrdB+1], s[sgprSrdB+1], 0        // gra SRD -= inc(upper)
+s_add_u32 s[sgprShadowLimitB+0], s[sgprShadowLimitB+0], s67 // limit -= inc)
+s_addc_u32 s[sgprShadowLimitB+1], s[sgprShadowLimitB+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitB+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdB+2], s[sgprShadowLimitB+0]    // Move shadow to real if we are within 2^32
+
+//numIterL = (((sizeL % LOCAL_DEPTHU) + LOCAL_SPLITU - 1) / LOCAL_SPLITU)
+s_lshr_b32 s66, s[sgprSizesSum+0], 2               // s66 = s[sgprSizesSum+0] / 4
+s_and_b32 s[sgprLoopCounters+0], 3, s[sgprSizesSum+0] // s[sgprLoopCounters+0] = s[sgprSizesSum+0] % 4
+s_cmp_eq_u32 s[sgprLoopCounters+0], 0x0            // numIterL == 0
+s_cbranch_scc1 label_0006                          // skip to end of tail loop b/c numIter==0
+s_sub_u32 s[sgprLoopCounters+0], 0x0, s[sgprLoopCounters+0] // counterL = -sizeL
+
+
+/* global read a */
+
+/* g2l=0, load component 0 */
+buffer_load_dwordx2 v[vgprG2LA+0+0:vgprG2LA+0+0+1], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // load one buffer value
+/* g2l=0, load component 1 */
+buffer_load_dwordx2 v[vgprG2LA+0+2:vgprG2LA+0+2+1], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:8 // load one buffer value
+_v_add_co_u32 v[vgprGlobalReadOffsetA+0], vcc, v[vgprGlobalReadOffsetA+0], 8 // graOffset += 1 * bpe
+
+
+/* global read b */
+
+/* g2l=0, load component 0 */
+buffer_load_dwordx2 v[vgprG2LB+0+0:vgprG2LB+0+0+1], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // load one buffer value
+/* g2l=0, load component 1 */
+buffer_load_dwordx2 v[vgprG2LB+0+2:vgprG2LB+0+2+1], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:8 // load one buffer value
+_v_add_co_u32 v[vgprGlobalReadOffsetB+0], vcc, v[vgprGlobalReadOffsetB+0], 8 // graOffset += 1 * bpe
+
+s_waitcnt vmcnt(0)                                 // 2wait for global read
+
+s_barrier //
+
+/* local write init pointers a */
+
+/* N/A */
+
+
+/* local write init pointers b */
+
+/* N/A */
+
+
+/* local write a */
+
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:0 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 0
+
+
+/* local write b */
+
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:0 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 0
+
+s_waitcnt lgkmcnt(0)                               // 5wait for local write
+
+s_barrier //
+
+
+/* local read reset offsets a */
+
+/* handled internally */
+v_and_b32 v[vgprLocalReadAddrA], 0xfff, v[vgprLocalReadAddrA] // reset Red,Blk -> Red
+
+
+/* local read reset offsets b */
+
+/* handled internally */
+v_and_b32 v[vgprLocalReadAddrB], 0xfff, v[vgprLocalReadAddrB] // reset Red,Blk -> Red
+
+
+/* local read init pointers a */
+
+
+
+/* local read init pointers b */
+
+
+
+/* tail loop: macs */
+
+s_cmp_ge_i32 s[sgprLoopCounters+0], 0x0            // LoopCounterL < EndCounter
+s_cbranch_scc1 label_0006                          // don't enter LoopL
+s_mov_b32 s[sgprOrigLoopCounter], 0                // repurpose to count each localRead increment
+label_0005:
+
+
+/* local read a */
+
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+
+/* local read b */
+
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+
+/* local read inc a */
+
+s_mov_b32 s65, 0x180                               // inc
+_v_add_co_u32 v[vgprLocalReadAddrA], vcc, s65, v[vgprLocalReadAddrA] // lrA += 384 (LSU*(MT+PAD)*bpe)
+
+
+/* local read inc b */
+
+s_mov_b32 s65, 0x200                               // inc
+_v_add_co_u32 v[vgprLocalReadAddrB], vcc, s65, v[vgprLocalReadAddrB] // lrB += 512 (LSU*(MT+PAD)*bpe)
+
+s_waitcnt lgkmcnt(0)                               // 4wait for local read
+
+MAC_6x4_X0
+s_add_u32 s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+s_add_u32 s[sgprOrigLoopCounter], s[sgprOrigLoopCounter], 0x1 // inc counterL
+s_cmp_eq_i32 s[sgprLoopCounters+0], 0x0            // counterL==0
+s_cbranch_scc0 label_0005                          // restart LoopL
+label_0006:
+
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // wait for all summation activity
+
+
+/* shift vector components d0 */
+
+v_mov_b32 v50, s[sgprWorkGroup0]                   //
+v_mul_i32_i24 v50, -0x30, v50                      // wg*MT
+_v_add_co_u32 v50, vcc, s[sgprSizesFree+0], v50    // wgMT = Size - wg*MT
+v_mov_b32 v48, 0x30                                // MT
+v_cmp_lt_u32 s[56:57], v50, v48                    // wgMT < MT
+v_cndmask_b32 v50, v48, v50, s[56:57]              // wgMT = (wgMT < MT) ? wgMT : MT
+v_lshrrev_b32 v52, 1, v50                          // vectorStaticDiv: v52 = v50 / 2
+v_and_b32 v53, 1, v50                              // vectorStaticDiv: v53 = v50 % 2
+v_lshrrev_b32 v54, 3, v52                          // vectorStaticDiv: v54 = v52 / 8
+v_and_b32 v55, 7, v52                              // vectorStaticDiv: v55 = v52 % 8
+v_and_b32 v56, 7, v[vgprSerial]                    // vectorStaticDiv: v56 = v[vgprSerial] % 8
+v_lshrrev_b32 v57, 4, v50                          // vectorStaticDiv: v57 = v50 / 16
+v_and_b32 v58, 1, v50                              // vectorStaticDiv: v58 = v50 % 2
+v_mov_b32 v59, v58                                 // duplicate
+v_lshrrev_b32 v58, 1, v59                          // vectorStaticDiv: v58 = v59 / 2
+_v_add_co_u32 v58, vcc, v57, v58                   // vId = 2 components
+v_cmp_eq_u32 s[56:57], v56, v55                    // mask
+v_mov_b32 v48, s56                                 //
+v_mov_b32 v49, s57                                 //
+v_cmp_eq_u32 vcc, v53, 0x1                         // wgMT%VW == 1
+s_cbranch_vccnz label_0010                         // shift d0 r=1
+s_branch label_0014                                // no shifting
+
+/******************************************/
+/* shift d0 r=1                           */
+/******************************************/
+label_0010:
+v_cmp_eq_u32 vcc, v58, 0x0                         // wgMT/(SG*VW) == 0
+s_cbranch_vccnz label_0011                         // shift d0, r=1, v=0
+v_cmp_eq_u32 vcc, v58, 0x1                         // wgMT/(SG*VW) == 1
+s_cbranch_vccnz label_0012                         // shift d0, r=1, v=1
+v_cmp_eq_u32 vcc, v58, 0x2                         // wgMT/(SG*VW) == 2
+s_cbranch_vccnz label_0013                         // shift d0, r=1, v=2
+
+/* shift d0 r=1 v=0 */
+label_0011:
+v_cmpx_eq_u32 s[56:57], v56, v55                   // serial % SG == (wgMT/VECTOR_WIDTH)%SG
+// src=1, dst=0
+v_mov_b32 v0, v2                                   // rC[0+0*VW+0*TT0I] = rC[1+0*VW+0*TT0I]
+v_mov_b32 v1, v3                                   // rC[0+0*VW+0*TT0I] = rC[1+0*VW+0*TT0I]
+// src=7, dst=6
+v_mov_b32 v12, v14                                 // rC[0+0*VW+1*TT0I] = rC[1+0*VW+1*TT0I]
+v_mov_b32 v13, v15                                 // rC[0+0*VW+1*TT0I] = rC[1+0*VW+1*TT0I]
+// src=13, dst=12
+v_mov_b32 v24, v26                                 // rC[0+0*VW+2*TT0I] = rC[1+0*VW+2*TT0I]
+v_mov_b32 v25, v27                                 // rC[0+0*VW+2*TT0I] = rC[1+0*VW+2*TT0I]
+// src=19, dst=18
+v_mov_b32 v36, v38                                 // rC[0+0*VW+3*TT0I] = rC[1+0*VW+3*TT0I]
+v_mov_b32 v37, v39                                 // rC[0+0*VW+3*TT0I] = rC[1+0*VW+3*TT0I]
+s_mov_b64 s[56:57], 0xFFFFFFFFFFFFFFFF             // to restore all threads active
+s_or_saveexec_b64 vcc, s[56:57]                    // all threads active
+s_branch label_0014                                // done shifting
+
+/* shift d0 r=1 v=1 */
+label_0012:
+v_cmpx_eq_u32 s[56:57], v56, v55                   // serial % SG == (wgMT/VECTOR_WIDTH)%SG
+// src=3, dst=2
+v_mov_b32 v4, v6                                   // rC[0+1*VW+0*TT0I] = rC[1+1*VW+0*TT0I]
+v_mov_b32 v5, v7                                   // rC[0+1*VW+0*TT0I] = rC[1+1*VW+0*TT0I]
+// src=9, dst=8
+v_mov_b32 v16, v18                                 // rC[0+1*VW+1*TT0I] = rC[1+1*VW+1*TT0I]
+v_mov_b32 v17, v19                                 // rC[0+1*VW+1*TT0I] = rC[1+1*VW+1*TT0I]
+// src=15, dst=14
+v_mov_b32 v28, v30                                 // rC[0+1*VW+2*TT0I] = rC[1+1*VW+2*TT0I]
+v_mov_b32 v29, v31                                 // rC[0+1*VW+2*TT0I] = rC[1+1*VW+2*TT0I]
+// src=21, dst=20
+v_mov_b32 v40, v42                                 // rC[0+1*VW+3*TT0I] = rC[1+1*VW+3*TT0I]
+v_mov_b32 v41, v43                                 // rC[0+1*VW+3*TT0I] = rC[1+1*VW+3*TT0I]
+s_mov_b64 s[56:57], 0xFFFFFFFFFFFFFFFF             // to restore all threads active
+s_or_saveexec_b64 vcc, s[56:57]                    // all threads active
+s_branch label_0014                                // done shifting
+
+/* shift d0 r=1 v=2 */
+label_0013:
+v_cmpx_eq_u32 s[56:57], v56, v55                   // serial % SG == (wgMT/VECTOR_WIDTH)%SG
+// src=5, dst=4
+v_mov_b32 v8, v10                                  // rC[0+2*VW+0*TT0I] = rC[1+2*VW+0*TT0I]
+v_mov_b32 v9, v11                                  // rC[0+2*VW+0*TT0I] = rC[1+2*VW+0*TT0I]
+// src=11, dst=10
+v_mov_b32 v20, v22                                 // rC[0+2*VW+1*TT0I] = rC[1+2*VW+1*TT0I]
+v_mov_b32 v21, v23                                 // rC[0+2*VW+1*TT0I] = rC[1+2*VW+1*TT0I]
+// src=17, dst=16
+v_mov_b32 v32, v34                                 // rC[0+2*VW+2*TT0I] = rC[1+2*VW+2*TT0I]
+v_mov_b32 v33, v35                                 // rC[0+2*VW+2*TT0I] = rC[1+2*VW+2*TT0I]
+// src=23, dst=22
+v_mov_b32 v44, v46                                 // rC[0+2*VW+3*TT0I] = rC[1+2*VW+3*TT0I]
+v_mov_b32 v45, v47                                 // rC[0+2*VW+3*TT0I] = rC[1+2*VW+3*TT0I]
+s_mov_b64 s[56:57], 0xFFFFFFFFFFFFFFFF             // to restore all threads active
+s_or_saveexec_b64 vcc, s[56:57]                    // all threads active
+s_branch label_0014                                // done shifting
+label_0014: // end shift0
+
+
+/* shift vector components d1 */
+
+v_mov_b32 v50, s[sgprWorkGroup1]                   //
+v_mul_i32_i24 v50, -0x40, v50                      // wg*MT
+_v_add_co_u32 v50, vcc, s[sgprSizesFree+1], v50    // wgMT = Size - wg*MT
+v_mov_b32 v48, 0x40                                // MT
+v_cmp_lt_u32 s[56:57], v50, v48                    // wgMT < MT
+v_cndmask_b32 v50, v48, v50, s[56:57]              // wgMT = (wgMT < MT) ? wgMT : MT
+v_lshrrev_b32 v52, 1, v50                          // vectorStaticDiv: v52 = v50 / 2
+v_and_b32 v53, 1, v50                              // vectorStaticDiv: v53 = v50 % 2
+v_lshrrev_b32 v54, 4, v52                          // vectorStaticDiv: v54 = v52 / 16
+v_and_b32 v55, 15, v52                             // vectorStaticDiv: v55 = v52 % 16
+v_lshrrev_b32 v56, 3, v[vgprSerial]                // vectorStaticDiv: v56 = v[vgprSerial] / 8
+v_and_b32 v57, 15, v56                             // vectorStaticDiv: v57 = v56 % 16
+v_lshrrev_b32 v56, 5, v50                          // vectorStaticDiv: v56 = v50 / 32
+v_and_b32 v58, 1, v50                              // vectorStaticDiv: v58 = v50 % 2
+v_mov_b32 v59, v58                                 // duplicate
+v_lshrrev_b32 v58, 1, v59                          // vectorStaticDiv: v58 = v59 / 2
+_v_add_co_u32 v58, vcc, v56, v58                   // vId = 2 components
+v_cmp_eq_u32 s[56:57], v57, v55                    // mask
+v_mov_b32 v48, s56                                 //
+v_mov_b32 v49, s57                                 //
+v_cmp_eq_u32 vcc, v53, 0x1                         // wgMT%VW == 1
+s_cbranch_vccnz label_0018                         // shift d1 r=1
+s_branch label_0021                                // no shifting
+
+/******************************************/
+/* shift d1 r=1                           */
+/******************************************/
+label_0018:
+v_cmp_eq_u32 vcc, v58, 0x0                         // wgMT/(SG*VW) == 0
+s_cbranch_vccnz label_0019                         // shift d1, r=1, v=0
+v_cmp_eq_u32 vcc, v58, 0x1                         // wgMT/(SG*VW) == 1
+s_cbranch_vccnz label_0020                         // shift d1, r=1, v=1
+
+/* shift d1 r=1 v=0 */
+label_0019:
+v_cmpx_eq_u32 s[56:57], v57, v55                   // serial % SG == (wgMT/VECTOR_WIDTH)%SG
+// src=6, dst=0
+v_mov_b32 v0, v12                                  // rC[0+0*TT0I*VW+0*TT0I] = rC[0+0*TT0I*VW+1*TT0I]
+v_mov_b32 v1, v13                                  // rC[0+0*TT0I*VW+0*TT0I] = rC[0+0*TT0I*VW+1*TT0I]
+// src=7, dst=1
+v_mov_b32 v2, v14                                  // rC[1+0*TT0I*VW+0*TT0I] = rC[1+0*TT0I*VW+1*TT0I]
+v_mov_b32 v3, v15                                  // rC[1+0*TT0I*VW+0*TT0I] = rC[1+0*TT0I*VW+1*TT0I]
+// src=8, dst=2
+v_mov_b32 v4, v16                                  // rC[2+0*TT0I*VW+0*TT0I] = rC[2+0*TT0I*VW+1*TT0I]
+v_mov_b32 v5, v17                                  // rC[2+0*TT0I*VW+0*TT0I] = rC[2+0*TT0I*VW+1*TT0I]
+// src=9, dst=3
+v_mov_b32 v6, v18                                  // rC[3+0*TT0I*VW+0*TT0I] = rC[3+0*TT0I*VW+1*TT0I]
+v_mov_b32 v7, v19                                  // rC[3+0*TT0I*VW+0*TT0I] = rC[3+0*TT0I*VW+1*TT0I]
+// src=10, dst=4
+v_mov_b32 v8, v20                                  // rC[4+0*TT0I*VW+0*TT0I] = rC[4+0*TT0I*VW+1*TT0I]
+v_mov_b32 v9, v21                                  // rC[4+0*TT0I*VW+0*TT0I] = rC[4+0*TT0I*VW+1*TT0I]
+// src=11, dst=5
+v_mov_b32 v10, v22                                 // rC[5+0*TT0I*VW+0*TT0I] = rC[5+0*TT0I*VW+1*TT0I]
+v_mov_b32 v11, v23                                 // rC[5+0*TT0I*VW+0*TT0I] = rC[5+0*TT0I*VW+1*TT0I]
+s_mov_b64 s[56:57], 0xFFFFFFFFFFFFFFFF             // to restore all threads active
+s_or_saveexec_b64 vcc, s[56:57]                    // all threads active
+s_branch label_0021                                // done shifting
+
+/* shift d1 r=1 v=1 */
+label_0020:
+v_cmpx_eq_u32 s[56:57], v57, v55                   // serial % SG == (wgMT/VECTOR_WIDTH)%SG
+// src=18, dst=12
+v_mov_b32 v24, v36                                 // rC[0+1*TT0I*VW+0*TT0I] = rC[0+1*TT0I*VW+1*TT0I]
+v_mov_b32 v25, v37                                 // rC[0+1*TT0I*VW+0*TT0I] = rC[0+1*TT0I*VW+1*TT0I]
+// src=19, dst=13
+v_mov_b32 v26, v38                                 // rC[1+1*TT0I*VW+0*TT0I] = rC[1+1*TT0I*VW+1*TT0I]
+v_mov_b32 v27, v39                                 // rC[1+1*TT0I*VW+0*TT0I] = rC[1+1*TT0I*VW+1*TT0I]
+// src=20, dst=14
+v_mov_b32 v28, v40                                 // rC[2+1*TT0I*VW+0*TT0I] = rC[2+1*TT0I*VW+1*TT0I]
+v_mov_b32 v29, v41                                 // rC[2+1*TT0I*VW+0*TT0I] = rC[2+1*TT0I*VW+1*TT0I]
+// src=21, dst=15
+v_mov_b32 v30, v42                                 // rC[3+1*TT0I*VW+0*TT0I] = rC[3+1*TT0I*VW+1*TT0I]
+v_mov_b32 v31, v43                                 // rC[3+1*TT0I*VW+0*TT0I] = rC[3+1*TT0I*VW+1*TT0I]
+// src=22, dst=16
+v_mov_b32 v32, v44                                 // rC[4+1*TT0I*VW+0*TT0I] = rC[4+1*TT0I*VW+1*TT0I]
+v_mov_b32 v33, v45                                 // rC[4+1*TT0I*VW+0*TT0I] = rC[4+1*TT0I*VW+1*TT0I]
+// src=23, dst=17
+v_mov_b32 v34, v46                                 // rC[5+1*TT0I*VW+0*TT0I] = rC[5+1*TT0I*VW+1*TT0I]
+v_mov_b32 v35, v47                                 // rC[5+1*TT0I*VW+0*TT0I] = rC[5+1*TT0I*VW+1*TT0I]
+s_mov_b64 s[56:57], 0xFFFFFFFFFFFFFFFF             // to restore all threads active
+s_or_saveexec_b64 vcc, s[56:57]                    // all threads active
+label_0021: // end shift0
+
+
+
+/* not-LocalSplitU: global write indices */
+
+s_mov_b32 s[sgprSrdD+0], s[sgprAddressD+0]         // init SRD base address (lower)
+s_mov_b32 s[sgprSrdD+1], s[sgprAddressD+1]         // init SRD base address (upper) + other fields
+s_mov_b32 s[sgprSrdD+2], 0x80000000                //
+s_mov_b32 s[sgprSrdD+3], Srd127_96                 // Set bits 127_96 in SRD
+s_mov_b32 s[sgprSrdC+0], s[sgprAddressC+0]         // init SRD base address (lower)
+s_mov_b32 s[sgprSrdC+1], s[sgprAddressC+1]         // init SRD base address (upper) + other fields
+s_mov_b32 s[sgprSrdC+2], 0x80000000                //
+s_mov_b32 s[sgprSrdC+3], Srd127_96                 // Set bits 127_96 in SRD
+
+s_mul_i32 s58, 0x40, s[sgprWorkGroup1]             // <- wg1*MT1
+s_mul_hi_u32 s57, s58, s[sgprStridesC+0]           // Scale s58 by Stride
+s_mul_i32 s56, s58, s[sgprStridesC+0]              // Scale s58 by Stride
+s_lshl_b64 s[56:57], s[56:57], 3                   // scale by bpe
+s_add_u32 s[sgprSrdD+0], s[sgprSrdD+0], s56        // add lo to SRD
+s_addc_u32 s[sgprSrdD+1], s[sgprSrdD+1], s57       // add hi to SRD
+s_add_u32 s[sgprSrdC+0], s[sgprSrdC+0], s56        // add lo to SRD
+s_addc_u32 s[sgprSrdC+1], s[sgprSrdC+1], s57       // add hi to SRD
+
+s_mul_hi_u32 s57, s[sgprWorkGroup2], s[sgprStridesC+1] // Scale s[sgprWorkGroup2] by Stride
+s_mul_i32 s56, s[sgprWorkGroup2], s[sgprStridesC+1] // Scale s[sgprWorkGroup2] by Stride
+s_lshl_b64 s[56:57], s[56:57], 3                   // scale by bpe
+s_add_u32 s[sgprSrdD+0], s[sgprSrdD+0], s56        // add lo to SRD
+s_addc_u32 s[sgprSrdD+1], s[sgprSrdD+1], s57       // add hi to SRD
+s_add_u32 s[sgprSrdC+0], s[sgprSrdC+0], s56        // add lo to SRD
+s_addc_u32 s[sgprSrdC+1], s[sgprSrdC+1], s57       // add hi to SRD
+
+v_lshrrev_b32 v49, 3, v[vgprSerial]                // vectorStaticDiv: v49 = v[vgprSerial] / 8
+v_and_b32 v48, 7, v[vgprSerial]                    // vectorStaticDiv: v48 = v[vgprSerial] % 8
+v_lshlrev_b32 v48, 1, v48                          // staticMultiply: v48 = v48 * 2
+v_lshlrev_b32 v49, 1, v49                          // staticMultiply: v49 = v49 * 2
+v_mul_lo_u32 v50, v49, s[sgprStridesC+0]           // rowStart vgpr
+
+s_mul_i32 s56, 0x30, s[sgprWorkGroup0]             // s56 = wg0*MT0
+_v_add_co_u32 v48, vcc, s56, v48                   // coord0 = tid0*VW + wg0*MT0
+s_mul_i32 s58, 0x40, s[sgprWorkGroup1]             // <- wg1*MT1
+_v_add_co_u32 v49, vcc, s58, v49                   // coord1 = tid1*VW + wg1*MT1
+
+//v_mov_b32 v48,v[vgprLocalWriteAddrA]
+//v_mov_b32 v49,v[vgprLocalWriteAddrB]
+//v_mov_b32 v50,v[vgprGlobalReadOffsetB]           // rowStart vgpr
+//_v_add_lshl_u32 v[vgprGlobalReadOffsetA], v[vgprGlobalReadOffsetB], v[vgprLocalWriteAddrA], 0x3                 // init cb addr <-  rowStart + coord0, scaled by BPE
+
+/* not-LocalSplitU: global write */
+
+s_mov_b32 s56, s[sgprBeta+0]                       // tmp = Beta[0]
+s_or_b32 s56, s[sgprBeta+1], s56                   // tmp |= Beta[1]
+s_cmpk_eq_u32 s56, 0x0                             // Beta == 0
+s_cbranch_scc0 label_0030                          // Beta is not zero; so jump to B nonzero
+
+s_mov_b32 s56, 0x0                                 // rMT0=0
+s_add_u32 s58, -0x1, s[sgprNumWorkGroups0]         //
+s_cmp_lt_u32 s[sgprWorkGroup0], s58                // wg0 < nwg0-1
+s_cbranch_scc1 label_0027                          // wg0 < nwg0-1 so skip rMT0 = Size0 % MT0
+/* TODO-packed- compare against product of all packed C0 sizes not just SizesFree+0 */
+s_mov_b32 s61, 0x0                                 // STATIC_DIV: divisior=48
+s_mul_i32 s60, 0xaaa, s[sgprSizesFree+0]           // tmp1 = dividend * magic hi
+s_lshl_b64 s[60:61], s[60:61], 0x10                // left shift 16 bits
+s_mul_i32 s58, s[sgprSizesFree+0], 0xaaab          // tmp0 = dividend * magic lo
+s_add_u32 s60, s58, s60                            // add lo
+s_addc_u32 s61, s61, 0x0                           // add hi
+s_lshr_b64 s[60:61], s[60:61], 0x21                // tmp1 = (dividend * magic) << shift
+s_mov_b32 s58, s60                                 // quotient
+s_mul_i32 s60, s58, 0x30                           // quotient*divisor
+s_sub_u32 s56, s[sgprSizesFree+0], s60             // rReg = dividend - quotient*divisor
+label_0027:
+s_cmpk_gt_u32 s56, 0x0                             // rMT0 > 0
+s_cbranch_scc1 label_0029                          // edges required so jump to E1
+s_mov_b32 s56, 0x0                                 // rMT1=0
+s_add_u32 s58, -0x1, s[sgprNumWorkGroups1]         //
+s_cmp_lt_u32 s[sgprWorkGroup1], s58                // wg1 < nwg1-1
+s_cbranch_scc1 label_0028                          // wg1 < nwg1-1 so skip rMT1 = Size1 % MT1
+s_lshr_b32 s58, s[sgprSizesFree+1], 6              // s58 = s[sgprSizesFree+1] / 64
+s_and_b32 s56, 63, s[sgprSizesFree+1]              // s56 = s[sgprSizesFree+1] % 64
+label_0028:
+s_cmpk_gt_u32 s56, 0x0                             // rMT1 > 0
+s_cbranch_scc1 label_0029                          // edges required so jump to E1
+label_0026:
+
+/******************************************/
+/* Global Write Batch #0 (d1,d0,vc1,vc0) =
+   (0,0,0,0:vw2); (0,1,0,0:vw2); (0,2,0,0:vw2); (0,0,1,0:vw2); (0,1,1,0:vw2); (0,2,1,0:vw2); (1,0,0,0:vw2); (1,1,0,0:vw2); (1,2,0,0:vw2); (1,0,1,0:vw2); (1,1,1,0:vw2); (1,2,1,0:vw2) */
+/******************************************/
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(0,0,0,0) coordOffset1=0 element-rows coordOffset0=0 rows */
+_v_add_lshl_u32 v54, v50, v48, 0x3                 // init cb addr <-  rowStart + coord0, scaled by BPE
+/* (d1,vc1,d0,vc0)=(0,0,1,0) coordOffset1=0 element-rows coordOffset0=16 rows */
+/* (d1,vc1,d0,vc0)=(0,0,2,0) coordOffset1=0 element-rows coordOffset0=32 rows */
+/* (d1,vc1,d0,vc0)=(0,1,0,0) coordOffset1=1 element-rows coordOffset0=0 rows */
+/* (d1,vc1,d0,vc0)=(0,1,1,0) coordOffset1=1 element-rows coordOffset0=16 rows */
+/* (d1,vc1,d0,vc0)=(0,1,2,0) coordOffset1=1 element-rows coordOffset0=32 rows */
+/* (d1,vc1,d0,vc0)=(1,0,0,0) coordOffset1=32 element-rows coordOffset0=0 rows */
+/* (d1,vc1,d0,vc0)=(1,0,1,0) coordOffset1=32 element-rows coordOffset0=16 rows */
+/* (d1,vc1,d0,vc0)=(1,0,2,0) coordOffset1=32 element-rows coordOffset0=32 rows */
+/* (d1,vc1,d0,vc0)=(1,1,0,0) coordOffset1=33 element-rows coordOffset0=0 rows */
+/* (d1,vc1,d0,vc0)=(1,1,1,0) coordOffset1=33 element-rows coordOffset0=16 rows */
+/* (d1,vc1,d0,vc0)=(1,1,2,0) coordOffset1=33 element-rows coordOffset0=32 rows */
+
+/* rC *= alpha batchEements=[(0, 0, 0, 0), (0, 1, 0, 0), (0, 2, 0, 0), (0, 0, 1, 0), (0, 1, 1, 0), (0, 2, 1, 0), (1, 0, 0, 0), (1, 1, 0, 0), (1, 2, 0, 0), (1, 0, 1, 0), (1, 1, 1, 0), (1, 2, 1, 0)] */
+//v_mul_f64 v[vgprValuC+0:vgprValuC+0+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+0:vgprValuC+0+1] // *= alpha
+//v_mul_f64 v[vgprValuC+2:vgprValuC+2+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+2:vgprValuC+2+1] // *= alpha
+//v_mul_f64 v[vgprValuC+4:vgprValuC+4+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+4:vgprValuC+4+1] // *= alpha
+//v_mul_f64 v[vgprValuC+6:vgprValuC+6+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+6:vgprValuC+6+1] // *= alpha
+//v_mul_f64 v[vgprValuC+8:vgprValuC+8+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+8:vgprValuC+8+1] // *= alpha
+//v_mul_f64 v[vgprValuC+10:vgprValuC+10+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+10:vgprValuC+10+1] // *= alpha
+//v_mul_f64 v[vgprValuC+12:vgprValuC+12+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+12:vgprValuC+12+1] // *= alpha
+//v_mul_f64 v[vgprValuC+14:vgprValuC+14+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+14:vgprValuC+14+1] // *= alpha
+//v_mul_f64 v[vgprValuC+16:vgprValuC+16+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+16:vgprValuC+16+1] // *= alpha
+//v_mul_f64 v[vgprValuC+18:vgprValuC+18+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+18:vgprValuC+18+1] // *= alpha
+//v_mul_f64 v[vgprValuC+20:vgprValuC+20+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+20:vgprValuC+20+1] // *= alpha
+//v_mul_f64 v[vgprValuC+22:vgprValuC+22+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+22:vgprValuC+22+1] // *= alpha
+//v_mul_f64 v[vgprValuC+24:vgprValuC+24+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+24:vgprValuC+24+1] // *= alpha
+//v_mul_f64 v[vgprValuC+26:vgprValuC+26+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+26:vgprValuC+26+1] // *= alpha
+//v_mul_f64 v[vgprValuC+28:vgprValuC+28+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+28:vgprValuC+28+1] // *= alpha
+//v_mul_f64 v[vgprValuC+30:vgprValuC+30+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+30:vgprValuC+30+1] // *= alpha
+//v_mul_f64 v[vgprValuC+32:vgprValuC+32+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+32:vgprValuC+32+1] // *= alpha
+//v_mul_f64 v[vgprValuC+34:vgprValuC+34+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+34:vgprValuC+34+1] // *= alpha
+//v_mul_f64 v[vgprValuC+36:vgprValuC+36+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+36:vgprValuC+36+1] // *= alpha
+//v_mul_f64 v[vgprValuC+38:vgprValuC+38+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+38:vgprValuC+38+1] // *= alpha
+//v_mul_f64 v[vgprValuC+40:vgprValuC+40+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+40:vgprValuC+40+1] // *= alpha
+//v_mul_f64 v[vgprValuC+42:vgprValuC+42+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+42:vgprValuC+42+1] // *= alpha
+//v_mul_f64 v[vgprValuC+44:vgprValuC+44+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+44:vgprValuC+44+1] // *= alpha
+//v_mul_f64 v[vgprValuC+46:vgprValuC+46+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+46:vgprValuC+46+1] // *= alpha
+
+/* apply mask, calc new C and issue write */
+buffer_store_dwordx4 v[0:3], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx4 v[4:7], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+buffer_store_dwordx4 v[8:11], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+buffer_store_dwordx4 v[12:15], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx4 v[16:19], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+buffer_store_dwordx4 v[20:23], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_mul_i32 s56, s[sgprStridesC+0], 248              // scale StrideC *= 31 * bpe
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+buffer_store_dwordx4 v[24:27], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx4 v[28:31], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+buffer_store_dwordx4 v[32:35], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+buffer_store_dwordx4 v[36:39], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx4 v[40:43], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+buffer_store_dwordx4 v[44:47], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_branch label_0037                                // jump to end
+label_0029:
+
+/******************************************/
+/* Global Write Edge Batch #0 (d1,d0,vc1,vc0) =
+   (0,0,0,0:vw1); (0,0,0,1:vw1); (0,1,0,0:vw1); (0,1,0,1:vw1); (0,2,0,0:vw1); (0,2,0,1:vw1); (0,0,1,0:vw1); (0,0,1,1:vw1); (0,1,1,0:vw1); (0,1,1,1:vw1); (0,2,1,0:vw1); (0,2,1,1:vw1); (1,0,0,0:vw1); (1,0,0,1:vw1); (1,1,0,0:vw1); (1,1,0,1:vw1); (1,2,0,0:vw1); (1,2,0,1:vw1) */
+/******************************************/
+
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(0,0,0,0) coordOffset1=0 element-rows coordOffset0=0 rows */
+v_mov_b32 v51, v50                                 // rowPtr <- rowStart (first row)
+_v_add_lshl_u32 v54, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[62:63], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v54, -1, v54, s[62:63]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,0,0,1) coordOffset1=0 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v55, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[64:65], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v55, -1, v55, s[64:65]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,0,1,0) coordOffset1=0 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v56, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[66:67], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v56, -1, v56, s[66:67]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,0,1,1) coordOffset1=0 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v57, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[68:69], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v57, -1, v57, s[68:69]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,0,2,0) coordOffset1=0 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v58, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[70:71], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v58, -1, v58, s[70:71]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,0,2,1) coordOffset1=0 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v59, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[72:73], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v59, -1, v59, s[72:73]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,1,0,0) coordOffset1=1 element-rows coordOffset0=0 rows */
+_v_add_co_u32 v53, vcc, v49, 1                     // coord1 += d1*sg1*VW + vc1
+_v_add_co_u32 v51, vcc, v51, s[sgprStridesC+0]     // rowPtr <- move to start of new row
+_v_add_lshl_u32 v60, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[74:75], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v60, -1, v60, s[74:75]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,1,0,1) coordOffset1=1 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v61, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[76:77], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v61, -1, v61, s[76:77]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,1,1,0) coordOffset1=1 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v62, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[78:79], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v62, -1, v62, s[78:79]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,1,1,1) coordOffset1=1 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v63, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[80:81], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v63, -1, v63, s[80:81]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,1,2,0) coordOffset1=1 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v64, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[82:83], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v64, -1, v64, s[82:83]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,1,2,1) coordOffset1=1 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v65, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[84:85], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v65, -1, v65, s[84:85]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,0,0,0) coordOffset1=32 element-rows coordOffset0=0 rows */
+_v_add_co_u32 v53, vcc, v49, 32                    // coord1 += d1*sg1*VW + vc1
+s_mul_i32 s56, s[sgprStridesC+0], 32               // scale StrideC *= coordOffset1(32)
+_v_add_co_u32 v51, vcc, v50, s56                   // rowPtr <- inc for non-0 (tt1+vc1))
+_v_add_lshl_u32 v66, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[86:87], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v66, -1, v66, s[86:87]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,0,0,1) coordOffset1=32 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v67, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[88:89], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v67, -1, v67, s[88:89]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,0,1,0) coordOffset1=32 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v68, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[90:91], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v68, -1, v68, s[90:91]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,0,1,1) coordOffset1=32 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v69, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[92:93], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v69, -1, v69, s[92:93]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,0,2,0) coordOffset1=32 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v70, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[94:95], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v70, -1, v70, s[94:95]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,0,2,1) coordOffset1=32 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v71, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[96:97], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v71, -1, v71, s[96:97]               // clip if OOB. offset
+
+/* rC *= alpha batchEements=[(0, 0, 0, 0), (0, 0, 0, 1), (0, 1, 0, 0), (0, 1, 0, 1), (0, 2, 0, 0), (0, 2, 0, 1), (0, 0, 1, 0), (0, 0, 1, 1), (0, 1, 1, 0), (0, 1, 1, 1), (0, 2, 1, 0), (0, 2, 1, 1), (1, 0, 0, 0), (1, 0, 0, 1), (1, 1, 0, 0), (1, 1, 0, 1), (1, 2, 0, 0), (1, 2, 0, 1)] */
+//v_mul_f64 v[vgprValuC+0:vgprValuC+0+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+0:vgprValuC+0+1] // *= alpha
+//v_mul_f64 v[vgprValuC+2:vgprValuC+2+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+2:vgprValuC+2+1] // *= alpha
+//v_mul_f64 v[vgprValuC+4:vgprValuC+4+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+4:vgprValuC+4+1] // *= alpha
+//v_mul_f64 v[vgprValuC+6:vgprValuC+6+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+6:vgprValuC+6+1] // *= alpha
+//v_mul_f64 v[vgprValuC+8:vgprValuC+8+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+8:vgprValuC+8+1] // *= alpha
+//v_mul_f64 v[vgprValuC+10:vgprValuC+10+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+10:vgprValuC+10+1] // *= alpha
+//v_mul_f64 v[vgprValuC+12:vgprValuC+12+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+12:vgprValuC+12+1] // *= alpha
+//v_mul_f64 v[vgprValuC+14:vgprValuC+14+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+14:vgprValuC+14+1] // *= alpha
+//v_mul_f64 v[vgprValuC+16:vgprValuC+16+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+16:vgprValuC+16+1] // *= alpha
+//v_mul_f64 v[vgprValuC+18:vgprValuC+18+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+18:vgprValuC+18+1] // *= alpha
+//v_mul_f64 v[vgprValuC+20:vgprValuC+20+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+20:vgprValuC+20+1] // *= alpha
+//v_mul_f64 v[vgprValuC+22:vgprValuC+22+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+22:vgprValuC+22+1] // *= alpha
+//v_mul_f64 v[vgprValuC+24:vgprValuC+24+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+24:vgprValuC+24+1] // *= alpha
+//v_mul_f64 v[vgprValuC+26:vgprValuC+26+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+26:vgprValuC+26+1] // *= alpha
+//v_mul_f64 v[vgprValuC+28:vgprValuC+28+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+28:vgprValuC+28+1] // *= alpha
+//v_mul_f64 v[vgprValuC+30:vgprValuC+30+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+30:vgprValuC+30+1] // *= alpha
+//v_mul_f64 v[vgprValuC+32:vgprValuC+32+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+32:vgprValuC+32+1] // *= alpha
+//v_mul_f64 v[vgprValuC+34:vgprValuC+34+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+34:vgprValuC+34+1] // *= alpha
+
+/* apply mask, calc new C and issue write */
+buffer_store_dwordx2 v[0:1], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[2:3], v55, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[4:5], v56, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[6:7], v57, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[8:9], v58, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[10:11], v59, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[12:13], v60, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[14:15], v61, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[16:17], v62, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[18:19], v63, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[20:21], v64, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[22:23], v65, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[24:25], v66, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[26:27], v67, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[28:29], v68, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[30:31], v69, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[32:33], v70, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[34:35], v71, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+/******************************************/
+/* Global Write Edge Batch #1 (d1,d0,vc1,vc0) =
+   (1,0,1,0:vw1); (1,0,1,1:vw1); (1,1,1,0:vw1); (1,1,1,1:vw1); (1,2,1,0:vw1); (1,2,1,1:vw1) */
+/******************************************/
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(1,1,0,0) coordOffset1=33 element-rows coordOffset0=0 rows */
+_v_add_co_u32 v53, vcc, v49, 33                    // coord1 += d1*sg1*VW + vc1
+_v_add_co_u32 v51, vcc, v51, s[sgprStridesC+0]     // rowPtr <- move to start of new row
+_v_add_lshl_u32 v54, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[62:63], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v54, -1, v54, s[62:63]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,1,0,1) coordOffset1=33 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v55, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[64:65], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v55, -1, v55, s[64:65]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,1,1,0) coordOffset1=33 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v56, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[66:67], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v56, -1, v56, s[66:67]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,1,1,1) coordOffset1=33 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v57, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[68:69], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v57, -1, v57, s[68:69]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,1,2,0) coordOffset1=33 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v58, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[70:71], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v58, -1, v58, s[70:71]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,1,2,1) coordOffset1=33 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v59, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[72:73], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v59, -1, v59, s[72:73]               // clip if OOB. offset
+
+/* rC *= alpha batchEements=[(1, 0, 1, 0), (1, 0, 1, 1), (1, 1, 1, 0), (1, 1, 1, 1), (1, 2, 1, 0), (1, 2, 1, 1)] */
+//v_mul_f64 v[vgprValuC+36:vgprValuC+36+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+36:vgprValuC+36+1] // *= alpha
+//v_mul_f64 v[vgprValuC+38:vgprValuC+38+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+38:vgprValuC+38+1] // *= alpha
+//v_mul_f64 v[vgprValuC+40:vgprValuC+40+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+40:vgprValuC+40+1] // *= alpha
+//v_mul_f64 v[vgprValuC+42:vgprValuC+42+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+42:vgprValuC+42+1] // *= alpha
+//v_mul_f64 v[vgprValuC+44:vgprValuC+44+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+44:vgprValuC+44+1] // *= alpha
+//v_mul_f64 v[vgprValuC+46:vgprValuC+46+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+46:vgprValuC+46+1] // *= alpha
+
+/* apply mask, calc new C and issue write */
+buffer_store_dwordx2 v[36:37], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[38:39], v55, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[40:41], v56, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[42:43], v57, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[44:45], v58, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[46:47], v59, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_branch label_0037                                // jump to end
+label_0030:
+s_mov_b32 s56, 0x0                                 // rMT0=0
+s_add_u32 s58, -0x1, s[sgprNumWorkGroups0]         //
+s_cmp_lt_u32 s[sgprWorkGroup0], s58                // wg0 < nwg0-1
+s_cbranch_scc1 label_0034                          // wg0 < nwg0-1 so skip rMT0 = Size0 % MT0
+/* TODO-packed- compare against product of all packed C0 sizes not just SizesFree+0 */
+s_mov_b32 s61, 0x0                                 // STATIC_DIV: divisior=48
+s_mul_i32 s60, 0xaaa, s[sgprSizesFree+0]           // tmp1 = dividend * magic hi
+s_lshl_b64 s[60:61], s[60:61], 0x10                // left shift 16 bits
+s_mul_i32 s58, s[sgprSizesFree+0], 0xaaab          // tmp0 = dividend * magic lo
+s_add_u32 s60, s58, s60                            // add lo
+s_addc_u32 s61, s61, 0x0                           // add hi
+s_lshr_b64 s[60:61], s[60:61], 0x21                // tmp1 = (dividend * magic) << shift
+s_mov_b32 s58, s60                                 // quotient
+s_mul_i32 s60, s58, 0x30                           // quotient*divisor
+s_sub_u32 s56, s[sgprSizesFree+0], s60             // rReg = dividend - quotient*divisor
+label_0034:
+s_cmpk_gt_u32 s56, 0x0                             // rMT0 > 0
+s_cbranch_scc1 label_0036                          // edges required so jump to E1
+s_mov_b32 s56, 0x0                                 // rMT1=0
+s_add_u32 s58, -0x1, s[sgprNumWorkGroups1]         //
+s_cmp_lt_u32 s[sgprWorkGroup1], s58                // wg1 < nwg1-1
+s_cbranch_scc1 label_0035                          // wg1 < nwg1-1 so skip rMT1 = Size1 % MT1
+s_lshr_b32 s58, s[sgprSizesFree+1], 6              // s58 = s[sgprSizesFree+1] / 64
+s_and_b32 s56, 63, s[sgprSizesFree+1]              // s56 = s[sgprSizesFree+1] % 64
+label_0035:
+s_cmpk_gt_u32 s56, 0x0                             // rMT1 > 0
+s_cbranch_scc1 label_0036                          // edges required so jump to E1
+label_0033:
+
+/******************************************/
+/* Global Write Beta Batch #0 (d1,d0,vc1,vc0) =
+   (0,0,0,0:vw2); (0,1,0,0:vw2); (0,2,0,0:vw2); (0,0,1,0:vw2); (0,1,1,0:vw2); (0,2,1,0:vw2) */
+/******************************************/
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(0,0,0,0) coordOffset1=0 element-rows coordOffset0=0 rows */
+_v_add_lshl_u32 v54, v[vgprGlobalReadOffsetB], v48, 0x3                 // init cb addr <-  rowStart + coord0, scaled by BPE
+buffer_load_dwordx4 v[55:58], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,1,0) coordOffset1=0 element-rows coordOffset0=16 rows */
+buffer_load_dwordx4 v[59:62], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,2,0) coordOffset1=0 element-rows coordOffset0=32 rows */
+buffer_load_dwordx4 v[63:66], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,0,0) coordOffset1=1 element-rows coordOffset0=0 rows */
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+buffer_load_dwordx4 v[67:70], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,1,0) coordOffset1=1 element-rows coordOffset0=16 rows */
+buffer_load_dwordx4 v[71:74], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,2,0) coordOffset1=1 element-rows coordOffset0=32 rows */
+buffer_load_dwordx4 v[75:78], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+
+/* rC *= alpha batchEements=[(0, 0, 0, 0), (0, 1, 0, 0), (0, 2, 0, 0), (0, 0, 1, 0), (0, 1, 1, 0), (0, 2, 1, 0)] */
+v_mul_f64 v[vgprValuC+0:vgprValuC+0+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+0:vgprValuC+0+1] // *= alpha
+v_mul_f64 v[vgprValuC+2:vgprValuC+2+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+2:vgprValuC+2+1] // *= alpha
+v_mul_f64 v[vgprValuC+4:vgprValuC+4+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+4:vgprValuC+4+1] // *= alpha
+v_mul_f64 v[vgprValuC+6:vgprValuC+6+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+6:vgprValuC+6+1] // *= alpha
+v_mul_f64 v[vgprValuC+8:vgprValuC+8+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+8:vgprValuC+8+1] // *= alpha
+v_mul_f64 v[vgprValuC+10:vgprValuC+10+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+10:vgprValuC+10+1] // *= alpha
+v_mul_f64 v[vgprValuC+12:vgprValuC+12+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+12:vgprValuC+12+1] // *= alpha
+v_mul_f64 v[vgprValuC+14:vgprValuC+14+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+14:vgprValuC+14+1] // *= alpha
+v_mul_f64 v[vgprValuC+16:vgprValuC+16+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+16:vgprValuC+16+1] // *= alpha
+v_mul_f64 v[vgprValuC+18:vgprValuC+18+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+18:vgprValuC+18+1] // *= alpha
+v_mul_f64 v[vgprValuC+20:vgprValuC+20+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+20:vgprValuC+20+1] // *= alpha
+v_mul_f64 v[vgprValuC+22:vgprValuC+22+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+22:vgprValuC+22+1] // *= alpha
+
+/* apply mask, calc new C and issue write */
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+0:vgprValuC+0+1], v[55:56], s[sgprBeta:sgprBeta+1], v[vgprValuC+0:vgprValuC+0+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+2:vgprValuC+2+1], v[57:58], s[sgprBeta:sgprBeta+1], v[vgprValuC+2:vgprValuC+2+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[0:3], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+4:vgprValuC+4+1], v[59:60], s[sgprBeta:sgprBeta+1], v[vgprValuC+4:vgprValuC+4+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+6:vgprValuC+6+1], v[61:62], s[sgprBeta:sgprBeta+1], v[vgprValuC+6:vgprValuC+6+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[4:7], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+8:vgprValuC+8+1], v[63:64], s[sgprBeta:sgprBeta+1], v[vgprValuC+8:vgprValuC+8+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+10:vgprValuC+10+1], v[65:66], s[sgprBeta:sgprBeta+1], v[vgprValuC+10:vgprValuC+10+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[8:11], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+12:vgprValuC+12+1], v[67:68], s[sgprBeta:sgprBeta+1], v[vgprValuC+12:vgprValuC+12+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+14:vgprValuC+14+1], v[69:70], s[sgprBeta:sgprBeta+1], v[vgprValuC+14:vgprValuC+14+1] // finalSum = sum*alpha + C*beta
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+buffer_store_dwordx4 v[12:15], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+16:vgprValuC+16+1], v[71:72], s[sgprBeta:sgprBeta+1], v[vgprValuC+16:vgprValuC+16+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+18:vgprValuC+18+1], v[73:74], s[sgprBeta:sgprBeta+1], v[vgprValuC+18:vgprValuC+18+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[16:19], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+20:vgprValuC+20+1], v[75:76], s[sgprBeta:sgprBeta+1], v[vgprValuC+20:vgprValuC+20+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+22:vgprValuC+22+1], v[77:78], s[sgprBeta:sgprBeta+1], v[vgprValuC+22:vgprValuC+22+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[20:23], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+
+/******************************************/
+/* Global Write Beta Batch #1 (d1,d0,vc1,vc0) =
+   (1,0,0,0:vw2); (1,1,0,0:vw2); (1,2,0,0:vw2); (1,0,1,0:vw2); (1,1,1,0:vw2); (1,2,1,0:vw2) */
+/******************************************/
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(1,0,0,0) coordOffset1=32 element-rows coordOffset0=0 rows */
+s_mul_i32 s56, s[sgprStridesD+0], 248              // scale StrideC *= 31 * bpe
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+buffer_load_dwordx4 v[55:58], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,1,0) coordOffset1=32 element-rows coordOffset0=16 rows */
+buffer_load_dwordx4 v[59:62], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,2,0) coordOffset1=32 element-rows coordOffset0=32 rows */
+buffer_load_dwordx4 v[63:66], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,0,0) coordOffset1=33 element-rows coordOffset0=0 rows */
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+buffer_load_dwordx4 v[67:70], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,1,0) coordOffset1=33 element-rows coordOffset0=16 rows */
+buffer_load_dwordx4 v[71:74], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,2,0) coordOffset1=33 element-rows coordOffset0=32 rows */
+buffer_load_dwordx4 v[75:78], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+
+/* rC *= alpha batchEements=[(1, 0, 0, 0), (1, 1, 0, 0), (1, 2, 0, 0), (1, 0, 1, 0), (1, 1, 1, 0), (1, 2, 1, 0)] */
+v_mul_f64 v[vgprValuC+24:vgprValuC+24+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+24:vgprValuC+24+1] // *= alpha
+v_mul_f64 v[vgprValuC+26:vgprValuC+26+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+26:vgprValuC+26+1] // *= alpha
+v_mul_f64 v[vgprValuC+28:vgprValuC+28+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+28:vgprValuC+28+1] // *= alpha
+v_mul_f64 v[vgprValuC+30:vgprValuC+30+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+30:vgprValuC+30+1] // *= alpha
+v_mul_f64 v[vgprValuC+32:vgprValuC+32+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+32:vgprValuC+32+1] // *= alpha
+v_mul_f64 v[vgprValuC+34:vgprValuC+34+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+34:vgprValuC+34+1] // *= alpha
+v_mul_f64 v[vgprValuC+36:vgprValuC+36+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+36:vgprValuC+36+1] // *= alpha
+v_mul_f64 v[vgprValuC+38:vgprValuC+38+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+38:vgprValuC+38+1] // *= alpha
+v_mul_f64 v[vgprValuC+40:vgprValuC+40+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+40:vgprValuC+40+1] // *= alpha
+v_mul_f64 v[vgprValuC+42:vgprValuC+42+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+42:vgprValuC+42+1] // *= alpha
+v_mul_f64 v[vgprValuC+44:vgprValuC+44+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+44:vgprValuC+44+1] // *= alpha
+v_mul_f64 v[vgprValuC+46:vgprValuC+46+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+46:vgprValuC+46+1] // *= alpha
+
+/* apply mask, calc new C and issue write */
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+24:vgprValuC+24+1], v[55:56], s[sgprBeta:sgprBeta+1], v[vgprValuC+24:vgprValuC+24+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+26:vgprValuC+26+1], v[57:58], s[sgprBeta:sgprBeta+1], v[vgprValuC+26:vgprValuC+26+1] // finalSum = sum*alpha + C*beta
+s_mul_i32 s56, s[sgprStridesD+0], 248              // scale StrideC *= 31 * bpe
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+buffer_store_dwordx4 v[24:27], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+28:vgprValuC+28+1], v[59:60], s[sgprBeta:sgprBeta+1], v[vgprValuC+28:vgprValuC+28+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+30:vgprValuC+30+1], v[61:62], s[sgprBeta:sgprBeta+1], v[vgprValuC+30:vgprValuC+30+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[28:31], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+32:vgprValuC+32+1], v[63:64], s[sgprBeta:sgprBeta+1], v[vgprValuC+32:vgprValuC+32+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+34:vgprValuC+34+1], v[65:66], s[sgprBeta:sgprBeta+1], v[vgprValuC+34:vgprValuC+34+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[32:35], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+36:vgprValuC+36+1], v[67:68], s[sgprBeta:sgprBeta+1], v[vgprValuC+36:vgprValuC+36+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+38:vgprValuC+38+1], v[69:70], s[sgprBeta:sgprBeta+1], v[vgprValuC+38:vgprValuC+38+1] // finalSum = sum*alpha + C*beta
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+buffer_store_dwordx4 v[36:39], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+40:vgprValuC+40+1], v[71:72], s[sgprBeta:sgprBeta+1], v[vgprValuC+40:vgprValuC+40+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+42:vgprValuC+42+1], v[73:74], s[sgprBeta:sgprBeta+1], v[vgprValuC+42:vgprValuC+42+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[40:43], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+44:vgprValuC+44+1], v[75:76], s[sgprBeta:sgprBeta+1], v[vgprValuC+44:vgprValuC+44+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+46:vgprValuC+46+1], v[77:78], s[sgprBeta:sgprBeta+1], v[vgprValuC+46:vgprValuC+46+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[44:47], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_branch label_0037                                // jump to end
+label_0036:
+
+/******************************************/
+/* Global Write Beta Edge Batch #0 (d1,d0,vc1,vc0) =
+   (0,0,0,0:vw1); (0,0,0,1:vw1); (0,1,0,0:vw1); (0,1,0,1:vw1); (0,2,0,0:vw1); (0,2,0,1:vw1); (0,0,1,0:vw1); (0,0,1,1:vw1) */
+/******************************************/
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(0,0,0,0) coordOffset1=0 element-rows coordOffset0=0 rows */
+v_mov_b32 v51, v50                                 // rowPtr <- rowStart (first row)
+_v_add_lshl_u32 v54, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[62:63], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v54, -1, v54, s[62:63]               // clip if OOB. offset
+buffer_load_dwordx2 v[55:56], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,0,1) coordOffset1=0 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v57, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[64:65], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v57, -1, v57, s[64:65]               // clip if OOB. offset
+buffer_load_dwordx2 v[58:59], v57, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,1,0) coordOffset1=0 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v60, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[66:67], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v60, -1, v60, s[66:67]               // clip if OOB. offset
+buffer_load_dwordx2 v[61:62], v60, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,1,1) coordOffset1=0 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v63, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[68:69], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v63, -1, v63, s[68:69]               // clip if OOB. offset
+buffer_load_dwordx2 v[64:65], v63, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,2,0) coordOffset1=0 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v66, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[70:71], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v66, -1, v66, s[70:71]               // clip if OOB. offset
+buffer_load_dwordx2 v[67:68], v66, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,2,1) coordOffset1=0 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v69, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[72:73], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v69, -1, v69, s[72:73]               // clip if OOB. offset
+buffer_load_dwordx2 v[70:71], v69, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,0,0) coordOffset1=1 element-rows coordOffset0=0 rows */
+_v_add_co_u32 v53, vcc, v49, 1                     // coord1 += d1*sg1*VW + vc1
+_v_add_co_u32 v51, vcc, v51, s[sgprStridesC+0]     // rowPtr <- move to start of new row
+_v_add_lshl_u32 v72, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[74:75], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v72, -1, v72, s[74:75]               // clip if OOB. offset
+buffer_load_dwordx2 v[73:74], v72, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,0,1) coordOffset1=1 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v75, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[76:77], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v75, -1, v75, s[76:77]               // clip if OOB. offset
+buffer_load_dwordx2 v[76:77], v75, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+
+/* rC *= alpha batchEements=[(0, 0, 0, 0), (0, 0, 0, 1), (0, 1, 0, 0), (0, 1, 0, 1), (0, 2, 0, 0), (0, 2, 0, 1), (0, 0, 1, 0), (0, 0, 1, 1)] */
+v_mul_f64 v[vgprValuC+0:vgprValuC+0+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+0:vgprValuC+0+1] // *= alpha
+v_mul_f64 v[vgprValuC+2:vgprValuC+2+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+2:vgprValuC+2+1] // *= alpha
+v_mul_f64 v[vgprValuC+4:vgprValuC+4+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+4:vgprValuC+4+1] // *= alpha
+v_mul_f64 v[vgprValuC+6:vgprValuC+6+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+6:vgprValuC+6+1] // *= alpha
+v_mul_f64 v[vgprValuC+8:vgprValuC+8+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+8:vgprValuC+8+1] // *= alpha
+v_mul_f64 v[vgprValuC+10:vgprValuC+10+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+10:vgprValuC+10+1] // *= alpha
+v_mul_f64 v[vgprValuC+12:vgprValuC+12+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+12:vgprValuC+12+1] // *= alpha
+v_mul_f64 v[vgprValuC+14:vgprValuC+14+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+14:vgprValuC+14+1] // *= alpha
+s_waitcnt vmcnt(0)                                 // wait C
+
+/* apply mask, calc new C and issue write */
+v_fma_f64 v[vgprValuC+0:vgprValuC+0+1], v[55:56], s[sgprBeta:sgprBeta+1], v[vgprValuC+0:vgprValuC+0+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[0:1], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+2:vgprValuC+2+1], v[58:59], s[sgprBeta:sgprBeta+1], v[vgprValuC+2:vgprValuC+2+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[2:3], v57, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+4:vgprValuC+4+1], v[61:62], s[sgprBeta:sgprBeta+1], v[vgprValuC+4:vgprValuC+4+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[4:5], v60, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+6:vgprValuC+6+1], v[64:65], s[sgprBeta:sgprBeta+1], v[vgprValuC+6:vgprValuC+6+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[6:7], v63, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+8:vgprValuC+8+1], v[67:68], s[sgprBeta:sgprBeta+1], v[vgprValuC+8:vgprValuC+8+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[8:9], v66, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+10:vgprValuC+10+1], v[70:71], s[sgprBeta:sgprBeta+1], v[vgprValuC+10:vgprValuC+10+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[10:11], v69, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+12:vgprValuC+12+1], v[73:74], s[sgprBeta:sgprBeta+1], v[vgprValuC+12:vgprValuC+12+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[12:13], v72, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+14:vgprValuC+14+1], v[76:77], s[sgprBeta:sgprBeta+1], v[vgprValuC+14:vgprValuC+14+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[14:15], v75, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+/******************************************/
+/* Global Write Beta Edge Batch #1 (d1,d0,vc1,vc0) =
+   (0,1,1,0:vw1); (0,1,1,1:vw1); (0,2,1,0:vw1); (0,2,1,1:vw1); (1,0,0,0:vw1); (1,0,0,1:vw1); (1,1,0,0:vw1); (1,1,0,1:vw1) */
+/******************************************/
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(0,1,1,0) coordOffset1=1 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v54, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[62:63], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v54, -1, v54, s[62:63]               // clip if OOB. offset
+buffer_load_dwordx2 v[55:56], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,1,1) coordOffset1=1 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v57, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[64:65], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v57, -1, v57, s[64:65]               // clip if OOB. offset
+buffer_load_dwordx2 v[58:59], v57, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,2,0) coordOffset1=1 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v60, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[66:67], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v60, -1, v60, s[66:67]               // clip if OOB. offset
+buffer_load_dwordx2 v[61:62], v60, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,2,1) coordOffset1=1 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v63, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[68:69], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v63, -1, v63, s[68:69]               // clip if OOB. offset
+buffer_load_dwordx2 v[64:65], v63, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,0,0) coordOffset1=32 element-rows coordOffset0=0 rows */
+_v_add_co_u32 v53, vcc, v49, 32                    // coord1 += d1*sg1*VW + vc1
+s_mul_i32 s56, s[sgprStridesC+0], 32               // scale StrideC *= coordOffset1(32)
+_v_add_co_u32 v51, vcc, v50, s56                   // rowPtr <- inc for non-0 (tt1+vc1))
+_v_add_lshl_u32 v66, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[70:71], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v66, -1, v66, s[70:71]               // clip if OOB. offset
+buffer_load_dwordx2 v[67:68], v66, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,0,1) coordOffset1=32 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v69, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[72:73], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v69, -1, v69, s[72:73]               // clip if OOB. offset
+buffer_load_dwordx2 v[70:71], v69, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,1,0) coordOffset1=32 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v72, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[74:75], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v72, -1, v72, s[74:75]               // clip if OOB. offset
+buffer_load_dwordx2 v[73:74], v72, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,1,1) coordOffset1=32 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v75, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[76:77], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v75, -1, v75, s[76:77]               // clip if OOB. offset
+buffer_load_dwordx2 v[76:77], v75, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+
+/* rC *= alpha batchEements=[(0, 1, 1, 0), (0, 1, 1, 1), (0, 2, 1, 0), (0, 2, 1, 1), (1, 0, 0, 0), (1, 0, 0, 1), (1, 1, 0, 0), (1, 1, 0, 1)] */
+v_mul_f64 v[vgprValuC+16:vgprValuC+16+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+16:vgprValuC+16+1] // *= alpha
+v_mul_f64 v[vgprValuC+18:vgprValuC+18+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+18:vgprValuC+18+1] // *= alpha
+v_mul_f64 v[vgprValuC+20:vgprValuC+20+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+20:vgprValuC+20+1] // *= alpha
+v_mul_f64 v[vgprValuC+22:vgprValuC+22+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+22:vgprValuC+22+1] // *= alpha
+v_mul_f64 v[vgprValuC+24:vgprValuC+24+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+24:vgprValuC+24+1] // *= alpha
+v_mul_f64 v[vgprValuC+26:vgprValuC+26+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+26:vgprValuC+26+1] // *= alpha
+v_mul_f64 v[vgprValuC+28:vgprValuC+28+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+28:vgprValuC+28+1] // *= alpha
+v_mul_f64 v[vgprValuC+30:vgprValuC+30+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+30:vgprValuC+30+1] // *= alpha
+s_waitcnt vmcnt(0)                                 // wait C
+
+/* apply mask, calc new C and issue write */
+v_fma_f64 v[vgprValuC+16:vgprValuC+16+1], v[55:56], s[sgprBeta:sgprBeta+1], v[vgprValuC+16:vgprValuC+16+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[16:17], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+18:vgprValuC+18+1], v[58:59], s[sgprBeta:sgprBeta+1], v[vgprValuC+18:vgprValuC+18+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[18:19], v57, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+20:vgprValuC+20+1], v[61:62], s[sgprBeta:sgprBeta+1], v[vgprValuC+20:vgprValuC+20+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[20:21], v60, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+22:vgprValuC+22+1], v[64:65], s[sgprBeta:sgprBeta+1], v[vgprValuC+22:vgprValuC+22+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[22:23], v63, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+24:vgprValuC+24+1], v[67:68], s[sgprBeta:sgprBeta+1], v[vgprValuC+24:vgprValuC+24+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[24:25], v66, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+26:vgprValuC+26+1], v[70:71], s[sgprBeta:sgprBeta+1], v[vgprValuC+26:vgprValuC+26+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[26:27], v69, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+28:vgprValuC+28+1], v[73:74], s[sgprBeta:sgprBeta+1], v[vgprValuC+28:vgprValuC+28+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[28:29], v72, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+30:vgprValuC+30+1], v[76:77], s[sgprBeta:sgprBeta+1], v[vgprValuC+30:vgprValuC+30+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[30:31], v75, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+/******************************************/
+/* Global Write Beta Edge Batch #2 (d1,d0,vc1,vc0) =
+   (1,2,0,0:vw1); (1,2,0,1:vw1); (1,0,1,0:vw1); (1,0,1,1:vw1); (1,1,1,0:vw1); (1,1,1,1:vw1); (1,2,1,0:vw1); (1,2,1,1:vw1) */
+/******************************************/
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(1,0,2,0) coordOffset1=32 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v54, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[62:63], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v54, -1, v54, s[62:63]               // clip if OOB. offset
+buffer_load_dwordx2 v[55:56], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,2,1) coordOffset1=32 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v57, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[64:65], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v57, -1, v57, s[64:65]               // clip if OOB. offset
+buffer_load_dwordx2 v[58:59], v57, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,0,0) coordOffset1=33 element-rows coordOffset0=0 rows */
+_v_add_co_u32 v53, vcc, v49, 33                    // coord1 += d1*sg1*VW + vc1
+_v_add_co_u32 v51, vcc, v51, s[sgprStridesC+0]     // rowPtr <- move to start of new row
+_v_add_lshl_u32 v60, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[66:67], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v60, -1, v60, s[66:67]               // clip if OOB. offset
+buffer_load_dwordx2 v[61:62], v60, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,0,1) coordOffset1=33 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v63, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[68:69], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v63, -1, v63, s[68:69]               // clip if OOB. offset
+buffer_load_dwordx2 v[64:65], v63, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,1,0) coordOffset1=33 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v66, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[70:71], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v66, -1, v66, s[70:71]               // clip if OOB. offset
+buffer_load_dwordx2 v[67:68], v66, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,1,1) coordOffset1=33 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v69, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[72:73], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v69, -1, v69, s[72:73]               // clip if OOB. offset
+buffer_load_dwordx2 v[70:71], v69, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,2,0) coordOffset1=33 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v72, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[74:75], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v72, -1, v72, s[74:75]               // clip if OOB. offset
+buffer_load_dwordx2 v[73:74], v72, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,2,1) coordOffset1=33 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v75, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[76:77], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v75, -1, v75, s[76:77]               // clip if OOB. offset
+buffer_load_dwordx2 v[76:77], v75, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+
+/* rC *= alpha batchEements=[(1, 2, 0, 0), (1, 2, 0, 1), (1, 0, 1, 0), (1, 0, 1, 1), (1, 1, 1, 0), (1, 1, 1, 1), (1, 2, 1, 0), (1, 2, 1, 1)] */
+v_mul_f64 v[vgprValuC+32:vgprValuC+32+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+32:vgprValuC+32+1] // *= alpha
+v_mul_f64 v[vgprValuC+34:vgprValuC+34+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+34:vgprValuC+34+1] // *= alpha
+v_mul_f64 v[vgprValuC+36:vgprValuC+36+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+36:vgprValuC+36+1] // *= alpha
+v_mul_f64 v[vgprValuC+38:vgprValuC+38+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+38:vgprValuC+38+1] // *= alpha
+v_mul_f64 v[vgprValuC+40:vgprValuC+40+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+40:vgprValuC+40+1] // *= alpha
+v_mul_f64 v[vgprValuC+42:vgprValuC+42+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+42:vgprValuC+42+1] // *= alpha
+v_mul_f64 v[vgprValuC+44:vgprValuC+44+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+44:vgprValuC+44+1] // *= alpha
+v_mul_f64 v[vgprValuC+46:vgprValuC+46+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+46:vgprValuC+46+1] // *= alpha
+s_waitcnt vmcnt(0)                                 // wait C
+
+/* apply mask, calc new C and issue write */
+v_fma_f64 v[vgprValuC+32:vgprValuC+32+1], v[55:56], s[sgprBeta:sgprBeta+1], v[vgprValuC+32:vgprValuC+32+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[32:33], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+34:vgprValuC+34+1], v[58:59], s[sgprBeta:sgprBeta+1], v[vgprValuC+34:vgprValuC+34+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[34:35], v57, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+36:vgprValuC+36+1], v[61:62], s[sgprBeta:sgprBeta+1], v[vgprValuC+36:vgprValuC+36+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[36:37], v60, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+38:vgprValuC+38+1], v[64:65], s[sgprBeta:sgprBeta+1], v[vgprValuC+38:vgprValuC+38+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[38:39], v63, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+40:vgprValuC+40+1], v[67:68], s[sgprBeta:sgprBeta+1], v[vgprValuC+40:vgprValuC+40+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[40:41], v66, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+42:vgprValuC+42+1], v[70:71], s[sgprBeta:sgprBeta+1], v[vgprValuC+42:vgprValuC+42+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[42:43], v69, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+44:vgprValuC+44+1], v[73:74], s[sgprBeta:sgprBeta+1], v[vgprValuC+44:vgprValuC+44+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[44:45], v72, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+46:vgprValuC+46+1], v[76:77], s[sgprBeta:sgprBeta+1], v[vgprValuC+46:vgprValuC+46+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[46:47], v75, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_branch label_0037                                // jump to end
+label_0037:
+
+label_0038:  /// KernelEnd
+s_endpgm                                           // Kernel End
+
+

--- a/Tensile/ReplacementKernels-cov3/Cijk_Ailk_Bjlk_DB_MT48x64x4_AF0EM1_ASEM1_FL1_GRVW2_ISA906_MDA2_PGR1_PLR0_SU0_TT6_4_VAW1_VW2_WG8_16_1_WGM8.s.txt
+++ b/Tensile/ReplacementKernels-cov3/Cijk_Ailk_Bjlk_DB_MT48x64x4_AF0EM1_ASEM1_FL1_GRVW2_ISA906_MDA2_PGR1_PLR0_SU0_TT6_4_VAW1_VW2_WG8_16_1_WGM8.s.txt
@@ -1,0 +1,3886 @@
+
+
+/******************************************/
+/* Function Prefix                        */
+/******************************************/
+
+
+
+/******************************************/
+/* Begin Kernel                           */
+/******************************************/
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx906"
+.text
+.protected Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA906_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM8
+.globl Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA906_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM8
+.p2align 8
+.type Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA906_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM8,@function
+.section .rodata,#alloc
+.p2align 6
+.amdhsa_kernel Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA906_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM8
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_next_free_vgpr 84 // vgprs
+  .amdhsa_next_free_sgpr 98 // sgprs
+  .amdhsa_group_segment_fixed_size 7680 // lds bytes
+  .amdhsa_private_segment_fixed_size 0
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+.text
+
+.amdgpu_metadata
+---
+amdhsa.version:
+  - 1
+  - 0
+amdhsa.kernels:
+  - .name: Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA906_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM8
+    .symbol: 'Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA906_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM8.kd'
+    .group_segment_fixed_size:   7680
+    .language:                   OpenCL C
+    .language_version:
+      - 2
+      - 0
+    .max_flat_workgroup_size: 128
+    .private_segment_fixed_size: 0
+    .sgpr_count:                 98
+    .sgpr_spill_count:           0
+    .vgpr_count:                 84
+    .vgpr_spill_count:           0
+    .wavefront_size:             64
+    .args:
+      - .name:            sizeC
+        .size:            8
+        .offset:          0
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            sizeA
+        .size:            8
+        .offset:          8
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            sizeB
+        .size:            8
+        .offset:          16
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            D
+        .size:            8
+        .offset:          24
+        .value_kind:      global_buffer
+        .value_type:      f64
+        .address_space:   generic
+      - .name:            C
+        .size:            8
+        .offset:          32
+        .value_kind:      global_buffer
+        .value_type:      f64
+        .address_space:   generic
+      - .name:            A
+        .size:            8
+        .offset:          40
+        .value_kind:      global_buffer
+        .value_type:      f64
+        .address_space:   generic
+      - .name:            B
+        .size:            8
+        .offset:          48
+        .value_kind:      global_buffer
+        .value_type:      f64
+        .address_space:   generic
+      - .name:            alpha
+        .size:            8
+        .offset:          56
+        .value_kind:      by_value
+        .value_type:      f64
+      - .name:            beta
+        .size:            8
+        .offset:          64
+        .value_kind:      by_value
+        .value_type:      f64
+      - .name:            strideD0
+        .size:            4
+        .offset:          72
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideD1
+        .size:            4
+        .offset:          76
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideC0
+        .size:            4
+        .offset:          80
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideC1
+        .size:            4
+        .offset:          84
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideA0
+        .size:            4
+        .offset:          88
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideA1
+        .size:            4
+        .offset:          92
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideB0
+        .size:            4
+        .offset:          96
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideB1
+        .size:            4
+        .offset:          100
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree0
+        .size:            4
+        .offset:          104
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree1
+        .size:            4
+        .offset:          108
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree2
+        .size:            4
+        .offset:          112
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesSum0
+        .size:            4
+        .offset:          116
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            OrigStaggerUIter
+        .size:            4
+        .offset:          120
+        .value_kind:      by_value
+        .value_type:      i32
+      - .name:            NumWorkGroups0
+        .size:            4
+        .offset:          124
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            NumWorkGroups1
+        .size:            4
+        .offset:          128
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            MagicNumberProblemNumGroupTiles0
+        .size:            4
+        .offset:          132
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            GridNumWorkGroups0
+        .size:            4
+        .offset:          136
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            NumFullBlocks
+        .size:            4
+        .offset:          140
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            WgmRemainder1
+        .size:            4
+        .offset:          144
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            MagicNumberWgmRemainder1
+        .size:            4
+        .offset:          148
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            padding
+        .size:            4
+        .offset:          152
+        .value_kind:      by_value
+        .value_type:      u32
+    .kernarg_segment_align:      8
+    .kernarg_segment_size:       160
+...
+.end_amdgpu_metadata
+Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA906_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM8:
+
+/******************************************/
+/* Optimizations and Config:              */
+/******************************************/
+/* ThreadTile= 6 x 4 */
+/* SubGroup= 8 x 16 */
+/* VectorWidth=2 */
+/* GlobalLoadVectorWidthA=2, GlobalLoadVectorWidthB=2 */
+/* DirectToLdsA=False */
+/* DirectToLdsB=False */
+/* UseSgprForGRO=False */
+
+/******************************************/
+/* Asm syntax workarounds                 */
+/******************************************/
+.macro _v_add_co_u32 dst, cc, src0, src1, dpp=
+   v_add_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+.macro _v_sub_co_u32 dst, cc, src0, src1, dpp=
+   v_sub_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+.macro _v_addc_co_u32 dst, ccOut, src0, ccIn, src1, dpp=
+   v_addc_co_u32 \dst, \ccOut, \src0, \ccIn, \src1 \dpp
+.endm
+.macro _v_add_lshl_u32 dst, src0, src1, shiftCnt
+    v_add_lshl_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+.macro _v_lshl_add_u32 dst, src0, src1, shiftCnt
+    v_lshl_add_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+/******************************************/
+/* Magic div and mod functions            */
+/******************************************/
+.macro V_MAGIC_DIV dstIdx, dividend, magicNumber, magicShift
+    v_mul_lo_u32 v[\dstIdx+0], \dividend, \magicNumber
+    v_mul_hi_u32 v[\dstIdx+1], \dividend, \magicNumber
+    v_lshrrev_b64 v[\dstIdx:\dstIdx+1], \magicShift, v[\dstIdx:\dstIdx+1]
+.endm
+
+/******************************************/
+/* VGPR Assignments                       */
+/******************************************/
+.set vgprValuC, 0
+/* ValuA/B   Xn=PLR buffer idx,  In=InnerUnroll idx */
+.set vgprValuA_X0_I0, 48
+.set vgprG2LA, 60
+.set vgprValuB_X0_I0, 64
+.set vgprG2LB, 72
+.set vgprLocalWriteAddrA, 76
+.set vgprLocalWriteAddrB, 77
+.set vgprGlobalReadOffsetA, 78
+.set vgprGlobalReadOffsetB, 79
+.set vgprLocalReadAddrA, 80
+.set vgprLocalReadAddrB, 81
+.set vgprSerial, 82
+/* Num VGPR=83 */
+
+/******************************************/
+/* SGPR Assignments                       */
+/******************************************/
+.set sgprKernArgAddress, 0
+.set sgprWorkGroup0, 2
+.set sgprWorkGroup1, 3
+.set sgprWorkGroup2, 4
+.set sgprNumWorkGroups0, 5
+.set sgprNumWorkGroups1, 6
+.set sgprSrdA, 8
+.set sgprSrdB, 12
+.set sgprSrdD, 16
+.set sgprSrdC, 20
+.set sgprTensor2dSizeC, 24
+.set sgprTensor2dSizeA, 26
+.set sgprTensor2dSizeB, 28
+.set sgprSaveExecMask, 30
+.set sgprAddressD, 32
+.set sgprAddressC, 34
+.set sgprStridesC, 36
+.set sgprAlpha, 38
+.set sgprBeta, 40
+.set sgprSizesFree, 42
+.set sgprSizesSum, 45
+.set sgprLoopCounters, 46
+.set sgprOrigLoopCounter, 47
+.set sgprStridesA, 48
+.set sgprStridesB, 50
+.set sgprAddressA, 52
+.set sgprAddressB, 54
+.set sgprShadowLimitA, 56
+.set sgprShadowLimitB, 58
+.set sgprNumFullBlocks, 60
+.set sgprWgmRemainder1, 61
+.set sgprMagicNumberWgmRemainder1, 62
+.set sgprGlobalReadIncsA, 63
+.set sgprGlobalReadIncsB, 64
+.set sgprStridesD, 74
+.set sgprTMP0, 90
+.set sgprTMP1, 91
+.set sgprEdgeSelMask0, 93
+.set sgprEdgeSelMask1, 94
+/* max SGPR=98 */
+
+/******************************************/
+/* 2GB limit - set offsets to -1 to exceed this and clamp */
+/******************************************/
+.set BufferLimit, 0x80000000
+
+/******************************************/
+/* Bits 127:96 of SRD.  Set DataFormat = 32 bit */
+/******************************************/
+.set Srd127_96, 0x0020000
+.set BufferOOB, 0x80000000
+
+/* Global Offset A */
+.macro GLOBAL_OFFSET_A vgprAddr vgprOffset0I vgprOffsetL vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStridesA+0], v[\vgprOffsetL] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprTmp+0], v[\vgprOffset0I] // accumulate d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, 0x2, v[\vgprAddr+0] // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x3, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/* Global Offset B */
+.macro GLOBAL_OFFSET_B vgprAddr vgprOffset1J vgprOffsetL vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStridesB+0], v[\vgprOffsetL] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprTmp+0], v[\vgprOffset1J] // accumulate d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, 0x2, v[\vgprAddr+0] // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x3, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/******************************************/
+/* Dynamic Scalar Divide: vQuotient=vDividend/vDivisor; vRemainder=vDividend%vDivisor; */
+/******************************************/
+.macro DYNAMIC_VECTOR_DIVIDE vQuotient vRemainder vDividend vDivisor vTmp0 vTmp1 sTmp
+v_cvt_f32_u32 v[\vQuotient], v[\vDivisor]          //
+v_rcp_f32 v[\vQuotient], v[\vQuotient]             //
+v_mul_f32 v[\vQuotient], 0x4f800000, v[\vQuotient] //
+v_cvt_u32_f32 v[\vQuotient], v[\vQuotient]         //
+v_mul_lo_u32 v[\vRemainder], v[\vDivisor], v[\vQuotient] //
+v_mul_hi_u32 v[\vTmp0], v[\vDivisor], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp1], vcc, 0x0, v[\vRemainder]  //
+v_cmp_ne_i32 s[\sTmp:\sTmp+1], 0x0, v[\vTmp0]      //
+v_cndmask_b32 v[\vRemainder], v[\vTmp1], v[\vRemainder], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vRemainder], v[\vRemainder], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vQuotient], v[\vRemainder] //
+_v_add_co_u32 v[\vQuotient], vcc, v[\vQuotient], v[\vRemainder] //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vTmp0], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vQuotient], v[\vQuotient], v[\vDividend] //
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vDividend], v[\vRemainder] //
+v_cmp_ge_u32 s[\sTmp:\sTmp+1], v[\vDividend], v[\vRemainder] //
+_v_add_co_u32 v[\vRemainder], vcc, 0x1, v[\vQuotient] //
+_v_add_co_u32 v[\vTmp1], vcc, -1, v[\vQuotient]    //
+v_cmp_le_u32 vcc, v[\vDivisor], v[\vTmp0]          //
+s_and_b64 vcc, s[\sTmp:\sTmp+1], vcc               //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vRemainder], vcc //
+v_cndmask_b32 v[\vQuotient], v[\vTmp1], v[\vQuotient], s[\sTmp:\sTmp+1] //
+v_cmp_ne_i32 vcc, 0x0, v[\vDivisor]                //
+v_cndmask_b32 v[\vQuotient], -1, v[\vQuotient], vcc // final result
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vRemainder], vcc, v[\vDividend], v[\vRemainder] // final result
+.endm
+
+/******************************************/
+/* 6x4 thread-tile                        */
+/******************************************/
+.macro MAC_6x4_X0
+v_fma_f64 v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1]
+s_setprio 1 // Raise priority while processing macs
+v_fma_f64 v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1]
+s_setprio 0 // Reset priority after macs
+.endm
+
+.macro MAC_6x4_X0_part_1
+v_fma_f64 v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1]
+s_setprio 1 // Raise priority while processing macs
+v_fma_f64 v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1]
+.endm
+
+.macro MAC_6x4_X0_part_2
+.endm
+
+.macro MAC_6x4_X0_part_3
+v_fma_f64 v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1]
+s_setprio 0 // Reset Priority
+.endm
+
+.macro MAC_6x4_X0_unprio_0
+v_fma_f64 v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1]
+s_setprio 1 // Raise priority while processing macs
+v_fma_f64 v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1]
+.endm
+
+
+.macro MAC_6x4_X0_part1
+v_fma_f64 v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1]
+s_setprio 1
+v_fma_f64 v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1]
+s_setprio 0
+.endm
+
+
+.macro MAC_6x4_X0_part2
+v_fma_f64 v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1]
+s_setprio 1
+v_fma_f64 v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1]
+s_setprio 0
+.endm
+.macro MAC_6x4_X0_part3
+v_fma_f64 v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1]
+s_setprio 1
+v_fma_f64 v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1]
+s_setprio 0
+.endm
+.macro MAC_6x4_X0_part4
+v_fma_f64 v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1]
+s_setprio 1
+v_fma_f64 v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1]
+//vnop_4
+s_setprio 0
+.endm
+.macro MAC_6x4_X0_part5
+v_fma_f64 v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1]
+s_setprio 1
+v_fma_f64 v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1]
+//vnop_4
+s_setprio 0
+.endm
+.macro MAC_6x4_X0_part6
+v_fma_f64 v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1]
+s_setprio 1
+v_fma_f64 v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1]
+s_setprio 0
+.endm
+
+/******************************************/
+/* Allocate Resources                     */
+/******************************************/
+
+s_mov_b32 m0, 0x1e00                               // LDS clamp at 7680 bytes
+v_mov_b32 v[vgprSerial], v0                        // thread serial id
+
+/* Load Kernel Args */
+s_load_dword s[sgprTensor2dSizeC+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x0 //
+s_load_dword s[sgprTensor2dSizeC+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x4 //
+s_load_dword s[sgprTensor2dSizeA+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x8 //
+s_load_dword s[sgprTensor2dSizeA+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0xc //
+s_load_dword s[sgprTensor2dSizeB+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x10 //
+s_load_dword s[sgprTensor2dSizeB+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x14 //
+s_load_dword s[sgprAddressD], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x18 //
+s_load_dword s[sgprAddressD+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x1c //
+s_load_dword s[sgprAddressC], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x20 //
+s_load_dword s[sgprAddressC+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x24 //
+s_load_dword s[sgprAddressA], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x28 //
+s_load_dword s[sgprAddressA+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x2c //
+s_load_dword s[sgprAddressB], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x30 //
+s_load_dword s[sgprAddressB+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x34 //
+s_load_dword s[sgprAlpha+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x38 //
+s_load_dword s[sgprAlpha+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x3c //
+s_load_dword s[sgprBeta+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x40 //
+s_load_dword s[sgprBeta+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x44 //
+s_load_dword s[sgprStridesD+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x48 //
+s_load_dword s[sgprStridesD+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x4c //
+s_load_dword s[sgprStridesC+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x50 //
+s_load_dword s[sgprStridesC+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x54 //
+s_load_dword s[sgprStridesA+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x58 //
+s_load_dword s[sgprStridesA+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x5c //
+s_load_dword s[sgprStridesB+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x60 //
+s_load_dword s[sgprStridesB+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x64 //
+s_load_dword s[sgprSizesFree+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x68 //
+s_load_dword s[sgprSizesFree+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x6c //
+s_load_dword s[sgprSizesFree+2], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x70 //
+s_load_dword s[sgprSizesSum+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x74 //
+s_load_dword s[sgprNumWorkGroups0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x7c //
+s_load_dword s[sgprNumWorkGroups1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x80 //
+s_load_dword s[sgprNumFullBlocks], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x8c //
+s_load_dword s[sgprWgmRemainder1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x90 //
+s_load_dword s[sgprMagicNumberWgmRemainder1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x94 //
+s_waitcnt lgkmcnt(0)                               // wait for 144 bytes of kern args
+
+
+/******************************************/
+/* Local Read Addresses                   */
+/******************************************/
+
+
+/* local read addresses: tile assignments a */
+
+/*lr0I = serial % SG0I*/
+v_lshrrev_b32 v0, 3, v[vgprSerial]                 // vectorStaticDiv: v0 = v[vgprSerial] / 8
+v_and_b32 v1, 7, v[vgprSerial]                     // vectorStaticDiv: v1 = v[vgprSerial] % 8
+
+
+/* local read addresses: tile assignments b */
+
+/*lr1J = (serial / SG1J) % SG1J*/
+v_lshrrev_b32 v2, 4, v0                            // vectorStaticDiv: v2 = v0 / 16
+v_and_b32 v3, 15, v0                               // vectorStaticDiv: v3 = v0 % 16
+
+
+/* local read addresses: final offsets a */
+
+v_lshrrev_b32 v0, 7, v[vgprSerial]                 // vectorStaticDiv: v0 = v[vgprSerial] / 128
+v_and_b32 v2, 127, v[vgprSerial]                   // vectorStaticDiv: v2 = v[vgprSerial] % 128
+s_mov_b32 s65, 0x30                                // MT0+PAD
+v_mul_lo_u32 v0, s65, v0                           // sgid=sgid*(MT0+PAD)
+v_lshlrev_b32 v1, 1, v1                            // staticMultiply: v1 = v1 * 2
+_v_add_lshl_u32 v[vgprLocalReadAddrA], v0, v1, 0x3 // o = (lroA*VW+sgid*MT0)*bpe
+
+
+/* local read addresses: final offsets b */
+
+v_lshrrev_b32 v0, 7, v[vgprSerial]                 // vectorStaticDiv: v0 = v[vgprSerial] / 128
+v_and_b32 v1, 127, v[vgprSerial]                   // vectorStaticDiv: v1 = v[vgprSerial] % 128
+s_mov_b32 s65, 0x40                                // MT1+PAD
+v_mul_lo_u32 v0, s65, v0                           // sgid=sgid*(MT1+PAD)
+v_lshlrev_b32 v3, 1, v3                            // staticMultiply: v3 = v3 * 2
+_v_add_lshl_u32 v[vgprLocalReadAddrB], v0, v3, 0x3 // o = (lroB*VW+sgid*MT1)*bpe
+
+
+/* local read addresses: declare addresses a */
+
+/* N/A */
+
+
+/* local read addresses: declare addresses b */
+
+_v_add_co_u32 v[vgprLocalReadAddrB+0], vcc, 0x600, v[vgprLocalReadAddrB+0] //  += LdsOffsetB (lower)
+
+
+s_load_dword s[sgprNumWorkGroups1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x80 //
+s_load_dword s[sgprNumFullBlocks], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x8c //
+s_load_dword s[sgprWgmRemainder1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x90 //
+s_load_dword s[sgprMagicNumberWgmRemainder1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x94 //
+/******************************************/
+/* Global Read Addresses                  */
+/******************************************/
+
+
+/* global read addresses: work-group */
+
+/* graWorkGroup mapping */
+s_mov_b32 s69, 0x10000001L                         // magic number for WGM==4
+s_mul_hi_u32 s67, s[sgprWorkGroup1], s69           // s_magic mul
+s_mul_i32 s66, s[sgprWorkGroup1], s69              // s_magic mul
+s_lshr_b64 s[66:67], s[66:67], 31                  // sMagicDiv
+s_mul_i32 s67, s66, 8                              // quotient * non-magic divisor
+s_sub_u32 s67, s[sgprWorkGroup1], s67              // WorkGroup1=remainder
+s_mul_i32 s67, s67, s[sgprNumWorkGroups0]          // (wg1 % WGM)*nwg0
+s_add_u32 s67, s67, s[sgprWorkGroup0]              // wgSerial = wg0 + (wg1 % WGM)*nwg0
+s_cmp_ge_u32 s66, s[sgprNumFullBlocks]             // blockId >= numFullBlocks ?
+s_cmov_b32 s69, s[sgprMagicNumberWgmRemainder1]    //
+s_cselect_b32 s68, s[sgprWgmRemainder1], 8         //
+s_mul_hi_u32 s3, s67, s69                          // s_magic mul
+s_mul_i32 s2, s67, s69                             // s_magic mul
+s_lshr_b64 s[2:3], s[2:3], 31                      // sMagicDiv
+s_mul_i32 s[sgprWorkGroup1], s[sgprWorkGroup0], s68 // quotient * non-magic divisor
+s_sub_u32 s[sgprWorkGroup1], s67, s[sgprWorkGroup1] // WorkGroup1=remainder
+s_mul_i32 s66, s66, 8                              // blockId * WGM
+s_add_u32 s[sgprWorkGroup1], s[sgprWorkGroup1], s66 // wg1 += blockId * WGM
+
+
+/* global read addresses: tile offset assignment a */
+
+/* LVCA = 24 */
+/* v0 = (local)groA-tile = serial%LVCA (note (wgA*MTA) will be added to SRD) */
+/* v1 = groA-unroll = serial/LVCA */
+s_mov_b32 s65, 0x15555556                          //
+v_mul_hi_u32 v3, v[vgprSerial], s65                //
+v_mul_lo_u32 v2, v[vgprSerial], s65                //
+v_lshrrev_b64 v[2:3], 0x21, v[2:3]                 //
+v_mov_b32 v1, v2                                   // vectorStaticDiv: quotient
+s_mov_b32 s65, 0x18                                // divisor
+v_mul_lo_u32 v2, v1, s65                           // vectorStaticDiv: product = quotient * divisor
+_v_sub_co_u32 v0, vcc, v[vgprSerial], v2           // vectorStaticDiv: remainder = dividend - product
+/* gro-tile *= glvw */
+v_lshlrev_b32 v0, 1, v0                            // staticMultiply: v0 = v0 * 2
+
+
+/* global read addresses: tile offset assignment b */
+
+/* LVCB = 32 */
+/* v2 = (local)groB-tile = serial%LVCB (note (wgB*MTB) will be added to SRD) */
+/* v3 = groB-unroll = serial/LVCB */
+v_lshrrev_b32 v3, 5, v[vgprSerial]                 // vectorStaticDiv: v3 = v[vgprSerial] / 32
+v_and_b32 v2, 31, v[vgprSerial]                    // vectorStaticDiv: v2 = v[vgprSerial] % 32
+/* gro-tile *= glvw */
+v_lshlrev_b32 v2, 1, v2                            // staticMultiply: v2 = v2 * 2
+
+
+/* global read addresses: unroll assignment a */
+
+/* v1 */
+
+
+/* global read addresses: unroll assignment b */
+
+/* v3 */
+
+
+/* global read addresses: other free assignments */
+
+/* s[sgprWorkGroup2] */
+
+
+/* global read addresses: tile offsets a */
+
+v_mov_b32 v4, v0                                   // groA0I_0
+
+
+/* global read addresses: tile offsets b */
+
+v_mov_b32 v5, v2                                   // groB1J_0
+
+
+/* global read addresses: unroll offsets a */
+
+v_mov_b32 v6, v1                                   // groAL_0
+
+
+/* global read addresses: unroll offsets b */
+
+v_mov_b32 v7, v3                                   // groBL_0
+
+
+/* global read addresses: shift a */
+
+s_mul_i32 s65, s[sgprWorkGroup0], 48               // WorkGroup[01] * MT
+s_sub_u32 s65, s[sgprSizesFree+0], s65             // edge = Size0I - WG*MT
+s_sub_u32 s65, s65, 2                              // edge -= margin
+v_mov_b32 v8, s65                                  // edge vgpr = Size0I-2
+_v_add_co_u32 v9, vcc, v8, 2                       // add srdShiftLift
+_v_add_co_u32 v10, vcc, v4, 2                      //
+v_cmp_lt_u32 s[66:67], v10, v9                     // offset < edge
+v_cndmask_b32 v4, v8, v4, s[66:67]                 // offset = (offset < edge) ? offset : edge
+
+
+/* global read addresses: shift b */
+
+s_mul_i32 s65, s[sgprWorkGroup1], 64               // WorkGroup[01] * MT
+s_sub_u32 s65, s[sgprSizesFree+1], s65             // edge = Size1J - WG*MT
+s_sub_u32 s65, s65, 2                              // edge -= margin
+v_mov_b32 v8, s65                                  // edge vgpr = Size1J-2
+_v_add_co_u32 v9, vcc, v8, 2                       // add srdShiftLift
+_v_add_co_u32 v10, vcc, v5, 2                      //
+v_cmp_lt_u32 s[66:67], v10, v9                     // offset < edge
+v_cndmask_b32 v5, v8, v5, s[66:67]                 // offset = (offset < edge) ? offset : edge
+
+
+/* global read addresses: final offsets a */
+
+GLOBAL_OFFSET_A vgprGlobalReadOffsetA+0,  4,  6, 8 // gROA_0_0_0_0
+// Offset only valid for 96/128 threads inside the PerLoadTile
+s_mov_b32 s66, 96                                  //
+v_cmp_lt_u32 vcc, v[vgprSerial], s66               // tid < valid-tid
+s_mov_b32 s66, BufferOOB                           //
+v_mov_b32 v11, s66                                 //
+v_cndmask_b32 v[vgprGlobalReadOffsetA+0], v11, v[vgprGlobalReadOffsetA+0], vcc // Mask load so OOB will return 0
+
+
+/* global read addresses: final offsets b */
+
+GLOBAL_OFFSET_B vgprGlobalReadOffsetB+0,  5,  7, 8 // gROB_0_0_0_0
+
+
+/* global read addresses: addresses a */
+
+/* max read offset = size[n] * stride[n-1] */
+s_mul_hi_u32 s69, s[sgprWorkGroup0], 48            // WorkGroup[01] * MT
+s_mul_i32 s68, s[sgprWorkGroup0], 48               // WorkGroup[01] * MT
+s_sub_u32 s[sgprShadowLimitA+0], s[sgprTensor2dSizeA], s68 // sub tileStart
+s_subb_u32 s[sgprShadowLimitA+1], s[sgprTensor2dSizeA+1], s69 // sub tileStart
+s_lshl_b64 s[sgprShadowLimitA:sgprShadowLimitA+1], s[sgprShadowLimitA:sgprShadowLimitA+1], 0x3 // Set limit to use bytes
+s_add_u32 s[sgprShadowLimitA+0], s[sgprShadowLimitA+0], 16 // extend limit for pre-pad
+s_addc_u32 s[sgprShadowLimitA+1], s[sgprShadowLimitA+1], 0 // extend limit for pre-pad
+s_cmp_eq_u32 s[sgprShadowLimitA+1], 0              // are we within 2^32?
+s_cselect_b32 s[sgprSrdA+2], s[sgprShadowLimitA+0], BufferLimit // Move shadow to real if we are within 2^32
+s_mul_hi_u32 s67, s[sgprStridesA+1], s[sgprWorkGroup2] // Stride*WG
+s_mul_i32 s66, s[sgprStridesA+1], s[sgprWorkGroup2] // Stride*WG
+s_add_u32 s68, s68, s66                            // accum wg term to tilestart
+s_addc_u32 s69, s69, s67                           // accum wg term to tilestart
+s_lshl_b64 s[68:69], s[68:69], 3                   // tileStart *= BPE
+s_add_u32 s[sgprSrdA+0], s[sgprAddressA+0], s68    // SRD base = Address+ tileStart0
+s_addc_u32 s[sgprSrdA+1], s[sgprAddressA+1], s69   // SRD base = Address+ tileStart1
+s_sub_u32 s[sgprSrdA+0], s[sgprSrdA+0], 16         // pre-pad to make room for possible pointer shift
+s_subb_u32 s[sgprSrdA+1], s[sgprSrdA+1], 0         // pre-pad to make room for possible pointer shift
+s_mov_b32 s[sgprSrdA+3], Srd127_96                 // Set bits 127_96 in SRD
+
+
+/* global read addresses: addresses b */
+
+/* max read offset = size[n] * stride[n-1] */
+s_mul_hi_u32 s69, s[sgprWorkGroup1], 64            // WorkGroup[01] * MT
+s_mul_i32 s68, s[sgprWorkGroup1], 64               // WorkGroup[01] * MT
+s_sub_u32 s[sgprShadowLimitB+0], s[sgprTensor2dSizeB], s68 // sub tileStart
+s_subb_u32 s[sgprShadowLimitB+1], s[sgprTensor2dSizeB+1], s69 // sub tileStart
+s_lshl_b64 s[sgprShadowLimitB:sgprShadowLimitB+1], s[sgprShadowLimitB:sgprShadowLimitB+1], 0x3 // Set limit to use bytes
+s_add_u32 s[sgprShadowLimitB+0], s[sgprShadowLimitB+0], 16 // extend limit for pre-pad
+s_addc_u32 s[sgprShadowLimitB+1], s[sgprShadowLimitB+1], 0 // extend limit for pre-pad
+s_cmp_eq_u32 s[sgprShadowLimitB+1], 0              // are we within 2^32?
+s_cselect_b32 s[sgprSrdB+2], s[sgprShadowLimitB+0], BufferLimit // Move shadow to real if we are within 2^32
+s_mul_hi_u32 s67, s[sgprStridesB+1], s[sgprWorkGroup2] // Stride*WG
+s_mul_i32 s66, s[sgprStridesB+1], s[sgprWorkGroup2] // Stride*WG
+s_add_u32 s68, s68, s66                            // accum wg term to tilestart
+s_addc_u32 s69, s69, s67                           // accum wg term to tilestart
+s_lshl_b64 s[68:69], s[68:69], 3                   // tileStart *= BPE
+s_add_u32 s[sgprSrdB+0], s[sgprAddressB+0], s68    // SRD base = Address+ tileStart0
+s_addc_u32 s[sgprSrdB+1], s[sgprAddressB+1], s69   // SRD base = Address+ tileStart1
+s_sub_u32 s[sgprSrdB+0], s[sgprSrdB+0], 16         // pre-pad to make room for possible pointer shift
+s_subb_u32 s[sgprSrdB+1], s[sgprSrdB+1], 0         // pre-pad to make room for possible pointer shift
+s_mov_b32 s[sgprSrdB+3], Srd127_96                 // Set bits 127_96 in SRD
+
+
+/* global read addresses: increments a */
+
+s_mul_i32 s[sgprGlobalReadIncsA+0], 0x20, s[sgprStridesA] // incr = stride*4*bytes
+
+
+/* global read addresses: increments b */
+
+s_mul_i32 s[sgprGlobalReadIncsB+0], 0x20, s[sgprStridesB] // incr = stride*4*bytes
+
+
+/******************************************/
+/* Local Write Addresses                  */
+/******************************************/
+
+
+/* local write addresses: tile assignment a */
+
+/* lwaTileA = v0 */
+
+
+/* local write addresses: tile assignment b */
+
+/* lwaTileB = v2 */
+
+
+/* local write addresses: unroll assignment a */
+
+/* lwaUnrollA = v1 */
+
+
+/* local write addresses: unroll assignment b */
+
+/* lwaUnrollB = v3 */
+
+
+/* local write addresses: first offset a */
+
+v_mul_u32_u24 v[vgprLocalWriteAddrA], 0x30, v1     // lwAL**(MTA + PAD)
+_v_add_lshl_u32 v[vgprLocalWriteAddrA], v0, v[vgprLocalWriteAddrA], 0x3 // lwFOA = (lwAA + lwAL*(MT0I+PAD))*bpe
+s_mov_b32 s65, 96                                  // lsc*lsp=48*4
+v_cmp_lt_u32 vcc, v[vgprSerial], s65               // fractional: ensure tid < global read tile elements
+v_mov_b32 v0, 0xf00000                             //
+v_cndmask_b32 v[vgprLocalWriteAddrA], v0, v[vgprLocalWriteAddrA], vcc // Mask load so out-of-gr-tile bounds returns 0
+
+
+/* local write addresses: first offset b */
+
+v_mul_u32_u24 v[vgprLocalWriteAddrB], 0x40, v3     // lwBL**(MTB + PAD)
+_v_add_lshl_u32 v[vgprLocalWriteAddrB], v2, v[vgprLocalWriteAddrB], 0x3 // lwFOB = (lwBB + lwBL*(MT1J+PAD))*bpe
+_v_add_co_u32 v[vgprLocalWriteAddrB], vcc, 0x600, v[vgprLocalWriteAddrB] // lwFOB = lwB1J + lwBL*MT1J + LDS_OFFSET_B=192*8
+
+
+/* local write addresses: final offsets a */
+
+
+/* N/A */
+
+
+/* local write addresses: final offsets b */
+
+
+/* N/A */
+
+
+/* local write addresses: declare addresses a */
+
+/* N/A */
+
+
+/* local write addresses: declare addresses b */
+
+/* N/A */
+
+
+/* local write addresses: init pointers a */
+
+/* N/A */
+
+
+/* local write addresses: init pointers b */
+
+/* N/A */
+
+
+/* declare loop num iterations */
+
+
+s_lshr_b32 s[sgprLoopCounters+0], s[sgprSizesSum+0], 2 // s[sgprLoopCounters+0] = s[sgprSizesSum+0] / 4
+s_mov_b32 s[sgprOrigLoopCounter], s[sgprLoopCounters+0] // copy loop counter
+s_sub_u32 s[sgprLoopCounters+0], 0x0, s[sgprLoopCounters+0] // counterL = -sizeL
+
+
+/* local read addresses: init pointers a */
+
+
+
+/* local read addresses: init pointers b */
+
+
+
+/* TODO-packed- compare against product of all packed C0 sizes not just SizesFree+0 */
+s_mov_b32 s91, 0x0                                 // STATIC_DIV: divisior=48
+s_mul_i32 s90, 0xaaa, s[sgprSizesFree+0]           // tmp1 = dividend * magic hi
+s_lshl_b64 s[90:91], s[90:91], 0x10                // left shift 16 bits
+s_mul_i32 s82, s[sgprSizesFree+0], 0xaaab          // tmp0 = dividend * magic lo
+s_add_u32 s90, s82, s90                            // add lo
+s_addc_u32 s91, s91, 0x0                           // add hi
+s_lshr_b64 s[90:91], s[90:91], 0x21                // tmp1 = (dividend * magic) << shift
+s_mov_b32 s82, s90                                 // quotient
+s_mul_i32 s90, s82, 0x30                           // quotient*divisor
+s_sub_u32 s[sgprEdgeSelMask0], s[sgprSizesFree+0], s90             // rReg = dividend - quotient*divisor
+s_lshr_b32 s82, s[sgprSizesFree+1], 6              // s58 = s[sgprSizesFree+1] / 64
+s_and_b32 s[sgprEdgeSelMask1], 63, s[sgprSizesFree+1]
+
+
+/* prefetch: global -> local */
+
+s_cmp_eq_u32 s[sgprLoopCounters+0], 0x0            // numIter0I == 0
+s_cbranch_scc1 label_0008                          // skip to ShadowInitStart iter b/c numIter==0
+
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+
+
+/* global read inc A */
+s_add_u32  s[sgprSrdA+0], s[sgprSrdA+0], s[sgprGlobalReadIncsA] // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdA+1], s[sgprSrdA+1], 0        // gra SRD += inc(upper)
+s_sub_u32 s[sgprShadowLimitA+0], s[sgprShadowLimitA+0], s[sgprGlobalReadIncsA] // limit -= inc)
+s_subb_u32 s[sgprShadowLimitA+1], s[sgprShadowLimitA+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitA+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdA+2], s[sgprShadowLimitA+0]    // Move shadow to real if we are within 2^32
+
+
+/* global read inc B */
+s_add_u32  s[sgprSrdB+0], s[sgprSrdB+0], s[sgprGlobalReadIncsB] // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdB+1], s[sgprSrdB+1], 0        // gra SRD += inc(upper)
+s_sub_u32 s[sgprShadowLimitB+0], s[sgprShadowLimitB+0], s[sgprGlobalReadIncsB] // limit -= inc)
+s_subb_u32 s[sgprShadowLimitB+1], s[sgprShadowLimitB+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitB+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdB+2], s[sgprShadowLimitB+0]    // Move shadow to real if we are within 2^32
+
+label_0008: // ShadowInitStart
+
+s_mov_b32 s[sgprSrdD+0], s[sgprAddressD+0]         // init SRD base address (lower)
+s_mov_b32 s[sgprSrdD+1], s[sgprAddressD+1]         // init SRD base address (upper) + other fields
+s_mov_b32 s[sgprSrdD+2], 0x80000000                //
+s_mov_b32 s[sgprSrdD+3], Srd127_96                 // Set bits 127_96 in SRD
+s_mov_b32 s[sgprSrdC+0], s[sgprAddressC+0]         // init SRD base address (lower)
+s_mov_b32 s[sgprSrdC+1], s[sgprAddressC+1]         // init SRD base address (upper) + other fields
+s_mov_b32 s[sgprSrdC+2], 0x80000000                //
+s_mov_b32 s[sgprSrdC+3], Srd127_96                 // Set bits 127_96 in SRD
+
+s_mul_i32 s[sgprTMP1], 0x40, s[sgprWorkGroup1]             // <- wg1*MT1
+s_mul_i32 s[sgprTMP0], 0x30, s[sgprWorkGroup1]             // <- wg1*MT1
+s_mul_hi_u32 s67, s[sgprTMP1], s[sgprStridesC+0]           // Scale s68 by Stride
+s_mul_i32 s66, s[sgprTMP1], s[sgprStridesC+0]              // Scale s68 by Stride
+s_lshl_b64 s[66:67], s[66:67], 3                   // scale by bpe
+s_add_u32 s[sgprSrdD+0], s[sgprSrdD+0], s66        // add lo to SRD
+s_addc_u32 s[sgprSrdD+1], s[sgprSrdD+1], s67       // add hi to SRD
+s_add_u32 s[sgprSrdC+0], s[sgprSrdC+0], s66        // add lo to SRD
+s_addc_u32 s[sgprSrdC+1], s[sgprSrdC+1], s67       // add hi to SRD
+
+s_mul_hi_u32 s67, s[sgprWorkGroup2], s[sgprStridesC+1] // Scale s[sgprWorkGroup2] by Stride
+s_mul_i32 s66, s[sgprWorkGroup2], s[sgprStridesC+1] // Scale s[sgprWorkGroup2] by Stride
+s_lshl_b64 s[66:67], s[66:67], 3                   // scale by bpe
+s_add_u32 s[sgprSrdD+0], s[sgprSrdD+0], s66        // add lo to SRD
+s_addc_u32 s[sgprSrdD+1], s[sgprSrdD+1], s67       // add hi to SRD
+s_add_u32 s[sgprSrdC+0], s[sgprSrdC+0], s66        // add lo to SRD
+s_addc_u32 s[sgprSrdC+1], s[sgprSrdC+1], s67       // add hi to SRD
+
+
+v_mov_b32 v[vgprValuC+0], 0x0                      // initC
+v_mov_b32 v[vgprValuC+1], 0x0                      // initC
+v_mov_b32 v[vgprValuC+2], 0x0                      // initC
+v_mov_b32 v[vgprValuC+3], 0x0                      // initC
+v_mov_b32 v[vgprValuC+4], 0x0                      // initC
+v_mov_b32 v[vgprValuC+5], 0x0                      // initC
+v_mov_b32 v[vgprValuC+6], 0x0                      // initC
+v_mov_b32 v[vgprValuC+7], 0x0                      // initC
+v_mov_b32 v[vgprValuC+8], 0x0                      // initC
+v_mov_b32 v[vgprValuC+9], 0x0                      // initC
+v_mov_b32 v[vgprValuC+10], 0x0                     // initC
+v_mov_b32 v[vgprValuC+11], 0x0                     // initC
+v_mov_b32 v[vgprValuC+12], 0x0                     // initC
+v_mov_b32 v[vgprValuC+13], 0x0                     // initC
+v_mov_b32 v[vgprValuC+14], 0x0                     // initC
+v_mov_b32 v[vgprValuC+15], 0x0                     // initC
+v_mov_b32 v[vgprValuC+16], 0x0                     // initC
+v_mov_b32 v[vgprValuC+17], 0x0                     // initC
+v_mov_b32 v[vgprValuC+18], 0x0                     // initC
+v_mov_b32 v[vgprValuC+19], 0x0                     // initC
+v_mov_b32 v[vgprValuC+20], 0x0                     // initC
+v_mov_b32 v[vgprValuC+21], 0x0                     // initC
+v_mov_b32 v[vgprValuC+22], 0x0                     // initC
+v_mov_b32 v[vgprValuC+23], 0x0                     // initC
+v_mov_b32 v[vgprValuC+24], 0x0                     // initC
+v_mov_b32 v[vgprValuC+25], 0x0                     // initC
+v_mov_b32 v[vgprValuC+26], 0x0                     // initC
+v_mov_b32 v[vgprValuC+27], 0x0                     // initC
+v_mov_b32 v[vgprValuC+28], 0x0                     // initC
+v_mov_b32 v[vgprValuC+29], 0x0                     // initC
+v_mov_b32 v[vgprValuC+30], 0x0                     // initC
+v_mov_b32 v[vgprValuC+31], 0x0                     // initC
+v_mov_b32 v[vgprValuC+32], 0x0                     // initC
+v_mov_b32 v[vgprValuC+33], 0x0                     // initC
+v_mov_b32 v[vgprValuC+34], 0x0                     // initC
+v_mov_b32 v[vgprValuC+35], 0x0                     // initC
+v_mov_b32 v[vgprValuC+36], 0x0                     // initC
+v_mov_b32 v[vgprValuC+37], 0x0                     // initC
+v_mov_b32 v[vgprValuC+38], 0x0                     // initC
+v_mov_b32 v[vgprValuC+39], 0x0                     // initC
+v_mov_b32 v[vgprValuC+40], 0x0                     // initC
+v_mov_b32 v[vgprValuC+41], 0x0                     // initC
+v_mov_b32 v[vgprValuC+42], 0x0                     // initC
+v_mov_b32 v[vgprValuC+43], 0x0                     // initC
+v_mov_b32 v[vgprValuC+44], 0x0                     // initC
+v_mov_b32 v[vgprValuC+45], 0x0                     // initC
+v_mov_b32 v[vgprValuC+46], 0x0                     // initC
+v_mov_b32 v[vgprValuC+47], 0x0                     // initC
+s_cmp_eq_u32 s[sgprLoopCounters+0], 0x0            // numIter0I == 0
+s_cbranch_scc1 label_0004                          // after InitC, skip to end of prefetch last iter b/c numIter==0
+
+s_waitcnt vmcnt(0)                                 // 8wait for global read
+
+
+/* local write a */
+
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:0 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 0
+
+
+/* local write b */
+
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:0 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 0
+
+
+/* local write swap a */
+
+
+
+/* local write swap b */
+
+
+
+/* local write init pointers a */
+
+/* N/A */
+
+
+/* local write init pointers b */
+
+/* N/A */
+
+/******************************************/
+/* Unrolled Loop(s) - Begin               */
+/******************************************/
+
+s_cmp_ge_i32 s[sgprLoopCounters+0], 0x0            // LoopCounterL < EndCounter
+s_cbranch_scc1 label_0004                          // don't enter LoopL
+label_0001:
+
+
+/******************************************/
+/* Unroll Loop 1/2 - Begin                */
+/******************************************/
+
+s_barrier //4sync for global read
+
+s_cmp_eq_i32 s[sgprLoopCounters+0], -1             // is this the last iteration
+s_cmov_b32 s[sgprSrdA+2], 0                        // Set limit to 0 for last iteration
+s_cmov_b32 s[sgprSrdB+2], 0                        // Set limit to 0 for last iteration
+
+s_waitcnt lgkmcnt(0)                               // 1wait for local write
+
+
+
+
+/* iter 0 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(2)                               // wait for prior local read old=0 new=0
+//MAC_6x4_X0
+MAC_6x4_X0_part_1
+
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:384 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:512 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* global read inc A */
+s_add_u32  s[sgprSrdA+0], s[sgprSrdA+0], s[sgprGlobalReadIncsA] // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdA+1], s[sgprSrdA+1], 0        // gra SRD += inc(upper)
+s_sub_u32 s[sgprShadowLimitA+0], s[sgprShadowLimitA+0], s[sgprGlobalReadIncsA] // limit -= inc)
+s_subb_u32 s[sgprShadowLimitA+1], s[sgprShadowLimitA+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitA+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdA+2], s[sgprShadowLimitA+0]    // Move shadow to real if we are within 2^32
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:640 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(2)                               // wait for prior local read old=0 new=0
+//MAC_6x4_X0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:768 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* global read inc B */
+s_add_u32  s[sgprSrdB+0], s[sgprSrdB+0], s[sgprGlobalReadIncsB] // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdB+1], s[sgprSrdB+1], 0        // gra SRD += inc(upper)
+s_sub_u32 s[sgprShadowLimitB+0], s[sgprShadowLimitB+0], s[sgprGlobalReadIncsB] // limit -= inc)
+s_subb_u32 s[sgprShadowLimitB+1], s[sgprShadowLimitB+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitB+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdB+2], s[sgprShadowLimitB+0]    // Move shadow to real if we are within 2^32
+
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:896 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1024 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 2 writesPerItem=1 */
+s_waitcnt vmcnt(1)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:4096 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 4096
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(3)                               // wait for prior local read old=0 new=0
+//MAC_6x4_X0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(1)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+/* iter 3 (last) */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:1152 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1280 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1408 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 3 writesPerItem=1 */
+s_waitcnt vmcnt(0)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:4096 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 4096
+
+/* local write swap offsets a */
+
+/* local write swap offsets b */
+
+/* local write init pointers a */
+/* N/A */
+
+/* local write init pointers b */
+/* N/A */
+
+/* local read swap offsets a */
+
+/* local read swap internal offset -> 4096 */
+
+/* local read swap offsets b */
+
+/* local read swap internal offset -> 4096 */
+
+/* local read init pointers a */
+
+/* local read init pointers b */
+s_waitcnt lgkmcnt(3)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(1)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0_part_3
+
+/******************************************/
+/* Unrolled Loop - End 1/2                */
+/******************************************/
+
+s_add_u32 s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+s_cmp_eq_i32 s[sgprLoopCounters+0],  -2            // counterL==0
+s_cbranch_scc1 label_0003                          // exit LoopL
+
+
+/******************************************/
+/* Unroll Loop 2/2 - Begin                */
+/******************************************/
+
+s_barrier //4sync for global read
+
+s_cmp_eq_i32 s[sgprLoopCounters+0], -1             // is this the last iteration
+s_cmov_b32 s[sgprSrdA+2], 0                        // Set limit to 0 for last iteration
+s_cmov_b32 s[sgprSrdB+2], 0                        // Set limit to 0 for last iteration
+
+s_waitcnt lgkmcnt(0)                               // 1wait for local write
+
+
+
+
+/* iter 0 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4096 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4224 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4352 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(2)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4480 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4608 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* global read inc A */
+s_add_u32  s[sgprSrdA+0], s[sgprSrdA+0], s[sgprGlobalReadIncsA] // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdA+1], s[sgprSrdA+1], 0        // gra SRD += inc(upper)
+s_sub_u32 s[sgprShadowLimitA+0], s[sgprShadowLimitA+0], s[sgprGlobalReadIncsA] // limit -= inc)
+s_subb_u32 s[sgprShadowLimitA+1], s[sgprShadowLimitA+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitA+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdA+2], s[sgprShadowLimitA+0]    // Move shadow to real if we are within 2^32
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4736 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(2)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4864 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* global read inc B */
+s_add_u32  s[sgprSrdB+0], s[sgprSrdB+0], s[sgprGlobalReadIncsB] // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdB+1], s[sgprSrdB+1], 0        // gra SRD += inc(upper)
+s_sub_u32 s[sgprShadowLimitB+0], s[sgprShadowLimitB+0], s[sgprGlobalReadIncsB] // limit -= inc)
+s_subb_u32 s[sgprShadowLimitB+1], s[sgprShadowLimitB+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitB+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdB+2], s[sgprShadowLimitB+0]    // Move shadow to real if we are within 2^32
+
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4992 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5120 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 2 writesPerItem=1 */
+s_waitcnt vmcnt(1)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:0 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 0
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(3)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(1)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:5248 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=192 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=192 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5376 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5504 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 3 writesPerItem=1 */
+s_waitcnt vmcnt(0)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:0 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 0
+
+/* local write swap offsets a */
+
+/* local write swap offsets b */
+
+/* local write init pointers a */
+/* N/A */
+
+/* local write init pointers b */
+/* N/A */
+
+/* local read swap offsets a */
+
+/* local read swap internal offset -> 0 */
+
+/* local read swap offsets b */
+
+/* local read swap internal offset -> 0 */
+
+/* local read init pointers a */
+
+/* local read init pointers b */
+s_waitcnt lgkmcnt(3)                               // 6wait for local read old=3 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(1)                               // 6wait for local read old=1 new=0
+MAC_6x4_X0_part_3
+
+/******************************************/
+/* Unrolled Loop - End 2/2 (final)        */
+/******************************************/
+
+s_add_u32 s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+s_cmp_eq_i32 s[sgprLoopCounters+0], -2              // counterL==0
+s_cbranch_scc0 label_0001                          // restart LoopL
+s_cbranch_scc1 label_0002                          // restart LoopL
+
+label_0003: // unroll loop odditer exit
+
+//check edge Batch calculation needed
+//for Batch edge jump to different beta loop optimization code
+s_add_u32      s83,-0x1, s[sgprNumWorkGroups0]       //
+s_cmp_lt_u32   s[sgprWorkGroup0], s83                // wg0 < nwg0-1
+s_cmov_b32     s[sgprEdgeSelMask0], 0x0
+s_cmpk_gt_u32  s[sgprEdgeSelMask0], 0x0
+s_cbranch_scc1 label_1003                            // wg1 < nwg1-1 so skip rMT1 = Size1 % MT1
+s_add_u32      s83, -0x1, s[sgprNumWorkGroups1]      //
+s_cmp_lt_u32   s[sgprWorkGroup1], s83                // wg1 < nwg1-1
+s_cmov_b32     s[sgprEdgeSelMask1], 0x0
+s_cmpk_gt_u32  s[sgprEdgeSelMask1], 0x0
+s_cbranch_scc1 label_1003                            // wg1 < nwg1-1 so skip rMT1 = Size1 % MT1
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4224 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4480 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4608 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4736 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4864 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4992 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5120 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:0 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 4096
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(1)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:5248 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5376 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5504 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_mul_i32 s56, 0x30, s[sgprWorkGroup0]             // s56 = wg0*MT0
+s_mul_i32 s58, 0x40, s[sgprWorkGroup1]             // s56 = wg0*MT0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 3 writesPerItem=1 */
+s_waitcnt vmcnt(0)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:0 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 4096
+
+s_waitcnt lgkmcnt(1)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0_unprio_0
+v_lshrrev_b32 v[vgprLocalWriteAddrB], 3, v[vgprSerial]                // vectorStaticDiv: v49 = v[vgprSerial] / 8
+v_and_b32 v[vgprLocalWriteAddrA], 7, v[vgprSerial]                    // vectorStaticDiv: v48 = v[vgprSerial] % 8
+v_lshlrev_b32 v[vgprLocalWriteAddrA], 1, v[vgprLocalWriteAddrA]       // staticMultiply: v48 = v48 * 2
+v_lshlrev_b32 v[vgprLocalWriteAddrB], 1, v[vgprLocalWriteAddrB]       // staticMultiply: v49 = v49 * 2
+v_mul_lo_u32 v[vgprGlobalReadOffsetB], v[vgprLocalWriteAddrB], s[sgprStridesC+0]           // rowStart vgpr
+_v_add_co_u32 v[vgprLocalWriteAddrA], vcc, s56, v[vgprLocalWriteAddrA]                   // coord0 = tid0*VW + wg0*MT0
+_v_add_lshl_u32 v[vgprGlobalReadOffsetA], v[vgprGlobalReadOffsetB], v[vgprLocalWriteAddrA], 0x3                 // init cb addr <-  rowStart + coord0, scaled by BPE
+s_setprio 0
+
+s_add_u32       s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+s_cmp_eq_i32    s[sgprLoopCounters+0], -1             // is this the last iteration
+s_cmov_b32 	s[sgprSrdA+2], 0                        // Set limit to 0 for last iteration
+s_cmov_b32 	s[sgprSrdB+2], 0                        // Set limit to 0 for last iteration
+s_mov_b32 	s85, s[sgprSrdC+0]
+s_mov_b32 	s86, s[sgprSrdC+1]
+s_mov_b32       s87, s[sgprSrdD+0]
+s_mov_b32       s88, s[sgprSrdD+1]
+
+
+s_waitcnt lgkmcnt(0)                               // 1wait for local write
+s_barrier //4sync for global read
+
+/* iter 0,1 */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:384 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part1
+
+/* iter 1 */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:768  // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1152 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part1
+
+
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:512 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+0:vgprValuC+0+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+0:vgprValuC+0+1] // *= alpha
+v_mul_f64 v[vgprValuC+2:vgprValuC+2+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+2:vgprValuC+2+1] // *= alpha
+v_fma_f64 v[vgprValuC+0:vgprValuC+0+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+0:vgprValuC+0+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+2:vgprValuC+2+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+2:vgprValuC+2+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[0:3], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+12:vgprValuC+12+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+12:vgprValuC+12+1] // *= alpha
+v_mul_f64 v[vgprValuC+14:vgprValuC+14+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+14:vgprValuC+14+1] // *= alpha
+v_fma_f64 v[vgprValuC+12:vgprValuC+12+1], v[vgprG2LB+0:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+12:vgprValuC+12+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+14:vgprValuC+14+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+14:vgprValuC+14+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[12:15], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part2
+
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:896 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1280 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part2
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:640 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+4:vgprValuC+4+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+4:vgprValuC+4+1] // *= alpha
+v_mul_f64 v[vgprValuC+6:vgprValuC+6+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+6:vgprValuC+6+1] // *= alpha
+v_fma_f64 v[vgprValuC+4:vgprValuC+4+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+4:vgprValuC+4+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+6:vgprValuC+6+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+6:vgprValuC+6+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[4:7], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+16:vgprValuC+16+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+16:vgprValuC+16+1] // *= alpha
+v_mul_f64 v[vgprValuC+18:vgprValuC+18+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+18:vgprValuC+18+1] // *= alpha
+v_fma_f64 v[vgprValuC+16:vgprValuC+16+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+16:vgprValuC+16+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+18:vgprValuC+18+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+18:vgprValuC+18+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[16:19], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part3
+
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1024 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:1408 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part3
+
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:384 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+8:vgprValuC+8+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+8:vgprValuC+8+1] // *= alpha
+v_mul_f64 v[vgprValuC+10:vgprValuC+10+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+10:vgprValuC+10+1] // *= alpha
+v_fma_f64 v[vgprValuC+8:vgprValuC+8+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+8:vgprValuC+8+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+10:vgprValuC+10+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+10:vgprValuC+10+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[8:11], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+20:vgprValuC+20+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+20:vgprValuC+20+1] // *= alpha
+v_mul_f64 v[vgprValuC+22:vgprValuC+22+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+22:vgprValuC+22+1] // *= alpha
+v_fma_f64 v[vgprValuC+20:vgprValuC+20+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+20:vgprValuC+20+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+22:vgprValuC+22+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+22:vgprValuC+22+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[20:23], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_mul_i32  s56, s[sgprStridesC+0], 248              // Scale by BPE
+s_add_u32   s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+s_mov_b32   s85, s[sgprSrdC+0]
+s_mov_b32   s86, s[sgprSrdC+1]                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part4
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:768 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+s_lshl_b32   s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32   s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1152 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part4
+
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+s_mul_i32   s56, s[sgprStridesD+0], 248              // Scale by BPE
+s_add_u32   s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:512 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+24:vgprValuC+24+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+24:vgprValuC+24+1] // *= alpha
+v_mul_f64 v[vgprValuC+26:vgprValuC+26+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+26:vgprValuC+26+1] // *= alpha
+v_fma_f64 v[vgprValuC+24:vgprValuC+24+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+24:vgprValuC+24+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+26:vgprValuC+26+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+26:vgprValuC+26+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[24:27], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_mov_b32       s87, s[sgprSrdD+0]
+s_mov_b32       s88, s[sgprSrdD+1]                 /* local read init pointers b */
+s_lshl_b32      s56, s[sgprStridesD+0], 3         // Scale     s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_add_u32       s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32      s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+36:vgprValuC+36+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+36:vgprValuC+36+1] // *= alpha
+v_mul_f64 v[vgprValuC+38:vgprValuC+38+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+38:vgprValuC+38+1] // *= alpha
+v_fma_f64 v[vgprValuC+36:vgprValuC+36+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+36:vgprValuC+36+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+38:vgprValuC+38+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+38:vgprValuC+38+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[36:39], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0_part5
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:896 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1280 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part5
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:640 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+28:vgprValuC+28+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+28:vgprValuC+28+1] // *= alpha
+v_mul_f64 v[vgprValuC+30:vgprValuC+30+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+30:vgprValuC+30+1] // *= alpha
+v_fma_f64 v[vgprValuC+28:vgprValuC+28+1], v[vgprG2LA+0:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+28:vgprValuC+28+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+30:vgprValuC+30+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+30:vgprValuC+30+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[28:31], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+40:vgprValuC+40+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+40:vgprValuC+40+1] // *= alpha
+v_mul_f64 v[vgprValuC+42:vgprValuC+42+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+42:vgprValuC+42+1] // *= alpha
+v_fma_f64 v[vgprValuC+40:vgprValuC+40+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+40:vgprValuC+40+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+42:vgprValuC+42+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+42:vgprValuC+42+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[40:43], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part6
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1024 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1408 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part6
+
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+32:vgprValuC+32+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+32:vgprValuC+32+1] // *= alpha
+v_mul_f64 v[vgprValuC+34:vgprValuC+34+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+34:vgprValuC+34+1] // *= alpha
+v_fma_f64 v[vgprValuC+32:vgprValuC+32+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+32:vgprValuC+32+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+34:vgprValuC+34+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+34:vgprValuC+34+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[32:35], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_lshl_b32  s56, 	   s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32   s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+
+v_mul_f64 v[vgprValuC+44:vgprValuC+44+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+44:vgprValuC+44+1] // *= alpha
+v_mul_f64 v[vgprValuC+46:vgprValuC+46+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+46:vgprValuC+46+1] // *= alpha
+v_fma_f64 v[vgprValuC+44:vgprValuC+44+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+44:vgprValuC+44+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+46:vgprValuC+46+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+46:vgprValuC+46+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[44:47], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_add_u32            s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+
+
+s_endpgm
+
+label_0002:
+
+/* TODO-packed- compare against product of all packed C0 sizes not just SizesFree+0 */
+//s_mov_b32 s91, 0x0                                 // STATIC_DIV: divisior=48
+//s_mul_i32 s90, 0xaaa, s[sgprSizesFree+0]           // tmp1 = dividend * magic hi
+//s_lshl_b64 s[90:91], s[90:91], 0x10                // left shift 16 bits
+//s_mul_i32 s82, s[sgprSizesFree+0], 0xaaab          // tmp0 = dividend * magic lo
+//s_add_u32 s90, s82, s90                            // add lo
+//s_addc_u32 s91, s91, 0x0                           // add hi
+//s_lshr_b64 s[90:91], s[90:91], 0x21                // tmp1 = (dividend * magic) << shift
+//s_mov_b32 s82, s90                                 // quotient
+//s_mul_i32 s90, s82, 0x30                           // quotient*divisor
+//s_sub_u32 s[sgprEdgeSelMask0], s[sgprSizesFree+0], s90             // rReg = dividend - quotient*divisor
+//s_lshr_b32 s82, s[sgprSizesFree+1], 6              // s58 = s[sgprSizesFree+1] / 64
+//s_and_b32 s[sgprEdgeSelMask1], 63, s[sgprSizesFree+1]
+
+//check edge Batch calculation needed
+//for Batch edge jump to different beta loop optimization code
+s_add_u32      s83,-0x1, s[sgprNumWorkGroups0]       //
+s_cmp_lt_u32   s[sgprWorkGroup0], s83                // wg0 < nwg0-1
+s_cmov_b32     s[sgprEdgeSelMask0], 0x0
+s_cmpk_gt_u32  s[sgprEdgeSelMask0], 0x0
+s_cbranch_scc1 label_1002                            // wg1 < nwg1-1 so skip rMT1 = Size1 % MT1
+s_add_u32      s83, -0x1, s[sgprNumWorkGroups1]      //
+s_cmp_lt_u32   s[sgprWorkGroup1], s83                // wg1 < nwg1-1
+s_cmov_b32     s[sgprEdgeSelMask1], 0x0
+s_cmpk_gt_u32  s[sgprEdgeSelMask1], 0x0
+s_cbranch_scc1 label_1002                            // wg1 < nwg1-1 so skip rMT1 = Size1 % MT1
+
+/******************************************/
+
+s_waitcnt lgkmcnt(0)                                 // 1wait for local write
+s_barrier //4sync for global read
+
+/* iter 0 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(2)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:384 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:512 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:640 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(2)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:768 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:896 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1024 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:4096 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 4096
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(3)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(1)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:1152 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1280 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+s_mul_i32 s56, 0x30, s[sgprWorkGroup0]             // s56 = wg0*MT0
+s_mul_i32 s58, 0x40, s[sgprWorkGroup1]             // s56 = wg0*MT0
+/* sched write - iter 3 writesPerItem=1 */
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1408 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(0)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:4096 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 4096
+
+s_waitcnt lgkmcnt(1)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0_unprio_0
+v_lshrrev_b32 v[vgprLocalWriteAddrB], 3, v[vgprSerial]                // vectorStaticDiv: v49 = v[vgprSerial] / 8
+v_and_b32 v[vgprLocalWriteAddrA], 7, v[vgprSerial]                    // vectorStaticDiv: v48 = v[vgprSerial] % 8
+v_lshlrev_b32 v[vgprLocalWriteAddrA], 1, v[vgprLocalWriteAddrA]       // staticMultiply: v48 = v48 * 2
+v_lshlrev_b32 v[vgprLocalWriteAddrB], 1, v[vgprLocalWriteAddrB]       // staticMultiply: v49 = v49 * 2
+v_mul_lo_u32 v[vgprGlobalReadOffsetB], v[vgprLocalWriteAddrB], s[sgprStridesC+0]           // rowStart vgpr
+_v_add_co_u32 v[vgprLocalWriteAddrA], vcc, s56, v[vgprLocalWriteAddrA]                   // coord0 = tid0*VW + wg0*MT0
+_v_add_lshl_u32 v[vgprGlobalReadOffsetA], v[vgprGlobalReadOffsetB], v[vgprLocalWriteAddrA], 0x3                 // init cb addr <-  rowStart + coord0, scaled by BPE
+s_setprio 0
+
+s_add_u32       s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+s_cmp_eq_i32    s[sgprLoopCounters+0], -1             // is this the last iteration
+s_cmov_b32 	s[sgprSrdA+2], 0                        // Set limit to 0 for last iteration
+s_cmov_b32 	s[sgprSrdB+2], 0                        // Set limit to 0 for last iteration
+s_mov_b32 	s85, s[sgprSrdC+0]
+s_mov_b32 	s86, s[sgprSrdC+1]
+s_mov_b32       s87, s[sgprSrdD+0]
+s_mov_b32       s88, s[sgprSrdD+1]
+
+
+s_waitcnt lgkmcnt(0)                               // 1wait for local write
+s_barrier //4sync for global read
+
+/* iter 0,1 */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4480 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part1
+
+/* iter 1 */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4864 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5248 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part1
+
+
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4224 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4608 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+0:vgprValuC+0+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+0:vgprValuC+0+1] // *= alpha
+v_mul_f64 v[vgprValuC+2:vgprValuC+2+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+2:vgprValuC+2+1] // *= alpha
+v_fma_f64 v[vgprValuC+0:vgprValuC+0+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+0:vgprValuC+0+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+2:vgprValuC+2+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+2:vgprValuC+2+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[0:3], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+12:vgprValuC+12+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+12:vgprValuC+12+1] // *= alpha
+v_mul_f64 v[vgprValuC+14:vgprValuC+14+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+14:vgprValuC+14+1] // *= alpha
+v_fma_f64 v[vgprValuC+12:vgprValuC+12+1], v[vgprG2LB+0:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+12:vgprValuC+12+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+14:vgprValuC+14+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+14:vgprValuC+14+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[12:15], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part2
+
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4992 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5376 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part2
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4736 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+4:vgprValuC+4+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+4:vgprValuC+4+1] // *= alpha
+v_mul_f64 v[vgprValuC+6:vgprValuC+6+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+6:vgprValuC+6+1] // *= alpha
+v_fma_f64 v[vgprValuC+4:vgprValuC+4+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+4:vgprValuC+4+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+6:vgprValuC+6+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+6:vgprValuC+6+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[4:7], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+16:vgprValuC+16+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+16:vgprValuC+16+1] // *= alpha
+v_mul_f64 v[vgprValuC+18:vgprValuC+18+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+18:vgprValuC+18+1] // *= alpha
+v_fma_f64 v[vgprValuC+16:vgprValuC+16+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+16:vgprValuC+16+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+18:vgprValuC+18+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+18:vgprValuC+18+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[16:19], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part3
+
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5120 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:5504 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part3
+
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4480 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+8:vgprValuC+8+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+8:vgprValuC+8+1] // *= alpha
+v_mul_f64 v[vgprValuC+10:vgprValuC+10+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+10:vgprValuC+10+1] // *= alpha
+v_fma_f64 v[vgprValuC+8:vgprValuC+8+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+8:vgprValuC+8+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+10:vgprValuC+10+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+10:vgprValuC+10+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[8:11], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+20:vgprValuC+20+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+20:vgprValuC+20+1] // *= alpha
+v_mul_f64 v[vgprValuC+22:vgprValuC+22+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+22:vgprValuC+22+1] // *= alpha
+v_fma_f64 v[vgprValuC+20:vgprValuC+20+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+20:vgprValuC+20+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+22:vgprValuC+22+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+22:vgprValuC+22+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[20:23], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_mul_i32  s56, s[sgprStridesC+0], 248              // Scale by BPE
+s_add_u32   s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+s_mov_b32   s85, s[sgprSrdC+0]
+s_mov_b32   s86, s[sgprSrdC+1]                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part4
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4864 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+s_lshl_b32   s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32   s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5248 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part4
+
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4224 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+s_mul_i32   s56, s[sgprStridesD+0], 248              // Scale by BPE
+s_add_u32   s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4608 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+24:vgprValuC+24+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+24:vgprValuC+24+1] // *= alpha
+v_mul_f64 v[vgprValuC+26:vgprValuC+26+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+26:vgprValuC+26+1] // *= alpha
+v_fma_f64 v[vgprValuC+24:vgprValuC+24+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+24:vgprValuC+24+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+26:vgprValuC+26+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+26:vgprValuC+26+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[24:27], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_mov_b32       s87, s[sgprSrdD+0]
+s_mov_b32       s88, s[sgprSrdD+1]                 /* local read init pointers b */
+s_lshl_b32      s56, s[sgprStridesD+0], 3         // Scale     s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_add_u32       s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32      s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+36:vgprValuC+36+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+36:vgprValuC+36+1] // *= alpha
+v_mul_f64 v[vgprValuC+38:vgprValuC+38+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+38:vgprValuC+38+1] // *= alpha
+v_fma_f64 v[vgprValuC+36:vgprValuC+36+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+36:vgprValuC+36+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+38:vgprValuC+38+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+38:vgprValuC+38+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[36:39], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0_part5
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4992 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5376 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part5
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4736 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+28:vgprValuC+28+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+28:vgprValuC+28+1] // *= alpha
+v_mul_f64 v[vgprValuC+30:vgprValuC+30+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+30:vgprValuC+30+1] // *= alpha
+v_fma_f64 v[vgprValuC+28:vgprValuC+28+1], v[vgprG2LA+0:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+28:vgprValuC+28+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+30:vgprValuC+30+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+30:vgprValuC+30+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[28:31], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+40:vgprValuC+40+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+40:vgprValuC+40+1] // *= alpha
+v_mul_f64 v[vgprValuC+42:vgprValuC+42+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+42:vgprValuC+42+1] // *= alpha
+v_fma_f64 v[vgprValuC+40:vgprValuC+40+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+40:vgprValuC+40+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+42:vgprValuC+42+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+42:vgprValuC+42+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[40:43], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part6
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5120 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5504 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part6
+
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+32:vgprValuC+32+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+32:vgprValuC+32+1] // *= alpha
+v_mul_f64 v[vgprValuC+34:vgprValuC+34+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+34:vgprValuC+34+1] // *= alpha
+v_fma_f64 v[vgprValuC+32:vgprValuC+32+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+32:vgprValuC+32+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+34:vgprValuC+34+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+34:vgprValuC+34+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[32:35], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_lshl_b32  s56, 	   s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32   s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+
+v_mul_f64 v[vgprValuC+44:vgprValuC+44+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+44:vgprValuC+44+1] // *= alpha
+v_mul_f64 v[vgprValuC+46:vgprValuC+46+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+46:vgprValuC+46+1] // *= alpha
+v_fma_f64 v[vgprValuC+44:vgprValuC+44+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+44:vgprValuC+44+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+46:vgprValuC+46+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+46:vgprValuC+46+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[44:47], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_add_u32            s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+
+
+s_endpgm
+
+label_1002:
+
+/******************************************/
+//branch logic gets executed for edge MT to use legacy alph_beta code
+
+s_waitcnt lgkmcnt(0)                                 // 1wait for local write
+s_barrier //4sync for global read
+
+/* iter 0 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:384 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:512 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:640 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:768 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:896 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt vmcnt(1)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:4096 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 4096
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1024 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:1152 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1280 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 3 writesPerItem=1 */
+s_waitcnt vmcnt(0)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:4096 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 4096
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1408 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0
+
+
+s_waitcnt lgkmcnt(0)                               // 1wait for local write
+s_barrier //4sync for global read
+
+
+/* iter 0 */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4096 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4224 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4352 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4480 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4608 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4736 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4864 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4992 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5120 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:5248 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5376 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5504 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=192 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=192 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0
+s_add_u32 s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+
+s_branch label_0004
+
+label_1003:
+
+s_waitcnt lgkmcnt(0)                               // 1wait for local write
+s_barrier //4sync for global read
+
+
+/* iter 0 */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4096 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4224 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4352 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4480 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4608 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4736 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4864 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4992 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* sched write - iter 2 writesPerItem=1 */
+s_waitcnt vmcnt(1)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:0 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5120 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:5248 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5376 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 3 writesPerItem=1 */
+s_waitcnt vmcnt(0)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:0 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5504 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=192 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=192 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+
+/* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0
+
+s_add_u32 s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+s_cmp_eq_i32 s[sgprLoopCounters+0], -1             // is this the last iteration
+s_cmov_b32 s[sgprSrdA+2], 0                        // Set limit to 0 for last iteration
+s_cmov_b32 s[sgprSrdB+2], 0                        // Set limit to 0 for last iteration
+
+s_waitcnt lgkmcnt(0)                               // 1wait for local write
+
+s_barrier //4sync for global read
+
+/* iter 0 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:384 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:512 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:640 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:768 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:896 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1024 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:1152 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1280 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1408 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0
+s_add_u32 s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+
+label_0004:
+
+
+/******************************************/
+/* Tail Loop                              */
+/******************************************/
+
+
+/* local write reset offsets a */
+
+
+
+/* local write reset offsets b */
+
+
+
+s_cmp_eq_u32 s[sgprOrigLoopCounter], 0             // completely skipped unroll loop?
+s_cselect_b32 s66, 0, s[sgprGlobalReadIncsA]       // force to 0?
+s_cselect_b32 s67, 0, s[sgprGlobalReadIncsB]       // force to 0?
+s_sub_u32  s[sgprSrdA+0], s[sgprSrdA+0], s66       // gra SRD -= inc(lower)
+s_subb_u32  s[sgprSrdA+1], s[sgprSrdA+1], 0        // gra SRD -= inc(upper)
+s_add_u32 s[sgprShadowLimitA+0], s[sgprShadowLimitA+0], s66 // limit -= inc)
+s_addc_u32 s[sgprShadowLimitA+1], s[sgprShadowLimitA+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitA+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdA+2], s[sgprShadowLimitA+0]    // Move shadow to real if we are within 2^32
+
+s_sub_u32  s[sgprSrdB+0], s[sgprSrdB+0], s67       // gra SRD -= inc(lower)
+s_subb_u32  s[sgprSrdB+1], s[sgprSrdB+1], 0        // gra SRD -= inc(upper)
+s_add_u32 s[sgprShadowLimitB+0], s[sgprShadowLimitB+0], s67 // limit -= inc)
+s_addc_u32 s[sgprShadowLimitB+1], s[sgprShadowLimitB+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitB+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdB+2], s[sgprShadowLimitB+0]    // Move shadow to real if we are within 2^32
+
+//numIterL = (((sizeL % LOCAL_DEPTHU) + LOCAL_SPLITU - 1) / LOCAL_SPLITU)
+s_lshr_b32 s66, s[sgprSizesSum+0], 2               // s66 = s[sgprSizesSum+0] / 4
+s_and_b32 s[sgprLoopCounters+0], 3, s[sgprSizesSum+0] // s[sgprLoopCounters+0] = s[sgprSizesSum+0] % 4
+s_cmp_eq_u32 s[sgprLoopCounters+0], 0x0            // numIterL == 0
+s_cbranch_scc1 label_0006                          // skip to end of tail loop b/c numIter==0
+s_sub_u32 s[sgprLoopCounters+0], 0x0, s[sgprLoopCounters+0] // counterL = -sizeL
+
+
+/* global read a */
+
+/* g2l=0, load component 0 */
+buffer_load_dwordx2 v[vgprG2LA+0+0:vgprG2LA+0+0+1], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // load one buffer value
+/* g2l=0, load component 1 */
+buffer_load_dwordx2 v[vgprG2LA+0+2:vgprG2LA+0+2+1], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:8 // load one buffer value
+_v_add_co_u32 v[vgprGlobalReadOffsetA+0], vcc, v[vgprGlobalReadOffsetA+0], 8 // graOffset += 1 * bpe
+
+
+/* global read b */
+
+/* g2l=0, load component 0 */
+buffer_load_dwordx2 v[vgprG2LB+0+0:vgprG2LB+0+0+1], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // load one buffer value
+/* g2l=0, load component 1 */
+buffer_load_dwordx2 v[vgprG2LB+0+2:vgprG2LB+0+2+1], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:8 // load one buffer value
+_v_add_co_u32 v[vgprGlobalReadOffsetB+0], vcc, v[vgprGlobalReadOffsetB+0], 8 // graOffset += 1 * bpe
+
+s_waitcnt vmcnt(0)                                 // 2wait for global read
+
+s_barrier //
+
+/* local write init pointers a */
+
+/* N/A */
+
+
+/* local write init pointers b */
+
+/* N/A */
+
+
+/* local write a */
+
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:0 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 0
+
+
+/* local write b */
+
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:0 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 0
+
+s_waitcnt lgkmcnt(0)                               // 5wait for local write
+
+s_barrier //
+
+
+/* local read reset offsets a */
+
+/* handled internally */
+v_and_b32 v[vgprLocalReadAddrA], 0xfff, v[vgprLocalReadAddrA] // reset Red,Blk -> Red
+
+
+/* local read reset offsets b */
+
+/* handled internally */
+v_and_b32 v[vgprLocalReadAddrB], 0xfff, v[vgprLocalReadAddrB] // reset Red,Blk -> Red
+
+
+/* local read init pointers a */
+
+
+
+/* local read init pointers b */
+
+
+
+/* tail loop: macs */
+
+s_cmp_ge_i32 s[sgprLoopCounters+0], 0x0            // LoopCounterL < EndCounter
+s_cbranch_scc1 label_0006                          // don't enter LoopL
+s_mov_b32 s[sgprOrigLoopCounter], 0                // repurpose to count each localRead increment
+label_0005:
+
+
+/* local read a */
+
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+
+/* local read b */
+
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+
+/* local read inc a */
+
+s_mov_b32 s65, 0x180                               // inc
+_v_add_co_u32 v[vgprLocalReadAddrA], vcc, s65, v[vgprLocalReadAddrA] // lrA += 384 (LSU*(MT+PAD)*bpe)
+
+
+/* local read inc b */
+
+s_mov_b32 s65, 0x200                               // inc
+_v_add_co_u32 v[vgprLocalReadAddrB], vcc, s65, v[vgprLocalReadAddrB] // lrB += 512 (LSU*(MT+PAD)*bpe)
+
+s_waitcnt lgkmcnt(0)                               // 4wait for local read
+
+MAC_6x4_X0
+s_add_u32 s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+s_add_u32 s[sgprOrigLoopCounter], s[sgprOrigLoopCounter], 0x1 // inc counterL
+s_cmp_eq_i32 s[sgprLoopCounters+0], 0x0            // counterL==0
+s_cbranch_scc0 label_0005                          // restart LoopL
+label_0006:
+
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // wait for all summation activity
+
+
+/* shift vector components d0 */
+
+v_mov_b32 v50, s[sgprWorkGroup0]                   //
+v_mul_i32_i24 v50, -0x30, v50                      // wg*MT
+_v_add_co_u32 v50, vcc, s[sgprSizesFree+0], v50    // wgMT = Size - wg*MT
+v_mov_b32 v48, 0x30                                // MT
+v_cmp_lt_u32 s[56:57], v50, v48                    // wgMT < MT
+v_cndmask_b32 v50, v48, v50, s[56:57]              // wgMT = (wgMT < MT) ? wgMT : MT
+v_lshrrev_b32 v52, 1, v50                          // vectorStaticDiv: v52 = v50 / 2
+v_and_b32 v53, 1, v50                              // vectorStaticDiv: v53 = v50 % 2
+v_lshrrev_b32 v54, 3, v52                          // vectorStaticDiv: v54 = v52 / 8
+v_and_b32 v55, 7, v52                              // vectorStaticDiv: v55 = v52 % 8
+v_and_b32 v56, 7, v[vgprSerial]                    // vectorStaticDiv: v56 = v[vgprSerial] % 8
+v_lshrrev_b32 v57, 4, v50                          // vectorStaticDiv: v57 = v50 / 16
+v_and_b32 v58, 1, v50                              // vectorStaticDiv: v58 = v50 % 2
+v_mov_b32 v59, v58                                 // duplicate
+v_lshrrev_b32 v58, 1, v59                          // vectorStaticDiv: v58 = v59 / 2
+_v_add_co_u32 v58, vcc, v57, v58                   // vId = 2 components
+v_cmp_eq_u32 s[56:57], v56, v55                    // mask
+v_mov_b32 v48, s56                                 //
+v_mov_b32 v49, s57                                 //
+v_cmp_eq_u32 vcc, v53, 0x1                         // wgMT%VW == 1
+s_cbranch_vccnz label_0010                         // shift d0 r=1
+s_branch label_0014                                // no shifting
+
+/******************************************/
+/* shift d0 r=1                           */
+/******************************************/
+label_0010:
+v_cmp_eq_u32 vcc, v58, 0x0                         // wgMT/(SG*VW) == 0
+s_cbranch_vccnz label_0011                         // shift d0, r=1, v=0
+v_cmp_eq_u32 vcc, v58, 0x1                         // wgMT/(SG*VW) == 1
+s_cbranch_vccnz label_0012                         // shift d0, r=1, v=1
+v_cmp_eq_u32 vcc, v58, 0x2                         // wgMT/(SG*VW) == 2
+s_cbranch_vccnz label_0013                         // shift d0, r=1, v=2
+
+/* shift d0 r=1 v=0 */
+label_0011:
+v_cmpx_eq_u32 s[56:57], v56, v55                   // serial % SG == (wgMT/VECTOR_WIDTH)%SG
+// src=1, dst=0
+v_mov_b32 v0, v2                                   // rC[0+0*VW+0*TT0I] = rC[1+0*VW+0*TT0I]
+v_mov_b32 v1, v3                                   // rC[0+0*VW+0*TT0I] = rC[1+0*VW+0*TT0I]
+// src=7, dst=6
+v_mov_b32 v12, v14                                 // rC[0+0*VW+1*TT0I] = rC[1+0*VW+1*TT0I]
+v_mov_b32 v13, v15                                 // rC[0+0*VW+1*TT0I] = rC[1+0*VW+1*TT0I]
+// src=13, dst=12
+v_mov_b32 v24, v26                                 // rC[0+0*VW+2*TT0I] = rC[1+0*VW+2*TT0I]
+v_mov_b32 v25, v27                                 // rC[0+0*VW+2*TT0I] = rC[1+0*VW+2*TT0I]
+// src=19, dst=18
+v_mov_b32 v36, v38                                 // rC[0+0*VW+3*TT0I] = rC[1+0*VW+3*TT0I]
+v_mov_b32 v37, v39                                 // rC[0+0*VW+3*TT0I] = rC[1+0*VW+3*TT0I]
+s_mov_b64 s[56:57], 0xFFFFFFFFFFFFFFFF             // to restore all threads active
+s_or_saveexec_b64 vcc, s[56:57]                    // all threads active
+s_branch label_0014                                // done shifting
+
+/* shift d0 r=1 v=1 */
+label_0012:
+v_cmpx_eq_u32 s[56:57], v56, v55                   // serial % SG == (wgMT/VECTOR_WIDTH)%SG
+// src=3, dst=2
+v_mov_b32 v4, v6                                   // rC[0+1*VW+0*TT0I] = rC[1+1*VW+0*TT0I]
+v_mov_b32 v5, v7                                   // rC[0+1*VW+0*TT0I] = rC[1+1*VW+0*TT0I]
+// src=9, dst=8
+v_mov_b32 v16, v18                                 // rC[0+1*VW+1*TT0I] = rC[1+1*VW+1*TT0I]
+v_mov_b32 v17, v19                                 // rC[0+1*VW+1*TT0I] = rC[1+1*VW+1*TT0I]
+// src=15, dst=14
+v_mov_b32 v28, v30                                 // rC[0+1*VW+2*TT0I] = rC[1+1*VW+2*TT0I]
+v_mov_b32 v29, v31                                 // rC[0+1*VW+2*TT0I] = rC[1+1*VW+2*TT0I]
+// src=21, dst=20
+v_mov_b32 v40, v42                                 // rC[0+1*VW+3*TT0I] = rC[1+1*VW+3*TT0I]
+v_mov_b32 v41, v43                                 // rC[0+1*VW+3*TT0I] = rC[1+1*VW+3*TT0I]
+s_mov_b64 s[56:57], 0xFFFFFFFFFFFFFFFF             // to restore all threads active
+s_or_saveexec_b64 vcc, s[56:57]                    // all threads active
+s_branch label_0014                                // done shifting
+
+/* shift d0 r=1 v=2 */
+label_0013:
+v_cmpx_eq_u32 s[56:57], v56, v55                   // serial % SG == (wgMT/VECTOR_WIDTH)%SG
+// src=5, dst=4
+v_mov_b32 v8, v10                                  // rC[0+2*VW+0*TT0I] = rC[1+2*VW+0*TT0I]
+v_mov_b32 v9, v11                                  // rC[0+2*VW+0*TT0I] = rC[1+2*VW+0*TT0I]
+// src=11, dst=10
+v_mov_b32 v20, v22                                 // rC[0+2*VW+1*TT0I] = rC[1+2*VW+1*TT0I]
+v_mov_b32 v21, v23                                 // rC[0+2*VW+1*TT0I] = rC[1+2*VW+1*TT0I]
+// src=17, dst=16
+v_mov_b32 v32, v34                                 // rC[0+2*VW+2*TT0I] = rC[1+2*VW+2*TT0I]
+v_mov_b32 v33, v35                                 // rC[0+2*VW+2*TT0I] = rC[1+2*VW+2*TT0I]
+// src=23, dst=22
+v_mov_b32 v44, v46                                 // rC[0+2*VW+3*TT0I] = rC[1+2*VW+3*TT0I]
+v_mov_b32 v45, v47                                 // rC[0+2*VW+3*TT0I] = rC[1+2*VW+3*TT0I]
+s_mov_b64 s[56:57], 0xFFFFFFFFFFFFFFFF             // to restore all threads active
+s_or_saveexec_b64 vcc, s[56:57]                    // all threads active
+s_branch label_0014                                // done shifting
+label_0014: // end shift0
+
+
+/* shift vector components d1 */
+
+v_mov_b32 v50, s[sgprWorkGroup1]                   //
+v_mul_i32_i24 v50, -0x40, v50                      // wg*MT
+_v_add_co_u32 v50, vcc, s[sgprSizesFree+1], v50    // wgMT = Size - wg*MT
+v_mov_b32 v48, 0x40                                // MT
+v_cmp_lt_u32 s[56:57], v50, v48                    // wgMT < MT
+v_cndmask_b32 v50, v48, v50, s[56:57]              // wgMT = (wgMT < MT) ? wgMT : MT
+v_lshrrev_b32 v52, 1, v50                          // vectorStaticDiv: v52 = v50 / 2
+v_and_b32 v53, 1, v50                              // vectorStaticDiv: v53 = v50 % 2
+v_lshrrev_b32 v54, 4, v52                          // vectorStaticDiv: v54 = v52 / 16
+v_and_b32 v55, 15, v52                             // vectorStaticDiv: v55 = v52 % 16
+v_lshrrev_b32 v56, 3, v[vgprSerial]                // vectorStaticDiv: v56 = v[vgprSerial] / 8
+v_and_b32 v57, 15, v56                             // vectorStaticDiv: v57 = v56 % 16
+v_lshrrev_b32 v56, 5, v50                          // vectorStaticDiv: v56 = v50 / 32
+v_and_b32 v58, 1, v50                              // vectorStaticDiv: v58 = v50 % 2
+v_mov_b32 v59, v58                                 // duplicate
+v_lshrrev_b32 v58, 1, v59                          // vectorStaticDiv: v58 = v59 / 2
+_v_add_co_u32 v58, vcc, v56, v58                   // vId = 2 components
+v_cmp_eq_u32 s[56:57], v57, v55                    // mask
+v_mov_b32 v48, s56                                 //
+v_mov_b32 v49, s57                                 //
+v_cmp_eq_u32 vcc, v53, 0x1                         // wgMT%VW == 1
+s_cbranch_vccnz label_0018                         // shift d1 r=1
+s_branch label_0021                                // no shifting
+
+/******************************************/
+/* shift d1 r=1                           */
+/******************************************/
+label_0018:
+v_cmp_eq_u32 vcc, v58, 0x0                         // wgMT/(SG*VW) == 0
+s_cbranch_vccnz label_0019                         // shift d1, r=1, v=0
+v_cmp_eq_u32 vcc, v58, 0x1                         // wgMT/(SG*VW) == 1
+s_cbranch_vccnz label_0020                         // shift d1, r=1, v=1
+
+/* shift d1 r=1 v=0 */
+label_0019:
+v_cmpx_eq_u32 s[56:57], v57, v55                   // serial % SG == (wgMT/VECTOR_WIDTH)%SG
+// src=6, dst=0
+v_mov_b32 v0, v12                                  // rC[0+0*TT0I*VW+0*TT0I] = rC[0+0*TT0I*VW+1*TT0I]
+v_mov_b32 v1, v13                                  // rC[0+0*TT0I*VW+0*TT0I] = rC[0+0*TT0I*VW+1*TT0I]
+// src=7, dst=1
+v_mov_b32 v2, v14                                  // rC[1+0*TT0I*VW+0*TT0I] = rC[1+0*TT0I*VW+1*TT0I]
+v_mov_b32 v3, v15                                  // rC[1+0*TT0I*VW+0*TT0I] = rC[1+0*TT0I*VW+1*TT0I]
+// src=8, dst=2
+v_mov_b32 v4, v16                                  // rC[2+0*TT0I*VW+0*TT0I] = rC[2+0*TT0I*VW+1*TT0I]
+v_mov_b32 v5, v17                                  // rC[2+0*TT0I*VW+0*TT0I] = rC[2+0*TT0I*VW+1*TT0I]
+// src=9, dst=3
+v_mov_b32 v6, v18                                  // rC[3+0*TT0I*VW+0*TT0I] = rC[3+0*TT0I*VW+1*TT0I]
+v_mov_b32 v7, v19                                  // rC[3+0*TT0I*VW+0*TT0I] = rC[3+0*TT0I*VW+1*TT0I]
+// src=10, dst=4
+v_mov_b32 v8, v20                                  // rC[4+0*TT0I*VW+0*TT0I] = rC[4+0*TT0I*VW+1*TT0I]
+v_mov_b32 v9, v21                                  // rC[4+0*TT0I*VW+0*TT0I] = rC[4+0*TT0I*VW+1*TT0I]
+// src=11, dst=5
+v_mov_b32 v10, v22                                 // rC[5+0*TT0I*VW+0*TT0I] = rC[5+0*TT0I*VW+1*TT0I]
+v_mov_b32 v11, v23                                 // rC[5+0*TT0I*VW+0*TT0I] = rC[5+0*TT0I*VW+1*TT0I]
+s_mov_b64 s[56:57], 0xFFFFFFFFFFFFFFFF             // to restore all threads active
+s_or_saveexec_b64 vcc, s[56:57]                    // all threads active
+s_branch label_0021                                // done shifting
+
+/* shift d1 r=1 v=1 */
+label_0020:
+v_cmpx_eq_u32 s[56:57], v57, v55                   // serial % SG == (wgMT/VECTOR_WIDTH)%SG
+// src=18, dst=12
+v_mov_b32 v24, v36                                 // rC[0+1*TT0I*VW+0*TT0I] = rC[0+1*TT0I*VW+1*TT0I]
+v_mov_b32 v25, v37                                 // rC[0+1*TT0I*VW+0*TT0I] = rC[0+1*TT0I*VW+1*TT0I]
+// src=19, dst=13
+v_mov_b32 v26, v38                                 // rC[1+1*TT0I*VW+0*TT0I] = rC[1+1*TT0I*VW+1*TT0I]
+v_mov_b32 v27, v39                                 // rC[1+1*TT0I*VW+0*TT0I] = rC[1+1*TT0I*VW+1*TT0I]
+// src=20, dst=14
+v_mov_b32 v28, v40                                 // rC[2+1*TT0I*VW+0*TT0I] = rC[2+1*TT0I*VW+1*TT0I]
+v_mov_b32 v29, v41                                 // rC[2+1*TT0I*VW+0*TT0I] = rC[2+1*TT0I*VW+1*TT0I]
+// src=21, dst=15
+v_mov_b32 v30, v42                                 // rC[3+1*TT0I*VW+0*TT0I] = rC[3+1*TT0I*VW+1*TT0I]
+v_mov_b32 v31, v43                                 // rC[3+1*TT0I*VW+0*TT0I] = rC[3+1*TT0I*VW+1*TT0I]
+// src=22, dst=16
+v_mov_b32 v32, v44                                 // rC[4+1*TT0I*VW+0*TT0I] = rC[4+1*TT0I*VW+1*TT0I]
+v_mov_b32 v33, v45                                 // rC[4+1*TT0I*VW+0*TT0I] = rC[4+1*TT0I*VW+1*TT0I]
+// src=23, dst=17
+v_mov_b32 v34, v46                                 // rC[5+1*TT0I*VW+0*TT0I] = rC[5+1*TT0I*VW+1*TT0I]
+v_mov_b32 v35, v47                                 // rC[5+1*TT0I*VW+0*TT0I] = rC[5+1*TT0I*VW+1*TT0I]
+s_mov_b64 s[56:57], 0xFFFFFFFFFFFFFFFF             // to restore all threads active
+s_or_saveexec_b64 vcc, s[56:57]                    // all threads active
+label_0021: // end shift0
+
+
+
+/* not-LocalSplitU: global write indices */
+
+s_mov_b32 s[sgprSrdD+0], s[sgprAddressD+0]         // init SRD base address (lower)
+s_mov_b32 s[sgprSrdD+1], s[sgprAddressD+1]         // init SRD base address (upper) + other fields
+s_mov_b32 s[sgprSrdD+2], 0x80000000                //
+s_mov_b32 s[sgprSrdD+3], Srd127_96                 // Set bits 127_96 in SRD
+s_mov_b32 s[sgprSrdC+0], s[sgprAddressC+0]         // init SRD base address (lower)
+s_mov_b32 s[sgprSrdC+1], s[sgprAddressC+1]         // init SRD base address (upper) + other fields
+s_mov_b32 s[sgprSrdC+2], 0x80000000                //
+s_mov_b32 s[sgprSrdC+3], Srd127_96                 // Set bits 127_96 in SRD
+
+s_mul_i32 s58, 0x40, s[sgprWorkGroup1]             // <- wg1*MT1
+s_mul_hi_u32 s57, s58, s[sgprStridesC+0]           // Scale s58 by Stride
+s_mul_i32 s56, s58, s[sgprStridesC+0]              // Scale s58 by Stride
+s_lshl_b64 s[56:57], s[56:57], 3                   // scale by bpe
+s_add_u32 s[sgprSrdD+0], s[sgprSrdD+0], s56        // add lo to SRD
+s_addc_u32 s[sgprSrdD+1], s[sgprSrdD+1], s57       // add hi to SRD
+s_add_u32 s[sgprSrdC+0], s[sgprSrdC+0], s56        // add lo to SRD
+s_addc_u32 s[sgprSrdC+1], s[sgprSrdC+1], s57       // add hi to SRD
+
+s_mul_hi_u32 s57, s[sgprWorkGroup2], s[sgprStridesC+1] // Scale s[sgprWorkGroup2] by Stride
+s_mul_i32 s56, s[sgprWorkGroup2], s[sgprStridesC+1] // Scale s[sgprWorkGroup2] by Stride
+s_lshl_b64 s[56:57], s[56:57], 3                   // scale by bpe
+s_add_u32 s[sgprSrdD+0], s[sgprSrdD+0], s56        // add lo to SRD
+s_addc_u32 s[sgprSrdD+1], s[sgprSrdD+1], s57       // add hi to SRD
+s_add_u32 s[sgprSrdC+0], s[sgprSrdC+0], s56        // add lo to SRD
+s_addc_u32 s[sgprSrdC+1], s[sgprSrdC+1], s57       // add hi to SRD
+
+v_lshrrev_b32 v49, 3, v[vgprSerial]                // vectorStaticDiv: v49 = v[vgprSerial] / 8
+v_and_b32 v48, 7, v[vgprSerial]                    // vectorStaticDiv: v48 = v[vgprSerial] % 8
+v_lshlrev_b32 v48, 1, v48                          // staticMultiply: v48 = v48 * 2
+v_lshlrev_b32 v49, 1, v49                          // staticMultiply: v49 = v49 * 2
+v_mul_lo_u32 v50, v49, s[sgprStridesC+0]           // rowStart vgpr
+
+s_mul_i32 s56, 0x30, s[sgprWorkGroup0]             // s56 = wg0*MT0
+_v_add_co_u32 v48, vcc, s56, v48                   // coord0 = tid0*VW + wg0*MT0
+s_mul_i32 s58, 0x40, s[sgprWorkGroup1]             // <- wg1*MT1
+_v_add_co_u32 v49, vcc, s58, v49                   // coord1 = tid1*VW + wg1*MT1
+
+//v_mov_b32 v48,v[vgprLocalWriteAddrA]
+//v_mov_b32 v49,v[vgprLocalWriteAddrB]
+//v_mov_b32 v50,v[vgprGlobalReadOffsetB]           // rowStart vgpr
+//_v_add_lshl_u32 v[vgprGlobalReadOffsetA], v[vgprGlobalReadOffsetB], v[vgprLocalWriteAddrA], 0x3                 // init cb addr <-  rowStart + coord0, scaled by BPE
+
+/* not-LocalSplitU: global write */
+
+s_mov_b32 s56, s[sgprBeta+0]                       // tmp = Beta[0]
+s_or_b32 s56, s[sgprBeta+1], s56                   // tmp |= Beta[1]
+s_cmpk_eq_u32 s56, 0x0                             // Beta == 0
+s_cbranch_scc0 label_0030                          // Beta is not zero; so jump to B nonzero
+
+s_mov_b32 s56, 0x0                                 // rMT0=0
+s_add_u32 s58, -0x1, s[sgprNumWorkGroups0]         //
+s_cmp_lt_u32 s[sgprWorkGroup0], s58                // wg0 < nwg0-1
+s_cbranch_scc1 label_0027                          // wg0 < nwg0-1 so skip rMT0 = Size0 % MT0
+/* TODO-packed- compare against product of all packed C0 sizes not just SizesFree+0 */
+s_mov_b32 s61, 0x0                                 // STATIC_DIV: divisior=48
+s_mul_i32 s60, 0xaaa, s[sgprSizesFree+0]           // tmp1 = dividend * magic hi
+s_lshl_b64 s[60:61], s[60:61], 0x10                // left shift 16 bits
+s_mul_i32 s58, s[sgprSizesFree+0], 0xaaab          // tmp0 = dividend * magic lo
+s_add_u32 s60, s58, s60                            // add lo
+s_addc_u32 s61, s61, 0x0                           // add hi
+s_lshr_b64 s[60:61], s[60:61], 0x21                // tmp1 = (dividend * magic) << shift
+s_mov_b32 s58, s60                                 // quotient
+s_mul_i32 s60, s58, 0x30                           // quotient*divisor
+s_sub_u32 s56, s[sgprSizesFree+0], s60             // rReg = dividend - quotient*divisor
+label_0027:
+s_cmpk_gt_u32 s56, 0x0                             // rMT0 > 0
+s_cbranch_scc1 label_0029                          // edges required so jump to E1
+s_mov_b32 s56, 0x0                                 // rMT1=0
+s_add_u32 s58, -0x1, s[sgprNumWorkGroups1]         //
+s_cmp_lt_u32 s[sgprWorkGroup1], s58                // wg1 < nwg1-1
+s_cbranch_scc1 label_0028                          // wg1 < nwg1-1 so skip rMT1 = Size1 % MT1
+s_lshr_b32 s58, s[sgprSizesFree+1], 6              // s58 = s[sgprSizesFree+1] / 64
+s_and_b32 s56, 63, s[sgprSizesFree+1]              // s56 = s[sgprSizesFree+1] % 64
+label_0028:
+s_cmpk_gt_u32 s56, 0x0                             // rMT1 > 0
+s_cbranch_scc1 label_0029                          // edges required so jump to E1
+label_0026:
+
+/******************************************/
+/* Global Write Batch #0 (d1,d0,vc1,vc0) =
+   (0,0,0,0:vw2); (0,1,0,0:vw2); (0,2,0,0:vw2); (0,0,1,0:vw2); (0,1,1,0:vw2); (0,2,1,0:vw2); (1,0,0,0:vw2); (1,1,0,0:vw2); (1,2,0,0:vw2); (1,0,1,0:vw2); (1,1,1,0:vw2); (1,2,1,0:vw2) */
+/******************************************/
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(0,0,0,0) coordOffset1=0 element-rows coordOffset0=0 rows */
+_v_add_lshl_u32 v54, v50, v48, 0x3                 // init cb addr <-  rowStart + coord0, scaled by BPE
+/* (d1,vc1,d0,vc0)=(0,0,1,0) coordOffset1=0 element-rows coordOffset0=16 rows */
+/* (d1,vc1,d0,vc0)=(0,0,2,0) coordOffset1=0 element-rows coordOffset0=32 rows */
+/* (d1,vc1,d0,vc0)=(0,1,0,0) coordOffset1=1 element-rows coordOffset0=0 rows */
+/* (d1,vc1,d0,vc0)=(0,1,1,0) coordOffset1=1 element-rows coordOffset0=16 rows */
+/* (d1,vc1,d0,vc0)=(0,1,2,0) coordOffset1=1 element-rows coordOffset0=32 rows */
+/* (d1,vc1,d0,vc0)=(1,0,0,0) coordOffset1=32 element-rows coordOffset0=0 rows */
+/* (d1,vc1,d0,vc0)=(1,0,1,0) coordOffset1=32 element-rows coordOffset0=16 rows */
+/* (d1,vc1,d0,vc0)=(1,0,2,0) coordOffset1=32 element-rows coordOffset0=32 rows */
+/* (d1,vc1,d0,vc0)=(1,1,0,0) coordOffset1=33 element-rows coordOffset0=0 rows */
+/* (d1,vc1,d0,vc0)=(1,1,1,0) coordOffset1=33 element-rows coordOffset0=16 rows */
+/* (d1,vc1,d0,vc0)=(1,1,2,0) coordOffset1=33 element-rows coordOffset0=32 rows */
+
+/* rC *= alpha batchEements=[(0, 0, 0, 0), (0, 1, 0, 0), (0, 2, 0, 0), (0, 0, 1, 0), (0, 1, 1, 0), (0, 2, 1, 0), (1, 0, 0, 0), (1, 1, 0, 0), (1, 2, 0, 0), (1, 0, 1, 0), (1, 1, 1, 0), (1, 2, 1, 0)] */
+//v_mul_f64 v[vgprValuC+0:vgprValuC+0+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+0:vgprValuC+0+1] // *= alpha
+//v_mul_f64 v[vgprValuC+2:vgprValuC+2+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+2:vgprValuC+2+1] // *= alpha
+//v_mul_f64 v[vgprValuC+4:vgprValuC+4+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+4:vgprValuC+4+1] // *= alpha
+//v_mul_f64 v[vgprValuC+6:vgprValuC+6+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+6:vgprValuC+6+1] // *= alpha
+//v_mul_f64 v[vgprValuC+8:vgprValuC+8+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+8:vgprValuC+8+1] // *= alpha
+//v_mul_f64 v[vgprValuC+10:vgprValuC+10+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+10:vgprValuC+10+1] // *= alpha
+//v_mul_f64 v[vgprValuC+12:vgprValuC+12+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+12:vgprValuC+12+1] // *= alpha
+//v_mul_f64 v[vgprValuC+14:vgprValuC+14+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+14:vgprValuC+14+1] // *= alpha
+//v_mul_f64 v[vgprValuC+16:vgprValuC+16+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+16:vgprValuC+16+1] // *= alpha
+//v_mul_f64 v[vgprValuC+18:vgprValuC+18+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+18:vgprValuC+18+1] // *= alpha
+//v_mul_f64 v[vgprValuC+20:vgprValuC+20+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+20:vgprValuC+20+1] // *= alpha
+//v_mul_f64 v[vgprValuC+22:vgprValuC+22+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+22:vgprValuC+22+1] // *= alpha
+//v_mul_f64 v[vgprValuC+24:vgprValuC+24+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+24:vgprValuC+24+1] // *= alpha
+//v_mul_f64 v[vgprValuC+26:vgprValuC+26+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+26:vgprValuC+26+1] // *= alpha
+//v_mul_f64 v[vgprValuC+28:vgprValuC+28+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+28:vgprValuC+28+1] // *= alpha
+//v_mul_f64 v[vgprValuC+30:vgprValuC+30+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+30:vgprValuC+30+1] // *= alpha
+//v_mul_f64 v[vgprValuC+32:vgprValuC+32+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+32:vgprValuC+32+1] // *= alpha
+//v_mul_f64 v[vgprValuC+34:vgprValuC+34+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+34:vgprValuC+34+1] // *= alpha
+//v_mul_f64 v[vgprValuC+36:vgprValuC+36+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+36:vgprValuC+36+1] // *= alpha
+//v_mul_f64 v[vgprValuC+38:vgprValuC+38+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+38:vgprValuC+38+1] // *= alpha
+//v_mul_f64 v[vgprValuC+40:vgprValuC+40+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+40:vgprValuC+40+1] // *= alpha
+//v_mul_f64 v[vgprValuC+42:vgprValuC+42+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+42:vgprValuC+42+1] // *= alpha
+//v_mul_f64 v[vgprValuC+44:vgprValuC+44+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+44:vgprValuC+44+1] // *= alpha
+//v_mul_f64 v[vgprValuC+46:vgprValuC+46+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+46:vgprValuC+46+1] // *= alpha
+
+/* apply mask, calc new C and issue write */
+buffer_store_dwordx4 v[0:3], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx4 v[4:7], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+buffer_store_dwordx4 v[8:11], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+buffer_store_dwordx4 v[12:15], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx4 v[16:19], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+buffer_store_dwordx4 v[20:23], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_mul_i32 s56, s[sgprStridesC+0], 248              // scale StrideC *= 31 * bpe
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+buffer_store_dwordx4 v[24:27], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx4 v[28:31], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+buffer_store_dwordx4 v[32:35], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+buffer_store_dwordx4 v[36:39], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx4 v[40:43], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+buffer_store_dwordx4 v[44:47], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_branch label_0037                                // jump to end
+label_0029:
+
+/******************************************/
+/* Global Write Edge Batch #0 (d1,d0,vc1,vc0) =
+   (0,0,0,0:vw1); (0,0,0,1:vw1); (0,1,0,0:vw1); (0,1,0,1:vw1); (0,2,0,0:vw1); (0,2,0,1:vw1); (0,0,1,0:vw1); (0,0,1,1:vw1); (0,1,1,0:vw1); (0,1,1,1:vw1); (0,2,1,0:vw1); (0,2,1,1:vw1); (1,0,0,0:vw1); (1,0,0,1:vw1); (1,1,0,0:vw1); (1,1,0,1:vw1); (1,2,0,0:vw1); (1,2,0,1:vw1) */
+/******************************************/
+
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(0,0,0,0) coordOffset1=0 element-rows coordOffset0=0 rows */
+v_mov_b32 v51, v50                                 // rowPtr <- rowStart (first row)
+_v_add_lshl_u32 v54, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[62:63], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v54, -1, v54, s[62:63]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,0,0,1) coordOffset1=0 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v55, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[64:65], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v55, -1, v55, s[64:65]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,0,1,0) coordOffset1=0 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v56, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[66:67], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v56, -1, v56, s[66:67]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,0,1,1) coordOffset1=0 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v57, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[68:69], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v57, -1, v57, s[68:69]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,0,2,0) coordOffset1=0 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v58, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[70:71], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v58, -1, v58, s[70:71]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,0,2,1) coordOffset1=0 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v59, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[72:73], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v59, -1, v59, s[72:73]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,1,0,0) coordOffset1=1 element-rows coordOffset0=0 rows */
+_v_add_co_u32 v53, vcc, v49, 1                     // coord1 += d1*sg1*VW + vc1
+_v_add_co_u32 v51, vcc, v51, s[sgprStridesC+0]     // rowPtr <- move to start of new row
+_v_add_lshl_u32 v60, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[74:75], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v60, -1, v60, s[74:75]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,1,0,1) coordOffset1=1 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v61, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[76:77], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v61, -1, v61, s[76:77]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,1,1,0) coordOffset1=1 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v62, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[78:79], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v62, -1, v62, s[78:79]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,1,1,1) coordOffset1=1 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v63, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[80:81], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v63, -1, v63, s[80:81]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,1,2,0) coordOffset1=1 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v64, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[82:83], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v64, -1, v64, s[82:83]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,1,2,1) coordOffset1=1 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v65, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[84:85], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v65, -1, v65, s[84:85]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,0,0,0) coordOffset1=32 element-rows coordOffset0=0 rows */
+_v_add_co_u32 v53, vcc, v49, 32                    // coord1 += d1*sg1*VW + vc1
+s_mul_i32 s56, s[sgprStridesC+0], 32               // scale StrideC *= coordOffset1(32)
+_v_add_co_u32 v51, vcc, v50, s56                   // rowPtr <- inc for non-0 (tt1+vc1))
+_v_add_lshl_u32 v66, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[86:87], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v66, -1, v66, s[86:87]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,0,0,1) coordOffset1=32 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v67, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[88:89], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v67, -1, v67, s[88:89]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,0,1,0) coordOffset1=32 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v68, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[90:91], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v68, -1, v68, s[90:91]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,0,1,1) coordOffset1=32 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v69, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[92:93], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v69, -1, v69, s[92:93]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,0,2,0) coordOffset1=32 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v70, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[94:95], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v70, -1, v70, s[94:95]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,0,2,1) coordOffset1=32 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v71, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[96:97], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v71, -1, v71, s[96:97]               // clip if OOB. offset
+
+/* rC *= alpha batchEements=[(0, 0, 0, 0), (0, 0, 0, 1), (0, 1, 0, 0), (0, 1, 0, 1), (0, 2, 0, 0), (0, 2, 0, 1), (0, 0, 1, 0), (0, 0, 1, 1), (0, 1, 1, 0), (0, 1, 1, 1), (0, 2, 1, 0), (0, 2, 1, 1), (1, 0, 0, 0), (1, 0, 0, 1), (1, 1, 0, 0), (1, 1, 0, 1), (1, 2, 0, 0), (1, 2, 0, 1)] */
+//v_mul_f64 v[vgprValuC+0:vgprValuC+0+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+0:vgprValuC+0+1] // *= alpha
+//v_mul_f64 v[vgprValuC+2:vgprValuC+2+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+2:vgprValuC+2+1] // *= alpha
+//v_mul_f64 v[vgprValuC+4:vgprValuC+4+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+4:vgprValuC+4+1] // *= alpha
+//v_mul_f64 v[vgprValuC+6:vgprValuC+6+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+6:vgprValuC+6+1] // *= alpha
+//v_mul_f64 v[vgprValuC+8:vgprValuC+8+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+8:vgprValuC+8+1] // *= alpha
+//v_mul_f64 v[vgprValuC+10:vgprValuC+10+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+10:vgprValuC+10+1] // *= alpha
+//v_mul_f64 v[vgprValuC+12:vgprValuC+12+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+12:vgprValuC+12+1] // *= alpha
+//v_mul_f64 v[vgprValuC+14:vgprValuC+14+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+14:vgprValuC+14+1] // *= alpha
+//v_mul_f64 v[vgprValuC+16:vgprValuC+16+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+16:vgprValuC+16+1] // *= alpha
+//v_mul_f64 v[vgprValuC+18:vgprValuC+18+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+18:vgprValuC+18+1] // *= alpha
+//v_mul_f64 v[vgprValuC+20:vgprValuC+20+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+20:vgprValuC+20+1] // *= alpha
+//v_mul_f64 v[vgprValuC+22:vgprValuC+22+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+22:vgprValuC+22+1] // *= alpha
+//v_mul_f64 v[vgprValuC+24:vgprValuC+24+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+24:vgprValuC+24+1] // *= alpha
+//v_mul_f64 v[vgprValuC+26:vgprValuC+26+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+26:vgprValuC+26+1] // *= alpha
+//v_mul_f64 v[vgprValuC+28:vgprValuC+28+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+28:vgprValuC+28+1] // *= alpha
+//v_mul_f64 v[vgprValuC+30:vgprValuC+30+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+30:vgprValuC+30+1] // *= alpha
+//v_mul_f64 v[vgprValuC+32:vgprValuC+32+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+32:vgprValuC+32+1] // *= alpha
+//v_mul_f64 v[vgprValuC+34:vgprValuC+34+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+34:vgprValuC+34+1] // *= alpha
+
+/* apply mask, calc new C and issue write */
+buffer_store_dwordx2 v[0:1], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[2:3], v55, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[4:5], v56, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[6:7], v57, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[8:9], v58, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[10:11], v59, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[12:13], v60, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[14:15], v61, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[16:17], v62, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[18:19], v63, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[20:21], v64, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[22:23], v65, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[24:25], v66, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[26:27], v67, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[28:29], v68, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[30:31], v69, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[32:33], v70, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[34:35], v71, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+/******************************************/
+/* Global Write Edge Batch #1 (d1,d0,vc1,vc0) =
+   (1,0,1,0:vw1); (1,0,1,1:vw1); (1,1,1,0:vw1); (1,1,1,1:vw1); (1,2,1,0:vw1); (1,2,1,1:vw1) */
+/******************************************/
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(1,1,0,0) coordOffset1=33 element-rows coordOffset0=0 rows */
+_v_add_co_u32 v53, vcc, v49, 33                    // coord1 += d1*sg1*VW + vc1
+_v_add_co_u32 v51, vcc, v51, s[sgprStridesC+0]     // rowPtr <- move to start of new row
+_v_add_lshl_u32 v54, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[62:63], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v54, -1, v54, s[62:63]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,1,0,1) coordOffset1=33 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v55, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[64:65], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v55, -1, v55, s[64:65]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,1,1,0) coordOffset1=33 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v56, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[66:67], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v56, -1, v56, s[66:67]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,1,1,1) coordOffset1=33 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v57, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[68:69], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v57, -1, v57, s[68:69]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,1,2,0) coordOffset1=33 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v58, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[70:71], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v58, -1, v58, s[70:71]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,1,2,1) coordOffset1=33 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v59, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[72:73], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v59, -1, v59, s[72:73]               // clip if OOB. offset
+
+/* rC *= alpha batchEements=[(1, 0, 1, 0), (1, 0, 1, 1), (1, 1, 1, 0), (1, 1, 1, 1), (1, 2, 1, 0), (1, 2, 1, 1)] */
+//v_mul_f64 v[vgprValuC+36:vgprValuC+36+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+36:vgprValuC+36+1] // *= alpha
+//v_mul_f64 v[vgprValuC+38:vgprValuC+38+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+38:vgprValuC+38+1] // *= alpha
+//v_mul_f64 v[vgprValuC+40:vgprValuC+40+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+40:vgprValuC+40+1] // *= alpha
+//v_mul_f64 v[vgprValuC+42:vgprValuC+42+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+42:vgprValuC+42+1] // *= alpha
+//v_mul_f64 v[vgprValuC+44:vgprValuC+44+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+44:vgprValuC+44+1] // *= alpha
+//v_mul_f64 v[vgprValuC+46:vgprValuC+46+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+46:vgprValuC+46+1] // *= alpha
+
+/* apply mask, calc new C and issue write */
+buffer_store_dwordx2 v[36:37], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[38:39], v55, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[40:41], v56, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[42:43], v57, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[44:45], v58, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[46:47], v59, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_branch label_0037                                // jump to end
+label_0030:
+s_mov_b32 s56, 0x0                                 // rMT0=0
+s_add_u32 s58, -0x1, s[sgprNumWorkGroups0]         //
+s_cmp_lt_u32 s[sgprWorkGroup0], s58                // wg0 < nwg0-1
+s_cbranch_scc1 label_0034                          // wg0 < nwg0-1 so skip rMT0 = Size0 % MT0
+/* TODO-packed- compare against product of all packed C0 sizes not just SizesFree+0 */
+s_mov_b32 s61, 0x0                                 // STATIC_DIV: divisior=48
+s_mul_i32 s60, 0xaaa, s[sgprSizesFree+0]           // tmp1 = dividend * magic hi
+s_lshl_b64 s[60:61], s[60:61], 0x10                // left shift 16 bits
+s_mul_i32 s58, s[sgprSizesFree+0], 0xaaab          // tmp0 = dividend * magic lo
+s_add_u32 s60, s58, s60                            // add lo
+s_addc_u32 s61, s61, 0x0                           // add hi
+s_lshr_b64 s[60:61], s[60:61], 0x21                // tmp1 = (dividend * magic) << shift
+s_mov_b32 s58, s60                                 // quotient
+s_mul_i32 s60, s58, 0x30                           // quotient*divisor
+s_sub_u32 s56, s[sgprSizesFree+0], s60             // rReg = dividend - quotient*divisor
+label_0034:
+s_cmpk_gt_u32 s56, 0x0                             // rMT0 > 0
+s_cbranch_scc1 label_0036                          // edges required so jump to E1
+s_mov_b32 s56, 0x0                                 // rMT1=0
+s_add_u32 s58, -0x1, s[sgprNumWorkGroups1]         //
+s_cmp_lt_u32 s[sgprWorkGroup1], s58                // wg1 < nwg1-1
+s_cbranch_scc1 label_0035                          // wg1 < nwg1-1 so skip rMT1 = Size1 % MT1
+s_lshr_b32 s58, s[sgprSizesFree+1], 6              // s58 = s[sgprSizesFree+1] / 64
+s_and_b32 s56, 63, s[sgprSizesFree+1]              // s56 = s[sgprSizesFree+1] % 64
+label_0035:
+s_cmpk_gt_u32 s56, 0x0                             // rMT1 > 0
+s_cbranch_scc1 label_0036                          // edges required so jump to E1
+label_0033:
+
+/******************************************/
+/* Global Write Beta Batch #0 (d1,d0,vc1,vc0) =
+   (0,0,0,0:vw2); (0,1,0,0:vw2); (0,2,0,0:vw2); (0,0,1,0:vw2); (0,1,1,0:vw2); (0,2,1,0:vw2) */
+/******************************************/
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(0,0,0,0) coordOffset1=0 element-rows coordOffset0=0 rows */
+_v_add_lshl_u32 v54, v[vgprGlobalReadOffsetB], v48, 0x3                 // init cb addr <-  rowStart + coord0, scaled by BPE
+buffer_load_dwordx4 v[55:58], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,1,0) coordOffset1=0 element-rows coordOffset0=16 rows */
+buffer_load_dwordx4 v[59:62], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,2,0) coordOffset1=0 element-rows coordOffset0=32 rows */
+buffer_load_dwordx4 v[63:66], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,0,0) coordOffset1=1 element-rows coordOffset0=0 rows */
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+buffer_load_dwordx4 v[67:70], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,1,0) coordOffset1=1 element-rows coordOffset0=16 rows */
+buffer_load_dwordx4 v[71:74], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,2,0) coordOffset1=1 element-rows coordOffset0=32 rows */
+buffer_load_dwordx4 v[75:78], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+
+/* rC *= alpha batchEements=[(0, 0, 0, 0), (0, 1, 0, 0), (0, 2, 0, 0), (0, 0, 1, 0), (0, 1, 1, 0), (0, 2, 1, 0)] */
+v_mul_f64 v[vgprValuC+0:vgprValuC+0+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+0:vgprValuC+0+1] // *= alpha
+v_mul_f64 v[vgprValuC+2:vgprValuC+2+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+2:vgprValuC+2+1] // *= alpha
+v_mul_f64 v[vgprValuC+4:vgprValuC+4+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+4:vgprValuC+4+1] // *= alpha
+v_mul_f64 v[vgprValuC+6:vgprValuC+6+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+6:vgprValuC+6+1] // *= alpha
+v_mul_f64 v[vgprValuC+8:vgprValuC+8+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+8:vgprValuC+8+1] // *= alpha
+v_mul_f64 v[vgprValuC+10:vgprValuC+10+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+10:vgprValuC+10+1] // *= alpha
+v_mul_f64 v[vgprValuC+12:vgprValuC+12+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+12:vgprValuC+12+1] // *= alpha
+v_mul_f64 v[vgprValuC+14:vgprValuC+14+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+14:vgprValuC+14+1] // *= alpha
+v_mul_f64 v[vgprValuC+16:vgprValuC+16+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+16:vgprValuC+16+1] // *= alpha
+v_mul_f64 v[vgprValuC+18:vgprValuC+18+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+18:vgprValuC+18+1] // *= alpha
+v_mul_f64 v[vgprValuC+20:vgprValuC+20+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+20:vgprValuC+20+1] // *= alpha
+v_mul_f64 v[vgprValuC+22:vgprValuC+22+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+22:vgprValuC+22+1] // *= alpha
+
+/* apply mask, calc new C and issue write */
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+0:vgprValuC+0+1], v[55:56], s[sgprBeta:sgprBeta+1], v[vgprValuC+0:vgprValuC+0+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+2:vgprValuC+2+1], v[57:58], s[sgprBeta:sgprBeta+1], v[vgprValuC+2:vgprValuC+2+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[0:3], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+4:vgprValuC+4+1], v[59:60], s[sgprBeta:sgprBeta+1], v[vgprValuC+4:vgprValuC+4+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+6:vgprValuC+6+1], v[61:62], s[sgprBeta:sgprBeta+1], v[vgprValuC+6:vgprValuC+6+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[4:7], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+8:vgprValuC+8+1], v[63:64], s[sgprBeta:sgprBeta+1], v[vgprValuC+8:vgprValuC+8+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+10:vgprValuC+10+1], v[65:66], s[sgprBeta:sgprBeta+1], v[vgprValuC+10:vgprValuC+10+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[8:11], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+12:vgprValuC+12+1], v[67:68], s[sgprBeta:sgprBeta+1], v[vgprValuC+12:vgprValuC+12+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+14:vgprValuC+14+1], v[69:70], s[sgprBeta:sgprBeta+1], v[vgprValuC+14:vgprValuC+14+1] // finalSum = sum*alpha + C*beta
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+buffer_store_dwordx4 v[12:15], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+16:vgprValuC+16+1], v[71:72], s[sgprBeta:sgprBeta+1], v[vgprValuC+16:vgprValuC+16+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+18:vgprValuC+18+1], v[73:74], s[sgprBeta:sgprBeta+1], v[vgprValuC+18:vgprValuC+18+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[16:19], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+20:vgprValuC+20+1], v[75:76], s[sgprBeta:sgprBeta+1], v[vgprValuC+20:vgprValuC+20+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+22:vgprValuC+22+1], v[77:78], s[sgprBeta:sgprBeta+1], v[vgprValuC+22:vgprValuC+22+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[20:23], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+
+/******************************************/
+/* Global Write Beta Batch #1 (d1,d0,vc1,vc0) =
+   (1,0,0,0:vw2); (1,1,0,0:vw2); (1,2,0,0:vw2); (1,0,1,0:vw2); (1,1,1,0:vw2); (1,2,1,0:vw2) */
+/******************************************/
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(1,0,0,0) coordOffset1=32 element-rows coordOffset0=0 rows */
+s_mul_i32 s56, s[sgprStridesD+0], 248              // scale StrideC *= 31 * bpe
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+buffer_load_dwordx4 v[55:58], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,1,0) coordOffset1=32 element-rows coordOffset0=16 rows */
+buffer_load_dwordx4 v[59:62], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,2,0) coordOffset1=32 element-rows coordOffset0=32 rows */
+buffer_load_dwordx4 v[63:66], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,0,0) coordOffset1=33 element-rows coordOffset0=0 rows */
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+buffer_load_dwordx4 v[67:70], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,1,0) coordOffset1=33 element-rows coordOffset0=16 rows */
+buffer_load_dwordx4 v[71:74], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,2,0) coordOffset1=33 element-rows coordOffset0=32 rows */
+buffer_load_dwordx4 v[75:78], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+
+/* rC *= alpha batchEements=[(1, 0, 0, 0), (1, 1, 0, 0), (1, 2, 0, 0), (1, 0, 1, 0), (1, 1, 1, 0), (1, 2, 1, 0)] */
+v_mul_f64 v[vgprValuC+24:vgprValuC+24+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+24:vgprValuC+24+1] // *= alpha
+v_mul_f64 v[vgprValuC+26:vgprValuC+26+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+26:vgprValuC+26+1] // *= alpha
+v_mul_f64 v[vgprValuC+28:vgprValuC+28+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+28:vgprValuC+28+1] // *= alpha
+v_mul_f64 v[vgprValuC+30:vgprValuC+30+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+30:vgprValuC+30+1] // *= alpha
+v_mul_f64 v[vgprValuC+32:vgprValuC+32+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+32:vgprValuC+32+1] // *= alpha
+v_mul_f64 v[vgprValuC+34:vgprValuC+34+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+34:vgprValuC+34+1] // *= alpha
+v_mul_f64 v[vgprValuC+36:vgprValuC+36+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+36:vgprValuC+36+1] // *= alpha
+v_mul_f64 v[vgprValuC+38:vgprValuC+38+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+38:vgprValuC+38+1] // *= alpha
+v_mul_f64 v[vgprValuC+40:vgprValuC+40+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+40:vgprValuC+40+1] // *= alpha
+v_mul_f64 v[vgprValuC+42:vgprValuC+42+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+42:vgprValuC+42+1] // *= alpha
+v_mul_f64 v[vgprValuC+44:vgprValuC+44+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+44:vgprValuC+44+1] // *= alpha
+v_mul_f64 v[vgprValuC+46:vgprValuC+46+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+46:vgprValuC+46+1] // *= alpha
+
+/* apply mask, calc new C and issue write */
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+24:vgprValuC+24+1], v[55:56], s[sgprBeta:sgprBeta+1], v[vgprValuC+24:vgprValuC+24+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+26:vgprValuC+26+1], v[57:58], s[sgprBeta:sgprBeta+1], v[vgprValuC+26:vgprValuC+26+1] // finalSum = sum*alpha + C*beta
+s_mul_i32 s56, s[sgprStridesD+0], 248              // scale StrideC *= 31 * bpe
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+buffer_store_dwordx4 v[24:27], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+28:vgprValuC+28+1], v[59:60], s[sgprBeta:sgprBeta+1], v[vgprValuC+28:vgprValuC+28+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+30:vgprValuC+30+1], v[61:62], s[sgprBeta:sgprBeta+1], v[vgprValuC+30:vgprValuC+30+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[28:31], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+32:vgprValuC+32+1], v[63:64], s[sgprBeta:sgprBeta+1], v[vgprValuC+32:vgprValuC+32+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+34:vgprValuC+34+1], v[65:66], s[sgprBeta:sgprBeta+1], v[vgprValuC+34:vgprValuC+34+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[32:35], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+36:vgprValuC+36+1], v[67:68], s[sgprBeta:sgprBeta+1], v[vgprValuC+36:vgprValuC+36+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+38:vgprValuC+38+1], v[69:70], s[sgprBeta:sgprBeta+1], v[vgprValuC+38:vgprValuC+38+1] // finalSum = sum*alpha + C*beta
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+buffer_store_dwordx4 v[36:39], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+40:vgprValuC+40+1], v[71:72], s[sgprBeta:sgprBeta+1], v[vgprValuC+40:vgprValuC+40+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+42:vgprValuC+42+1], v[73:74], s[sgprBeta:sgprBeta+1], v[vgprValuC+42:vgprValuC+42+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[40:43], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+44:vgprValuC+44+1], v[75:76], s[sgprBeta:sgprBeta+1], v[vgprValuC+44:vgprValuC+44+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+46:vgprValuC+46+1], v[77:78], s[sgprBeta:sgprBeta+1], v[vgprValuC+46:vgprValuC+46+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[44:47], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_branch label_0037                                // jump to end
+label_0036:
+
+/******************************************/
+/* Global Write Beta Edge Batch #0 (d1,d0,vc1,vc0) =
+   (0,0,0,0:vw1); (0,0,0,1:vw1); (0,1,0,0:vw1); (0,1,0,1:vw1); (0,2,0,0:vw1); (0,2,0,1:vw1); (0,0,1,0:vw1); (0,0,1,1:vw1) */
+/******************************************/
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(0,0,0,0) coordOffset1=0 element-rows coordOffset0=0 rows */
+v_mov_b32 v51, v50                                 // rowPtr <- rowStart (first row)
+_v_add_lshl_u32 v54, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[62:63], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v54, -1, v54, s[62:63]               // clip if OOB. offset
+buffer_load_dwordx2 v[55:56], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,0,1) coordOffset1=0 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v57, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[64:65], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v57, -1, v57, s[64:65]               // clip if OOB. offset
+buffer_load_dwordx2 v[58:59], v57, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,1,0) coordOffset1=0 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v60, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[66:67], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v60, -1, v60, s[66:67]               // clip if OOB. offset
+buffer_load_dwordx2 v[61:62], v60, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,1,1) coordOffset1=0 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v63, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[68:69], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v63, -1, v63, s[68:69]               // clip if OOB. offset
+buffer_load_dwordx2 v[64:65], v63, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,2,0) coordOffset1=0 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v66, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[70:71], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v66, -1, v66, s[70:71]               // clip if OOB. offset
+buffer_load_dwordx2 v[67:68], v66, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,2,1) coordOffset1=0 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v69, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[72:73], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v69, -1, v69, s[72:73]               // clip if OOB. offset
+buffer_load_dwordx2 v[70:71], v69, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,0,0) coordOffset1=1 element-rows coordOffset0=0 rows */
+_v_add_co_u32 v53, vcc, v49, 1                     // coord1 += d1*sg1*VW + vc1
+_v_add_co_u32 v51, vcc, v51, s[sgprStridesC+0]     // rowPtr <- move to start of new row
+_v_add_lshl_u32 v72, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[74:75], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v72, -1, v72, s[74:75]               // clip if OOB. offset
+buffer_load_dwordx2 v[73:74], v72, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,0,1) coordOffset1=1 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v75, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[76:77], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v75, -1, v75, s[76:77]               // clip if OOB. offset
+buffer_load_dwordx2 v[76:77], v75, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+
+/* rC *= alpha batchEements=[(0, 0, 0, 0), (0, 0, 0, 1), (0, 1, 0, 0), (0, 1, 0, 1), (0, 2, 0, 0), (0, 2, 0, 1), (0, 0, 1, 0), (0, 0, 1, 1)] */
+v_mul_f64 v[vgprValuC+0:vgprValuC+0+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+0:vgprValuC+0+1] // *= alpha
+v_mul_f64 v[vgprValuC+2:vgprValuC+2+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+2:vgprValuC+2+1] // *= alpha
+v_mul_f64 v[vgprValuC+4:vgprValuC+4+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+4:vgprValuC+4+1] // *= alpha
+v_mul_f64 v[vgprValuC+6:vgprValuC+6+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+6:vgprValuC+6+1] // *= alpha
+v_mul_f64 v[vgprValuC+8:vgprValuC+8+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+8:vgprValuC+8+1] // *= alpha
+v_mul_f64 v[vgprValuC+10:vgprValuC+10+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+10:vgprValuC+10+1] // *= alpha
+v_mul_f64 v[vgprValuC+12:vgprValuC+12+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+12:vgprValuC+12+1] // *= alpha
+v_mul_f64 v[vgprValuC+14:vgprValuC+14+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+14:vgprValuC+14+1] // *= alpha
+s_waitcnt vmcnt(0)                                 // wait C
+
+/* apply mask, calc new C and issue write */
+v_fma_f64 v[vgprValuC+0:vgprValuC+0+1], v[55:56], s[sgprBeta:sgprBeta+1], v[vgprValuC+0:vgprValuC+0+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[0:1], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+2:vgprValuC+2+1], v[58:59], s[sgprBeta:sgprBeta+1], v[vgprValuC+2:vgprValuC+2+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[2:3], v57, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+4:vgprValuC+4+1], v[61:62], s[sgprBeta:sgprBeta+1], v[vgprValuC+4:vgprValuC+4+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[4:5], v60, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+6:vgprValuC+6+1], v[64:65], s[sgprBeta:sgprBeta+1], v[vgprValuC+6:vgprValuC+6+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[6:7], v63, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+8:vgprValuC+8+1], v[67:68], s[sgprBeta:sgprBeta+1], v[vgprValuC+8:vgprValuC+8+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[8:9], v66, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+10:vgprValuC+10+1], v[70:71], s[sgprBeta:sgprBeta+1], v[vgprValuC+10:vgprValuC+10+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[10:11], v69, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+12:vgprValuC+12+1], v[73:74], s[sgprBeta:sgprBeta+1], v[vgprValuC+12:vgprValuC+12+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[12:13], v72, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+14:vgprValuC+14+1], v[76:77], s[sgprBeta:sgprBeta+1], v[vgprValuC+14:vgprValuC+14+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[14:15], v75, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+/******************************************/
+/* Global Write Beta Edge Batch #1 (d1,d0,vc1,vc0) =
+   (0,1,1,0:vw1); (0,1,1,1:vw1); (0,2,1,0:vw1); (0,2,1,1:vw1); (1,0,0,0:vw1); (1,0,0,1:vw1); (1,1,0,0:vw1); (1,1,0,1:vw1) */
+/******************************************/
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(0,1,1,0) coordOffset1=1 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v54, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[62:63], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v54, -1, v54, s[62:63]               // clip if OOB. offset
+buffer_load_dwordx2 v[55:56], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,1,1) coordOffset1=1 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v57, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[64:65], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v57, -1, v57, s[64:65]               // clip if OOB. offset
+buffer_load_dwordx2 v[58:59], v57, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,2,0) coordOffset1=1 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v60, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[66:67], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v60, -1, v60, s[66:67]               // clip if OOB. offset
+buffer_load_dwordx2 v[61:62], v60, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,2,1) coordOffset1=1 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v63, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[68:69], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v63, -1, v63, s[68:69]               // clip if OOB. offset
+buffer_load_dwordx2 v[64:65], v63, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,0,0) coordOffset1=32 element-rows coordOffset0=0 rows */
+_v_add_co_u32 v53, vcc, v49, 32                    // coord1 += d1*sg1*VW + vc1
+s_mul_i32 s56, s[sgprStridesC+0], 32               // scale StrideC *= coordOffset1(32)
+_v_add_co_u32 v51, vcc, v50, s56                   // rowPtr <- inc for non-0 (tt1+vc1))
+_v_add_lshl_u32 v66, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[70:71], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v66, -1, v66, s[70:71]               // clip if OOB. offset
+buffer_load_dwordx2 v[67:68], v66, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,0,1) coordOffset1=32 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v69, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[72:73], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v69, -1, v69, s[72:73]               // clip if OOB. offset
+buffer_load_dwordx2 v[70:71], v69, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,1,0) coordOffset1=32 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v72, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[74:75], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v72, -1, v72, s[74:75]               // clip if OOB. offset
+buffer_load_dwordx2 v[73:74], v72, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,1,1) coordOffset1=32 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v75, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[76:77], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v75, -1, v75, s[76:77]               // clip if OOB. offset
+buffer_load_dwordx2 v[76:77], v75, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+
+/* rC *= alpha batchEements=[(0, 1, 1, 0), (0, 1, 1, 1), (0, 2, 1, 0), (0, 2, 1, 1), (1, 0, 0, 0), (1, 0, 0, 1), (1, 1, 0, 0), (1, 1, 0, 1)] */
+v_mul_f64 v[vgprValuC+16:vgprValuC+16+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+16:vgprValuC+16+1] // *= alpha
+v_mul_f64 v[vgprValuC+18:vgprValuC+18+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+18:vgprValuC+18+1] // *= alpha
+v_mul_f64 v[vgprValuC+20:vgprValuC+20+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+20:vgprValuC+20+1] // *= alpha
+v_mul_f64 v[vgprValuC+22:vgprValuC+22+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+22:vgprValuC+22+1] // *= alpha
+v_mul_f64 v[vgprValuC+24:vgprValuC+24+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+24:vgprValuC+24+1] // *= alpha
+v_mul_f64 v[vgprValuC+26:vgprValuC+26+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+26:vgprValuC+26+1] // *= alpha
+v_mul_f64 v[vgprValuC+28:vgprValuC+28+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+28:vgprValuC+28+1] // *= alpha
+v_mul_f64 v[vgprValuC+30:vgprValuC+30+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+30:vgprValuC+30+1] // *= alpha
+s_waitcnt vmcnt(0)                                 // wait C
+
+/* apply mask, calc new C and issue write */
+v_fma_f64 v[vgprValuC+16:vgprValuC+16+1], v[55:56], s[sgprBeta:sgprBeta+1], v[vgprValuC+16:vgprValuC+16+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[16:17], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+18:vgprValuC+18+1], v[58:59], s[sgprBeta:sgprBeta+1], v[vgprValuC+18:vgprValuC+18+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[18:19], v57, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+20:vgprValuC+20+1], v[61:62], s[sgprBeta:sgprBeta+1], v[vgprValuC+20:vgprValuC+20+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[20:21], v60, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+22:vgprValuC+22+1], v[64:65], s[sgprBeta:sgprBeta+1], v[vgprValuC+22:vgprValuC+22+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[22:23], v63, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+24:vgprValuC+24+1], v[67:68], s[sgprBeta:sgprBeta+1], v[vgprValuC+24:vgprValuC+24+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[24:25], v66, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+26:vgprValuC+26+1], v[70:71], s[sgprBeta:sgprBeta+1], v[vgprValuC+26:vgprValuC+26+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[26:27], v69, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+28:vgprValuC+28+1], v[73:74], s[sgprBeta:sgprBeta+1], v[vgprValuC+28:vgprValuC+28+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[28:29], v72, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+30:vgprValuC+30+1], v[76:77], s[sgprBeta:sgprBeta+1], v[vgprValuC+30:vgprValuC+30+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[30:31], v75, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+/******************************************/
+/* Global Write Beta Edge Batch #2 (d1,d0,vc1,vc0) =
+   (1,2,0,0:vw1); (1,2,0,1:vw1); (1,0,1,0:vw1); (1,0,1,1:vw1); (1,1,1,0:vw1); (1,1,1,1:vw1); (1,2,1,0:vw1); (1,2,1,1:vw1) */
+/******************************************/
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(1,0,2,0) coordOffset1=32 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v54, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[62:63], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v54, -1, v54, s[62:63]               // clip if OOB. offset
+buffer_load_dwordx2 v[55:56], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,2,1) coordOffset1=32 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v57, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[64:65], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v57, -1, v57, s[64:65]               // clip if OOB. offset
+buffer_load_dwordx2 v[58:59], v57, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,0,0) coordOffset1=33 element-rows coordOffset0=0 rows */
+_v_add_co_u32 v53, vcc, v49, 33                    // coord1 += d1*sg1*VW + vc1
+_v_add_co_u32 v51, vcc, v51, s[sgprStridesC+0]     // rowPtr <- move to start of new row
+_v_add_lshl_u32 v60, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[66:67], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v60, -1, v60, s[66:67]               // clip if OOB. offset
+buffer_load_dwordx2 v[61:62], v60, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,0,1) coordOffset1=33 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v63, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[68:69], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v63, -1, v63, s[68:69]               // clip if OOB. offset
+buffer_load_dwordx2 v[64:65], v63, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,1,0) coordOffset1=33 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v66, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[70:71], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v66, -1, v66, s[70:71]               // clip if OOB. offset
+buffer_load_dwordx2 v[67:68], v66, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,1,1) coordOffset1=33 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v69, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[72:73], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v69, -1, v69, s[72:73]               // clip if OOB. offset
+buffer_load_dwordx2 v[70:71], v69, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,2,0) coordOffset1=33 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v72, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[74:75], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v72, -1, v72, s[74:75]               // clip if OOB. offset
+buffer_load_dwordx2 v[73:74], v72, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,2,1) coordOffset1=33 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v75, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[76:77], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v75, -1, v75, s[76:77]               // clip if OOB. offset
+buffer_load_dwordx2 v[76:77], v75, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+
+/* rC *= alpha batchEements=[(1, 2, 0, 0), (1, 2, 0, 1), (1, 0, 1, 0), (1, 0, 1, 1), (1, 1, 1, 0), (1, 1, 1, 1), (1, 2, 1, 0), (1, 2, 1, 1)] */
+v_mul_f64 v[vgprValuC+32:vgprValuC+32+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+32:vgprValuC+32+1] // *= alpha
+v_mul_f64 v[vgprValuC+34:vgprValuC+34+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+34:vgprValuC+34+1] // *= alpha
+v_mul_f64 v[vgprValuC+36:vgprValuC+36+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+36:vgprValuC+36+1] // *= alpha
+v_mul_f64 v[vgprValuC+38:vgprValuC+38+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+38:vgprValuC+38+1] // *= alpha
+v_mul_f64 v[vgprValuC+40:vgprValuC+40+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+40:vgprValuC+40+1] // *= alpha
+v_mul_f64 v[vgprValuC+42:vgprValuC+42+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+42:vgprValuC+42+1] // *= alpha
+v_mul_f64 v[vgprValuC+44:vgprValuC+44+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+44:vgprValuC+44+1] // *= alpha
+v_mul_f64 v[vgprValuC+46:vgprValuC+46+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+46:vgprValuC+46+1] // *= alpha
+s_waitcnt vmcnt(0)                                 // wait C
+
+/* apply mask, calc new C and issue write */
+v_fma_f64 v[vgprValuC+32:vgprValuC+32+1], v[55:56], s[sgprBeta:sgprBeta+1], v[vgprValuC+32:vgprValuC+32+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[32:33], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+34:vgprValuC+34+1], v[58:59], s[sgprBeta:sgprBeta+1], v[vgprValuC+34:vgprValuC+34+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[34:35], v57, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+36:vgprValuC+36+1], v[61:62], s[sgprBeta:sgprBeta+1], v[vgprValuC+36:vgprValuC+36+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[36:37], v60, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+38:vgprValuC+38+1], v[64:65], s[sgprBeta:sgprBeta+1], v[vgprValuC+38:vgprValuC+38+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[38:39], v63, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+40:vgprValuC+40+1], v[67:68], s[sgprBeta:sgprBeta+1], v[vgprValuC+40:vgprValuC+40+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[40:41], v66, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+42:vgprValuC+42+1], v[70:71], s[sgprBeta:sgprBeta+1], v[vgprValuC+42:vgprValuC+42+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[42:43], v69, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+44:vgprValuC+44+1], v[73:74], s[sgprBeta:sgprBeta+1], v[vgprValuC+44:vgprValuC+44+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[44:45], v72, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+46:vgprValuC+46+1], v[76:77], s[sgprBeta:sgprBeta+1], v[vgprValuC+46:vgprValuC+46+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[46:47], v75, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_branch label_0037                                // jump to end
+label_0037:
+
+label_0038:  /// KernelEnd
+s_endpgm                                           // Kernel End
+
+

--- a/Tensile/ReplacementKernels-cov3/Cijk_Ailk_Bjlk_DB_MT48x64x4_AF0EM1_ASEM1_FL1_GRVW2_ISA908_MDA2_PGR1_PLR0_SU0_TT6_4_VAW1_VW2_WG8_16_1_WGM4.s.txt
+++ b/Tensile/ReplacementKernels-cov3/Cijk_Ailk_Bjlk_DB_MT48x64x4_AF0EM1_ASEM1_FL1_GRVW2_ISA908_MDA2_PGR1_PLR0_SU0_TT6_4_VAW1_VW2_WG8_16_1_WGM4.s.txt
@@ -1,0 +1,3897 @@
+
+
+/******************************************/
+/* Function Prefix                        */
+/******************************************/
+
+
+
+/******************************************/
+/* Begin Kernel                           */
+/******************************************/
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx908+sram-ecc"
+.text
+.protected Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM4
+.globl Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM4
+.p2align 8
+.type Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM4,@function
+.section .rodata,#alloc
+.p2align 6
+.amdhsa_kernel Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM4
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_next_free_vgpr 84 // vgprs
+  .amdhsa_next_free_sgpr 98 // sgprs
+  .amdhsa_group_segment_fixed_size 7680 // lds bytes
+  .amdhsa_private_segment_fixed_size 0
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+.text
+
+.amdgpu_metadata
+---
+amdhsa.version:
+  - 1
+  - 0
+amdhsa.kernels:
+  - .name: Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM4
+    .symbol: 'Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM4.kd'
+    .group_segment_fixed_size:   7680
+    .language:                   OpenCL C
+    .language_version:
+      - 2
+      - 0
+    .max_flat_workgroup_size: 128
+    .private_segment_fixed_size: 0
+    .sgpr_count:                 98
+    .sgpr_spill_count:           0
+    .vgpr_count:                 84
+    .vgpr_spill_count:           0
+    .wavefront_size:             64
+    .args:
+      - .name:            sizeC
+        .size:            8
+        .offset:          0
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            sizeA
+        .size:            8
+        .offset:          8
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            sizeB
+        .size:            8
+        .offset:          16
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            D
+        .size:            8
+        .offset:          24
+        .value_kind:      global_buffer
+        .value_type:      f64
+        .address_space:   generic
+      - .name:            C
+        .size:            8
+        .offset:          32
+        .value_kind:      global_buffer
+        .value_type:      f64
+        .address_space:   generic
+      - .name:            A
+        .size:            8
+        .offset:          40
+        .value_kind:      global_buffer
+        .value_type:      f64
+        .address_space:   generic
+      - .name:            B
+        .size:            8
+        .offset:          48
+        .value_kind:      global_buffer
+        .value_type:      f64
+        .address_space:   generic
+      - .name:            alpha
+        .size:            8
+        .offset:          56
+        .value_kind:      by_value
+        .value_type:      f64
+      - .name:            beta
+        .size:            8
+        .offset:          64
+        .value_kind:      by_value
+        .value_type:      f64
+      - .name:            strideD0
+        .size:            4
+        .offset:          72
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideD1
+        .size:            4
+        .offset:          76
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideC0
+        .size:            4
+        .offset:          80
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideC1
+        .size:            4
+        .offset:          84
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideA0
+        .size:            4
+        .offset:          88
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideA1
+        .size:            4
+        .offset:          92
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideB0
+        .size:            4
+        .offset:          96
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideB1
+        .size:            4
+        .offset:          100
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree0
+        .size:            4
+        .offset:          104
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree1
+        .size:            4
+        .offset:          108
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree2
+        .size:            4
+        .offset:          112
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesSum0
+        .size:            4
+        .offset:          116
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            OrigStaggerUIter
+        .size:            4
+        .offset:          120
+        .value_kind:      by_value
+        .value_type:      i32
+      - .name:            NumWorkGroups0
+        .size:            4
+        .offset:          124
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            NumWorkGroups1
+        .size:            4
+        .offset:          128
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            MagicNumberProblemNumGroupTiles0
+        .size:            4
+        .offset:          132
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            GridNumWorkGroups0
+        .size:            4
+        .offset:          136
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            NumFullBlocks
+        .size:            4
+        .offset:          140
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            WgmRemainder1
+        .size:            4
+        .offset:          144
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            MagicNumberWgmRemainder1
+        .size:            4
+        .offset:          148
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            padding
+        .size:            4
+        .offset:          152
+        .value_kind:      by_value
+        .value_type:      u32
+    .kernarg_segment_align:      8
+    .kernarg_segment_size:       160
+...
+.end_amdgpu_metadata
+Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM4:
+
+/******************************************/
+/* Optimizations and Config:              */
+/******************************************/
+/* ThreadTile= 6 x 4 */
+/* SubGroup= 8 x 16 */
+/* VectorWidth=2 */
+/* GlobalLoadVectorWidthA=2, GlobalLoadVectorWidthB=2 */
+/* DirectToLdsA=False */
+/* DirectToLdsB=False */
+/* UseSgprForGRO=False */
+
+/******************************************/
+/* Asm syntax workarounds                 */
+/******************************************/
+.macro _v_add_co_u32 dst, cc, src0, src1, dpp=
+   v_add_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+.macro _v_sub_co_u32 dst, cc, src0, src1, dpp=
+   v_sub_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+.macro _v_addc_co_u32 dst, ccOut, src0, ccIn, src1, dpp=
+   v_addc_co_u32 \dst, \ccOut, \src0, \ccIn, \src1 \dpp
+.endm
+.macro _v_add_lshl_u32 dst, src0, src1, shiftCnt
+    v_add_lshl_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+.macro _v_lshl_add_u32 dst, src0, src1, shiftCnt
+    v_lshl_add_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+/******************************************/
+/* Magic div and mod functions            */
+/******************************************/
+.macro V_MAGIC_DIV dstIdx, dividend, magicNumber, magicShift
+    v_mul_lo_u32 v[\dstIdx+0], \dividend, \magicNumber
+    v_mul_hi_u32 v[\dstIdx+1], \dividend, \magicNumber
+    v_lshrrev_b64 v[\dstIdx:\dstIdx+1], \magicShift, v[\dstIdx:\dstIdx+1]
+.endm
+
+/******************************************/
+/* VGPR Assignments                       */
+/******************************************/
+.set vgprValuC, 0
+/* ValuA/B   Xn=PLR buffer idx,  In=InnerUnroll idx */
+.set vgprValuA_X0_I0, 48
+.set vgprG2LA, 60
+.set vgprValuB_X0_I0, 64
+.set vgprG2LB, 72
+.set vgprLocalWriteAddrA, 76
+.set vgprLocalWriteAddrB, 77
+.set vgprGlobalReadOffsetA, 78
+.set vgprGlobalReadOffsetB, 79
+.set vgprLocalReadAddrA, 80
+.set vgprLocalReadAddrB, 81
+.set vgprSerial, 82
+/* Num VGPR=83 */
+
+/******************************************/
+/* SGPR Assignments                       */
+/******************************************/
+.set sgprKernArgAddress, 0
+.set sgprWorkGroup0, 2
+.set sgprWorkGroup1, 3
+.set sgprWorkGroup2, 4
+.set sgprNumWorkGroups0, 5
+.set sgprNumWorkGroups1, 6
+.set sgprSrdA, 8
+.set sgprSrdB, 12
+.set sgprSrdD, 16
+.set sgprSrdC, 20
+.set sgprTensor2dSizeC, 24
+.set sgprTensor2dSizeA, 26
+.set sgprTensor2dSizeB, 28
+.set sgprSaveExecMask, 30
+.set sgprAddressD, 32
+.set sgprAddressC, 34
+.set sgprStridesC, 36
+.set sgprAlpha, 38
+.set sgprBeta, 40
+.set sgprSizesFree, 42
+.set sgprSizesSum, 45
+.set sgprLoopCounters, 46
+.set sgprOrigLoopCounter, 47
+.set sgprStridesA, 48
+.set sgprStridesB, 50
+.set sgprAddressA, 52
+.set sgprAddressB, 54
+.set sgprShadowLimitA, 56
+.set sgprShadowLimitB, 58
+.set sgprNumFullBlocks, 60
+.set sgprWgmRemainder1, 61
+.set sgprMagicNumberWgmRemainder1, 62
+.set sgprGlobalReadIncsA, 63
+.set sgprGlobalReadIncsB, 64
+.set sgprStridesD, 74
+.set sgprTMP0, 90
+.set sgprTMP1, 91
+.set sgprEdgeSelMask0, 93
+.set sgprEdgeSelMask1, 94
+/* max SGPR=98 */
+
+/******************************************/
+/* 2GB limit - set offsets to -1 to exceed this and clamp */
+/******************************************/
+.set BufferLimit, 0x80000000
+
+/******************************************/
+/* Bits 127:96 of SRD.  Set DataFormat = 32 bit */
+/******************************************/
+.set Srd127_96, 0x0020000
+.set BufferOOB, 0x80000000
+
+/* Global Offset A */
+.macro GLOBAL_OFFSET_A vgprAddr vgprOffset0I vgprOffsetL vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStridesA+0], v[\vgprOffsetL] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprTmp+0], v[\vgprOffset0I] // accumulate d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, 0x2, v[\vgprAddr+0] // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x3, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/* Global Offset B */
+.macro GLOBAL_OFFSET_B vgprAddr vgprOffset1J vgprOffsetL vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStridesB+0], v[\vgprOffsetL] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprTmp+0], v[\vgprOffset1J] // accumulate d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, 0x2, v[\vgprAddr+0] // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x3, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/******************************************/
+/* Dynamic Scalar Divide: vQuotient=vDividend/vDivisor; vRemainder=vDividend%vDivisor; */
+/******************************************/
+.macro DYNAMIC_VECTOR_DIVIDE vQuotient vRemainder vDividend vDivisor vTmp0 vTmp1 sTmp
+v_cvt_f32_u32 v[\vQuotient], v[\vDivisor]          //
+v_rcp_f32 v[\vQuotient], v[\vQuotient]             //
+v_mul_f32 v[\vQuotient], 0x4f800000, v[\vQuotient] //
+v_cvt_u32_f32 v[\vQuotient], v[\vQuotient]         //
+v_mul_lo_u32 v[\vRemainder], v[\vDivisor], v[\vQuotient] //
+v_mul_hi_u32 v[\vTmp0], v[\vDivisor], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp1], vcc, 0x0, v[\vRemainder]  //
+v_cmp_ne_i32 s[\sTmp:\sTmp+1], 0x0, v[\vTmp0]      //
+v_cndmask_b32 v[\vRemainder], v[\vTmp1], v[\vRemainder], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vRemainder], v[\vRemainder], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vQuotient], v[\vRemainder] //
+_v_add_co_u32 v[\vQuotient], vcc, v[\vQuotient], v[\vRemainder] //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vTmp0], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vQuotient], v[\vQuotient], v[\vDividend] //
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vDividend], v[\vRemainder] //
+v_cmp_ge_u32 s[\sTmp:\sTmp+1], v[\vDividend], v[\vRemainder] //
+_v_add_co_u32 v[\vRemainder], vcc, 0x1, v[\vQuotient] //
+_v_add_co_u32 v[\vTmp1], vcc, -1, v[\vQuotient]    //
+v_cmp_le_u32 vcc, v[\vDivisor], v[\vTmp0]          //
+s_and_b64 vcc, s[\sTmp:\sTmp+1], vcc               //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vRemainder], vcc //
+v_cndmask_b32 v[\vQuotient], v[\vTmp1], v[\vQuotient], s[\sTmp:\sTmp+1] //
+v_cmp_ne_i32 vcc, 0x0, v[\vDivisor]                //
+v_cndmask_b32 v[\vQuotient], -1, v[\vQuotient], vcc // final result
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vRemainder], vcc, v[\vDividend], v[\vRemainder] // final result
+.endm
+
+/******************************************/
+/* 6x4 thread-tile                        */
+/******************************************/
+.macro MAC_6x4_X0
+v_fma_f64 v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1]
+s_setprio 1 // Raise priority while processing macs
+v_fma_f64 v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1]
+s_setprio 0 // Reset priority after macs
+.endm
+
+.macro MAC_6x4_X0_part_1
+v_fma_f64 v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1]
+s_setprio 1 // Raise priority while processing macs
+v_fma_f64 v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1]
+.endm
+
+.macro MAC_6x4_X0_part_2
+.endm
+
+.macro MAC_6x4_X0_part_3
+v_fma_f64 v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1]
+s_setprio 0 // Reset Priority
+.endm
+
+.macro MAC_6x4_X0_unprio_0
+v_fma_f64 v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1]
+s_setprio 1 // Raise priority while processing macs
+v_fma_f64 v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1]
+.endm
+
+
+.macro MAC_6x4_X0_part1
+v_fma_f64 v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1]
+s_setprio 1
+v_fma_f64 v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1]
+s_setprio 0
+.endm
+
+
+.macro MAC_6x4_X0_part2
+v_fma_f64 v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1]
+s_setprio 1
+v_fma_f64 v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1]
+s_setprio 0
+.endm
+.macro MAC_6x4_X0_part3
+v_fma_f64 v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1]
+s_setprio 1
+v_fma_f64 v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1]
+s_setprio 0
+.endm
+.macro MAC_6x4_X0_part4
+v_fma_f64 v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1]
+s_setprio 1
+v_fma_f64 v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1]
+//vnop_4
+s_setprio 0
+.endm
+.macro MAC_6x4_X0_part5
+v_fma_f64 v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1]
+s_setprio 1
+v_fma_f64 v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1]
+//vnop_4
+s_setprio 0
+.endm
+.macro MAC_6x4_X0_part6
+v_fma_f64 v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1]
+s_setprio 1
+v_fma_f64 v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1]
+s_setprio 0
+.endm
+
+/******************************************/
+/* Allocate Resources                     */
+/******************************************/
+
+s_mov_b32 m0, 0x1e00                               // LDS clamp at 7680 bytes
+v_mov_b32 v[vgprSerial], v0                        // thread serial id
+
+/* Load Kernel Args */
+s_load_dword s[sgprTensor2dSizeC+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x0 //
+s_load_dword s[sgprTensor2dSizeC+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x4 //
+s_load_dword s[sgprTensor2dSizeA+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x8 //
+s_load_dword s[sgprTensor2dSizeA+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0xc //
+s_load_dword s[sgprTensor2dSizeB+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x10 //
+s_load_dword s[sgprTensor2dSizeB+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x14 //
+s_load_dword s[sgprAddressD], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x18 //
+s_load_dword s[sgprAddressD+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x1c //
+s_load_dword s[sgprAddressC], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x20 //
+s_load_dword s[sgprAddressC+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x24 //
+s_load_dword s[sgprAddressA], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x28 //
+s_load_dword s[sgprAddressA+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x2c //
+s_load_dword s[sgprAddressB], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x30 //
+s_load_dword s[sgprAddressB+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x34 //
+s_load_dword s[sgprAlpha+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x38 //
+s_load_dword s[sgprAlpha+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x3c //
+s_load_dword s[sgprBeta+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x40 //
+s_load_dword s[sgprBeta+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x44 //
+s_load_dword s[sgprStridesD+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x48 //
+s_load_dword s[sgprStridesD+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x4c //
+s_load_dword s[sgprStridesC+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x50 //
+s_load_dword s[sgprStridesC+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x54 //
+s_load_dword s[sgprStridesA+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x58 //
+s_load_dword s[sgprStridesA+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x5c //
+s_load_dword s[sgprStridesB+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x60 //
+s_load_dword s[sgprStridesB+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x64 //
+s_load_dword s[sgprSizesFree+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x68 //
+s_load_dword s[sgprSizesFree+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x6c //
+s_load_dword s[sgprSizesFree+2], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x70 //
+s_load_dword s[sgprSizesSum+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x74 //
+s_load_dword s[sgprNumWorkGroups0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x7c //
+s_load_dword s[sgprNumWorkGroups1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x80 //
+s_load_dword s[sgprNumFullBlocks], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x8c //
+s_load_dword s[sgprWgmRemainder1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x90 //
+s_load_dword s[sgprMagicNumberWgmRemainder1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x94 //
+s_waitcnt lgkmcnt(0)                               // wait for 144 bytes of kern args
+
+
+/******************************************/
+/* Local Read Addresses                   */
+/******************************************/
+
+
+/* local read addresses: tile assignments a */
+
+/*lr0I = serial % SG0I*/
+v_lshrrev_b32 v0, 3, v[vgprSerial]                 // vectorStaticDiv: v0 = v[vgprSerial] / 8
+v_and_b32 v1, 7, v[vgprSerial]                     // vectorStaticDiv: v1 = v[vgprSerial] % 8
+
+
+/* local read addresses: tile assignments b */
+
+/*lr1J = (serial / SG1J) % SG1J*/
+v_lshrrev_b32 v2, 4, v0                            // vectorStaticDiv: v2 = v0 / 16
+v_and_b32 v3, 15, v0                               // vectorStaticDiv: v3 = v0 % 16
+
+
+/* local read addresses: final offsets a */
+
+v_lshrrev_b32 v0, 7, v[vgprSerial]                 // vectorStaticDiv: v0 = v[vgprSerial] / 128
+v_and_b32 v2, 127, v[vgprSerial]                   // vectorStaticDiv: v2 = v[vgprSerial] % 128
+s_mov_b32 s65, 0x30                                // MT0+PAD
+v_mul_lo_u32 v0, s65, v0                           // sgid=sgid*(MT0+PAD)
+v_lshlrev_b32 v1, 1, v1                            // staticMultiply: v1 = v1 * 2
+_v_add_lshl_u32 v[vgprLocalReadAddrA], v0, v1, 0x3 // o = (lroA*VW+sgid*MT0)*bpe
+
+
+/* local read addresses: final offsets b */
+
+v_lshrrev_b32 v0, 7, v[vgprSerial]                 // vectorStaticDiv: v0 = v[vgprSerial] / 128
+v_and_b32 v1, 127, v[vgprSerial]                   // vectorStaticDiv: v1 = v[vgprSerial] % 128
+s_mov_b32 s65, 0x40                                // MT1+PAD
+v_mul_lo_u32 v0, s65, v0                           // sgid=sgid*(MT1+PAD)
+v_lshlrev_b32 v3, 1, v3                            // staticMultiply: v3 = v3 * 2
+_v_add_lshl_u32 v[vgprLocalReadAddrB], v0, v3, 0x3 // o = (lroB*VW+sgid*MT1)*bpe
+
+
+/* local read addresses: declare addresses a */
+
+/* N/A */
+
+
+/* local read addresses: declare addresses b */
+
+_v_add_co_u32 v[vgprLocalReadAddrB+0], vcc, 0x600, v[vgprLocalReadAddrB+0] //  += LdsOffsetB (lower)
+
+
+s_load_dword s[sgprNumWorkGroups1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x80 //
+s_load_dword s[sgprNumFullBlocks], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x8c //
+s_load_dword s[sgprWgmRemainder1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x90 //
+s_load_dword s[sgprMagicNumberWgmRemainder1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x94 //
+/******************************************/
+/* Global Read Addresses                  */
+/******************************************/
+
+
+/* global read addresses: work-group */
+
+/* graWorkGroup mapping */
+s_mov_b32 s69, 0x20000001L                         // magic number for WGM==4
+s_mul_hi_u32 s67, s[sgprWorkGroup1], s69           // s_magic mul
+s_mul_i32 s66, s[sgprWorkGroup1], s69              // s_magic mul
+s_lshr_b64 s[66:67], s[66:67], 31                  // sMagicDiv
+s_mul_i32 s67, s66, 4                              // quotient * non-magic divisor
+s_sub_u32 s67, s[sgprWorkGroup1], s67              // WorkGroup1=remainder
+s_mul_i32 s67, s67, s[sgprNumWorkGroups0]          // (wg1 % WGM)*nwg0
+s_add_u32 s67, s67, s[sgprWorkGroup0]              // wgSerial = wg0 + (wg1 % WGM)*nwg0
+s_cmp_ge_u32 s66, s[sgprNumFullBlocks]             // blockId >= numFullBlocks ?
+s_cmov_b32 s69, s[sgprMagicNumberWgmRemainder1]    //
+s_cselect_b32 s68, s[sgprWgmRemainder1], 4         //
+s_mul_hi_u32 s3, s67, s69                          // s_magic mul
+s_mul_i32 s2, s67, s69                             // s_magic mul
+s_lshr_b64 s[2:3], s[2:3], 31                      // sMagicDiv
+s_mul_i32 s[sgprWorkGroup1], s[sgprWorkGroup0], s68 // quotient * non-magic divisor
+s_sub_u32 s[sgprWorkGroup1], s67, s[sgprWorkGroup1] // WorkGroup1=remainder
+s_mul_i32 s66, s66, 4                              // blockId * WGM
+s_add_u32 s[sgprWorkGroup1], s[sgprWorkGroup1], s66 // wg1 += blockId * WGM
+
+
+/* global read addresses: tile offset assignment a */
+
+/* LVCA = 24 */
+/* v0 = (local)groA-tile = serial%LVCA (note (wgA*MTA) will be added to SRD) */
+/* v1 = groA-unroll = serial/LVCA */
+s_mov_b32 s65, 0x15555556                          //
+v_mul_hi_u32 v3, v[vgprSerial], s65                //
+v_mul_lo_u32 v2, v[vgprSerial], s65                //
+v_lshrrev_b64 v[2:3], 0x21, v[2:3]                 //
+v_mov_b32 v1, v2                                   // vectorStaticDiv: quotient
+s_mov_b32 s65, 0x18                                // divisor
+v_mul_lo_u32 v2, v1, s65                           // vectorStaticDiv: product = quotient * divisor
+_v_sub_co_u32 v0, vcc, v[vgprSerial], v2           // vectorStaticDiv: remainder = dividend - product
+/* gro-tile *= glvw */
+v_lshlrev_b32 v0, 1, v0                            // staticMultiply: v0 = v0 * 2
+
+
+/* global read addresses: tile offset assignment b */
+
+/* LVCB = 32 */
+/* v2 = (local)groB-tile = serial%LVCB (note (wgB*MTB) will be added to SRD) */
+/* v3 = groB-unroll = serial/LVCB */
+v_lshrrev_b32 v3, 5, v[vgprSerial]                 // vectorStaticDiv: v3 = v[vgprSerial] / 32
+v_and_b32 v2, 31, v[vgprSerial]                    // vectorStaticDiv: v2 = v[vgprSerial] % 32
+/* gro-tile *= glvw */
+v_lshlrev_b32 v2, 1, v2                            // staticMultiply: v2 = v2 * 2
+
+
+/* global read addresses: unroll assignment a */
+
+/* v1 */
+
+
+/* global read addresses: unroll assignment b */
+
+/* v3 */
+
+
+/* global read addresses: other free assignments */
+
+/* s[sgprWorkGroup2] */
+
+
+/* global read addresses: tile offsets a */
+
+v_mov_b32 v4, v0                                   // groA0I_0
+
+
+/* global read addresses: tile offsets b */
+
+v_mov_b32 v5, v2                                   // groB1J_0
+
+
+/* global read addresses: unroll offsets a */
+
+v_mov_b32 v6, v1                                   // groAL_0
+
+
+/* global read addresses: unroll offsets b */
+
+v_mov_b32 v7, v3                                   // groBL_0
+
+
+/* global read addresses: shift a */
+
+s_mul_i32 s65, s[sgprWorkGroup0], 48               // WorkGroup[01] * MT
+s_sub_u32 s65, s[sgprSizesFree+0], s65             // edge = Size0I - WG*MT
+s_sub_u32 s65, s65, 2                              // edge -= margin
+v_mov_b32 v8, s65                                  // edge vgpr = Size0I-2
+_v_add_co_u32 v9, vcc, v8, 2                       // add srdShiftLift
+_v_add_co_u32 v10, vcc, v4, 2                      //
+v_cmp_lt_u32 s[66:67], v10, v9                     // offset < edge
+v_cndmask_b32 v4, v8, v4, s[66:67]                 // offset = (offset < edge) ? offset : edge
+
+
+/* global read addresses: shift b */
+
+s_mul_i32 s65, s[sgprWorkGroup1], 64               // WorkGroup[01] * MT
+s_sub_u32 s65, s[sgprSizesFree+1], s65             // edge = Size1J - WG*MT
+s_sub_u32 s65, s65, 2                              // edge -= margin
+v_mov_b32 v8, s65                                  // edge vgpr = Size1J-2
+_v_add_co_u32 v9, vcc, v8, 2                       // add srdShiftLift
+_v_add_co_u32 v10, vcc, v5, 2                      //
+v_cmp_lt_u32 s[66:67], v10, v9                     // offset < edge
+v_cndmask_b32 v5, v8, v5, s[66:67]                 // offset = (offset < edge) ? offset : edge
+
+
+/* global read addresses: final offsets a */
+
+GLOBAL_OFFSET_A vgprGlobalReadOffsetA+0,  4,  6, 8 // gROA_0_0_0_0
+// Offset only valid for 96/128 threads inside the PerLoadTile
+s_mov_b32 s66, 96                                  //
+v_cmp_lt_u32 vcc, v[vgprSerial], s66               // tid < valid-tid
+s_mov_b32 s66, BufferOOB                           //
+v_mov_b32 v11, s66                                 //
+v_cndmask_b32 v[vgprGlobalReadOffsetA+0], v11, v[vgprGlobalReadOffsetA+0], vcc // Mask load so OOB will return 0
+
+
+/* global read addresses: final offsets b */
+
+GLOBAL_OFFSET_B vgprGlobalReadOffsetB+0,  5,  7, 8 // gROB_0_0_0_0
+
+
+/* global read addresses: addresses a */
+
+/* max read offset = size[n] * stride[n-1] */
+s_mul_hi_u32 s69, s[sgprWorkGroup0], 48            // WorkGroup[01] * MT
+s_mul_i32 s68, s[sgprWorkGroup0], 48               // WorkGroup[01] * MT
+s_sub_u32 s[sgprShadowLimitA+0], s[sgprTensor2dSizeA], s68 // sub tileStart
+s_subb_u32 s[sgprShadowLimitA+1], s[sgprTensor2dSizeA+1], s69 // sub tileStart
+s_lshl_b64 s[sgprShadowLimitA:sgprShadowLimitA+1], s[sgprShadowLimitA:sgprShadowLimitA+1], 0x3 // Set limit to use bytes
+s_add_u32 s[sgprShadowLimitA+0], s[sgprShadowLimitA+0], 16 // extend limit for pre-pad
+s_addc_u32 s[sgprShadowLimitA+1], s[sgprShadowLimitA+1], 0 // extend limit for pre-pad
+s_cmp_eq_u32 s[sgprShadowLimitA+1], 0              // are we within 2^32?
+s_cselect_b32 s[sgprSrdA+2], s[sgprShadowLimitA+0], BufferLimit // Move shadow to real if we are within 2^32
+s_mul_hi_u32 s67, s[sgprStridesA+1], s[sgprWorkGroup2] // Stride*WG
+s_mul_i32 s66, s[sgprStridesA+1], s[sgprWorkGroup2] // Stride*WG
+s_add_u32 s68, s68, s66                            // accum wg term to tilestart
+s_addc_u32 s69, s69, s67                           // accum wg term to tilestart
+s_lshl_b64 s[68:69], s[68:69], 3                   // tileStart *= BPE
+s_add_u32 s[sgprSrdA+0], s[sgprAddressA+0], s68    // SRD base = Address+ tileStart0
+s_addc_u32 s[sgprSrdA+1], s[sgprAddressA+1], s69   // SRD base = Address+ tileStart1
+s_sub_u32 s[sgprSrdA+0], s[sgprSrdA+0], 16         // pre-pad to make room for possible pointer shift
+s_subb_u32 s[sgprSrdA+1], s[sgprSrdA+1], 0         // pre-pad to make room for possible pointer shift
+s_mov_b32 s[sgprSrdA+3], Srd127_96                 // Set bits 127_96 in SRD
+
+
+/* global read addresses: addresses b */
+
+/* max read offset = size[n] * stride[n-1] */
+s_mul_hi_u32 s69, s[sgprWorkGroup1], 64            // WorkGroup[01] * MT
+s_mul_i32 s68, s[sgprWorkGroup1], 64               // WorkGroup[01] * MT
+s_sub_u32 s[sgprShadowLimitB+0], s[sgprTensor2dSizeB], s68 // sub tileStart
+s_subb_u32 s[sgprShadowLimitB+1], s[sgprTensor2dSizeB+1], s69 // sub tileStart
+s_lshl_b64 s[sgprShadowLimitB:sgprShadowLimitB+1], s[sgprShadowLimitB:sgprShadowLimitB+1], 0x3 // Set limit to use bytes
+s_add_u32 s[sgprShadowLimitB+0], s[sgprShadowLimitB+0], 16 // extend limit for pre-pad
+s_addc_u32 s[sgprShadowLimitB+1], s[sgprShadowLimitB+1], 0 // extend limit for pre-pad
+s_cmp_eq_u32 s[sgprShadowLimitB+1], 0              // are we within 2^32?
+s_cselect_b32 s[sgprSrdB+2], s[sgprShadowLimitB+0], BufferLimit // Move shadow to real if we are within 2^32
+s_mul_hi_u32 s67, s[sgprStridesB+1], s[sgprWorkGroup2] // Stride*WG
+s_mul_i32 s66, s[sgprStridesB+1], s[sgprWorkGroup2] // Stride*WG
+s_add_u32 s68, s68, s66                            // accum wg term to tilestart
+s_addc_u32 s69, s69, s67                           // accum wg term to tilestart
+s_lshl_b64 s[68:69], s[68:69], 3                   // tileStart *= BPE
+s_add_u32 s[sgprSrdB+0], s[sgprAddressB+0], s68    // SRD base = Address+ tileStart0
+s_addc_u32 s[sgprSrdB+1], s[sgprAddressB+1], s69   // SRD base = Address+ tileStart1
+s_sub_u32 s[sgprSrdB+0], s[sgprSrdB+0], 16         // pre-pad to make room for possible pointer shift
+s_subb_u32 s[sgprSrdB+1], s[sgprSrdB+1], 0         // pre-pad to make room for possible pointer shift
+s_mov_b32 s[sgprSrdB+3], Srd127_96                 // Set bits 127_96 in SRD
+
+
+/* global read addresses: increments a */
+
+s_mul_i32 s[sgprGlobalReadIncsA+0], 0x20, s[sgprStridesA] // incr = stride*4*bytes
+
+
+/* global read addresses: increments b */
+
+s_mul_i32 s[sgprGlobalReadIncsB+0], 0x20, s[sgprStridesB] // incr = stride*4*bytes
+
+
+/******************************************/
+/* Local Write Addresses                  */
+/******************************************/
+
+
+/* local write addresses: tile assignment a */
+
+/* lwaTileA = v0 */
+
+
+/* local write addresses: tile assignment b */
+
+/* lwaTileB = v2 */
+
+
+/* local write addresses: unroll assignment a */
+
+/* lwaUnrollA = v1 */
+
+
+/* local write addresses: unroll assignment b */
+
+/* lwaUnrollB = v3 */
+
+
+/* local write addresses: first offset a */
+
+v_mul_u32_u24 v[vgprLocalWriteAddrA], 0x30, v1     // lwAL**(MTA + PAD)
+_v_add_lshl_u32 v[vgprLocalWriteAddrA], v0, v[vgprLocalWriteAddrA], 0x3 // lwFOA = (lwAA + lwAL*(MT0I+PAD))*bpe
+s_mov_b32 s65, 96                                  // lsc*lsp=48*4
+v_cmp_lt_u32 vcc, v[vgprSerial], s65               // fractional: ensure tid < global read tile elements
+v_mov_b32 v0, 0xf00000                             //
+v_cndmask_b32 v[vgprLocalWriteAddrA], v0, v[vgprLocalWriteAddrA], vcc // Mask load so out-of-gr-tile bounds returns 0
+
+
+/* local write addresses: first offset b */
+
+v_mul_u32_u24 v[vgprLocalWriteAddrB], 0x40, v3     // lwBL**(MTB + PAD)
+_v_add_lshl_u32 v[vgprLocalWriteAddrB], v2, v[vgprLocalWriteAddrB], 0x3 // lwFOB = (lwBB + lwBL*(MT1J+PAD))*bpe
+_v_add_co_u32 v[vgprLocalWriteAddrB], vcc, 0x600, v[vgprLocalWriteAddrB] // lwFOB = lwB1J + lwBL*MT1J + LDS_OFFSET_B=192*8
+
+
+/* local write addresses: final offsets a */
+
+
+/* N/A */
+
+
+/* local write addresses: final offsets b */
+
+
+/* N/A */
+
+
+/* local write addresses: declare addresses a */
+
+/* N/A */
+
+
+/* local write addresses: declare addresses b */
+
+/* N/A */
+
+
+/* local write addresses: init pointers a */
+
+/* N/A */
+
+
+/* local write addresses: init pointers b */
+
+/* N/A */
+
+
+/* declare loop num iterations */
+
+
+s_lshr_b32 s[sgprLoopCounters+0], s[sgprSizesSum+0], 2 // s[sgprLoopCounters+0] = s[sgprSizesSum+0] / 4
+s_mov_b32 s[sgprOrigLoopCounter], s[sgprLoopCounters+0] // copy loop counter
+s_sub_u32 s[sgprLoopCounters+0], 0x0, s[sgprLoopCounters+0] // counterL = -sizeL
+
+
+/* local read addresses: init pointers a */
+
+
+
+/* local read addresses: init pointers b */
+
+
+
+/* TODO-packed- compare against product of all packed C0 sizes not just SizesFree+0 */
+s_mov_b32 s91, 0x0                                 // STATIC_DIV: divisior=48
+s_mul_i32 s90, 0xaaa, s[sgprSizesFree+0]           // tmp1 = dividend * magic hi
+s_lshl_b64 s[90:91], s[90:91], 0x10                // left shift 16 bits
+s_mul_i32 s82, s[sgprSizesFree+0], 0xaaab          // tmp0 = dividend * magic lo
+s_add_u32 s90, s82, s90                            // add lo
+s_addc_u32 s91, s91, 0x0                           // add hi
+s_lshr_b64 s[90:91], s[90:91], 0x21                // tmp1 = (dividend * magic) << shift
+s_mov_b32 s82, s90                                 // quotient
+s_mul_i32 s90, s82, 0x30                           // quotient*divisor
+s_sub_u32 s[sgprEdgeSelMask0], s[sgprSizesFree+0], s90             // rReg = dividend - quotient*divisor
+s_lshr_b32 s82, s[sgprSizesFree+1], 6              // s58 = s[sgprSizesFree+1] / 64
+s_and_b32 s[sgprEdgeSelMask1], 63, s[sgprSizesFree+1]
+
+
+/* prefetch: global -> local */
+
+s_cmp_eq_u32 s[sgprLoopCounters+0], 0x0            // numIter0I == 0
+s_cbranch_scc1 label_0008                          // skip to ShadowInitStart iter b/c numIter==0
+
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+
+
+/* global read inc A */
+s_add_u32  s[sgprSrdA+0], s[sgprSrdA+0], s[sgprGlobalReadIncsA] // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdA+1], s[sgprSrdA+1], 0        // gra SRD += inc(upper)
+s_sub_u32 s[sgprShadowLimitA+0], s[sgprShadowLimitA+0], s[sgprGlobalReadIncsA] // limit -= inc)
+s_subb_u32 s[sgprShadowLimitA+1], s[sgprShadowLimitA+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitA+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdA+2], s[sgprShadowLimitA+0]    // Move shadow to real if we are within 2^32
+
+
+/* global read inc B */
+s_add_u32  s[sgprSrdB+0], s[sgprSrdB+0], s[sgprGlobalReadIncsB] // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdB+1], s[sgprSrdB+1], 0        // gra SRD += inc(upper)
+s_sub_u32 s[sgprShadowLimitB+0], s[sgprShadowLimitB+0], s[sgprGlobalReadIncsB] // limit -= inc)
+s_subb_u32 s[sgprShadowLimitB+1], s[sgprShadowLimitB+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitB+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdB+2], s[sgprShadowLimitB+0]    // Move shadow to real if we are within 2^32
+
+label_0008: // ShadowInitStart
+
+s_mov_b32 s[sgprSrdD+0], s[sgprAddressD+0]         // init SRD base address (lower)
+s_mov_b32 s[sgprSrdD+1], s[sgprAddressD+1]         // init SRD base address (upper) + other fields
+s_mov_b32 s[sgprSrdD+2], 0x80000000                //
+s_mov_b32 s[sgprSrdD+3], Srd127_96                 // Set bits 127_96 in SRD
+s_mov_b32 s[sgprSrdC+0], s[sgprAddressC+0]         // init SRD base address (lower)
+s_mov_b32 s[sgprSrdC+1], s[sgprAddressC+1]         // init SRD base address (upper) + other fields
+s_mov_b32 s[sgprSrdC+2], 0x80000000                //
+s_mov_b32 s[sgprSrdC+3], Srd127_96                 // Set bits 127_96 in SRD
+
+s_mul_i32 s[sgprTMP1], 0x40, s[sgprWorkGroup1]             // <- wg1*MT1
+s_mul_i32 s[sgprTMP0], 0x30, s[sgprWorkGroup1]             // <- wg1*MT1
+s_mul_hi_u32 s67, s[sgprTMP1], s[sgprStridesC+0]           // Scale s68 by Stride
+s_mul_i32 s66, s[sgprTMP1], s[sgprStridesC+0]              // Scale s68 by Stride
+s_lshl_b64 s[66:67], s[66:67], 3                   // scale by bpe
+s_add_u32 s[sgprSrdD+0], s[sgprSrdD+0], s66        // add lo to SRD
+s_addc_u32 s[sgprSrdD+1], s[sgprSrdD+1], s67       // add hi to SRD
+s_add_u32 s[sgprSrdC+0], s[sgprSrdC+0], s66        // add lo to SRD
+s_addc_u32 s[sgprSrdC+1], s[sgprSrdC+1], s67       // add hi to SRD
+
+s_mul_hi_u32 s67, s[sgprWorkGroup2], s[sgprStridesC+1] // Scale s[sgprWorkGroup2] by Stride
+s_mul_i32 s66, s[sgprWorkGroup2], s[sgprStridesC+1] // Scale s[sgprWorkGroup2] by Stride
+s_lshl_b64 s[66:67], s[66:67], 3                   // scale by bpe
+s_add_u32 s[sgprSrdD+0], s[sgprSrdD+0], s66        // add lo to SRD
+s_addc_u32 s[sgprSrdD+1], s[sgprSrdD+1], s67       // add hi to SRD
+s_add_u32 s[sgprSrdC+0], s[sgprSrdC+0], s66        // add lo to SRD
+s_addc_u32 s[sgprSrdC+1], s[sgprSrdC+1], s67       // add hi to SRD
+
+
+v_mov_b32 v[vgprValuC+0], 0x0                      // initC
+v_mov_b32 v[vgprValuC+1], 0x0                      // initC
+v_mov_b32 v[vgprValuC+2], 0x0                      // initC
+v_mov_b32 v[vgprValuC+3], 0x0                      // initC
+v_mov_b32 v[vgprValuC+4], 0x0                      // initC
+v_mov_b32 v[vgprValuC+5], 0x0                      // initC
+v_mov_b32 v[vgprValuC+6], 0x0                      // initC
+v_mov_b32 v[vgprValuC+7], 0x0                      // initC
+v_mov_b32 v[vgprValuC+8], 0x0                      // initC
+v_mov_b32 v[vgprValuC+9], 0x0                      // initC
+v_mov_b32 v[vgprValuC+10], 0x0                     // initC
+v_mov_b32 v[vgprValuC+11], 0x0                     // initC
+v_mov_b32 v[vgprValuC+12], 0x0                     // initC
+v_mov_b32 v[vgprValuC+13], 0x0                     // initC
+v_mov_b32 v[vgprValuC+14], 0x0                     // initC
+v_mov_b32 v[vgprValuC+15], 0x0                     // initC
+v_mov_b32 v[vgprValuC+16], 0x0                     // initC
+v_mov_b32 v[vgprValuC+17], 0x0                     // initC
+v_mov_b32 v[vgprValuC+18], 0x0                     // initC
+v_mov_b32 v[vgprValuC+19], 0x0                     // initC
+v_mov_b32 v[vgprValuC+20], 0x0                     // initC
+v_mov_b32 v[vgprValuC+21], 0x0                     // initC
+v_mov_b32 v[vgprValuC+22], 0x0                     // initC
+v_mov_b32 v[vgprValuC+23], 0x0                     // initC
+v_mov_b32 v[vgprValuC+24], 0x0                     // initC
+v_mov_b32 v[vgprValuC+25], 0x0                     // initC
+v_mov_b32 v[vgprValuC+26], 0x0                     // initC
+v_mov_b32 v[vgprValuC+27], 0x0                     // initC
+v_mov_b32 v[vgprValuC+28], 0x0                     // initC
+v_mov_b32 v[vgprValuC+29], 0x0                     // initC
+v_mov_b32 v[vgprValuC+30], 0x0                     // initC
+v_mov_b32 v[vgprValuC+31], 0x0                     // initC
+v_mov_b32 v[vgprValuC+32], 0x0                     // initC
+v_mov_b32 v[vgprValuC+33], 0x0                     // initC
+v_mov_b32 v[vgprValuC+34], 0x0                     // initC
+v_mov_b32 v[vgprValuC+35], 0x0                     // initC
+v_mov_b32 v[vgprValuC+36], 0x0                     // initC
+v_mov_b32 v[vgprValuC+37], 0x0                     // initC
+v_mov_b32 v[vgprValuC+38], 0x0                     // initC
+v_mov_b32 v[vgprValuC+39], 0x0                     // initC
+v_mov_b32 v[vgprValuC+40], 0x0                     // initC
+v_mov_b32 v[vgprValuC+41], 0x0                     // initC
+v_mov_b32 v[vgprValuC+42], 0x0                     // initC
+v_mov_b32 v[vgprValuC+43], 0x0                     // initC
+v_mov_b32 v[vgprValuC+44], 0x0                     // initC
+v_mov_b32 v[vgprValuC+45], 0x0                     // initC
+v_mov_b32 v[vgprValuC+46], 0x0                     // initC
+v_mov_b32 v[vgprValuC+47], 0x0                     // initC
+s_cmp_eq_u32 s[sgprLoopCounters+0], 0x0            // numIter0I == 0
+s_cbranch_scc1 label_0004                          // after InitC, skip to end of prefetch last iter b/c numIter==0
+
+s_waitcnt vmcnt(0)                                 // 8wait for global read
+
+
+/* local write a */
+
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:0 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 0
+
+
+/* local write b */
+
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:0 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 0
+
+
+/* local write swap a */
+
+
+
+/* local write swap b */
+
+
+
+/* local write init pointers a */
+
+/* N/A */
+
+
+/* local write init pointers b */
+
+/* N/A */
+
+/******************************************/
+/* Unrolled Loop(s) - Begin               */
+/******************************************/
+
+s_cmp_ge_i32 s[sgprLoopCounters+0], 0x0            // LoopCounterL < EndCounter
+s_cbranch_scc1 label_0004                          // don't enter LoopL
+label_0001:
+
+
+/******************************************/
+/* Unroll Loop 1/2 - Begin                */
+/******************************************/
+
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
+s_barrier //4sync for global read
+
+s_cmp_eq_i32 s[sgprLoopCounters+0], -1             // is this the last iteration
+s_cmov_b32 s[sgprSrdA+2], 0                        // Set limit to 0 for last iteration
+s_cmov_b32 s[sgprSrdB+2], 0                        // Set limit to 0 for last iteration
+
+s_waitcnt lgkmcnt(0)                               // 1wait for local write
+
+
+
+
+/* iter 0 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(2)                               // wait for prior local read old=0 new=0
+//MAC_6x4_X0
+MAC_6x4_X0_part_1
+
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:384 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:512 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* global read inc A */
+s_add_u32  s[sgprSrdA+0], s[sgprSrdA+0], s[sgprGlobalReadIncsA] // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdA+1], s[sgprSrdA+1], 0        // gra SRD += inc(upper)
+s_sub_u32 s[sgprShadowLimitA+0], s[sgprShadowLimitA+0], s[sgprGlobalReadIncsA] // limit -= inc)
+s_subb_u32 s[sgprShadowLimitA+1], s[sgprShadowLimitA+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitA+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdA+2], s[sgprShadowLimitA+0]    // Move shadow to real if we are within 2^32
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:640 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(2)                               // wait for prior local read old=0 new=0
+//MAC_6x4_X0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:768 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* global read inc B */
+s_add_u32  s[sgprSrdB+0], s[sgprSrdB+0], s[sgprGlobalReadIncsB] // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdB+1], s[sgprSrdB+1], 0        // gra SRD += inc(upper)
+s_sub_u32 s[sgprShadowLimitB+0], s[sgprShadowLimitB+0], s[sgprGlobalReadIncsB] // limit -= inc)
+s_subb_u32 s[sgprShadowLimitB+1], s[sgprShadowLimitB+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitB+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdB+2], s[sgprShadowLimitB+0]    // Move shadow to real if we are within 2^32
+
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:896 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1024 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 2 writesPerItem=1 */
+s_waitcnt vmcnt(1)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:4096 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 4096
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(3)                               // wait for prior local read old=0 new=0
+//MAC_6x4_X0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(1)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+/* iter 3 (last) */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:1152 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1280 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1408 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 3 writesPerItem=1 */
+s_waitcnt vmcnt(0)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:4096 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 4096
+
+/* local write swap offsets a */
+
+/* local write swap offsets b */
+
+/* local write init pointers a */
+/* N/A */
+
+/* local write init pointers b */
+/* N/A */
+
+/* local read swap offsets a */
+
+/* local read swap internal offset -> 4096 */
+
+/* local read swap offsets b */
+
+/* local read swap internal offset -> 4096 */
+
+/* local read init pointers a */
+
+/* local read init pointers b */
+s_waitcnt lgkmcnt(3)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(1)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0_part_3
+
+/******************************************/
+/* Unrolled Loop - End 1/2                */
+/******************************************/
+
+s_add_u32 s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+s_cmp_eq_i32 s[sgprLoopCounters+0],  -2            // counterL==0
+s_cbranch_scc1 label_0003                          // exit LoopL
+
+
+/******************************************/
+/* Unroll Loop 2/2 - Begin                */
+/******************************************/
+
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
+s_barrier //4sync for global read
+
+s_cmp_eq_i32 s[sgprLoopCounters+0], -1             // is this the last iteration
+s_cmov_b32 s[sgprSrdA+2], 0                        // Set limit to 0 for last iteration
+s_cmov_b32 s[sgprSrdB+2], 0                        // Set limit to 0 for last iteration
+
+s_waitcnt lgkmcnt(0)                               // 1wait for local write
+
+
+
+
+/* iter 0 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4096 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4224 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4352 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(2)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4480 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4608 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* global read inc A */
+s_add_u32  s[sgprSrdA+0], s[sgprSrdA+0], s[sgprGlobalReadIncsA] // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdA+1], s[sgprSrdA+1], 0        // gra SRD += inc(upper)
+s_sub_u32 s[sgprShadowLimitA+0], s[sgprShadowLimitA+0], s[sgprGlobalReadIncsA] // limit -= inc)
+s_subb_u32 s[sgprShadowLimitA+1], s[sgprShadowLimitA+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitA+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdA+2], s[sgprShadowLimitA+0]    // Move shadow to real if we are within 2^32
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4736 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(2)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4864 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* global read inc B */
+s_add_u32  s[sgprSrdB+0], s[sgprSrdB+0], s[sgprGlobalReadIncsB] // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdB+1], s[sgprSrdB+1], 0        // gra SRD += inc(upper)
+s_sub_u32 s[sgprShadowLimitB+0], s[sgprShadowLimitB+0], s[sgprGlobalReadIncsB] // limit -= inc)
+s_subb_u32 s[sgprShadowLimitB+1], s[sgprShadowLimitB+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitB+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdB+2], s[sgprShadowLimitB+0]    // Move shadow to real if we are within 2^32
+
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4992 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5120 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 2 writesPerItem=1 */
+s_waitcnt vmcnt(1)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:0 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 0
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(3)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(1)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:5248 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=192 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=192 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5376 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5504 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 3 writesPerItem=1 */
+s_waitcnt vmcnt(0)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:0 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 0
+
+/* local write swap offsets a */
+
+/* local write swap offsets b */
+
+/* local write init pointers a */
+/* N/A */
+
+/* local write init pointers b */
+/* N/A */
+
+/* local read swap offsets a */
+
+/* local read swap internal offset -> 0 */
+
+/* local read swap offsets b */
+
+/* local read swap internal offset -> 0 */
+
+/* local read init pointers a */
+
+/* local read init pointers b */
+s_waitcnt lgkmcnt(3)                               // 6wait for local read old=3 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(1)                               // 6wait for local read old=1 new=0
+MAC_6x4_X0_part_3
+
+/******************************************/
+/* Unrolled Loop - End 2/2 (final)        */
+/******************************************/
+
+s_add_u32 s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+s_cmp_eq_i32 s[sgprLoopCounters+0], -2              // counterL==0
+s_cbranch_scc0 label_0001                          // restart LoopL
+s_cbranch_scc1 label_0002                          // restart LoopL
+
+label_0003: // unroll loop odditer exit
+
+//check edge Batch calculation needed
+//for Batch edge jump to different beta loop optimization code
+s_add_u32      s83,-0x1, s[sgprNumWorkGroups0]       //
+s_cmp_lt_u32   s[sgprWorkGroup0], s83                // wg0 < nwg0-1
+s_cmov_b32     s[sgprEdgeSelMask0], 0x0
+s_cmpk_gt_u32  s[sgprEdgeSelMask0], 0x0
+s_cbranch_scc1 label_1003                            // wg1 < nwg1-1 so skip rMT1 = Size1 % MT1
+s_add_u32      s83, -0x1, s[sgprNumWorkGroups1]      //
+s_cmp_lt_u32   s[sgprWorkGroup1], s83                // wg1 < nwg1-1
+s_cmov_b32     s[sgprEdgeSelMask1], 0x0
+s_cmpk_gt_u32  s[sgprEdgeSelMask1], 0x0
+s_cbranch_scc1 label_1003                            // wg1 < nwg1-1 so skip rMT1 = Size1 % MT1
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4224 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4480 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4608 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4736 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4864 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4992 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5120 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:0 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 4096
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(1)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:5248 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5376 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5504 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_mul_i32 s56, 0x30, s[sgprWorkGroup0]             // s56 = wg0*MT0
+s_mul_i32 s58, 0x40, s[sgprWorkGroup1]             // s56 = wg0*MT0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 3 writesPerItem=1 */
+s_waitcnt vmcnt(0)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:0 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 4096
+
+s_waitcnt lgkmcnt(1)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0_unprio_0
+v_lshrrev_b32 v[vgprLocalWriteAddrB], 3, v[vgprSerial]                // vectorStaticDiv: v49 = v[vgprSerial] / 8
+v_and_b32 v[vgprLocalWriteAddrA], 7, v[vgprSerial]                    // vectorStaticDiv: v48 = v[vgprSerial] % 8
+v_lshlrev_b32 v[vgprLocalWriteAddrA], 1, v[vgprLocalWriteAddrA]       // staticMultiply: v48 = v48 * 2
+v_lshlrev_b32 v[vgprLocalWriteAddrB], 1, v[vgprLocalWriteAddrB]       // staticMultiply: v49 = v49 * 2
+v_mul_lo_u32 v[vgprGlobalReadOffsetB], v[vgprLocalWriteAddrB], s[sgprStridesC+0]           // rowStart vgpr
+_v_add_co_u32 v[vgprLocalWriteAddrA], vcc, s56, v[vgprLocalWriteAddrA]                   // coord0 = tid0*VW + wg0*MT0
+_v_add_lshl_u32 v[vgprGlobalReadOffsetA], v[vgprGlobalReadOffsetB], v[vgprLocalWriteAddrA], 0x3                 // init cb addr <-  rowStart + coord0, scaled by BPE
+s_setprio 0
+
+s_add_u32       s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+s_cmp_eq_i32    s[sgprLoopCounters+0], -1             // is this the last iteration
+s_cmov_b32 	s[sgprSrdA+2], 0                        // Set limit to 0 for last iteration
+s_cmov_b32 	s[sgprSrdB+2], 0                        // Set limit to 0 for last iteration
+s_mov_b32 	s85, s[sgprSrdC+0]
+s_mov_b32 	s86, s[sgprSrdC+1]
+s_mov_b32       s87, s[sgprSrdD+0]
+s_mov_b32       s88, s[sgprSrdD+1]
+
+
+//s_waitcnt lgkmcnt(0)                               // 1wait for local write
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
+s_barrier //4sync for global read
+
+/* iter 0,1 */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:384 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part1
+
+/* iter 1 */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:768  // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1152 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part1
+
+
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:512 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+0:vgprValuC+0+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+0:vgprValuC+0+1] // *= alpha
+v_mul_f64 v[vgprValuC+2:vgprValuC+2+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+2:vgprValuC+2+1] // *= alpha
+v_fma_f64 v[vgprValuC+0:vgprValuC+0+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+0:vgprValuC+0+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+2:vgprValuC+2+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+2:vgprValuC+2+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[0:3], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+12:vgprValuC+12+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+12:vgprValuC+12+1] // *= alpha
+v_mul_f64 v[vgprValuC+14:vgprValuC+14+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+14:vgprValuC+14+1] // *= alpha
+v_fma_f64 v[vgprValuC+12:vgprValuC+12+1], v[vgprG2LB+0:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+12:vgprValuC+12+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+14:vgprValuC+14+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+14:vgprValuC+14+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[12:15], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part2
+
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:896 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1280 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part2
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:640 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+4:vgprValuC+4+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+4:vgprValuC+4+1] // *= alpha
+v_mul_f64 v[vgprValuC+6:vgprValuC+6+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+6:vgprValuC+6+1] // *= alpha
+v_fma_f64 v[vgprValuC+4:vgprValuC+4+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+4:vgprValuC+4+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+6:vgprValuC+6+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+6:vgprValuC+6+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[4:7], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+16:vgprValuC+16+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+16:vgprValuC+16+1] // *= alpha
+v_mul_f64 v[vgprValuC+18:vgprValuC+18+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+18:vgprValuC+18+1] // *= alpha
+v_fma_f64 v[vgprValuC+16:vgprValuC+16+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+16:vgprValuC+16+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+18:vgprValuC+18+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+18:vgprValuC+18+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[16:19], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part3
+
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1024 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:1408 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part3
+
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:384 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+8:vgprValuC+8+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+8:vgprValuC+8+1] // *= alpha
+v_mul_f64 v[vgprValuC+10:vgprValuC+10+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+10:vgprValuC+10+1] // *= alpha
+v_fma_f64 v[vgprValuC+8:vgprValuC+8+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+8:vgprValuC+8+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+10:vgprValuC+10+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+10:vgprValuC+10+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[8:11], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+20:vgprValuC+20+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+20:vgprValuC+20+1] // *= alpha
+v_mul_f64 v[vgprValuC+22:vgprValuC+22+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+22:vgprValuC+22+1] // *= alpha
+v_fma_f64 v[vgprValuC+20:vgprValuC+20+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+20:vgprValuC+20+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+22:vgprValuC+22+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+22:vgprValuC+22+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[20:23], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_mul_i32  s56, s[sgprStridesC+0], 248              // Scale by BPE
+s_add_u32   s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+s_mov_b32   s85, s[sgprSrdC+0]
+s_mov_b32   s86, s[sgprSrdC+1]                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part4
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:768 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+s_lshl_b32   s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32   s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1152 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part4
+
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+s_mul_i32   s56, s[sgprStridesD+0], 248              // Scale by BPE
+s_add_u32   s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:512 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+24:vgprValuC+24+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+24:vgprValuC+24+1] // *= alpha
+v_mul_f64 v[vgprValuC+26:vgprValuC+26+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+26:vgprValuC+26+1] // *= alpha
+v_fma_f64 v[vgprValuC+24:vgprValuC+24+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+24:vgprValuC+24+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+26:vgprValuC+26+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+26:vgprValuC+26+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[24:27], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_mov_b32       s87, s[sgprSrdD+0]
+s_mov_b32       s88, s[sgprSrdD+1]                 /* local read init pointers b */
+s_lshl_b32      s56, s[sgprStridesD+0], 3         // Scale     s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_add_u32       s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32      s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+36:vgprValuC+36+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+36:vgprValuC+36+1] // *= alpha
+v_mul_f64 v[vgprValuC+38:vgprValuC+38+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+38:vgprValuC+38+1] // *= alpha
+v_fma_f64 v[vgprValuC+36:vgprValuC+36+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+36:vgprValuC+36+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+38:vgprValuC+38+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+38:vgprValuC+38+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[36:39], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0_part5
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:896 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1280 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part5
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:640 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+28:vgprValuC+28+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+28:vgprValuC+28+1] // *= alpha
+v_mul_f64 v[vgprValuC+30:vgprValuC+30+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+30:vgprValuC+30+1] // *= alpha
+v_fma_f64 v[vgprValuC+28:vgprValuC+28+1], v[vgprG2LA+0:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+28:vgprValuC+28+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+30:vgprValuC+30+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+30:vgprValuC+30+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[28:31], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+40:vgprValuC+40+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+40:vgprValuC+40+1] // *= alpha
+v_mul_f64 v[vgprValuC+42:vgprValuC+42+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+42:vgprValuC+42+1] // *= alpha
+v_fma_f64 v[vgprValuC+40:vgprValuC+40+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+40:vgprValuC+40+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+42:vgprValuC+42+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+42:vgprValuC+42+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[40:43], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part6
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1024 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1408 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part6
+
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+32:vgprValuC+32+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+32:vgprValuC+32+1] // *= alpha
+v_mul_f64 v[vgprValuC+34:vgprValuC+34+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+34:vgprValuC+34+1] // *= alpha
+v_fma_f64 v[vgprValuC+32:vgprValuC+32+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+32:vgprValuC+32+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+34:vgprValuC+34+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+34:vgprValuC+34+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[32:35], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_lshl_b32  s56, 	   s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32   s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+
+v_mul_f64 v[vgprValuC+44:vgprValuC+44+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+44:vgprValuC+44+1] // *= alpha
+v_mul_f64 v[vgprValuC+46:vgprValuC+46+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+46:vgprValuC+46+1] // *= alpha
+v_fma_f64 v[vgprValuC+44:vgprValuC+44+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+44:vgprValuC+44+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+46:vgprValuC+46+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+46:vgprValuC+46+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[44:47], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_add_u32            s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+
+
+s_endpgm
+
+label_0002:
+
+/* TODO-packed- compare against product of all packed C0 sizes not just SizesFree+0 */
+//s_mov_b32 s91, 0x0                                 // STATIC_DIV: divisior=48
+//s_mul_i32 s90, 0xaaa, s[sgprSizesFree+0]           // tmp1 = dividend * magic hi
+//s_lshl_b64 s[90:91], s[90:91], 0x10                // left shift 16 bits
+//s_mul_i32 s82, s[sgprSizesFree+0], 0xaaab          // tmp0 = dividend * magic lo
+//s_add_u32 s90, s82, s90                            // add lo
+//s_addc_u32 s91, s91, 0x0                           // add hi
+//s_lshr_b64 s[90:91], s[90:91], 0x21                // tmp1 = (dividend * magic) << shift
+//s_mov_b32 s82, s90                                 // quotient
+//s_mul_i32 s90, s82, 0x30                           // quotient*divisor
+//s_sub_u32 s[sgprEdgeSelMask0], s[sgprSizesFree+0], s90             // rReg = dividend - quotient*divisor
+//s_lshr_b32 s82, s[sgprSizesFree+1], 6              // s58 = s[sgprSizesFree+1] / 64
+//s_and_b32 s[sgprEdgeSelMask1], 63, s[sgprSizesFree+1]
+
+//check edge Batch calculation needed
+//for Batch edge jump to different beta loop optimization code
+s_add_u32      s83,-0x1, s[sgprNumWorkGroups0]       //
+s_cmp_lt_u32   s[sgprWorkGroup0], s83                // wg0 < nwg0-1
+s_cmov_b32     s[sgprEdgeSelMask0], 0x0
+s_cmpk_gt_u32  s[sgprEdgeSelMask0], 0x0
+s_cbranch_scc1 label_1002                            // wg1 < nwg1-1 so skip rMT1 = Size1 % MT1
+s_add_u32      s83, -0x1, s[sgprNumWorkGroups1]      //
+s_cmp_lt_u32   s[sgprWorkGroup1], s83                // wg1 < nwg1-1
+s_cmov_b32     s[sgprEdgeSelMask1], 0x0
+s_cmpk_gt_u32  s[sgprEdgeSelMask1], 0x0
+s_cbranch_scc1 label_1002                            // wg1 < nwg1-1 so skip rMT1 = Size1 % MT1
+
+/******************************************/
+
+//s_waitcnt lgkmcnt(0)                                 // 1wait for local write
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
+s_barrier //4sync for global read
+
+/* iter 0 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(2)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:384 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:512 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:640 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(2)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:768 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:896 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1024 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:4096 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 4096
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(3)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(1)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:1152 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1280 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+s_mul_i32 s56, 0x30, s[sgprWorkGroup0]             // s56 = wg0*MT0
+s_mul_i32 s58, 0x40, s[sgprWorkGroup1]             // s56 = wg0*MT0
+/* sched write - iter 3 writesPerItem=1 */
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1408 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(0)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:4096 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 4096
+
+s_waitcnt lgkmcnt(1)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0_unprio_0
+v_lshrrev_b32 v[vgprLocalWriteAddrB], 3, v[vgprSerial]                // vectorStaticDiv: v49 = v[vgprSerial] / 8
+v_and_b32 v[vgprLocalWriteAddrA], 7, v[vgprSerial]                    // vectorStaticDiv: v48 = v[vgprSerial] % 8
+v_lshlrev_b32 v[vgprLocalWriteAddrA], 1, v[vgprLocalWriteAddrA]       // staticMultiply: v48 = v48 * 2
+v_lshlrev_b32 v[vgprLocalWriteAddrB], 1, v[vgprLocalWriteAddrB]       // staticMultiply: v49 = v49 * 2
+v_mul_lo_u32 v[vgprGlobalReadOffsetB], v[vgprLocalWriteAddrB], s[sgprStridesC+0]           // rowStart vgpr
+_v_add_co_u32 v[vgprLocalWriteAddrA], vcc, s56, v[vgprLocalWriteAddrA]                   // coord0 = tid0*VW + wg0*MT0
+_v_add_lshl_u32 v[vgprGlobalReadOffsetA], v[vgprGlobalReadOffsetB], v[vgprLocalWriteAddrA], 0x3                 // init cb addr <-  rowStart + coord0, scaled by BPE
+s_setprio 0
+
+s_add_u32       s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+s_cmp_eq_i32    s[sgprLoopCounters+0], -1             // is this the last iteration
+s_cmov_b32 	s[sgprSrdA+2], 0                        // Set limit to 0 for last iteration
+s_cmov_b32 	s[sgprSrdB+2], 0                        // Set limit to 0 for last iteration
+s_mov_b32 	s85, s[sgprSrdC+0]
+s_mov_b32 	s86, s[sgprSrdC+1]
+s_mov_b32       s87, s[sgprSrdD+0]
+s_mov_b32       s88, s[sgprSrdD+1]
+
+
+//s_waitcnt lgkmcnt(0)                               // 1wait for local write
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
+s_barrier //4sync for global read
+
+/* iter 0,1 */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4480 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part1
+
+/* iter 1 */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4864 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5248 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part1
+
+
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4224 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4608 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+0:vgprValuC+0+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+0:vgprValuC+0+1] // *= alpha
+v_mul_f64 v[vgprValuC+2:vgprValuC+2+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+2:vgprValuC+2+1] // *= alpha
+v_fma_f64 v[vgprValuC+0:vgprValuC+0+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+0:vgprValuC+0+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+2:vgprValuC+2+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+2:vgprValuC+2+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[0:3], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+12:vgprValuC+12+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+12:vgprValuC+12+1] // *= alpha
+v_mul_f64 v[vgprValuC+14:vgprValuC+14+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+14:vgprValuC+14+1] // *= alpha
+v_fma_f64 v[vgprValuC+12:vgprValuC+12+1], v[vgprG2LB+0:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+12:vgprValuC+12+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+14:vgprValuC+14+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+14:vgprValuC+14+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[12:15], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part2
+
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4992 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5376 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part2
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4736 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+4:vgprValuC+4+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+4:vgprValuC+4+1] // *= alpha
+v_mul_f64 v[vgprValuC+6:vgprValuC+6+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+6:vgprValuC+6+1] // *= alpha
+v_fma_f64 v[vgprValuC+4:vgprValuC+4+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+4:vgprValuC+4+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+6:vgprValuC+6+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+6:vgprValuC+6+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[4:7], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+16:vgprValuC+16+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+16:vgprValuC+16+1] // *= alpha
+v_mul_f64 v[vgprValuC+18:vgprValuC+18+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+18:vgprValuC+18+1] // *= alpha
+v_fma_f64 v[vgprValuC+16:vgprValuC+16+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+16:vgprValuC+16+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+18:vgprValuC+18+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+18:vgprValuC+18+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[16:19], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part3
+
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5120 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:5504 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part3
+
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4480 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+8:vgprValuC+8+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+8:vgprValuC+8+1] // *= alpha
+v_mul_f64 v[vgprValuC+10:vgprValuC+10+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+10:vgprValuC+10+1] // *= alpha
+v_fma_f64 v[vgprValuC+8:vgprValuC+8+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+8:vgprValuC+8+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+10:vgprValuC+10+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+10:vgprValuC+10+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[8:11], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+20:vgprValuC+20+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+20:vgprValuC+20+1] // *= alpha
+v_mul_f64 v[vgprValuC+22:vgprValuC+22+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+22:vgprValuC+22+1] // *= alpha
+v_fma_f64 v[vgprValuC+20:vgprValuC+20+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+20:vgprValuC+20+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+22:vgprValuC+22+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+22:vgprValuC+22+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[20:23], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_mul_i32  s56, s[sgprStridesC+0], 248              // Scale by BPE
+s_add_u32   s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+s_mov_b32   s85, s[sgprSrdC+0]
+s_mov_b32   s86, s[sgprSrdC+1]                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part4
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4864 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+s_lshl_b32   s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32   s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5248 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part4
+
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4224 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+s_mul_i32   s56, s[sgprStridesD+0], 248              // Scale by BPE
+s_add_u32   s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4608 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+24:vgprValuC+24+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+24:vgprValuC+24+1] // *= alpha
+v_mul_f64 v[vgprValuC+26:vgprValuC+26+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+26:vgprValuC+26+1] // *= alpha
+v_fma_f64 v[vgprValuC+24:vgprValuC+24+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+24:vgprValuC+24+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+26:vgprValuC+26+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+26:vgprValuC+26+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[24:27], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_mov_b32       s87, s[sgprSrdD+0]
+s_mov_b32       s88, s[sgprSrdD+1]                 /* local read init pointers b */
+s_lshl_b32      s56, s[sgprStridesD+0], 3         // Scale     s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_add_u32       s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32      s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+36:vgprValuC+36+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+36:vgprValuC+36+1] // *= alpha
+v_mul_f64 v[vgprValuC+38:vgprValuC+38+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+38:vgprValuC+38+1] // *= alpha
+v_fma_f64 v[vgprValuC+36:vgprValuC+36+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+36:vgprValuC+36+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+38:vgprValuC+38+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+38:vgprValuC+38+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[36:39], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0_part5
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4992 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5376 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part5
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4736 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+28:vgprValuC+28+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+28:vgprValuC+28+1] // *= alpha
+v_mul_f64 v[vgprValuC+30:vgprValuC+30+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+30:vgprValuC+30+1] // *= alpha
+v_fma_f64 v[vgprValuC+28:vgprValuC+28+1], v[vgprG2LA+0:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+28:vgprValuC+28+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+30:vgprValuC+30+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+30:vgprValuC+30+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[28:31], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+40:vgprValuC+40+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+40:vgprValuC+40+1] // *= alpha
+v_mul_f64 v[vgprValuC+42:vgprValuC+42+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+42:vgprValuC+42+1] // *= alpha
+v_fma_f64 v[vgprValuC+40:vgprValuC+40+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+40:vgprValuC+40+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+42:vgprValuC+42+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+42:vgprValuC+42+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[40:43], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part6
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5120 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5504 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part6
+
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+32:vgprValuC+32+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+32:vgprValuC+32+1] // *= alpha
+v_mul_f64 v[vgprValuC+34:vgprValuC+34+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+34:vgprValuC+34+1] // *= alpha
+v_fma_f64 v[vgprValuC+32:vgprValuC+32+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+32:vgprValuC+32+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+34:vgprValuC+34+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+34:vgprValuC+34+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[32:35], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_lshl_b32  s56, 	   s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32   s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+
+v_mul_f64 v[vgprValuC+44:vgprValuC+44+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+44:vgprValuC+44+1] // *= alpha
+v_mul_f64 v[vgprValuC+46:vgprValuC+46+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+46:vgprValuC+46+1] // *= alpha
+v_fma_f64 v[vgprValuC+44:vgprValuC+44+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+44:vgprValuC+44+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+46:vgprValuC+46+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+46:vgprValuC+46+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[44:47], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_add_u32            s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+
+
+s_endpgm
+
+label_1002:
+
+/******************************************/
+//branch logic gets executed for edge MT to use legacy alph_beta code
+
+//s_waitcnt lgkmcnt(0)                                 // 1wait for local write
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
+s_barrier //4sync for global read
+
+/* iter 0 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:384 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:512 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:640 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:768 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:896 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt vmcnt(1)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:4096 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 4096
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1024 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:1152 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1280 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 3 writesPerItem=1 */
+s_waitcnt vmcnt(0)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:4096 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 4096
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1408 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0
+
+
+//s_waitcnt lgkmcnt(0)                               // 1wait for local write
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
+s_barrier //4sync for global read
+
+
+/* iter 0 */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4096 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4224 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4352 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4480 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4608 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4736 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4864 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4992 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5120 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:5248 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5376 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5504 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=192 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=192 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0
+s_add_u32 s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+
+s_branch label_0004
+
+label_1003:
+
+//s_waitcnt lgkmcnt(0)                               // 1wait for local write
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
+s_barrier //4sync for global read
+
+
+/* iter 0 */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4096 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4224 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4352 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4480 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4608 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4736 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4864 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4992 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* sched write - iter 2 writesPerItem=1 */
+s_waitcnt vmcnt(1)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:0 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5120 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:5248 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5376 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 3 writesPerItem=1 */
+s_waitcnt vmcnt(0)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:0 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5504 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=192 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=192 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+
+/* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0
+
+s_add_u32 s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+s_cmp_eq_i32 s[sgprLoopCounters+0], -1             // is this the last iteration
+s_cmov_b32 s[sgprSrdA+2], 0                        // Set limit to 0 for last iteration
+s_cmov_b32 s[sgprSrdB+2], 0                        // Set limit to 0 for last iteration
+
+//s_waitcnt lgkmcnt(0)                               // 1wait for local write
+
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
+s_barrier //4sync for global read
+
+/* iter 0 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:384 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:512 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:640 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:768 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:896 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1024 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:1152 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1280 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1408 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0
+s_add_u32 s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+
+label_0004:
+
+
+/******************************************/
+/* Tail Loop                              */
+/******************************************/
+
+
+/* local write reset offsets a */
+
+
+
+/* local write reset offsets b */
+
+
+
+s_cmp_eq_u32 s[sgprOrigLoopCounter], 0             // completely skipped unroll loop?
+s_cselect_b32 s66, 0, s[sgprGlobalReadIncsA]       // force to 0?
+s_cselect_b32 s67, 0, s[sgprGlobalReadIncsB]       // force to 0?
+s_sub_u32  s[sgprSrdA+0], s[sgprSrdA+0], s66       // gra SRD -= inc(lower)
+s_subb_u32  s[sgprSrdA+1], s[sgprSrdA+1], 0        // gra SRD -= inc(upper)
+s_add_u32 s[sgprShadowLimitA+0], s[sgprShadowLimitA+0], s66 // limit -= inc)
+s_addc_u32 s[sgprShadowLimitA+1], s[sgprShadowLimitA+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitA+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdA+2], s[sgprShadowLimitA+0]    // Move shadow to real if we are within 2^32
+
+s_sub_u32  s[sgprSrdB+0], s[sgprSrdB+0], s67       // gra SRD -= inc(lower)
+s_subb_u32  s[sgprSrdB+1], s[sgprSrdB+1], 0        // gra SRD -= inc(upper)
+s_add_u32 s[sgprShadowLimitB+0], s[sgprShadowLimitB+0], s67 // limit -= inc)
+s_addc_u32 s[sgprShadowLimitB+1], s[sgprShadowLimitB+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitB+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdB+2], s[sgprShadowLimitB+0]    // Move shadow to real if we are within 2^32
+
+//numIterL = (((sizeL % LOCAL_DEPTHU) + LOCAL_SPLITU - 1) / LOCAL_SPLITU)
+s_lshr_b32 s66, s[sgprSizesSum+0], 2               // s66 = s[sgprSizesSum+0] / 4
+s_and_b32 s[sgprLoopCounters+0], 3, s[sgprSizesSum+0] // s[sgprLoopCounters+0] = s[sgprSizesSum+0] % 4
+s_cmp_eq_u32 s[sgprLoopCounters+0], 0x0            // numIterL == 0
+s_cbranch_scc1 label_0006                          // skip to end of tail loop b/c numIter==0
+s_sub_u32 s[sgprLoopCounters+0], 0x0, s[sgprLoopCounters+0] // counterL = -sizeL
+
+
+/* global read a */
+
+/* g2l=0, load component 0 */
+buffer_load_dwordx2 v[vgprG2LA+0+0:vgprG2LA+0+0+1], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // load one buffer value
+/* g2l=0, load component 1 */
+buffer_load_dwordx2 v[vgprG2LA+0+2:vgprG2LA+0+2+1], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:8 // load one buffer value
+_v_add_co_u32 v[vgprGlobalReadOffsetA+0], vcc, v[vgprGlobalReadOffsetA+0], 8 // graOffset += 1 * bpe
+
+
+/* global read b */
+
+/* g2l=0, load component 0 */
+buffer_load_dwordx2 v[vgprG2LB+0+0:vgprG2LB+0+0+1], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // load one buffer value
+/* g2l=0, load component 1 */
+buffer_load_dwordx2 v[vgprG2LB+0+2:vgprG2LB+0+2+1], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:8 // load one buffer value
+_v_add_co_u32 v[vgprGlobalReadOffsetB+0], vcc, v[vgprGlobalReadOffsetB+0], 8 // graOffset += 1 * bpe
+
+//s_waitcnt vmcnt(0)                                 // 2wait for global read
+
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
+s_barrier //
+
+/* local write init pointers a */
+
+/* N/A */
+
+
+/* local write init pointers b */
+
+/* N/A */
+
+
+/* local write a */
+
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:0 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 0
+
+
+/* local write b */
+
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:0 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 0
+
+//s_waitcnt lgkmcnt(0)                               // 5wait for local write
+
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
+s_barrier //
+
+
+/* local read reset offsets a */
+
+/* handled internally */
+v_and_b32 v[vgprLocalReadAddrA], 0xfff, v[vgprLocalReadAddrA] // reset Red,Blk -> Red
+
+
+/* local read reset offsets b */
+
+/* handled internally */
+v_and_b32 v[vgprLocalReadAddrB], 0xfff, v[vgprLocalReadAddrB] // reset Red,Blk -> Red
+
+
+/* local read init pointers a */
+
+
+
+/* local read init pointers b */
+
+
+
+/* tail loop: macs */
+
+s_cmp_ge_i32 s[sgprLoopCounters+0], 0x0            // LoopCounterL < EndCounter
+s_cbranch_scc1 label_0006                          // don't enter LoopL
+s_mov_b32 s[sgprOrigLoopCounter], 0                // repurpose to count each localRead increment
+label_0005:
+
+
+/* local read a */
+
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+
+/* local read b */
+
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+
+/* local read inc a */
+
+s_mov_b32 s65, 0x180                               // inc
+_v_add_co_u32 v[vgprLocalReadAddrA], vcc, s65, v[vgprLocalReadAddrA] // lrA += 384 (LSU*(MT+PAD)*bpe)
+
+
+/* local read inc b */
+
+s_mov_b32 s65, 0x200                               // inc
+_v_add_co_u32 v[vgprLocalReadAddrB], vcc, s65, v[vgprLocalReadAddrB] // lrB += 512 (LSU*(MT+PAD)*bpe)
+
+s_waitcnt lgkmcnt(0)                               // 4wait for local read
+
+MAC_6x4_X0
+s_add_u32 s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+s_add_u32 s[sgprOrigLoopCounter], s[sgprOrigLoopCounter], 0x1 // inc counterL
+s_cmp_eq_i32 s[sgprLoopCounters+0], 0x0            // counterL==0
+s_cbranch_scc0 label_0005                          // restart LoopL
+label_0006:
+
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // wait for all summation activity
+
+
+/* shift vector components d0 */
+
+v_mov_b32 v50, s[sgprWorkGroup0]                   //
+v_mul_i32_i24 v50, -0x30, v50                      // wg*MT
+_v_add_co_u32 v50, vcc, s[sgprSizesFree+0], v50    // wgMT = Size - wg*MT
+v_mov_b32 v48, 0x30                                // MT
+v_cmp_lt_u32 s[56:57], v50, v48                    // wgMT < MT
+v_cndmask_b32 v50, v48, v50, s[56:57]              // wgMT = (wgMT < MT) ? wgMT : MT
+v_lshrrev_b32 v52, 1, v50                          // vectorStaticDiv: v52 = v50 / 2
+v_and_b32 v53, 1, v50                              // vectorStaticDiv: v53 = v50 % 2
+v_lshrrev_b32 v54, 3, v52                          // vectorStaticDiv: v54 = v52 / 8
+v_and_b32 v55, 7, v52                              // vectorStaticDiv: v55 = v52 % 8
+v_and_b32 v56, 7, v[vgprSerial]                    // vectorStaticDiv: v56 = v[vgprSerial] % 8
+v_lshrrev_b32 v57, 4, v50                          // vectorStaticDiv: v57 = v50 / 16
+v_and_b32 v58, 1, v50                              // vectorStaticDiv: v58 = v50 % 2
+v_mov_b32 v59, v58                                 // duplicate
+v_lshrrev_b32 v58, 1, v59                          // vectorStaticDiv: v58 = v59 / 2
+_v_add_co_u32 v58, vcc, v57, v58                   // vId = 2 components
+v_cmp_eq_u32 s[56:57], v56, v55                    // mask
+v_mov_b32 v48, s56                                 //
+v_mov_b32 v49, s57                                 //
+v_cmp_eq_u32 vcc, v53, 0x1                         // wgMT%VW == 1
+s_cbranch_vccnz label_0010                         // shift d0 r=1
+s_branch label_0014                                // no shifting
+
+/******************************************/
+/* shift d0 r=1                           */
+/******************************************/
+label_0010:
+v_cmp_eq_u32 vcc, v58, 0x0                         // wgMT/(SG*VW) == 0
+s_cbranch_vccnz label_0011                         // shift d0, r=1, v=0
+v_cmp_eq_u32 vcc, v58, 0x1                         // wgMT/(SG*VW) == 1
+s_cbranch_vccnz label_0012                         // shift d0, r=1, v=1
+v_cmp_eq_u32 vcc, v58, 0x2                         // wgMT/(SG*VW) == 2
+s_cbranch_vccnz label_0013                         // shift d0, r=1, v=2
+
+/* shift d0 r=1 v=0 */
+label_0011:
+v_cmpx_eq_u32 s[56:57], v56, v55                   // serial % SG == (wgMT/VECTOR_WIDTH)%SG
+// src=1, dst=0
+v_mov_b32 v0, v2                                   // rC[0+0*VW+0*TT0I] = rC[1+0*VW+0*TT0I]
+v_mov_b32 v1, v3                                   // rC[0+0*VW+0*TT0I] = rC[1+0*VW+0*TT0I]
+// src=7, dst=6
+v_mov_b32 v12, v14                                 // rC[0+0*VW+1*TT0I] = rC[1+0*VW+1*TT0I]
+v_mov_b32 v13, v15                                 // rC[0+0*VW+1*TT0I] = rC[1+0*VW+1*TT0I]
+// src=13, dst=12
+v_mov_b32 v24, v26                                 // rC[0+0*VW+2*TT0I] = rC[1+0*VW+2*TT0I]
+v_mov_b32 v25, v27                                 // rC[0+0*VW+2*TT0I] = rC[1+0*VW+2*TT0I]
+// src=19, dst=18
+v_mov_b32 v36, v38                                 // rC[0+0*VW+3*TT0I] = rC[1+0*VW+3*TT0I]
+v_mov_b32 v37, v39                                 // rC[0+0*VW+3*TT0I] = rC[1+0*VW+3*TT0I]
+s_mov_b64 s[56:57], 0xFFFFFFFFFFFFFFFF             // to restore all threads active
+s_or_saveexec_b64 vcc, s[56:57]                    // all threads active
+s_branch label_0014                                // done shifting
+
+/* shift d0 r=1 v=1 */
+label_0012:
+v_cmpx_eq_u32 s[56:57], v56, v55                   // serial % SG == (wgMT/VECTOR_WIDTH)%SG
+// src=3, dst=2
+v_mov_b32 v4, v6                                   // rC[0+1*VW+0*TT0I] = rC[1+1*VW+0*TT0I]
+v_mov_b32 v5, v7                                   // rC[0+1*VW+0*TT0I] = rC[1+1*VW+0*TT0I]
+// src=9, dst=8
+v_mov_b32 v16, v18                                 // rC[0+1*VW+1*TT0I] = rC[1+1*VW+1*TT0I]
+v_mov_b32 v17, v19                                 // rC[0+1*VW+1*TT0I] = rC[1+1*VW+1*TT0I]
+// src=15, dst=14
+v_mov_b32 v28, v30                                 // rC[0+1*VW+2*TT0I] = rC[1+1*VW+2*TT0I]
+v_mov_b32 v29, v31                                 // rC[0+1*VW+2*TT0I] = rC[1+1*VW+2*TT0I]
+// src=21, dst=20
+v_mov_b32 v40, v42                                 // rC[0+1*VW+3*TT0I] = rC[1+1*VW+3*TT0I]
+v_mov_b32 v41, v43                                 // rC[0+1*VW+3*TT0I] = rC[1+1*VW+3*TT0I]
+s_mov_b64 s[56:57], 0xFFFFFFFFFFFFFFFF             // to restore all threads active
+s_or_saveexec_b64 vcc, s[56:57]                    // all threads active
+s_branch label_0014                                // done shifting
+
+/* shift d0 r=1 v=2 */
+label_0013:
+v_cmpx_eq_u32 s[56:57], v56, v55                   // serial % SG == (wgMT/VECTOR_WIDTH)%SG
+// src=5, dst=4
+v_mov_b32 v8, v10                                  // rC[0+2*VW+0*TT0I] = rC[1+2*VW+0*TT0I]
+v_mov_b32 v9, v11                                  // rC[0+2*VW+0*TT0I] = rC[1+2*VW+0*TT0I]
+// src=11, dst=10
+v_mov_b32 v20, v22                                 // rC[0+2*VW+1*TT0I] = rC[1+2*VW+1*TT0I]
+v_mov_b32 v21, v23                                 // rC[0+2*VW+1*TT0I] = rC[1+2*VW+1*TT0I]
+// src=17, dst=16
+v_mov_b32 v32, v34                                 // rC[0+2*VW+2*TT0I] = rC[1+2*VW+2*TT0I]
+v_mov_b32 v33, v35                                 // rC[0+2*VW+2*TT0I] = rC[1+2*VW+2*TT0I]
+// src=23, dst=22
+v_mov_b32 v44, v46                                 // rC[0+2*VW+3*TT0I] = rC[1+2*VW+3*TT0I]
+v_mov_b32 v45, v47                                 // rC[0+2*VW+3*TT0I] = rC[1+2*VW+3*TT0I]
+s_mov_b64 s[56:57], 0xFFFFFFFFFFFFFFFF             // to restore all threads active
+s_or_saveexec_b64 vcc, s[56:57]                    // all threads active
+s_branch label_0014                                // done shifting
+label_0014: // end shift0
+
+
+/* shift vector components d1 */
+
+v_mov_b32 v50, s[sgprWorkGroup1]                   //
+v_mul_i32_i24 v50, -0x40, v50                      // wg*MT
+_v_add_co_u32 v50, vcc, s[sgprSizesFree+1], v50    // wgMT = Size - wg*MT
+v_mov_b32 v48, 0x40                                // MT
+v_cmp_lt_u32 s[56:57], v50, v48                    // wgMT < MT
+v_cndmask_b32 v50, v48, v50, s[56:57]              // wgMT = (wgMT < MT) ? wgMT : MT
+v_lshrrev_b32 v52, 1, v50                          // vectorStaticDiv: v52 = v50 / 2
+v_and_b32 v53, 1, v50                              // vectorStaticDiv: v53 = v50 % 2
+v_lshrrev_b32 v54, 4, v52                          // vectorStaticDiv: v54 = v52 / 16
+v_and_b32 v55, 15, v52                             // vectorStaticDiv: v55 = v52 % 16
+v_lshrrev_b32 v56, 3, v[vgprSerial]                // vectorStaticDiv: v56 = v[vgprSerial] / 8
+v_and_b32 v57, 15, v56                             // vectorStaticDiv: v57 = v56 % 16
+v_lshrrev_b32 v56, 5, v50                          // vectorStaticDiv: v56 = v50 / 32
+v_and_b32 v58, 1, v50                              // vectorStaticDiv: v58 = v50 % 2
+v_mov_b32 v59, v58                                 // duplicate
+v_lshrrev_b32 v58, 1, v59                          // vectorStaticDiv: v58 = v59 / 2
+_v_add_co_u32 v58, vcc, v56, v58                   // vId = 2 components
+v_cmp_eq_u32 s[56:57], v57, v55                    // mask
+v_mov_b32 v48, s56                                 //
+v_mov_b32 v49, s57                                 //
+v_cmp_eq_u32 vcc, v53, 0x1                         // wgMT%VW == 1
+s_cbranch_vccnz label_0018                         // shift d1 r=1
+s_branch label_0021                                // no shifting
+
+/******************************************/
+/* shift d1 r=1                           */
+/******************************************/
+label_0018:
+v_cmp_eq_u32 vcc, v58, 0x0                         // wgMT/(SG*VW) == 0
+s_cbranch_vccnz label_0019                         // shift d1, r=1, v=0
+v_cmp_eq_u32 vcc, v58, 0x1                         // wgMT/(SG*VW) == 1
+s_cbranch_vccnz label_0020                         // shift d1, r=1, v=1
+
+/* shift d1 r=1 v=0 */
+label_0019:
+v_cmpx_eq_u32 s[56:57], v57, v55                   // serial % SG == (wgMT/VECTOR_WIDTH)%SG
+// src=6, dst=0
+v_mov_b32 v0, v12                                  // rC[0+0*TT0I*VW+0*TT0I] = rC[0+0*TT0I*VW+1*TT0I]
+v_mov_b32 v1, v13                                  // rC[0+0*TT0I*VW+0*TT0I] = rC[0+0*TT0I*VW+1*TT0I]
+// src=7, dst=1
+v_mov_b32 v2, v14                                  // rC[1+0*TT0I*VW+0*TT0I] = rC[1+0*TT0I*VW+1*TT0I]
+v_mov_b32 v3, v15                                  // rC[1+0*TT0I*VW+0*TT0I] = rC[1+0*TT0I*VW+1*TT0I]
+// src=8, dst=2
+v_mov_b32 v4, v16                                  // rC[2+0*TT0I*VW+0*TT0I] = rC[2+0*TT0I*VW+1*TT0I]
+v_mov_b32 v5, v17                                  // rC[2+0*TT0I*VW+0*TT0I] = rC[2+0*TT0I*VW+1*TT0I]
+// src=9, dst=3
+v_mov_b32 v6, v18                                  // rC[3+0*TT0I*VW+0*TT0I] = rC[3+0*TT0I*VW+1*TT0I]
+v_mov_b32 v7, v19                                  // rC[3+0*TT0I*VW+0*TT0I] = rC[3+0*TT0I*VW+1*TT0I]
+// src=10, dst=4
+v_mov_b32 v8, v20                                  // rC[4+0*TT0I*VW+0*TT0I] = rC[4+0*TT0I*VW+1*TT0I]
+v_mov_b32 v9, v21                                  // rC[4+0*TT0I*VW+0*TT0I] = rC[4+0*TT0I*VW+1*TT0I]
+// src=11, dst=5
+v_mov_b32 v10, v22                                 // rC[5+0*TT0I*VW+0*TT0I] = rC[5+0*TT0I*VW+1*TT0I]
+v_mov_b32 v11, v23                                 // rC[5+0*TT0I*VW+0*TT0I] = rC[5+0*TT0I*VW+1*TT0I]
+s_mov_b64 s[56:57], 0xFFFFFFFFFFFFFFFF             // to restore all threads active
+s_or_saveexec_b64 vcc, s[56:57]                    // all threads active
+s_branch label_0021                                // done shifting
+
+/* shift d1 r=1 v=1 */
+label_0020:
+v_cmpx_eq_u32 s[56:57], v57, v55                   // serial % SG == (wgMT/VECTOR_WIDTH)%SG
+// src=18, dst=12
+v_mov_b32 v24, v36                                 // rC[0+1*TT0I*VW+0*TT0I] = rC[0+1*TT0I*VW+1*TT0I]
+v_mov_b32 v25, v37                                 // rC[0+1*TT0I*VW+0*TT0I] = rC[0+1*TT0I*VW+1*TT0I]
+// src=19, dst=13
+v_mov_b32 v26, v38                                 // rC[1+1*TT0I*VW+0*TT0I] = rC[1+1*TT0I*VW+1*TT0I]
+v_mov_b32 v27, v39                                 // rC[1+1*TT0I*VW+0*TT0I] = rC[1+1*TT0I*VW+1*TT0I]
+// src=20, dst=14
+v_mov_b32 v28, v40                                 // rC[2+1*TT0I*VW+0*TT0I] = rC[2+1*TT0I*VW+1*TT0I]
+v_mov_b32 v29, v41                                 // rC[2+1*TT0I*VW+0*TT0I] = rC[2+1*TT0I*VW+1*TT0I]
+// src=21, dst=15
+v_mov_b32 v30, v42                                 // rC[3+1*TT0I*VW+0*TT0I] = rC[3+1*TT0I*VW+1*TT0I]
+v_mov_b32 v31, v43                                 // rC[3+1*TT0I*VW+0*TT0I] = rC[3+1*TT0I*VW+1*TT0I]
+// src=22, dst=16
+v_mov_b32 v32, v44                                 // rC[4+1*TT0I*VW+0*TT0I] = rC[4+1*TT0I*VW+1*TT0I]
+v_mov_b32 v33, v45                                 // rC[4+1*TT0I*VW+0*TT0I] = rC[4+1*TT0I*VW+1*TT0I]
+// src=23, dst=17
+v_mov_b32 v34, v46                                 // rC[5+1*TT0I*VW+0*TT0I] = rC[5+1*TT0I*VW+1*TT0I]
+v_mov_b32 v35, v47                                 // rC[5+1*TT0I*VW+0*TT0I] = rC[5+1*TT0I*VW+1*TT0I]
+s_mov_b64 s[56:57], 0xFFFFFFFFFFFFFFFF             // to restore all threads active
+s_or_saveexec_b64 vcc, s[56:57]                    // all threads active
+label_0021: // end shift0
+
+
+
+/* not-LocalSplitU: global write indices */
+
+s_mov_b32 s[sgprSrdD+0], s[sgprAddressD+0]         // init SRD base address (lower)
+s_mov_b32 s[sgprSrdD+1], s[sgprAddressD+1]         // init SRD base address (upper) + other fields
+s_mov_b32 s[sgprSrdD+2], 0x80000000                //
+s_mov_b32 s[sgprSrdD+3], Srd127_96                 // Set bits 127_96 in SRD
+s_mov_b32 s[sgprSrdC+0], s[sgprAddressC+0]         // init SRD base address (lower)
+s_mov_b32 s[sgprSrdC+1], s[sgprAddressC+1]         // init SRD base address (upper) + other fields
+s_mov_b32 s[sgprSrdC+2], 0x80000000                //
+s_mov_b32 s[sgprSrdC+3], Srd127_96                 // Set bits 127_96 in SRD
+
+s_mul_i32 s58, 0x40, s[sgprWorkGroup1]             // <- wg1*MT1
+s_mul_hi_u32 s57, s58, s[sgprStridesC+0]           // Scale s58 by Stride
+s_mul_i32 s56, s58, s[sgprStridesC+0]              // Scale s58 by Stride
+s_lshl_b64 s[56:57], s[56:57], 3                   // scale by bpe
+s_add_u32 s[sgprSrdD+0], s[sgprSrdD+0], s56        // add lo to SRD
+s_addc_u32 s[sgprSrdD+1], s[sgprSrdD+1], s57       // add hi to SRD
+s_add_u32 s[sgprSrdC+0], s[sgprSrdC+0], s56        // add lo to SRD
+s_addc_u32 s[sgprSrdC+1], s[sgprSrdC+1], s57       // add hi to SRD
+
+s_mul_hi_u32 s57, s[sgprWorkGroup2], s[sgprStridesC+1] // Scale s[sgprWorkGroup2] by Stride
+s_mul_i32 s56, s[sgprWorkGroup2], s[sgprStridesC+1] // Scale s[sgprWorkGroup2] by Stride
+s_lshl_b64 s[56:57], s[56:57], 3                   // scale by bpe
+s_add_u32 s[sgprSrdD+0], s[sgprSrdD+0], s56        // add lo to SRD
+s_addc_u32 s[sgprSrdD+1], s[sgprSrdD+1], s57       // add hi to SRD
+s_add_u32 s[sgprSrdC+0], s[sgprSrdC+0], s56        // add lo to SRD
+s_addc_u32 s[sgprSrdC+1], s[sgprSrdC+1], s57       // add hi to SRD
+
+v_lshrrev_b32 v49, 3, v[vgprSerial]                // vectorStaticDiv: v49 = v[vgprSerial] / 8
+v_and_b32 v48, 7, v[vgprSerial]                    // vectorStaticDiv: v48 = v[vgprSerial] % 8
+v_lshlrev_b32 v48, 1, v48                          // staticMultiply: v48 = v48 * 2
+v_lshlrev_b32 v49, 1, v49                          // staticMultiply: v49 = v49 * 2
+v_mul_lo_u32 v50, v49, s[sgprStridesC+0]           // rowStart vgpr
+
+s_mul_i32 s56, 0x30, s[sgprWorkGroup0]             // s56 = wg0*MT0
+_v_add_co_u32 v48, vcc, s56, v48                   // coord0 = tid0*VW + wg0*MT0
+s_mul_i32 s58, 0x40, s[sgprWorkGroup1]             // <- wg1*MT1
+_v_add_co_u32 v49, vcc, s58, v49                   // coord1 = tid1*VW + wg1*MT1
+
+//v_mov_b32 v48,v[vgprLocalWriteAddrA]
+//v_mov_b32 v49,v[vgprLocalWriteAddrB]
+//v_mov_b32 v50,v[vgprGlobalReadOffsetB]           // rowStart vgpr
+//_v_add_lshl_u32 v[vgprGlobalReadOffsetA], v[vgprGlobalReadOffsetB], v[vgprLocalWriteAddrA], 0x3                 // init cb addr <-  rowStart + coord0, scaled by BPE
+
+/* not-LocalSplitU: global write */
+
+s_mov_b32 s56, s[sgprBeta+0]                       // tmp = Beta[0]
+s_or_b32 s56, s[sgprBeta+1], s56                   // tmp |= Beta[1]
+s_cmpk_eq_u32 s56, 0x0                             // Beta == 0
+s_cbranch_scc0 label_0030                          // Beta is not zero; so jump to B nonzero
+
+s_mov_b32 s56, 0x0                                 // rMT0=0
+s_add_u32 s58, -0x1, s[sgprNumWorkGroups0]         //
+s_cmp_lt_u32 s[sgprWorkGroup0], s58                // wg0 < nwg0-1
+s_cbranch_scc1 label_0027                          // wg0 < nwg0-1 so skip rMT0 = Size0 % MT0
+/* TODO-packed- compare against product of all packed C0 sizes not just SizesFree+0 */
+s_mov_b32 s61, 0x0                                 // STATIC_DIV: divisior=48
+s_mul_i32 s60, 0xaaa, s[sgprSizesFree+0]           // tmp1 = dividend * magic hi
+s_lshl_b64 s[60:61], s[60:61], 0x10                // left shift 16 bits
+s_mul_i32 s58, s[sgprSizesFree+0], 0xaaab          // tmp0 = dividend * magic lo
+s_add_u32 s60, s58, s60                            // add lo
+s_addc_u32 s61, s61, 0x0                           // add hi
+s_lshr_b64 s[60:61], s[60:61], 0x21                // tmp1 = (dividend * magic) << shift
+s_mov_b32 s58, s60                                 // quotient
+s_mul_i32 s60, s58, 0x30                           // quotient*divisor
+s_sub_u32 s56, s[sgprSizesFree+0], s60             // rReg = dividend - quotient*divisor
+label_0027:
+s_cmpk_gt_u32 s56, 0x0                             // rMT0 > 0
+s_cbranch_scc1 label_0029                          // edges required so jump to E1
+s_mov_b32 s56, 0x0                                 // rMT1=0
+s_add_u32 s58, -0x1, s[sgprNumWorkGroups1]         //
+s_cmp_lt_u32 s[sgprWorkGroup1], s58                // wg1 < nwg1-1
+s_cbranch_scc1 label_0028                          // wg1 < nwg1-1 so skip rMT1 = Size1 % MT1
+s_lshr_b32 s58, s[sgprSizesFree+1], 6              // s58 = s[sgprSizesFree+1] / 64
+s_and_b32 s56, 63, s[sgprSizesFree+1]              // s56 = s[sgprSizesFree+1] % 64
+label_0028:
+s_cmpk_gt_u32 s56, 0x0                             // rMT1 > 0
+s_cbranch_scc1 label_0029                          // edges required so jump to E1
+label_0026:
+
+/******************************************/
+/* Global Write Batch #0 (d1,d0,vc1,vc0) =
+   (0,0,0,0:vw2); (0,1,0,0:vw2); (0,2,0,0:vw2); (0,0,1,0:vw2); (0,1,1,0:vw2); (0,2,1,0:vw2); (1,0,0,0:vw2); (1,1,0,0:vw2); (1,2,0,0:vw2); (1,0,1,0:vw2); (1,1,1,0:vw2); (1,2,1,0:vw2) */
+/******************************************/
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(0,0,0,0) coordOffset1=0 element-rows coordOffset0=0 rows */
+_v_add_lshl_u32 v54, v50, v48, 0x3                 // init cb addr <-  rowStart + coord0, scaled by BPE
+/* (d1,vc1,d0,vc0)=(0,0,1,0) coordOffset1=0 element-rows coordOffset0=16 rows */
+/* (d1,vc1,d0,vc0)=(0,0,2,0) coordOffset1=0 element-rows coordOffset0=32 rows */
+/* (d1,vc1,d0,vc0)=(0,1,0,0) coordOffset1=1 element-rows coordOffset0=0 rows */
+/* (d1,vc1,d0,vc0)=(0,1,1,0) coordOffset1=1 element-rows coordOffset0=16 rows */
+/* (d1,vc1,d0,vc0)=(0,1,2,0) coordOffset1=1 element-rows coordOffset0=32 rows */
+/* (d1,vc1,d0,vc0)=(1,0,0,0) coordOffset1=32 element-rows coordOffset0=0 rows */
+/* (d1,vc1,d0,vc0)=(1,0,1,0) coordOffset1=32 element-rows coordOffset0=16 rows */
+/* (d1,vc1,d0,vc0)=(1,0,2,0) coordOffset1=32 element-rows coordOffset0=32 rows */
+/* (d1,vc1,d0,vc0)=(1,1,0,0) coordOffset1=33 element-rows coordOffset0=0 rows */
+/* (d1,vc1,d0,vc0)=(1,1,1,0) coordOffset1=33 element-rows coordOffset0=16 rows */
+/* (d1,vc1,d0,vc0)=(1,1,2,0) coordOffset1=33 element-rows coordOffset0=32 rows */
+
+/* rC *= alpha batchEements=[(0, 0, 0, 0), (0, 1, 0, 0), (0, 2, 0, 0), (0, 0, 1, 0), (0, 1, 1, 0), (0, 2, 1, 0), (1, 0, 0, 0), (1, 1, 0, 0), (1, 2, 0, 0), (1, 0, 1, 0), (1, 1, 1, 0), (1, 2, 1, 0)] */
+//v_mul_f64 v[vgprValuC+0:vgprValuC+0+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+0:vgprValuC+0+1] // *= alpha
+//v_mul_f64 v[vgprValuC+2:vgprValuC+2+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+2:vgprValuC+2+1] // *= alpha
+//v_mul_f64 v[vgprValuC+4:vgprValuC+4+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+4:vgprValuC+4+1] // *= alpha
+//v_mul_f64 v[vgprValuC+6:vgprValuC+6+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+6:vgprValuC+6+1] // *= alpha
+//v_mul_f64 v[vgprValuC+8:vgprValuC+8+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+8:vgprValuC+8+1] // *= alpha
+//v_mul_f64 v[vgprValuC+10:vgprValuC+10+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+10:vgprValuC+10+1] // *= alpha
+//v_mul_f64 v[vgprValuC+12:vgprValuC+12+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+12:vgprValuC+12+1] // *= alpha
+//v_mul_f64 v[vgprValuC+14:vgprValuC+14+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+14:vgprValuC+14+1] // *= alpha
+//v_mul_f64 v[vgprValuC+16:vgprValuC+16+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+16:vgprValuC+16+1] // *= alpha
+//v_mul_f64 v[vgprValuC+18:vgprValuC+18+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+18:vgprValuC+18+1] // *= alpha
+//v_mul_f64 v[vgprValuC+20:vgprValuC+20+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+20:vgprValuC+20+1] // *= alpha
+//v_mul_f64 v[vgprValuC+22:vgprValuC+22+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+22:vgprValuC+22+1] // *= alpha
+//v_mul_f64 v[vgprValuC+24:vgprValuC+24+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+24:vgprValuC+24+1] // *= alpha
+//v_mul_f64 v[vgprValuC+26:vgprValuC+26+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+26:vgprValuC+26+1] // *= alpha
+//v_mul_f64 v[vgprValuC+28:vgprValuC+28+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+28:vgprValuC+28+1] // *= alpha
+//v_mul_f64 v[vgprValuC+30:vgprValuC+30+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+30:vgprValuC+30+1] // *= alpha
+//v_mul_f64 v[vgprValuC+32:vgprValuC+32+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+32:vgprValuC+32+1] // *= alpha
+//v_mul_f64 v[vgprValuC+34:vgprValuC+34+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+34:vgprValuC+34+1] // *= alpha
+//v_mul_f64 v[vgprValuC+36:vgprValuC+36+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+36:vgprValuC+36+1] // *= alpha
+//v_mul_f64 v[vgprValuC+38:vgprValuC+38+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+38:vgprValuC+38+1] // *= alpha
+//v_mul_f64 v[vgprValuC+40:vgprValuC+40+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+40:vgprValuC+40+1] // *= alpha
+//v_mul_f64 v[vgprValuC+42:vgprValuC+42+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+42:vgprValuC+42+1] // *= alpha
+//v_mul_f64 v[vgprValuC+44:vgprValuC+44+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+44:vgprValuC+44+1] // *= alpha
+//v_mul_f64 v[vgprValuC+46:vgprValuC+46+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+46:vgprValuC+46+1] // *= alpha
+
+/* apply mask, calc new C and issue write */
+buffer_store_dwordx4 v[0:3], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx4 v[4:7], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+buffer_store_dwordx4 v[8:11], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+buffer_store_dwordx4 v[12:15], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx4 v[16:19], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+buffer_store_dwordx4 v[20:23], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_mul_i32 s56, s[sgprStridesC+0], 248              // scale StrideC *= 31 * bpe
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+buffer_store_dwordx4 v[24:27], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx4 v[28:31], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+buffer_store_dwordx4 v[32:35], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+buffer_store_dwordx4 v[36:39], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx4 v[40:43], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+buffer_store_dwordx4 v[44:47], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_branch label_0037                                // jump to end
+label_0029:
+
+/******************************************/
+/* Global Write Edge Batch #0 (d1,d0,vc1,vc0) =
+   (0,0,0,0:vw1); (0,0,0,1:vw1); (0,1,0,0:vw1); (0,1,0,1:vw1); (0,2,0,0:vw1); (0,2,0,1:vw1); (0,0,1,0:vw1); (0,0,1,1:vw1); (0,1,1,0:vw1); (0,1,1,1:vw1); (0,2,1,0:vw1); (0,2,1,1:vw1); (1,0,0,0:vw1); (1,0,0,1:vw1); (1,1,0,0:vw1); (1,1,0,1:vw1); (1,2,0,0:vw1); (1,2,0,1:vw1) */
+/******************************************/
+
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(0,0,0,0) coordOffset1=0 element-rows coordOffset0=0 rows */
+v_mov_b32 v51, v50                                 // rowPtr <- rowStart (first row)
+_v_add_lshl_u32 v54, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[62:63], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v54, -1, v54, s[62:63]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,0,0,1) coordOffset1=0 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v55, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[64:65], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v55, -1, v55, s[64:65]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,0,1,0) coordOffset1=0 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v56, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[66:67], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v56, -1, v56, s[66:67]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,0,1,1) coordOffset1=0 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v57, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[68:69], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v57, -1, v57, s[68:69]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,0,2,0) coordOffset1=0 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v58, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[70:71], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v58, -1, v58, s[70:71]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,0,2,1) coordOffset1=0 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v59, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[72:73], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v59, -1, v59, s[72:73]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,1,0,0) coordOffset1=1 element-rows coordOffset0=0 rows */
+_v_add_co_u32 v53, vcc, v49, 1                     // coord1 += d1*sg1*VW + vc1
+_v_add_co_u32 v51, vcc, v51, s[sgprStridesC+0]     // rowPtr <- move to start of new row
+_v_add_lshl_u32 v60, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[74:75], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v60, -1, v60, s[74:75]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,1,0,1) coordOffset1=1 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v61, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[76:77], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v61, -1, v61, s[76:77]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,1,1,0) coordOffset1=1 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v62, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[78:79], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v62, -1, v62, s[78:79]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,1,1,1) coordOffset1=1 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v63, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[80:81], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v63, -1, v63, s[80:81]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,1,2,0) coordOffset1=1 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v64, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[82:83], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v64, -1, v64, s[82:83]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,1,2,1) coordOffset1=1 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v65, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[84:85], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v65, -1, v65, s[84:85]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,0,0,0) coordOffset1=32 element-rows coordOffset0=0 rows */
+_v_add_co_u32 v53, vcc, v49, 32                    // coord1 += d1*sg1*VW + vc1
+s_mul_i32 s56, s[sgprStridesC+0], 32               // scale StrideC *= coordOffset1(32)
+_v_add_co_u32 v51, vcc, v50, s56                   // rowPtr <- inc for non-0 (tt1+vc1))
+_v_add_lshl_u32 v66, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[86:87], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v66, -1, v66, s[86:87]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,0,0,1) coordOffset1=32 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v67, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[88:89], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v67, -1, v67, s[88:89]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,0,1,0) coordOffset1=32 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v68, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[90:91], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v68, -1, v68, s[90:91]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,0,1,1) coordOffset1=32 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v69, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[92:93], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v69, -1, v69, s[92:93]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,0,2,0) coordOffset1=32 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v70, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[94:95], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v70, -1, v70, s[94:95]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,0,2,1) coordOffset1=32 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v71, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[96:97], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v71, -1, v71, s[96:97]               // clip if OOB. offset
+
+/* rC *= alpha batchEements=[(0, 0, 0, 0), (0, 0, 0, 1), (0, 1, 0, 0), (0, 1, 0, 1), (0, 2, 0, 0), (0, 2, 0, 1), (0, 0, 1, 0), (0, 0, 1, 1), (0, 1, 1, 0), (0, 1, 1, 1), (0, 2, 1, 0), (0, 2, 1, 1), (1, 0, 0, 0), (1, 0, 0, 1), (1, 1, 0, 0), (1, 1, 0, 1), (1, 2, 0, 0), (1, 2, 0, 1)] */
+//v_mul_f64 v[vgprValuC+0:vgprValuC+0+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+0:vgprValuC+0+1] // *= alpha
+//v_mul_f64 v[vgprValuC+2:vgprValuC+2+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+2:vgprValuC+2+1] // *= alpha
+//v_mul_f64 v[vgprValuC+4:vgprValuC+4+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+4:vgprValuC+4+1] // *= alpha
+//v_mul_f64 v[vgprValuC+6:vgprValuC+6+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+6:vgprValuC+6+1] // *= alpha
+//v_mul_f64 v[vgprValuC+8:vgprValuC+8+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+8:vgprValuC+8+1] // *= alpha
+//v_mul_f64 v[vgprValuC+10:vgprValuC+10+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+10:vgprValuC+10+1] // *= alpha
+//v_mul_f64 v[vgprValuC+12:vgprValuC+12+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+12:vgprValuC+12+1] // *= alpha
+//v_mul_f64 v[vgprValuC+14:vgprValuC+14+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+14:vgprValuC+14+1] // *= alpha
+//v_mul_f64 v[vgprValuC+16:vgprValuC+16+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+16:vgprValuC+16+1] // *= alpha
+//v_mul_f64 v[vgprValuC+18:vgprValuC+18+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+18:vgprValuC+18+1] // *= alpha
+//v_mul_f64 v[vgprValuC+20:vgprValuC+20+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+20:vgprValuC+20+1] // *= alpha
+//v_mul_f64 v[vgprValuC+22:vgprValuC+22+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+22:vgprValuC+22+1] // *= alpha
+//v_mul_f64 v[vgprValuC+24:vgprValuC+24+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+24:vgprValuC+24+1] // *= alpha
+//v_mul_f64 v[vgprValuC+26:vgprValuC+26+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+26:vgprValuC+26+1] // *= alpha
+//v_mul_f64 v[vgprValuC+28:vgprValuC+28+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+28:vgprValuC+28+1] // *= alpha
+//v_mul_f64 v[vgprValuC+30:vgprValuC+30+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+30:vgprValuC+30+1] // *= alpha
+//v_mul_f64 v[vgprValuC+32:vgprValuC+32+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+32:vgprValuC+32+1] // *= alpha
+//v_mul_f64 v[vgprValuC+34:vgprValuC+34+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+34:vgprValuC+34+1] // *= alpha
+
+/* apply mask, calc new C and issue write */
+buffer_store_dwordx2 v[0:1], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[2:3], v55, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[4:5], v56, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[6:7], v57, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[8:9], v58, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[10:11], v59, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[12:13], v60, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[14:15], v61, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[16:17], v62, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[18:19], v63, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[20:21], v64, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[22:23], v65, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[24:25], v66, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[26:27], v67, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[28:29], v68, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[30:31], v69, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[32:33], v70, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[34:35], v71, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+/******************************************/
+/* Global Write Edge Batch #1 (d1,d0,vc1,vc0) =
+   (1,0,1,0:vw1); (1,0,1,1:vw1); (1,1,1,0:vw1); (1,1,1,1:vw1); (1,2,1,0:vw1); (1,2,1,1:vw1) */
+/******************************************/
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(1,1,0,0) coordOffset1=33 element-rows coordOffset0=0 rows */
+_v_add_co_u32 v53, vcc, v49, 33                    // coord1 += d1*sg1*VW + vc1
+_v_add_co_u32 v51, vcc, v51, s[sgprStridesC+0]     // rowPtr <- move to start of new row
+_v_add_lshl_u32 v54, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[62:63], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v54, -1, v54, s[62:63]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,1,0,1) coordOffset1=33 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v55, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[64:65], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v55, -1, v55, s[64:65]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,1,1,0) coordOffset1=33 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v56, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[66:67], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v56, -1, v56, s[66:67]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,1,1,1) coordOffset1=33 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v57, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[68:69], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v57, -1, v57, s[68:69]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,1,2,0) coordOffset1=33 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v58, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[70:71], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v58, -1, v58, s[70:71]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,1,2,1) coordOffset1=33 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v59, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[72:73], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v59, -1, v59, s[72:73]               // clip if OOB. offset
+
+/* rC *= alpha batchEements=[(1, 0, 1, 0), (1, 0, 1, 1), (1, 1, 1, 0), (1, 1, 1, 1), (1, 2, 1, 0), (1, 2, 1, 1)] */
+//v_mul_f64 v[vgprValuC+36:vgprValuC+36+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+36:vgprValuC+36+1] // *= alpha
+//v_mul_f64 v[vgprValuC+38:vgprValuC+38+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+38:vgprValuC+38+1] // *= alpha
+//v_mul_f64 v[vgprValuC+40:vgprValuC+40+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+40:vgprValuC+40+1] // *= alpha
+//v_mul_f64 v[vgprValuC+42:vgprValuC+42+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+42:vgprValuC+42+1] // *= alpha
+//v_mul_f64 v[vgprValuC+44:vgprValuC+44+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+44:vgprValuC+44+1] // *= alpha
+//v_mul_f64 v[vgprValuC+46:vgprValuC+46+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+46:vgprValuC+46+1] // *= alpha
+
+/* apply mask, calc new C and issue write */
+buffer_store_dwordx2 v[36:37], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[38:39], v55, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[40:41], v56, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[42:43], v57, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[44:45], v58, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[46:47], v59, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_branch label_0037                                // jump to end
+label_0030:
+s_mov_b32 s56, 0x0                                 // rMT0=0
+s_add_u32 s58, -0x1, s[sgprNumWorkGroups0]         //
+s_cmp_lt_u32 s[sgprWorkGroup0], s58                // wg0 < nwg0-1
+s_cbranch_scc1 label_0034                          // wg0 < nwg0-1 so skip rMT0 = Size0 % MT0
+/* TODO-packed- compare against product of all packed C0 sizes not just SizesFree+0 */
+s_mov_b32 s61, 0x0                                 // STATIC_DIV: divisior=48
+s_mul_i32 s60, 0xaaa, s[sgprSizesFree+0]           // tmp1 = dividend * magic hi
+s_lshl_b64 s[60:61], s[60:61], 0x10                // left shift 16 bits
+s_mul_i32 s58, s[sgprSizesFree+0], 0xaaab          // tmp0 = dividend * magic lo
+s_add_u32 s60, s58, s60                            // add lo
+s_addc_u32 s61, s61, 0x0                           // add hi
+s_lshr_b64 s[60:61], s[60:61], 0x21                // tmp1 = (dividend * magic) << shift
+s_mov_b32 s58, s60                                 // quotient
+s_mul_i32 s60, s58, 0x30                           // quotient*divisor
+s_sub_u32 s56, s[sgprSizesFree+0], s60             // rReg = dividend - quotient*divisor
+label_0034:
+s_cmpk_gt_u32 s56, 0x0                             // rMT0 > 0
+s_cbranch_scc1 label_0036                          // edges required so jump to E1
+s_mov_b32 s56, 0x0                                 // rMT1=0
+s_add_u32 s58, -0x1, s[sgprNumWorkGroups1]         //
+s_cmp_lt_u32 s[sgprWorkGroup1], s58                // wg1 < nwg1-1
+s_cbranch_scc1 label_0035                          // wg1 < nwg1-1 so skip rMT1 = Size1 % MT1
+s_lshr_b32 s58, s[sgprSizesFree+1], 6              // s58 = s[sgprSizesFree+1] / 64
+s_and_b32 s56, 63, s[sgprSizesFree+1]              // s56 = s[sgprSizesFree+1] % 64
+label_0035:
+s_cmpk_gt_u32 s56, 0x0                             // rMT1 > 0
+s_cbranch_scc1 label_0036                          // edges required so jump to E1
+label_0033:
+
+/******************************************/
+/* Global Write Beta Batch #0 (d1,d0,vc1,vc0) =
+   (0,0,0,0:vw2); (0,1,0,0:vw2); (0,2,0,0:vw2); (0,0,1,0:vw2); (0,1,1,0:vw2); (0,2,1,0:vw2) */
+/******************************************/
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(0,0,0,0) coordOffset1=0 element-rows coordOffset0=0 rows */
+_v_add_lshl_u32 v54, v[vgprGlobalReadOffsetB], v48, 0x3                 // init cb addr <-  rowStart + coord0, scaled by BPE
+buffer_load_dwordx4 v[55:58], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,1,0) coordOffset1=0 element-rows coordOffset0=16 rows */
+buffer_load_dwordx4 v[59:62], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,2,0) coordOffset1=0 element-rows coordOffset0=32 rows */
+buffer_load_dwordx4 v[63:66], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,0,0) coordOffset1=1 element-rows coordOffset0=0 rows */
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+buffer_load_dwordx4 v[67:70], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,1,0) coordOffset1=1 element-rows coordOffset0=16 rows */
+buffer_load_dwordx4 v[71:74], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,2,0) coordOffset1=1 element-rows coordOffset0=32 rows */
+buffer_load_dwordx4 v[75:78], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+
+/* rC *= alpha batchEements=[(0, 0, 0, 0), (0, 1, 0, 0), (0, 2, 0, 0), (0, 0, 1, 0), (0, 1, 1, 0), (0, 2, 1, 0)] */
+v_mul_f64 v[vgprValuC+0:vgprValuC+0+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+0:vgprValuC+0+1] // *= alpha
+v_mul_f64 v[vgprValuC+2:vgprValuC+2+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+2:vgprValuC+2+1] // *= alpha
+v_mul_f64 v[vgprValuC+4:vgprValuC+4+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+4:vgprValuC+4+1] // *= alpha
+v_mul_f64 v[vgprValuC+6:vgprValuC+6+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+6:vgprValuC+6+1] // *= alpha
+v_mul_f64 v[vgprValuC+8:vgprValuC+8+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+8:vgprValuC+8+1] // *= alpha
+v_mul_f64 v[vgprValuC+10:vgprValuC+10+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+10:vgprValuC+10+1] // *= alpha
+v_mul_f64 v[vgprValuC+12:vgprValuC+12+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+12:vgprValuC+12+1] // *= alpha
+v_mul_f64 v[vgprValuC+14:vgprValuC+14+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+14:vgprValuC+14+1] // *= alpha
+v_mul_f64 v[vgprValuC+16:vgprValuC+16+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+16:vgprValuC+16+1] // *= alpha
+v_mul_f64 v[vgprValuC+18:vgprValuC+18+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+18:vgprValuC+18+1] // *= alpha
+v_mul_f64 v[vgprValuC+20:vgprValuC+20+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+20:vgprValuC+20+1] // *= alpha
+v_mul_f64 v[vgprValuC+22:vgprValuC+22+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+22:vgprValuC+22+1] // *= alpha
+
+/* apply mask, calc new C and issue write */
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+0:vgprValuC+0+1], v[55:56], s[sgprBeta:sgprBeta+1], v[vgprValuC+0:vgprValuC+0+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+2:vgprValuC+2+1], v[57:58], s[sgprBeta:sgprBeta+1], v[vgprValuC+2:vgprValuC+2+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[0:3], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+4:vgprValuC+4+1], v[59:60], s[sgprBeta:sgprBeta+1], v[vgprValuC+4:vgprValuC+4+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+6:vgprValuC+6+1], v[61:62], s[sgprBeta:sgprBeta+1], v[vgprValuC+6:vgprValuC+6+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[4:7], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+8:vgprValuC+8+1], v[63:64], s[sgprBeta:sgprBeta+1], v[vgprValuC+8:vgprValuC+8+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+10:vgprValuC+10+1], v[65:66], s[sgprBeta:sgprBeta+1], v[vgprValuC+10:vgprValuC+10+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[8:11], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+12:vgprValuC+12+1], v[67:68], s[sgprBeta:sgprBeta+1], v[vgprValuC+12:vgprValuC+12+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+14:vgprValuC+14+1], v[69:70], s[sgprBeta:sgprBeta+1], v[vgprValuC+14:vgprValuC+14+1] // finalSum = sum*alpha + C*beta
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+buffer_store_dwordx4 v[12:15], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+16:vgprValuC+16+1], v[71:72], s[sgprBeta:sgprBeta+1], v[vgprValuC+16:vgprValuC+16+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+18:vgprValuC+18+1], v[73:74], s[sgprBeta:sgprBeta+1], v[vgprValuC+18:vgprValuC+18+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[16:19], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+20:vgprValuC+20+1], v[75:76], s[sgprBeta:sgprBeta+1], v[vgprValuC+20:vgprValuC+20+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+22:vgprValuC+22+1], v[77:78], s[sgprBeta:sgprBeta+1], v[vgprValuC+22:vgprValuC+22+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[20:23], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+
+/******************************************/
+/* Global Write Beta Batch #1 (d1,d0,vc1,vc0) =
+   (1,0,0,0:vw2); (1,1,0,0:vw2); (1,2,0,0:vw2); (1,0,1,0:vw2); (1,1,1,0:vw2); (1,2,1,0:vw2) */
+/******************************************/
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(1,0,0,0) coordOffset1=32 element-rows coordOffset0=0 rows */
+s_mul_i32 s56, s[sgprStridesD+0], 248              // scale StrideC *= 31 * bpe
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+buffer_load_dwordx4 v[55:58], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,1,0) coordOffset1=32 element-rows coordOffset0=16 rows */
+buffer_load_dwordx4 v[59:62], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,2,0) coordOffset1=32 element-rows coordOffset0=32 rows */
+buffer_load_dwordx4 v[63:66], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,0,0) coordOffset1=33 element-rows coordOffset0=0 rows */
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+buffer_load_dwordx4 v[67:70], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,1,0) coordOffset1=33 element-rows coordOffset0=16 rows */
+buffer_load_dwordx4 v[71:74], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,2,0) coordOffset1=33 element-rows coordOffset0=32 rows */
+buffer_load_dwordx4 v[75:78], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+
+/* rC *= alpha batchEements=[(1, 0, 0, 0), (1, 1, 0, 0), (1, 2, 0, 0), (1, 0, 1, 0), (1, 1, 1, 0), (1, 2, 1, 0)] */
+v_mul_f64 v[vgprValuC+24:vgprValuC+24+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+24:vgprValuC+24+1] // *= alpha
+v_mul_f64 v[vgprValuC+26:vgprValuC+26+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+26:vgprValuC+26+1] // *= alpha
+v_mul_f64 v[vgprValuC+28:vgprValuC+28+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+28:vgprValuC+28+1] // *= alpha
+v_mul_f64 v[vgprValuC+30:vgprValuC+30+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+30:vgprValuC+30+1] // *= alpha
+v_mul_f64 v[vgprValuC+32:vgprValuC+32+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+32:vgprValuC+32+1] // *= alpha
+v_mul_f64 v[vgprValuC+34:vgprValuC+34+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+34:vgprValuC+34+1] // *= alpha
+v_mul_f64 v[vgprValuC+36:vgprValuC+36+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+36:vgprValuC+36+1] // *= alpha
+v_mul_f64 v[vgprValuC+38:vgprValuC+38+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+38:vgprValuC+38+1] // *= alpha
+v_mul_f64 v[vgprValuC+40:vgprValuC+40+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+40:vgprValuC+40+1] // *= alpha
+v_mul_f64 v[vgprValuC+42:vgprValuC+42+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+42:vgprValuC+42+1] // *= alpha
+v_mul_f64 v[vgprValuC+44:vgprValuC+44+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+44:vgprValuC+44+1] // *= alpha
+v_mul_f64 v[vgprValuC+46:vgprValuC+46+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+46:vgprValuC+46+1] // *= alpha
+
+/* apply mask, calc new C and issue write */
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+24:vgprValuC+24+1], v[55:56], s[sgprBeta:sgprBeta+1], v[vgprValuC+24:vgprValuC+24+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+26:vgprValuC+26+1], v[57:58], s[sgprBeta:sgprBeta+1], v[vgprValuC+26:vgprValuC+26+1] // finalSum = sum*alpha + C*beta
+s_mul_i32 s56, s[sgprStridesD+0], 248              // scale StrideC *= 31 * bpe
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+buffer_store_dwordx4 v[24:27], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+28:vgprValuC+28+1], v[59:60], s[sgprBeta:sgprBeta+1], v[vgprValuC+28:vgprValuC+28+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+30:vgprValuC+30+1], v[61:62], s[sgprBeta:sgprBeta+1], v[vgprValuC+30:vgprValuC+30+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[28:31], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+32:vgprValuC+32+1], v[63:64], s[sgprBeta:sgprBeta+1], v[vgprValuC+32:vgprValuC+32+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+34:vgprValuC+34+1], v[65:66], s[sgprBeta:sgprBeta+1], v[vgprValuC+34:vgprValuC+34+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[32:35], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+36:vgprValuC+36+1], v[67:68], s[sgprBeta:sgprBeta+1], v[vgprValuC+36:vgprValuC+36+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+38:vgprValuC+38+1], v[69:70], s[sgprBeta:sgprBeta+1], v[vgprValuC+38:vgprValuC+38+1] // finalSum = sum*alpha + C*beta
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+buffer_store_dwordx4 v[36:39], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+40:vgprValuC+40+1], v[71:72], s[sgprBeta:sgprBeta+1], v[vgprValuC+40:vgprValuC+40+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+42:vgprValuC+42+1], v[73:74], s[sgprBeta:sgprBeta+1], v[vgprValuC+42:vgprValuC+42+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[40:43], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+44:vgprValuC+44+1], v[75:76], s[sgprBeta:sgprBeta+1], v[vgprValuC+44:vgprValuC+44+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+46:vgprValuC+46+1], v[77:78], s[sgprBeta:sgprBeta+1], v[vgprValuC+46:vgprValuC+46+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[44:47], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_branch label_0037                                // jump to end
+label_0036:
+
+/******************************************/
+/* Global Write Beta Edge Batch #0 (d1,d0,vc1,vc0) =
+   (0,0,0,0:vw1); (0,0,0,1:vw1); (0,1,0,0:vw1); (0,1,0,1:vw1); (0,2,0,0:vw1); (0,2,0,1:vw1); (0,0,1,0:vw1); (0,0,1,1:vw1) */
+/******************************************/
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(0,0,0,0) coordOffset1=0 element-rows coordOffset0=0 rows */
+v_mov_b32 v51, v50                                 // rowPtr <- rowStart (first row)
+_v_add_lshl_u32 v54, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[62:63], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v54, -1, v54, s[62:63]               // clip if OOB. offset
+buffer_load_dwordx2 v[55:56], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,0,1) coordOffset1=0 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v57, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[64:65], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v57, -1, v57, s[64:65]               // clip if OOB. offset
+buffer_load_dwordx2 v[58:59], v57, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,1,0) coordOffset1=0 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v60, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[66:67], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v60, -1, v60, s[66:67]               // clip if OOB. offset
+buffer_load_dwordx2 v[61:62], v60, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,1,1) coordOffset1=0 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v63, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[68:69], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v63, -1, v63, s[68:69]               // clip if OOB. offset
+buffer_load_dwordx2 v[64:65], v63, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,2,0) coordOffset1=0 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v66, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[70:71], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v66, -1, v66, s[70:71]               // clip if OOB. offset
+buffer_load_dwordx2 v[67:68], v66, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,2,1) coordOffset1=0 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v69, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[72:73], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v69, -1, v69, s[72:73]               // clip if OOB. offset
+buffer_load_dwordx2 v[70:71], v69, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,0,0) coordOffset1=1 element-rows coordOffset0=0 rows */
+_v_add_co_u32 v53, vcc, v49, 1                     // coord1 += d1*sg1*VW + vc1
+_v_add_co_u32 v51, vcc, v51, s[sgprStridesC+0]     // rowPtr <- move to start of new row
+_v_add_lshl_u32 v72, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[74:75], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v72, -1, v72, s[74:75]               // clip if OOB. offset
+buffer_load_dwordx2 v[73:74], v72, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,0,1) coordOffset1=1 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v75, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[76:77], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v75, -1, v75, s[76:77]               // clip if OOB. offset
+buffer_load_dwordx2 v[76:77], v75, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+
+/* rC *= alpha batchEements=[(0, 0, 0, 0), (0, 0, 0, 1), (0, 1, 0, 0), (0, 1, 0, 1), (0, 2, 0, 0), (0, 2, 0, 1), (0, 0, 1, 0), (0, 0, 1, 1)] */
+v_mul_f64 v[vgprValuC+0:vgprValuC+0+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+0:vgprValuC+0+1] // *= alpha
+v_mul_f64 v[vgprValuC+2:vgprValuC+2+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+2:vgprValuC+2+1] // *= alpha
+v_mul_f64 v[vgprValuC+4:vgprValuC+4+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+4:vgprValuC+4+1] // *= alpha
+v_mul_f64 v[vgprValuC+6:vgprValuC+6+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+6:vgprValuC+6+1] // *= alpha
+v_mul_f64 v[vgprValuC+8:vgprValuC+8+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+8:vgprValuC+8+1] // *= alpha
+v_mul_f64 v[vgprValuC+10:vgprValuC+10+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+10:vgprValuC+10+1] // *= alpha
+v_mul_f64 v[vgprValuC+12:vgprValuC+12+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+12:vgprValuC+12+1] // *= alpha
+v_mul_f64 v[vgprValuC+14:vgprValuC+14+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+14:vgprValuC+14+1] // *= alpha
+s_waitcnt vmcnt(0)                                 // wait C
+
+/* apply mask, calc new C and issue write */
+v_fma_f64 v[vgprValuC+0:vgprValuC+0+1], v[55:56], s[sgprBeta:sgprBeta+1], v[vgprValuC+0:vgprValuC+0+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[0:1], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+2:vgprValuC+2+1], v[58:59], s[sgprBeta:sgprBeta+1], v[vgprValuC+2:vgprValuC+2+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[2:3], v57, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+4:vgprValuC+4+1], v[61:62], s[sgprBeta:sgprBeta+1], v[vgprValuC+4:vgprValuC+4+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[4:5], v60, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+6:vgprValuC+6+1], v[64:65], s[sgprBeta:sgprBeta+1], v[vgprValuC+6:vgprValuC+6+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[6:7], v63, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+8:vgprValuC+8+1], v[67:68], s[sgprBeta:sgprBeta+1], v[vgprValuC+8:vgprValuC+8+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[8:9], v66, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+10:vgprValuC+10+1], v[70:71], s[sgprBeta:sgprBeta+1], v[vgprValuC+10:vgprValuC+10+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[10:11], v69, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+12:vgprValuC+12+1], v[73:74], s[sgprBeta:sgprBeta+1], v[vgprValuC+12:vgprValuC+12+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[12:13], v72, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+14:vgprValuC+14+1], v[76:77], s[sgprBeta:sgprBeta+1], v[vgprValuC+14:vgprValuC+14+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[14:15], v75, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+/******************************************/
+/* Global Write Beta Edge Batch #1 (d1,d0,vc1,vc0) =
+   (0,1,1,0:vw1); (0,1,1,1:vw1); (0,2,1,0:vw1); (0,2,1,1:vw1); (1,0,0,0:vw1); (1,0,0,1:vw1); (1,1,0,0:vw1); (1,1,0,1:vw1) */
+/******************************************/
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(0,1,1,0) coordOffset1=1 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v54, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[62:63], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v54, -1, v54, s[62:63]               // clip if OOB. offset
+buffer_load_dwordx2 v[55:56], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,1,1) coordOffset1=1 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v57, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[64:65], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v57, -1, v57, s[64:65]               // clip if OOB. offset
+buffer_load_dwordx2 v[58:59], v57, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,2,0) coordOffset1=1 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v60, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[66:67], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v60, -1, v60, s[66:67]               // clip if OOB. offset
+buffer_load_dwordx2 v[61:62], v60, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,2,1) coordOffset1=1 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v63, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[68:69], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v63, -1, v63, s[68:69]               // clip if OOB. offset
+buffer_load_dwordx2 v[64:65], v63, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,0,0) coordOffset1=32 element-rows coordOffset0=0 rows */
+_v_add_co_u32 v53, vcc, v49, 32                    // coord1 += d1*sg1*VW + vc1
+s_mul_i32 s56, s[sgprStridesC+0], 32               // scale StrideC *= coordOffset1(32)
+_v_add_co_u32 v51, vcc, v50, s56                   // rowPtr <- inc for non-0 (tt1+vc1))
+_v_add_lshl_u32 v66, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[70:71], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v66, -1, v66, s[70:71]               // clip if OOB. offset
+buffer_load_dwordx2 v[67:68], v66, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,0,1) coordOffset1=32 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v69, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[72:73], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v69, -1, v69, s[72:73]               // clip if OOB. offset
+buffer_load_dwordx2 v[70:71], v69, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,1,0) coordOffset1=32 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v72, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[74:75], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v72, -1, v72, s[74:75]               // clip if OOB. offset
+buffer_load_dwordx2 v[73:74], v72, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,1,1) coordOffset1=32 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v75, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[76:77], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v75, -1, v75, s[76:77]               // clip if OOB. offset
+buffer_load_dwordx2 v[76:77], v75, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+
+/* rC *= alpha batchEements=[(0, 1, 1, 0), (0, 1, 1, 1), (0, 2, 1, 0), (0, 2, 1, 1), (1, 0, 0, 0), (1, 0, 0, 1), (1, 1, 0, 0), (1, 1, 0, 1)] */
+v_mul_f64 v[vgprValuC+16:vgprValuC+16+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+16:vgprValuC+16+1] // *= alpha
+v_mul_f64 v[vgprValuC+18:vgprValuC+18+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+18:vgprValuC+18+1] // *= alpha
+v_mul_f64 v[vgprValuC+20:vgprValuC+20+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+20:vgprValuC+20+1] // *= alpha
+v_mul_f64 v[vgprValuC+22:vgprValuC+22+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+22:vgprValuC+22+1] // *= alpha
+v_mul_f64 v[vgprValuC+24:vgprValuC+24+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+24:vgprValuC+24+1] // *= alpha
+v_mul_f64 v[vgprValuC+26:vgprValuC+26+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+26:vgprValuC+26+1] // *= alpha
+v_mul_f64 v[vgprValuC+28:vgprValuC+28+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+28:vgprValuC+28+1] // *= alpha
+v_mul_f64 v[vgprValuC+30:vgprValuC+30+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+30:vgprValuC+30+1] // *= alpha
+s_waitcnt vmcnt(0)                                 // wait C
+
+/* apply mask, calc new C and issue write */
+v_fma_f64 v[vgprValuC+16:vgprValuC+16+1], v[55:56], s[sgprBeta:sgprBeta+1], v[vgprValuC+16:vgprValuC+16+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[16:17], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+18:vgprValuC+18+1], v[58:59], s[sgprBeta:sgprBeta+1], v[vgprValuC+18:vgprValuC+18+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[18:19], v57, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+20:vgprValuC+20+1], v[61:62], s[sgprBeta:sgprBeta+1], v[vgprValuC+20:vgprValuC+20+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[20:21], v60, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+22:vgprValuC+22+1], v[64:65], s[sgprBeta:sgprBeta+1], v[vgprValuC+22:vgprValuC+22+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[22:23], v63, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+24:vgprValuC+24+1], v[67:68], s[sgprBeta:sgprBeta+1], v[vgprValuC+24:vgprValuC+24+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[24:25], v66, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+26:vgprValuC+26+1], v[70:71], s[sgprBeta:sgprBeta+1], v[vgprValuC+26:vgprValuC+26+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[26:27], v69, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+28:vgprValuC+28+1], v[73:74], s[sgprBeta:sgprBeta+1], v[vgprValuC+28:vgprValuC+28+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[28:29], v72, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+30:vgprValuC+30+1], v[76:77], s[sgprBeta:sgprBeta+1], v[vgprValuC+30:vgprValuC+30+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[30:31], v75, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+/******************************************/
+/* Global Write Beta Edge Batch #2 (d1,d0,vc1,vc0) =
+   (1,2,0,0:vw1); (1,2,0,1:vw1); (1,0,1,0:vw1); (1,0,1,1:vw1); (1,1,1,0:vw1); (1,1,1,1:vw1); (1,2,1,0:vw1); (1,2,1,1:vw1) */
+/******************************************/
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(1,0,2,0) coordOffset1=32 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v54, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[62:63], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v54, -1, v54, s[62:63]               // clip if OOB. offset
+buffer_load_dwordx2 v[55:56], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,2,1) coordOffset1=32 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v57, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[64:65], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v57, -1, v57, s[64:65]               // clip if OOB. offset
+buffer_load_dwordx2 v[58:59], v57, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,0,0) coordOffset1=33 element-rows coordOffset0=0 rows */
+_v_add_co_u32 v53, vcc, v49, 33                    // coord1 += d1*sg1*VW + vc1
+_v_add_co_u32 v51, vcc, v51, s[sgprStridesC+0]     // rowPtr <- move to start of new row
+_v_add_lshl_u32 v60, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[66:67], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v60, -1, v60, s[66:67]               // clip if OOB. offset
+buffer_load_dwordx2 v[61:62], v60, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,0,1) coordOffset1=33 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v63, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[68:69], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v63, -1, v63, s[68:69]               // clip if OOB. offset
+buffer_load_dwordx2 v[64:65], v63, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,1,0) coordOffset1=33 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v66, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[70:71], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v66, -1, v66, s[70:71]               // clip if OOB. offset
+buffer_load_dwordx2 v[67:68], v66, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,1,1) coordOffset1=33 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v69, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[72:73], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v69, -1, v69, s[72:73]               // clip if OOB. offset
+buffer_load_dwordx2 v[70:71], v69, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,2,0) coordOffset1=33 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v72, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[74:75], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v72, -1, v72, s[74:75]               // clip if OOB. offset
+buffer_load_dwordx2 v[73:74], v72, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,2,1) coordOffset1=33 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v75, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[76:77], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v75, -1, v75, s[76:77]               // clip if OOB. offset
+buffer_load_dwordx2 v[76:77], v75, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+
+/* rC *= alpha batchEements=[(1, 2, 0, 0), (1, 2, 0, 1), (1, 0, 1, 0), (1, 0, 1, 1), (1, 1, 1, 0), (1, 1, 1, 1), (1, 2, 1, 0), (1, 2, 1, 1)] */
+v_mul_f64 v[vgprValuC+32:vgprValuC+32+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+32:vgprValuC+32+1] // *= alpha
+v_mul_f64 v[vgprValuC+34:vgprValuC+34+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+34:vgprValuC+34+1] // *= alpha
+v_mul_f64 v[vgprValuC+36:vgprValuC+36+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+36:vgprValuC+36+1] // *= alpha
+v_mul_f64 v[vgprValuC+38:vgprValuC+38+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+38:vgprValuC+38+1] // *= alpha
+v_mul_f64 v[vgprValuC+40:vgprValuC+40+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+40:vgprValuC+40+1] // *= alpha
+v_mul_f64 v[vgprValuC+42:vgprValuC+42+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+42:vgprValuC+42+1] // *= alpha
+v_mul_f64 v[vgprValuC+44:vgprValuC+44+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+44:vgprValuC+44+1] // *= alpha
+v_mul_f64 v[vgprValuC+46:vgprValuC+46+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+46:vgprValuC+46+1] // *= alpha
+s_waitcnt vmcnt(0)                                 // wait C
+
+/* apply mask, calc new C and issue write */
+v_fma_f64 v[vgprValuC+32:vgprValuC+32+1], v[55:56], s[sgprBeta:sgprBeta+1], v[vgprValuC+32:vgprValuC+32+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[32:33], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+34:vgprValuC+34+1], v[58:59], s[sgprBeta:sgprBeta+1], v[vgprValuC+34:vgprValuC+34+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[34:35], v57, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+36:vgprValuC+36+1], v[61:62], s[sgprBeta:sgprBeta+1], v[vgprValuC+36:vgprValuC+36+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[36:37], v60, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+38:vgprValuC+38+1], v[64:65], s[sgprBeta:sgprBeta+1], v[vgprValuC+38:vgprValuC+38+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[38:39], v63, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+40:vgprValuC+40+1], v[67:68], s[sgprBeta:sgprBeta+1], v[vgprValuC+40:vgprValuC+40+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[40:41], v66, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+42:vgprValuC+42+1], v[70:71], s[sgprBeta:sgprBeta+1], v[vgprValuC+42:vgprValuC+42+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[42:43], v69, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+44:vgprValuC+44+1], v[73:74], s[sgprBeta:sgprBeta+1], v[vgprValuC+44:vgprValuC+44+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[44:45], v72, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+46:vgprValuC+46+1], v[76:77], s[sgprBeta:sgprBeta+1], v[vgprValuC+46:vgprValuC+46+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[46:47], v75, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_branch label_0037                                // jump to end
+label_0037:
+
+label_0038:  /// KernelEnd
+s_endpgm                                           // Kernel End
+
+

--- a/Tensile/ReplacementKernels-cov3/Cijk_Ailk_Bjlk_DB_MT48x64x4_AF0EM1_ASEM1_FL1_GRVW2_ISA908_MDA2_PGR1_PLR0_SU0_TT6_4_VAW1_VW2_WG8_16_1_WGM8.s.txt
+++ b/Tensile/ReplacementKernels-cov3/Cijk_Ailk_Bjlk_DB_MT48x64x4_AF0EM1_ASEM1_FL1_GRVW2_ISA908_MDA2_PGR1_PLR0_SU0_TT6_4_VAW1_VW2_WG8_16_1_WGM8.s.txt
@@ -1,0 +1,3897 @@
+
+
+/******************************************/
+/* Function Prefix                        */
+/******************************************/
+
+
+
+/******************************************/
+/* Begin Kernel                           */
+/******************************************/
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx908+sram-ecc"
+.text
+.protected Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM8
+.globl Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM8
+.p2align 8
+.type Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM8,@function
+.section .rodata,#alloc
+.p2align 6
+.amdhsa_kernel Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM8
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_next_free_vgpr 84 // vgprs
+  .amdhsa_next_free_sgpr 98 // sgprs
+  .amdhsa_group_segment_fixed_size 7680 // lds bytes
+  .amdhsa_private_segment_fixed_size 0
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+.text
+
+.amdgpu_metadata
+---
+amdhsa.version:
+  - 1
+  - 0
+amdhsa.kernels:
+  - .name: Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM8
+    .symbol: 'Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM8.kd'
+    .group_segment_fixed_size:   7680
+    .language:                   OpenCL C
+    .language_version:
+      - 2
+      - 0
+    .max_flat_workgroup_size: 128
+    .private_segment_fixed_size: 0
+    .sgpr_count:                 98
+    .sgpr_spill_count:           0
+    .vgpr_count:                 84
+    .vgpr_spill_count:           0
+    .wavefront_size:             64
+    .args:
+      - .name:            sizeC
+        .size:            8
+        .offset:          0
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            sizeA
+        .size:            8
+        .offset:          8
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            sizeB
+        .size:            8
+        .offset:          16
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            D
+        .size:            8
+        .offset:          24
+        .value_kind:      global_buffer
+        .value_type:      f64
+        .address_space:   generic
+      - .name:            C
+        .size:            8
+        .offset:          32
+        .value_kind:      global_buffer
+        .value_type:      f64
+        .address_space:   generic
+      - .name:            A
+        .size:            8
+        .offset:          40
+        .value_kind:      global_buffer
+        .value_type:      f64
+        .address_space:   generic
+      - .name:            B
+        .size:            8
+        .offset:          48
+        .value_kind:      global_buffer
+        .value_type:      f64
+        .address_space:   generic
+      - .name:            alpha
+        .size:            8
+        .offset:          56
+        .value_kind:      by_value
+        .value_type:      f64
+      - .name:            beta
+        .size:            8
+        .offset:          64
+        .value_kind:      by_value
+        .value_type:      f64
+      - .name:            strideD0
+        .size:            4
+        .offset:          72
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideD1
+        .size:            4
+        .offset:          76
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideC0
+        .size:            4
+        .offset:          80
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideC1
+        .size:            4
+        .offset:          84
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideA0
+        .size:            4
+        .offset:          88
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideA1
+        .size:            4
+        .offset:          92
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideB0
+        .size:            4
+        .offset:          96
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideB1
+        .size:            4
+        .offset:          100
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree0
+        .size:            4
+        .offset:          104
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree1
+        .size:            4
+        .offset:          108
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree2
+        .size:            4
+        .offset:          112
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesSum0
+        .size:            4
+        .offset:          116
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            OrigStaggerUIter
+        .size:            4
+        .offset:          120
+        .value_kind:      by_value
+        .value_type:      i32
+      - .name:            NumWorkGroups0
+        .size:            4
+        .offset:          124
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            NumWorkGroups1
+        .size:            4
+        .offset:          128
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            MagicNumberProblemNumGroupTiles0
+        .size:            4
+        .offset:          132
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            GridNumWorkGroups0
+        .size:            4
+        .offset:          136
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            NumFullBlocks
+        .size:            4
+        .offset:          140
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            WgmRemainder1
+        .size:            4
+        .offset:          144
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            MagicNumberWgmRemainder1
+        .size:            4
+        .offset:          148
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            padding
+        .size:            4
+        .offset:          152
+        .value_kind:      by_value
+        .value_type:      u32
+    .kernarg_segment_align:      8
+    .kernarg_segment_size:       160
+...
+.end_amdgpu_metadata
+Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM8:
+
+/******************************************/
+/* Optimizations and Config:              */
+/******************************************/
+/* ThreadTile= 6 x 4 */
+/* SubGroup= 8 x 16 */
+/* VectorWidth=2 */
+/* GlobalLoadVectorWidthA=2, GlobalLoadVectorWidthB=2 */
+/* DirectToLdsA=False */
+/* DirectToLdsB=False */
+/* UseSgprForGRO=False */
+
+/******************************************/
+/* Asm syntax workarounds                 */
+/******************************************/
+.macro _v_add_co_u32 dst, cc, src0, src1, dpp=
+   v_add_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+.macro _v_sub_co_u32 dst, cc, src0, src1, dpp=
+   v_sub_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+.macro _v_addc_co_u32 dst, ccOut, src0, ccIn, src1, dpp=
+   v_addc_co_u32 \dst, \ccOut, \src0, \ccIn, \src1 \dpp
+.endm
+.macro _v_add_lshl_u32 dst, src0, src1, shiftCnt
+    v_add_lshl_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+.macro _v_lshl_add_u32 dst, src0, src1, shiftCnt
+    v_lshl_add_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+/******************************************/
+/* Magic div and mod functions            */
+/******************************************/
+.macro V_MAGIC_DIV dstIdx, dividend, magicNumber, magicShift
+    v_mul_lo_u32 v[\dstIdx+0], \dividend, \magicNumber
+    v_mul_hi_u32 v[\dstIdx+1], \dividend, \magicNumber
+    v_lshrrev_b64 v[\dstIdx:\dstIdx+1], \magicShift, v[\dstIdx:\dstIdx+1]
+.endm
+
+/******************************************/
+/* VGPR Assignments                       */
+/******************************************/
+.set vgprValuC, 0
+/* ValuA/B   Xn=PLR buffer idx,  In=InnerUnroll idx */
+.set vgprValuA_X0_I0, 48
+.set vgprG2LA, 60
+.set vgprValuB_X0_I0, 64
+.set vgprG2LB, 72
+.set vgprLocalWriteAddrA, 76
+.set vgprLocalWriteAddrB, 77
+.set vgprGlobalReadOffsetA, 78
+.set vgprGlobalReadOffsetB, 79
+.set vgprLocalReadAddrA, 80
+.set vgprLocalReadAddrB, 81
+.set vgprSerial, 82
+/* Num VGPR=83 */
+
+/******************************************/
+/* SGPR Assignments                       */
+/******************************************/
+.set sgprKernArgAddress, 0
+.set sgprWorkGroup0, 2
+.set sgprWorkGroup1, 3
+.set sgprWorkGroup2, 4
+.set sgprNumWorkGroups0, 5
+.set sgprNumWorkGroups1, 6
+.set sgprSrdA, 8
+.set sgprSrdB, 12
+.set sgprSrdD, 16
+.set sgprSrdC, 20
+.set sgprTensor2dSizeC, 24
+.set sgprTensor2dSizeA, 26
+.set sgprTensor2dSizeB, 28
+.set sgprSaveExecMask, 30
+.set sgprAddressD, 32
+.set sgprAddressC, 34
+.set sgprStridesC, 36
+.set sgprAlpha, 38
+.set sgprBeta, 40
+.set sgprSizesFree, 42
+.set sgprSizesSum, 45
+.set sgprLoopCounters, 46
+.set sgprOrigLoopCounter, 47
+.set sgprStridesA, 48
+.set sgprStridesB, 50
+.set sgprAddressA, 52
+.set sgprAddressB, 54
+.set sgprShadowLimitA, 56
+.set sgprShadowLimitB, 58
+.set sgprNumFullBlocks, 60
+.set sgprWgmRemainder1, 61
+.set sgprMagicNumberWgmRemainder1, 62
+.set sgprGlobalReadIncsA, 63
+.set sgprGlobalReadIncsB, 64
+.set sgprStridesD, 74
+.set sgprTMP0, 90
+.set sgprTMP1, 91
+.set sgprEdgeSelMask0, 93
+.set sgprEdgeSelMask1, 94
+/* max SGPR=98 */
+
+/******************************************/
+/* 2GB limit - set offsets to -1 to exceed this and clamp */
+/******************************************/
+.set BufferLimit, 0x80000000
+
+/******************************************/
+/* Bits 127:96 of SRD.  Set DataFormat = 32 bit */
+/******************************************/
+.set Srd127_96, 0x0020000
+.set BufferOOB, 0x80000000
+
+/* Global Offset A */
+.macro GLOBAL_OFFSET_A vgprAddr vgprOffset0I vgprOffsetL vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStridesA+0], v[\vgprOffsetL] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprTmp+0], v[\vgprOffset0I] // accumulate d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, 0x2, v[\vgprAddr+0] // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x3, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/* Global Offset B */
+.macro GLOBAL_OFFSET_B vgprAddr vgprOffset1J vgprOffsetL vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStridesB+0], v[\vgprOffsetL] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprTmp+0], v[\vgprOffset1J] // accumulate d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, 0x2, v[\vgprAddr+0] // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x3, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/******************************************/
+/* Dynamic Scalar Divide: vQuotient=vDividend/vDivisor; vRemainder=vDividend%vDivisor; */
+/******************************************/
+.macro DYNAMIC_VECTOR_DIVIDE vQuotient vRemainder vDividend vDivisor vTmp0 vTmp1 sTmp
+v_cvt_f32_u32 v[\vQuotient], v[\vDivisor]          //
+v_rcp_f32 v[\vQuotient], v[\vQuotient]             //
+v_mul_f32 v[\vQuotient], 0x4f800000, v[\vQuotient] //
+v_cvt_u32_f32 v[\vQuotient], v[\vQuotient]         //
+v_mul_lo_u32 v[\vRemainder], v[\vDivisor], v[\vQuotient] //
+v_mul_hi_u32 v[\vTmp0], v[\vDivisor], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp1], vcc, 0x0, v[\vRemainder]  //
+v_cmp_ne_i32 s[\sTmp:\sTmp+1], 0x0, v[\vTmp0]      //
+v_cndmask_b32 v[\vRemainder], v[\vTmp1], v[\vRemainder], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vRemainder], v[\vRemainder], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vQuotient], v[\vRemainder] //
+_v_add_co_u32 v[\vQuotient], vcc, v[\vQuotient], v[\vRemainder] //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vTmp0], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vQuotient], v[\vQuotient], v[\vDividend] //
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vDividend], v[\vRemainder] //
+v_cmp_ge_u32 s[\sTmp:\sTmp+1], v[\vDividend], v[\vRemainder] //
+_v_add_co_u32 v[\vRemainder], vcc, 0x1, v[\vQuotient] //
+_v_add_co_u32 v[\vTmp1], vcc, -1, v[\vQuotient]    //
+v_cmp_le_u32 vcc, v[\vDivisor], v[\vTmp0]          //
+s_and_b64 vcc, s[\sTmp:\sTmp+1], vcc               //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vRemainder], vcc //
+v_cndmask_b32 v[\vQuotient], v[\vTmp1], v[\vQuotient], s[\sTmp:\sTmp+1] //
+v_cmp_ne_i32 vcc, 0x0, v[\vDivisor]                //
+v_cndmask_b32 v[\vQuotient], -1, v[\vQuotient], vcc // final result
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vRemainder], vcc, v[\vDividend], v[\vRemainder] // final result
+.endm
+
+/******************************************/
+/* 6x4 thread-tile                        */
+/******************************************/
+.macro MAC_6x4_X0
+v_fma_f64 v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1]
+s_setprio 1 // Raise priority while processing macs
+v_fma_f64 v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1]
+s_setprio 0 // Reset priority after macs
+.endm
+
+.macro MAC_6x4_X0_part_1
+v_fma_f64 v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1]
+s_setprio 1 // Raise priority while processing macs
+v_fma_f64 v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1]
+.endm
+
+.macro MAC_6x4_X0_part_2
+.endm
+
+.macro MAC_6x4_X0_part_3
+v_fma_f64 v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1]
+s_setprio 0 // Reset Priority
+.endm
+
+.macro MAC_6x4_X0_unprio_0
+v_fma_f64 v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1]
+s_setprio 1 // Raise priority while processing macs
+v_fma_f64 v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1]
+.endm
+
+
+.macro MAC_6x4_X0_part1
+v_fma_f64 v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1]
+s_setprio 1
+v_fma_f64 v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1]
+s_setprio 0
+.endm
+
+
+.macro MAC_6x4_X0_part2
+v_fma_f64 v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1]
+s_setprio 1
+v_fma_f64 v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1]
+s_setprio 0
+.endm
+.macro MAC_6x4_X0_part3
+v_fma_f64 v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1]
+s_setprio 1
+v_fma_f64 v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1]
+s_setprio 0
+.endm
+.macro MAC_6x4_X0_part4
+v_fma_f64 v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1]
+s_setprio 1
+v_fma_f64 v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1]
+//vnop_4
+s_setprio 0
+.endm
+.macro MAC_6x4_X0_part5
+v_fma_f64 v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1]
+s_setprio 1
+v_fma_f64 v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1]
+//vnop_4
+s_setprio 0
+.endm
+.macro MAC_6x4_X0_part6
+v_fma_f64 v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1]
+s_setprio 1
+v_fma_f64 v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1]
+s_setprio 0
+.endm
+
+/******************************************/
+/* Allocate Resources                     */
+/******************************************/
+
+s_mov_b32 m0, 0x1e00                               // LDS clamp at 7680 bytes
+v_mov_b32 v[vgprSerial], v0                        // thread serial id
+
+/* Load Kernel Args */
+s_load_dword s[sgprTensor2dSizeC+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x0 //
+s_load_dword s[sgprTensor2dSizeC+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x4 //
+s_load_dword s[sgprTensor2dSizeA+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x8 //
+s_load_dword s[sgprTensor2dSizeA+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0xc //
+s_load_dword s[sgprTensor2dSizeB+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x10 //
+s_load_dword s[sgprTensor2dSizeB+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x14 //
+s_load_dword s[sgprAddressD], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x18 //
+s_load_dword s[sgprAddressD+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x1c //
+s_load_dword s[sgprAddressC], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x20 //
+s_load_dword s[sgprAddressC+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x24 //
+s_load_dword s[sgprAddressA], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x28 //
+s_load_dword s[sgprAddressA+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x2c //
+s_load_dword s[sgprAddressB], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x30 //
+s_load_dword s[sgprAddressB+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x34 //
+s_load_dword s[sgprAlpha+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x38 //
+s_load_dword s[sgprAlpha+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x3c //
+s_load_dword s[sgprBeta+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x40 //
+s_load_dword s[sgprBeta+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x44 //
+s_load_dword s[sgprStridesD+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x48 //
+s_load_dword s[sgprStridesD+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x4c //
+s_load_dword s[sgprStridesC+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x50 //
+s_load_dword s[sgprStridesC+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x54 //
+s_load_dword s[sgprStridesA+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x58 //
+s_load_dword s[sgprStridesA+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x5c //
+s_load_dword s[sgprStridesB+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x60 //
+s_load_dword s[sgprStridesB+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x64 //
+s_load_dword s[sgprSizesFree+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x68 //
+s_load_dword s[sgprSizesFree+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x6c //
+s_load_dword s[sgprSizesFree+2], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x70 //
+s_load_dword s[sgprSizesSum+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x74 //
+s_load_dword s[sgprNumWorkGroups0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x7c //
+s_load_dword s[sgprNumWorkGroups1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x80 //
+s_load_dword s[sgprNumFullBlocks], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x8c //
+s_load_dword s[sgprWgmRemainder1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x90 //
+s_load_dword s[sgprMagicNumberWgmRemainder1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x94 //
+s_waitcnt lgkmcnt(0)                               // wait for 144 bytes of kern args
+
+
+/******************************************/
+/* Local Read Addresses                   */
+/******************************************/
+
+
+/* local read addresses: tile assignments a */
+
+/*lr0I = serial % SG0I*/
+v_lshrrev_b32 v0, 3, v[vgprSerial]                 // vectorStaticDiv: v0 = v[vgprSerial] / 8
+v_and_b32 v1, 7, v[vgprSerial]                     // vectorStaticDiv: v1 = v[vgprSerial] % 8
+
+
+/* local read addresses: tile assignments b */
+
+/*lr1J = (serial / SG1J) % SG1J*/
+v_lshrrev_b32 v2, 4, v0                            // vectorStaticDiv: v2 = v0 / 16
+v_and_b32 v3, 15, v0                               // vectorStaticDiv: v3 = v0 % 16
+
+
+/* local read addresses: final offsets a */
+
+v_lshrrev_b32 v0, 7, v[vgprSerial]                 // vectorStaticDiv: v0 = v[vgprSerial] / 128
+v_and_b32 v2, 127, v[vgprSerial]                   // vectorStaticDiv: v2 = v[vgprSerial] % 128
+s_mov_b32 s65, 0x30                                // MT0+PAD
+v_mul_lo_u32 v0, s65, v0                           // sgid=sgid*(MT0+PAD)
+v_lshlrev_b32 v1, 1, v1                            // staticMultiply: v1 = v1 * 2
+_v_add_lshl_u32 v[vgprLocalReadAddrA], v0, v1, 0x3 // o = (lroA*VW+sgid*MT0)*bpe
+
+
+/* local read addresses: final offsets b */
+
+v_lshrrev_b32 v0, 7, v[vgprSerial]                 // vectorStaticDiv: v0 = v[vgprSerial] / 128
+v_and_b32 v1, 127, v[vgprSerial]                   // vectorStaticDiv: v1 = v[vgprSerial] % 128
+s_mov_b32 s65, 0x40                                // MT1+PAD
+v_mul_lo_u32 v0, s65, v0                           // sgid=sgid*(MT1+PAD)
+v_lshlrev_b32 v3, 1, v3                            // staticMultiply: v3 = v3 * 2
+_v_add_lshl_u32 v[vgprLocalReadAddrB], v0, v3, 0x3 // o = (lroB*VW+sgid*MT1)*bpe
+
+
+/* local read addresses: declare addresses a */
+
+/* N/A */
+
+
+/* local read addresses: declare addresses b */
+
+_v_add_co_u32 v[vgprLocalReadAddrB+0], vcc, 0x600, v[vgprLocalReadAddrB+0] //  += LdsOffsetB (lower)
+
+
+s_load_dword s[sgprNumWorkGroups1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x80 //
+s_load_dword s[sgprNumFullBlocks], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x8c //
+s_load_dword s[sgprWgmRemainder1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x90 //
+s_load_dword s[sgprMagicNumberWgmRemainder1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x94 //
+/******************************************/
+/* Global Read Addresses                  */
+/******************************************/
+
+
+/* global read addresses: work-group */
+
+/* graWorkGroup mapping */
+s_mov_b32 s69, 0x10000001L                         // magic number for WGM==4
+s_mul_hi_u32 s67, s[sgprWorkGroup1], s69           // s_magic mul
+s_mul_i32 s66, s[sgprWorkGroup1], s69              // s_magic mul
+s_lshr_b64 s[66:67], s[66:67], 31                  // sMagicDiv
+s_mul_i32 s67, s66, 8                              // quotient * non-magic divisor
+s_sub_u32 s67, s[sgprWorkGroup1], s67              // WorkGroup1=remainder
+s_mul_i32 s67, s67, s[sgprNumWorkGroups0]          // (wg1 % WGM)*nwg0
+s_add_u32 s67, s67, s[sgprWorkGroup0]              // wgSerial = wg0 + (wg1 % WGM)*nwg0
+s_cmp_ge_u32 s66, s[sgprNumFullBlocks]             // blockId >= numFullBlocks ?
+s_cmov_b32 s69, s[sgprMagicNumberWgmRemainder1]    //
+s_cselect_b32 s68, s[sgprWgmRemainder1], 8         //
+s_mul_hi_u32 s3, s67, s69                          // s_magic mul
+s_mul_i32 s2, s67, s69                             // s_magic mul
+s_lshr_b64 s[2:3], s[2:3], 31                      // sMagicDiv
+s_mul_i32 s[sgprWorkGroup1], s[sgprWorkGroup0], s68 // quotient * non-magic divisor
+s_sub_u32 s[sgprWorkGroup1], s67, s[sgprWorkGroup1] // WorkGroup1=remainder
+s_mul_i32 s66, s66, 8                              // blockId * WGM
+s_add_u32 s[sgprWorkGroup1], s[sgprWorkGroup1], s66 // wg1 += blockId * WGM
+
+
+/* global read addresses: tile offset assignment a */
+
+/* LVCA = 24 */
+/* v0 = (local)groA-tile = serial%LVCA (note (wgA*MTA) will be added to SRD) */
+/* v1 = groA-unroll = serial/LVCA */
+s_mov_b32 s65, 0x15555556                          //
+v_mul_hi_u32 v3, v[vgprSerial], s65                //
+v_mul_lo_u32 v2, v[vgprSerial], s65                //
+v_lshrrev_b64 v[2:3], 0x21, v[2:3]                 //
+v_mov_b32 v1, v2                                   // vectorStaticDiv: quotient
+s_mov_b32 s65, 0x18                                // divisor
+v_mul_lo_u32 v2, v1, s65                           // vectorStaticDiv: product = quotient * divisor
+_v_sub_co_u32 v0, vcc, v[vgprSerial], v2           // vectorStaticDiv: remainder = dividend - product
+/* gro-tile *= glvw */
+v_lshlrev_b32 v0, 1, v0                            // staticMultiply: v0 = v0 * 2
+
+
+/* global read addresses: tile offset assignment b */
+
+/* LVCB = 32 */
+/* v2 = (local)groB-tile = serial%LVCB (note (wgB*MTB) will be added to SRD) */
+/* v3 = groB-unroll = serial/LVCB */
+v_lshrrev_b32 v3, 5, v[vgprSerial]                 // vectorStaticDiv: v3 = v[vgprSerial] / 32
+v_and_b32 v2, 31, v[vgprSerial]                    // vectorStaticDiv: v2 = v[vgprSerial] % 32
+/* gro-tile *= glvw */
+v_lshlrev_b32 v2, 1, v2                            // staticMultiply: v2 = v2 * 2
+
+
+/* global read addresses: unroll assignment a */
+
+/* v1 */
+
+
+/* global read addresses: unroll assignment b */
+
+/* v3 */
+
+
+/* global read addresses: other free assignments */
+
+/* s[sgprWorkGroup2] */
+
+
+/* global read addresses: tile offsets a */
+
+v_mov_b32 v4, v0                                   // groA0I_0
+
+
+/* global read addresses: tile offsets b */
+
+v_mov_b32 v5, v2                                   // groB1J_0
+
+
+/* global read addresses: unroll offsets a */
+
+v_mov_b32 v6, v1                                   // groAL_0
+
+
+/* global read addresses: unroll offsets b */
+
+v_mov_b32 v7, v3                                   // groBL_0
+
+
+/* global read addresses: shift a */
+
+s_mul_i32 s65, s[sgprWorkGroup0], 48               // WorkGroup[01] * MT
+s_sub_u32 s65, s[sgprSizesFree+0], s65             // edge = Size0I - WG*MT
+s_sub_u32 s65, s65, 2                              // edge -= margin
+v_mov_b32 v8, s65                                  // edge vgpr = Size0I-2
+_v_add_co_u32 v9, vcc, v8, 2                       // add srdShiftLift
+_v_add_co_u32 v10, vcc, v4, 2                      //
+v_cmp_lt_u32 s[66:67], v10, v9                     // offset < edge
+v_cndmask_b32 v4, v8, v4, s[66:67]                 // offset = (offset < edge) ? offset : edge
+
+
+/* global read addresses: shift b */
+
+s_mul_i32 s65, s[sgprWorkGroup1], 64               // WorkGroup[01] * MT
+s_sub_u32 s65, s[sgprSizesFree+1], s65             // edge = Size1J - WG*MT
+s_sub_u32 s65, s65, 2                              // edge -= margin
+v_mov_b32 v8, s65                                  // edge vgpr = Size1J-2
+_v_add_co_u32 v9, vcc, v8, 2                       // add srdShiftLift
+_v_add_co_u32 v10, vcc, v5, 2                      //
+v_cmp_lt_u32 s[66:67], v10, v9                     // offset < edge
+v_cndmask_b32 v5, v8, v5, s[66:67]                 // offset = (offset < edge) ? offset : edge
+
+
+/* global read addresses: final offsets a */
+
+GLOBAL_OFFSET_A vgprGlobalReadOffsetA+0,  4,  6, 8 // gROA_0_0_0_0
+// Offset only valid for 96/128 threads inside the PerLoadTile
+s_mov_b32 s66, 96                                  //
+v_cmp_lt_u32 vcc, v[vgprSerial], s66               // tid < valid-tid
+s_mov_b32 s66, BufferOOB                           //
+v_mov_b32 v11, s66                                 //
+v_cndmask_b32 v[vgprGlobalReadOffsetA+0], v11, v[vgprGlobalReadOffsetA+0], vcc // Mask load so OOB will return 0
+
+
+/* global read addresses: final offsets b */
+
+GLOBAL_OFFSET_B vgprGlobalReadOffsetB+0,  5,  7, 8 // gROB_0_0_0_0
+
+
+/* global read addresses: addresses a */
+
+/* max read offset = size[n] * stride[n-1] */
+s_mul_hi_u32 s69, s[sgprWorkGroup0], 48            // WorkGroup[01] * MT
+s_mul_i32 s68, s[sgprWorkGroup0], 48               // WorkGroup[01] * MT
+s_sub_u32 s[sgprShadowLimitA+0], s[sgprTensor2dSizeA], s68 // sub tileStart
+s_subb_u32 s[sgprShadowLimitA+1], s[sgprTensor2dSizeA+1], s69 // sub tileStart
+s_lshl_b64 s[sgprShadowLimitA:sgprShadowLimitA+1], s[sgprShadowLimitA:sgprShadowLimitA+1], 0x3 // Set limit to use bytes
+s_add_u32 s[sgprShadowLimitA+0], s[sgprShadowLimitA+0], 16 // extend limit for pre-pad
+s_addc_u32 s[sgprShadowLimitA+1], s[sgprShadowLimitA+1], 0 // extend limit for pre-pad
+s_cmp_eq_u32 s[sgprShadowLimitA+1], 0              // are we within 2^32?
+s_cselect_b32 s[sgprSrdA+2], s[sgprShadowLimitA+0], BufferLimit // Move shadow to real if we are within 2^32
+s_mul_hi_u32 s67, s[sgprStridesA+1], s[sgprWorkGroup2] // Stride*WG
+s_mul_i32 s66, s[sgprStridesA+1], s[sgprWorkGroup2] // Stride*WG
+s_add_u32 s68, s68, s66                            // accum wg term to tilestart
+s_addc_u32 s69, s69, s67                           // accum wg term to tilestart
+s_lshl_b64 s[68:69], s[68:69], 3                   // tileStart *= BPE
+s_add_u32 s[sgprSrdA+0], s[sgprAddressA+0], s68    // SRD base = Address+ tileStart0
+s_addc_u32 s[sgprSrdA+1], s[sgprAddressA+1], s69   // SRD base = Address+ tileStart1
+s_sub_u32 s[sgprSrdA+0], s[sgprSrdA+0], 16         // pre-pad to make room for possible pointer shift
+s_subb_u32 s[sgprSrdA+1], s[sgprSrdA+1], 0         // pre-pad to make room for possible pointer shift
+s_mov_b32 s[sgprSrdA+3], Srd127_96                 // Set bits 127_96 in SRD
+
+
+/* global read addresses: addresses b */
+
+/* max read offset = size[n] * stride[n-1] */
+s_mul_hi_u32 s69, s[sgprWorkGroup1], 64            // WorkGroup[01] * MT
+s_mul_i32 s68, s[sgprWorkGroup1], 64               // WorkGroup[01] * MT
+s_sub_u32 s[sgprShadowLimitB+0], s[sgprTensor2dSizeB], s68 // sub tileStart
+s_subb_u32 s[sgprShadowLimitB+1], s[sgprTensor2dSizeB+1], s69 // sub tileStart
+s_lshl_b64 s[sgprShadowLimitB:sgprShadowLimitB+1], s[sgprShadowLimitB:sgprShadowLimitB+1], 0x3 // Set limit to use bytes
+s_add_u32 s[sgprShadowLimitB+0], s[sgprShadowLimitB+0], 16 // extend limit for pre-pad
+s_addc_u32 s[sgprShadowLimitB+1], s[sgprShadowLimitB+1], 0 // extend limit for pre-pad
+s_cmp_eq_u32 s[sgprShadowLimitB+1], 0              // are we within 2^32?
+s_cselect_b32 s[sgprSrdB+2], s[sgprShadowLimitB+0], BufferLimit // Move shadow to real if we are within 2^32
+s_mul_hi_u32 s67, s[sgprStridesB+1], s[sgprWorkGroup2] // Stride*WG
+s_mul_i32 s66, s[sgprStridesB+1], s[sgprWorkGroup2] // Stride*WG
+s_add_u32 s68, s68, s66                            // accum wg term to tilestart
+s_addc_u32 s69, s69, s67                           // accum wg term to tilestart
+s_lshl_b64 s[68:69], s[68:69], 3                   // tileStart *= BPE
+s_add_u32 s[sgprSrdB+0], s[sgprAddressB+0], s68    // SRD base = Address+ tileStart0
+s_addc_u32 s[sgprSrdB+1], s[sgprAddressB+1], s69   // SRD base = Address+ tileStart1
+s_sub_u32 s[sgprSrdB+0], s[sgprSrdB+0], 16         // pre-pad to make room for possible pointer shift
+s_subb_u32 s[sgprSrdB+1], s[sgprSrdB+1], 0         // pre-pad to make room for possible pointer shift
+s_mov_b32 s[sgprSrdB+3], Srd127_96                 // Set bits 127_96 in SRD
+
+
+/* global read addresses: increments a */
+
+s_mul_i32 s[sgprGlobalReadIncsA+0], 0x20, s[sgprStridesA] // incr = stride*4*bytes
+
+
+/* global read addresses: increments b */
+
+s_mul_i32 s[sgprGlobalReadIncsB+0], 0x20, s[sgprStridesB] // incr = stride*4*bytes
+
+
+/******************************************/
+/* Local Write Addresses                  */
+/******************************************/
+
+
+/* local write addresses: tile assignment a */
+
+/* lwaTileA = v0 */
+
+
+/* local write addresses: tile assignment b */
+
+/* lwaTileB = v2 */
+
+
+/* local write addresses: unroll assignment a */
+
+/* lwaUnrollA = v1 */
+
+
+/* local write addresses: unroll assignment b */
+
+/* lwaUnrollB = v3 */
+
+
+/* local write addresses: first offset a */
+
+v_mul_u32_u24 v[vgprLocalWriteAddrA], 0x30, v1     // lwAL**(MTA + PAD)
+_v_add_lshl_u32 v[vgprLocalWriteAddrA], v0, v[vgprLocalWriteAddrA], 0x3 // lwFOA = (lwAA + lwAL*(MT0I+PAD))*bpe
+s_mov_b32 s65, 96                                  // lsc*lsp=48*4
+v_cmp_lt_u32 vcc, v[vgprSerial], s65               // fractional: ensure tid < global read tile elements
+v_mov_b32 v0, 0xf00000                             //
+v_cndmask_b32 v[vgprLocalWriteAddrA], v0, v[vgprLocalWriteAddrA], vcc // Mask load so out-of-gr-tile bounds returns 0
+
+
+/* local write addresses: first offset b */
+
+v_mul_u32_u24 v[vgprLocalWriteAddrB], 0x40, v3     // lwBL**(MTB + PAD)
+_v_add_lshl_u32 v[vgprLocalWriteAddrB], v2, v[vgprLocalWriteAddrB], 0x3 // lwFOB = (lwBB + lwBL*(MT1J+PAD))*bpe
+_v_add_co_u32 v[vgprLocalWriteAddrB], vcc, 0x600, v[vgprLocalWriteAddrB] // lwFOB = lwB1J + lwBL*MT1J + LDS_OFFSET_B=192*8
+
+
+/* local write addresses: final offsets a */
+
+
+/* N/A */
+
+
+/* local write addresses: final offsets b */
+
+
+/* N/A */
+
+
+/* local write addresses: declare addresses a */
+
+/* N/A */
+
+
+/* local write addresses: declare addresses b */
+
+/* N/A */
+
+
+/* local write addresses: init pointers a */
+
+/* N/A */
+
+
+/* local write addresses: init pointers b */
+
+/* N/A */
+
+
+/* declare loop num iterations */
+
+
+s_lshr_b32 s[sgprLoopCounters+0], s[sgprSizesSum+0], 2 // s[sgprLoopCounters+0] = s[sgprSizesSum+0] / 4
+s_mov_b32 s[sgprOrigLoopCounter], s[sgprLoopCounters+0] // copy loop counter
+s_sub_u32 s[sgprLoopCounters+0], 0x0, s[sgprLoopCounters+0] // counterL = -sizeL
+
+
+/* local read addresses: init pointers a */
+
+
+
+/* local read addresses: init pointers b */
+
+
+
+/* TODO-packed- compare against product of all packed C0 sizes not just SizesFree+0 */
+s_mov_b32 s91, 0x0                                 // STATIC_DIV: divisior=48
+s_mul_i32 s90, 0xaaa, s[sgprSizesFree+0]           // tmp1 = dividend * magic hi
+s_lshl_b64 s[90:91], s[90:91], 0x10                // left shift 16 bits
+s_mul_i32 s82, s[sgprSizesFree+0], 0xaaab          // tmp0 = dividend * magic lo
+s_add_u32 s90, s82, s90                            // add lo
+s_addc_u32 s91, s91, 0x0                           // add hi
+s_lshr_b64 s[90:91], s[90:91], 0x21                // tmp1 = (dividend * magic) << shift
+s_mov_b32 s82, s90                                 // quotient
+s_mul_i32 s90, s82, 0x30                           // quotient*divisor
+s_sub_u32 s[sgprEdgeSelMask0], s[sgprSizesFree+0], s90             // rReg = dividend - quotient*divisor
+s_lshr_b32 s82, s[sgprSizesFree+1], 6              // s58 = s[sgprSizesFree+1] / 64
+s_and_b32 s[sgprEdgeSelMask1], 63, s[sgprSizesFree+1]
+
+
+/* prefetch: global -> local */
+
+s_cmp_eq_u32 s[sgprLoopCounters+0], 0x0            // numIter0I == 0
+s_cbranch_scc1 label_0008                          // skip to ShadowInitStart iter b/c numIter==0
+
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+
+
+/* global read inc A */
+s_add_u32  s[sgprSrdA+0], s[sgprSrdA+0], s[sgprGlobalReadIncsA] // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdA+1], s[sgprSrdA+1], 0        // gra SRD += inc(upper)
+s_sub_u32 s[sgprShadowLimitA+0], s[sgprShadowLimitA+0], s[sgprGlobalReadIncsA] // limit -= inc)
+s_subb_u32 s[sgprShadowLimitA+1], s[sgprShadowLimitA+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitA+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdA+2], s[sgprShadowLimitA+0]    // Move shadow to real if we are within 2^32
+
+
+/* global read inc B */
+s_add_u32  s[sgprSrdB+0], s[sgprSrdB+0], s[sgprGlobalReadIncsB] // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdB+1], s[sgprSrdB+1], 0        // gra SRD += inc(upper)
+s_sub_u32 s[sgprShadowLimitB+0], s[sgprShadowLimitB+0], s[sgprGlobalReadIncsB] // limit -= inc)
+s_subb_u32 s[sgprShadowLimitB+1], s[sgprShadowLimitB+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitB+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdB+2], s[sgprShadowLimitB+0]    // Move shadow to real if we are within 2^32
+
+label_0008: // ShadowInitStart
+
+s_mov_b32 s[sgprSrdD+0], s[sgprAddressD+0]         // init SRD base address (lower)
+s_mov_b32 s[sgprSrdD+1], s[sgprAddressD+1]         // init SRD base address (upper) + other fields
+s_mov_b32 s[sgprSrdD+2], 0x80000000                //
+s_mov_b32 s[sgprSrdD+3], Srd127_96                 // Set bits 127_96 in SRD
+s_mov_b32 s[sgprSrdC+0], s[sgprAddressC+0]         // init SRD base address (lower)
+s_mov_b32 s[sgprSrdC+1], s[sgprAddressC+1]         // init SRD base address (upper) + other fields
+s_mov_b32 s[sgprSrdC+2], 0x80000000                //
+s_mov_b32 s[sgprSrdC+3], Srd127_96                 // Set bits 127_96 in SRD
+
+s_mul_i32 s[sgprTMP1], 0x40, s[sgprWorkGroup1]             // <- wg1*MT1
+s_mul_i32 s[sgprTMP0], 0x30, s[sgprWorkGroup1]             // <- wg1*MT1
+s_mul_hi_u32 s67, s[sgprTMP1], s[sgprStridesC+0]           // Scale s68 by Stride
+s_mul_i32 s66, s[sgprTMP1], s[sgprStridesC+0]              // Scale s68 by Stride
+s_lshl_b64 s[66:67], s[66:67], 3                   // scale by bpe
+s_add_u32 s[sgprSrdD+0], s[sgprSrdD+0], s66        // add lo to SRD
+s_addc_u32 s[sgprSrdD+1], s[sgprSrdD+1], s67       // add hi to SRD
+s_add_u32 s[sgprSrdC+0], s[sgprSrdC+0], s66        // add lo to SRD
+s_addc_u32 s[sgprSrdC+1], s[sgprSrdC+1], s67       // add hi to SRD
+
+s_mul_hi_u32 s67, s[sgprWorkGroup2], s[sgprStridesC+1] // Scale s[sgprWorkGroup2] by Stride
+s_mul_i32 s66, s[sgprWorkGroup2], s[sgprStridesC+1] // Scale s[sgprWorkGroup2] by Stride
+s_lshl_b64 s[66:67], s[66:67], 3                   // scale by bpe
+s_add_u32 s[sgprSrdD+0], s[sgprSrdD+0], s66        // add lo to SRD
+s_addc_u32 s[sgprSrdD+1], s[sgprSrdD+1], s67       // add hi to SRD
+s_add_u32 s[sgprSrdC+0], s[sgprSrdC+0], s66        // add lo to SRD
+s_addc_u32 s[sgprSrdC+1], s[sgprSrdC+1], s67       // add hi to SRD
+
+
+v_mov_b32 v[vgprValuC+0], 0x0                      // initC
+v_mov_b32 v[vgprValuC+1], 0x0                      // initC
+v_mov_b32 v[vgprValuC+2], 0x0                      // initC
+v_mov_b32 v[vgprValuC+3], 0x0                      // initC
+v_mov_b32 v[vgprValuC+4], 0x0                      // initC
+v_mov_b32 v[vgprValuC+5], 0x0                      // initC
+v_mov_b32 v[vgprValuC+6], 0x0                      // initC
+v_mov_b32 v[vgprValuC+7], 0x0                      // initC
+v_mov_b32 v[vgprValuC+8], 0x0                      // initC
+v_mov_b32 v[vgprValuC+9], 0x0                      // initC
+v_mov_b32 v[vgprValuC+10], 0x0                     // initC
+v_mov_b32 v[vgprValuC+11], 0x0                     // initC
+v_mov_b32 v[vgprValuC+12], 0x0                     // initC
+v_mov_b32 v[vgprValuC+13], 0x0                     // initC
+v_mov_b32 v[vgprValuC+14], 0x0                     // initC
+v_mov_b32 v[vgprValuC+15], 0x0                     // initC
+v_mov_b32 v[vgprValuC+16], 0x0                     // initC
+v_mov_b32 v[vgprValuC+17], 0x0                     // initC
+v_mov_b32 v[vgprValuC+18], 0x0                     // initC
+v_mov_b32 v[vgprValuC+19], 0x0                     // initC
+v_mov_b32 v[vgprValuC+20], 0x0                     // initC
+v_mov_b32 v[vgprValuC+21], 0x0                     // initC
+v_mov_b32 v[vgprValuC+22], 0x0                     // initC
+v_mov_b32 v[vgprValuC+23], 0x0                     // initC
+v_mov_b32 v[vgprValuC+24], 0x0                     // initC
+v_mov_b32 v[vgprValuC+25], 0x0                     // initC
+v_mov_b32 v[vgprValuC+26], 0x0                     // initC
+v_mov_b32 v[vgprValuC+27], 0x0                     // initC
+v_mov_b32 v[vgprValuC+28], 0x0                     // initC
+v_mov_b32 v[vgprValuC+29], 0x0                     // initC
+v_mov_b32 v[vgprValuC+30], 0x0                     // initC
+v_mov_b32 v[vgprValuC+31], 0x0                     // initC
+v_mov_b32 v[vgprValuC+32], 0x0                     // initC
+v_mov_b32 v[vgprValuC+33], 0x0                     // initC
+v_mov_b32 v[vgprValuC+34], 0x0                     // initC
+v_mov_b32 v[vgprValuC+35], 0x0                     // initC
+v_mov_b32 v[vgprValuC+36], 0x0                     // initC
+v_mov_b32 v[vgprValuC+37], 0x0                     // initC
+v_mov_b32 v[vgprValuC+38], 0x0                     // initC
+v_mov_b32 v[vgprValuC+39], 0x0                     // initC
+v_mov_b32 v[vgprValuC+40], 0x0                     // initC
+v_mov_b32 v[vgprValuC+41], 0x0                     // initC
+v_mov_b32 v[vgprValuC+42], 0x0                     // initC
+v_mov_b32 v[vgprValuC+43], 0x0                     // initC
+v_mov_b32 v[vgprValuC+44], 0x0                     // initC
+v_mov_b32 v[vgprValuC+45], 0x0                     // initC
+v_mov_b32 v[vgprValuC+46], 0x0                     // initC
+v_mov_b32 v[vgprValuC+47], 0x0                     // initC
+s_cmp_eq_u32 s[sgprLoopCounters+0], 0x0            // numIter0I == 0
+s_cbranch_scc1 label_0004                          // after InitC, skip to end of prefetch last iter b/c numIter==0
+
+s_waitcnt vmcnt(0)                                 // 8wait for global read
+
+
+/* local write a */
+
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:0 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 0
+
+
+/* local write b */
+
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:0 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 0
+
+
+/* local write swap a */
+
+
+
+/* local write swap b */
+
+
+
+/* local write init pointers a */
+
+/* N/A */
+
+
+/* local write init pointers b */
+
+/* N/A */
+
+/******************************************/
+/* Unrolled Loop(s) - Begin               */
+/******************************************/
+
+s_cmp_ge_i32 s[sgprLoopCounters+0], 0x0            // LoopCounterL < EndCounter
+s_cbranch_scc1 label_0004                          // don't enter LoopL
+label_0001:
+
+
+/******************************************/
+/* Unroll Loop 1/2 - Begin                */
+/******************************************/
+
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
+s_barrier //4sync for global read
+
+s_cmp_eq_i32 s[sgprLoopCounters+0], -1             // is this the last iteration
+s_cmov_b32 s[sgprSrdA+2], 0                        // Set limit to 0 for last iteration
+s_cmov_b32 s[sgprSrdB+2], 0                        // Set limit to 0 for last iteration
+
+s_waitcnt lgkmcnt(0)                               // 1wait for local write
+
+
+
+
+/* iter 0 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(2)                               // wait for prior local read old=0 new=0
+//MAC_6x4_X0
+MAC_6x4_X0_part_1
+
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:384 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:512 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* global read inc A */
+s_add_u32  s[sgprSrdA+0], s[sgprSrdA+0], s[sgprGlobalReadIncsA] // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdA+1], s[sgprSrdA+1], 0        // gra SRD += inc(upper)
+s_sub_u32 s[sgprShadowLimitA+0], s[sgprShadowLimitA+0], s[sgprGlobalReadIncsA] // limit -= inc)
+s_subb_u32 s[sgprShadowLimitA+1], s[sgprShadowLimitA+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitA+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdA+2], s[sgprShadowLimitA+0]    // Move shadow to real if we are within 2^32
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:640 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(2)                               // wait for prior local read old=0 new=0
+//MAC_6x4_X0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:768 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* global read inc B */
+s_add_u32  s[sgprSrdB+0], s[sgprSrdB+0], s[sgprGlobalReadIncsB] // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdB+1], s[sgprSrdB+1], 0        // gra SRD += inc(upper)
+s_sub_u32 s[sgprShadowLimitB+0], s[sgprShadowLimitB+0], s[sgprGlobalReadIncsB] // limit -= inc)
+s_subb_u32 s[sgprShadowLimitB+1], s[sgprShadowLimitB+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitB+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdB+2], s[sgprShadowLimitB+0]    // Move shadow to real if we are within 2^32
+
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:896 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1024 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 2 writesPerItem=1 */
+s_waitcnt vmcnt(1)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:4096 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 4096
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(3)                               // wait for prior local read old=0 new=0
+//MAC_6x4_X0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(1)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+/* iter 3 (last) */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:1152 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1280 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1408 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 3 writesPerItem=1 */
+s_waitcnt vmcnt(0)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:4096 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 4096
+
+/* local write swap offsets a */
+
+/* local write swap offsets b */
+
+/* local write init pointers a */
+/* N/A */
+
+/* local write init pointers b */
+/* N/A */
+
+/* local read swap offsets a */
+
+/* local read swap internal offset -> 4096 */
+
+/* local read swap offsets b */
+
+/* local read swap internal offset -> 4096 */
+
+/* local read init pointers a */
+
+/* local read init pointers b */
+s_waitcnt lgkmcnt(3)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(1)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0_part_3
+
+/******************************************/
+/* Unrolled Loop - End 1/2                */
+/******************************************/
+
+s_add_u32 s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+s_cmp_eq_i32 s[sgprLoopCounters+0],  -2            // counterL==0
+s_cbranch_scc1 label_0003                          // exit LoopL
+
+
+/******************************************/
+/* Unroll Loop 2/2 - Begin                */
+/******************************************/
+
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
+s_barrier //4sync for global read
+
+s_cmp_eq_i32 s[sgprLoopCounters+0], -1             // is this the last iteration
+s_cmov_b32 s[sgprSrdA+2], 0                        // Set limit to 0 for last iteration
+s_cmov_b32 s[sgprSrdB+2], 0                        // Set limit to 0 for last iteration
+
+s_waitcnt lgkmcnt(0)                               // 1wait for local write
+
+
+
+
+/* iter 0 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4096 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4224 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4352 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(2)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4480 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4608 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* global read inc A */
+s_add_u32  s[sgprSrdA+0], s[sgprSrdA+0], s[sgprGlobalReadIncsA] // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdA+1], s[sgprSrdA+1], 0        // gra SRD += inc(upper)
+s_sub_u32 s[sgprShadowLimitA+0], s[sgprShadowLimitA+0], s[sgprGlobalReadIncsA] // limit -= inc)
+s_subb_u32 s[sgprShadowLimitA+1], s[sgprShadowLimitA+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitA+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdA+2], s[sgprShadowLimitA+0]    // Move shadow to real if we are within 2^32
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4736 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(2)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4864 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* global read inc B */
+s_add_u32  s[sgprSrdB+0], s[sgprSrdB+0], s[sgprGlobalReadIncsB] // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdB+1], s[sgprSrdB+1], 0        // gra SRD += inc(upper)
+s_sub_u32 s[sgprShadowLimitB+0], s[sgprShadowLimitB+0], s[sgprGlobalReadIncsB] // limit -= inc)
+s_subb_u32 s[sgprShadowLimitB+1], s[sgprShadowLimitB+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitB+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdB+2], s[sgprShadowLimitB+0]    // Move shadow to real if we are within 2^32
+
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4992 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5120 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 2 writesPerItem=1 */
+s_waitcnt vmcnt(1)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:0 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 0
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(3)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(1)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:5248 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=192 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=192 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5376 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5504 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 3 writesPerItem=1 */
+s_waitcnt vmcnt(0)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:0 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 0
+
+/* local write swap offsets a */
+
+/* local write swap offsets b */
+
+/* local write init pointers a */
+/* N/A */
+
+/* local write init pointers b */
+/* N/A */
+
+/* local read swap offsets a */
+
+/* local read swap internal offset -> 0 */
+
+/* local read swap offsets b */
+
+/* local read swap internal offset -> 0 */
+
+/* local read init pointers a */
+
+/* local read init pointers b */
+s_waitcnt lgkmcnt(3)                               // 6wait for local read old=3 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(1)                               // 6wait for local read old=1 new=0
+MAC_6x4_X0_part_3
+
+/******************************************/
+/* Unrolled Loop - End 2/2 (final)        */
+/******************************************/
+
+s_add_u32 s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+s_cmp_eq_i32 s[sgprLoopCounters+0], -2              // counterL==0
+s_cbranch_scc0 label_0001                          // restart LoopL
+s_cbranch_scc1 label_0002                          // restart LoopL
+
+label_0003: // unroll loop odditer exit
+
+//check edge Batch calculation needed
+//for Batch edge jump to different beta loop optimization code
+s_add_u32      s83,-0x1, s[sgprNumWorkGroups0]       //
+s_cmp_lt_u32   s[sgprWorkGroup0], s83                // wg0 < nwg0-1
+s_cmov_b32     s[sgprEdgeSelMask0], 0x0
+s_cmpk_gt_u32  s[sgprEdgeSelMask0], 0x0
+s_cbranch_scc1 label_1003                            // wg1 < nwg1-1 so skip rMT1 = Size1 % MT1
+s_add_u32      s83, -0x1, s[sgprNumWorkGroups1]      //
+s_cmp_lt_u32   s[sgprWorkGroup1], s83                // wg1 < nwg1-1
+s_cmov_b32     s[sgprEdgeSelMask1], 0x0
+s_cmpk_gt_u32  s[sgprEdgeSelMask1], 0x0
+s_cbranch_scc1 label_1003                            // wg1 < nwg1-1 so skip rMT1 = Size1 % MT1
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4224 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4480 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4608 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4736 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4864 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4992 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5120 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:0 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 4096
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(1)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:5248 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5376 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5504 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_mul_i32 s56, 0x30, s[sgprWorkGroup0]             // s56 = wg0*MT0
+s_mul_i32 s58, 0x40, s[sgprWorkGroup1]             // s56 = wg0*MT0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 3 writesPerItem=1 */
+s_waitcnt vmcnt(0)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:0 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 4096
+
+s_waitcnt lgkmcnt(1)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0_unprio_0
+v_lshrrev_b32 v[vgprLocalWriteAddrB], 3, v[vgprSerial]                // vectorStaticDiv: v49 = v[vgprSerial] / 8
+v_and_b32 v[vgprLocalWriteAddrA], 7, v[vgprSerial]                    // vectorStaticDiv: v48 = v[vgprSerial] % 8
+v_lshlrev_b32 v[vgprLocalWriteAddrA], 1, v[vgprLocalWriteAddrA]       // staticMultiply: v48 = v48 * 2
+v_lshlrev_b32 v[vgprLocalWriteAddrB], 1, v[vgprLocalWriteAddrB]       // staticMultiply: v49 = v49 * 2
+v_mul_lo_u32 v[vgprGlobalReadOffsetB], v[vgprLocalWriteAddrB], s[sgprStridesC+0]           // rowStart vgpr
+_v_add_co_u32 v[vgprLocalWriteAddrA], vcc, s56, v[vgprLocalWriteAddrA]                   // coord0 = tid0*VW + wg0*MT0
+_v_add_lshl_u32 v[vgprGlobalReadOffsetA], v[vgprGlobalReadOffsetB], v[vgprLocalWriteAddrA], 0x3                 // init cb addr <-  rowStart + coord0, scaled by BPE
+s_setprio 0
+
+s_add_u32       s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+s_cmp_eq_i32    s[sgprLoopCounters+0], -1             // is this the last iteration
+s_cmov_b32 	s[sgprSrdA+2], 0                        // Set limit to 0 for last iteration
+s_cmov_b32 	s[sgprSrdB+2], 0                        // Set limit to 0 for last iteration
+s_mov_b32 	s85, s[sgprSrdC+0]
+s_mov_b32 	s86, s[sgprSrdC+1]
+s_mov_b32       s87, s[sgprSrdD+0]
+s_mov_b32       s88, s[sgprSrdD+1]
+
+
+//s_waitcnt lgkmcnt(0)                               // 1wait for local write
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
+s_barrier //4sync for global read
+
+/* iter 0,1 */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:384 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part1
+
+/* iter 1 */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:768  // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1152 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part1
+
+
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:512 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+0:vgprValuC+0+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+0:vgprValuC+0+1] // *= alpha
+v_mul_f64 v[vgprValuC+2:vgprValuC+2+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+2:vgprValuC+2+1] // *= alpha
+v_fma_f64 v[vgprValuC+0:vgprValuC+0+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+0:vgprValuC+0+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+2:vgprValuC+2+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+2:vgprValuC+2+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[0:3], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+12:vgprValuC+12+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+12:vgprValuC+12+1] // *= alpha
+v_mul_f64 v[vgprValuC+14:vgprValuC+14+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+14:vgprValuC+14+1] // *= alpha
+v_fma_f64 v[vgprValuC+12:vgprValuC+12+1], v[vgprG2LB+0:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+12:vgprValuC+12+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+14:vgprValuC+14+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+14:vgprValuC+14+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[12:15], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part2
+
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:896 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1280 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part2
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:640 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+4:vgprValuC+4+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+4:vgprValuC+4+1] // *= alpha
+v_mul_f64 v[vgprValuC+6:vgprValuC+6+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+6:vgprValuC+6+1] // *= alpha
+v_fma_f64 v[vgprValuC+4:vgprValuC+4+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+4:vgprValuC+4+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+6:vgprValuC+6+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+6:vgprValuC+6+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[4:7], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+16:vgprValuC+16+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+16:vgprValuC+16+1] // *= alpha
+v_mul_f64 v[vgprValuC+18:vgprValuC+18+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+18:vgprValuC+18+1] // *= alpha
+v_fma_f64 v[vgprValuC+16:vgprValuC+16+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+16:vgprValuC+16+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+18:vgprValuC+18+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+18:vgprValuC+18+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[16:19], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part3
+
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1024 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:1408 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part3
+
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:384 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+8:vgprValuC+8+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+8:vgprValuC+8+1] // *= alpha
+v_mul_f64 v[vgprValuC+10:vgprValuC+10+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+10:vgprValuC+10+1] // *= alpha
+v_fma_f64 v[vgprValuC+8:vgprValuC+8+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+8:vgprValuC+8+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+10:vgprValuC+10+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+10:vgprValuC+10+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[8:11], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+20:vgprValuC+20+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+20:vgprValuC+20+1] // *= alpha
+v_mul_f64 v[vgprValuC+22:vgprValuC+22+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+22:vgprValuC+22+1] // *= alpha
+v_fma_f64 v[vgprValuC+20:vgprValuC+20+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+20:vgprValuC+20+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+22:vgprValuC+22+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+22:vgprValuC+22+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[20:23], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_mul_i32  s56, s[sgprStridesC+0], 248              // Scale by BPE
+s_add_u32   s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+s_mov_b32   s85, s[sgprSrdC+0]
+s_mov_b32   s86, s[sgprSrdC+1]                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part4
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:768 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+s_lshl_b32   s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32   s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1152 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part4
+
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+s_mul_i32   s56, s[sgprStridesD+0], 248              // Scale by BPE
+s_add_u32   s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:512 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+24:vgprValuC+24+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+24:vgprValuC+24+1] // *= alpha
+v_mul_f64 v[vgprValuC+26:vgprValuC+26+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+26:vgprValuC+26+1] // *= alpha
+v_fma_f64 v[vgprValuC+24:vgprValuC+24+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+24:vgprValuC+24+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+26:vgprValuC+26+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+26:vgprValuC+26+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[24:27], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_mov_b32       s87, s[sgprSrdD+0]
+s_mov_b32       s88, s[sgprSrdD+1]                 /* local read init pointers b */
+s_lshl_b32      s56, s[sgprStridesD+0], 3         // Scale     s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_add_u32       s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32      s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+36:vgprValuC+36+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+36:vgprValuC+36+1] // *= alpha
+v_mul_f64 v[vgprValuC+38:vgprValuC+38+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+38:vgprValuC+38+1] // *= alpha
+v_fma_f64 v[vgprValuC+36:vgprValuC+36+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+36:vgprValuC+36+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+38:vgprValuC+38+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+38:vgprValuC+38+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[36:39], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0_part5
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:896 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1280 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part5
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:640 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+28:vgprValuC+28+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+28:vgprValuC+28+1] // *= alpha
+v_mul_f64 v[vgprValuC+30:vgprValuC+30+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+30:vgprValuC+30+1] // *= alpha
+v_fma_f64 v[vgprValuC+28:vgprValuC+28+1], v[vgprG2LA+0:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+28:vgprValuC+28+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+30:vgprValuC+30+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+30:vgprValuC+30+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[28:31], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+40:vgprValuC+40+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+40:vgprValuC+40+1] // *= alpha
+v_mul_f64 v[vgprValuC+42:vgprValuC+42+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+42:vgprValuC+42+1] // *= alpha
+v_fma_f64 v[vgprValuC+40:vgprValuC+40+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+40:vgprValuC+40+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+42:vgprValuC+42+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+42:vgprValuC+42+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[40:43], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part6
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1024 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1408 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part6
+
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+32:vgprValuC+32+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+32:vgprValuC+32+1] // *= alpha
+v_mul_f64 v[vgprValuC+34:vgprValuC+34+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+34:vgprValuC+34+1] // *= alpha
+v_fma_f64 v[vgprValuC+32:vgprValuC+32+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+32:vgprValuC+32+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+34:vgprValuC+34+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+34:vgprValuC+34+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[32:35], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_lshl_b32  s56, 	   s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32   s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+
+v_mul_f64 v[vgprValuC+44:vgprValuC+44+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+44:vgprValuC+44+1] // *= alpha
+v_mul_f64 v[vgprValuC+46:vgprValuC+46+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+46:vgprValuC+46+1] // *= alpha
+v_fma_f64 v[vgprValuC+44:vgprValuC+44+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+44:vgprValuC+44+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+46:vgprValuC+46+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+46:vgprValuC+46+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[44:47], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_add_u32            s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+
+
+s_endpgm
+
+label_0002:
+
+/* TODO-packed- compare against product of all packed C0 sizes not just SizesFree+0 */
+//s_mov_b32 s91, 0x0                                 // STATIC_DIV: divisior=48
+//s_mul_i32 s90, 0xaaa, s[sgprSizesFree+0]           // tmp1 = dividend * magic hi
+//s_lshl_b64 s[90:91], s[90:91], 0x10                // left shift 16 bits
+//s_mul_i32 s82, s[sgprSizesFree+0], 0xaaab          // tmp0 = dividend * magic lo
+//s_add_u32 s90, s82, s90                            // add lo
+//s_addc_u32 s91, s91, 0x0                           // add hi
+//s_lshr_b64 s[90:91], s[90:91], 0x21                // tmp1 = (dividend * magic) << shift
+//s_mov_b32 s82, s90                                 // quotient
+//s_mul_i32 s90, s82, 0x30                           // quotient*divisor
+//s_sub_u32 s[sgprEdgeSelMask0], s[sgprSizesFree+0], s90             // rReg = dividend - quotient*divisor
+//s_lshr_b32 s82, s[sgprSizesFree+1], 6              // s58 = s[sgprSizesFree+1] / 64
+//s_and_b32 s[sgprEdgeSelMask1], 63, s[sgprSizesFree+1]
+
+//check edge Batch calculation needed
+//for Batch edge jump to different beta loop optimization code
+s_add_u32      s83,-0x1, s[sgprNumWorkGroups0]       //
+s_cmp_lt_u32   s[sgprWorkGroup0], s83                // wg0 < nwg0-1
+s_cmov_b32     s[sgprEdgeSelMask0], 0x0
+s_cmpk_gt_u32  s[sgprEdgeSelMask0], 0x0
+s_cbranch_scc1 label_1002                            // wg1 < nwg1-1 so skip rMT1 = Size1 % MT1
+s_add_u32      s83, -0x1, s[sgprNumWorkGroups1]      //
+s_cmp_lt_u32   s[sgprWorkGroup1], s83                // wg1 < nwg1-1
+s_cmov_b32     s[sgprEdgeSelMask1], 0x0
+s_cmpk_gt_u32  s[sgprEdgeSelMask1], 0x0
+s_cbranch_scc1 label_1002                            // wg1 < nwg1-1 so skip rMT1 = Size1 % MT1
+
+/******************************************/
+
+//s_waitcnt lgkmcnt(0)                                 // 1wait for local write
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
+s_barrier //4sync for global read
+
+/* iter 0 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(2)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:384 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:512 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:640 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(2)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:768 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:896 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1024 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:4096 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 4096
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(3)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(1)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:1152 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1280 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+s_mul_i32 s56, 0x30, s[sgprWorkGroup0]             // s56 = wg0*MT0
+s_mul_i32 s58, 0x40, s[sgprWorkGroup1]             // s56 = wg0*MT0
+/* sched write - iter 3 writesPerItem=1 */
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1408 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(0)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:4096 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 4096
+
+s_waitcnt lgkmcnt(1)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0_unprio_0
+v_lshrrev_b32 v[vgprLocalWriteAddrB], 3, v[vgprSerial]                // vectorStaticDiv: v49 = v[vgprSerial] / 8
+v_and_b32 v[vgprLocalWriteAddrA], 7, v[vgprSerial]                    // vectorStaticDiv: v48 = v[vgprSerial] % 8
+v_lshlrev_b32 v[vgprLocalWriteAddrA], 1, v[vgprLocalWriteAddrA]       // staticMultiply: v48 = v48 * 2
+v_lshlrev_b32 v[vgprLocalWriteAddrB], 1, v[vgprLocalWriteAddrB]       // staticMultiply: v49 = v49 * 2
+v_mul_lo_u32 v[vgprGlobalReadOffsetB], v[vgprLocalWriteAddrB], s[sgprStridesC+0]           // rowStart vgpr
+_v_add_co_u32 v[vgprLocalWriteAddrA], vcc, s56, v[vgprLocalWriteAddrA]                   // coord0 = tid0*VW + wg0*MT0
+_v_add_lshl_u32 v[vgprGlobalReadOffsetA], v[vgprGlobalReadOffsetB], v[vgprLocalWriteAddrA], 0x3                 // init cb addr <-  rowStart + coord0, scaled by BPE
+s_setprio 0
+
+s_add_u32       s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+s_cmp_eq_i32    s[sgprLoopCounters+0], -1             // is this the last iteration
+s_cmov_b32 	s[sgprSrdA+2], 0                        // Set limit to 0 for last iteration
+s_cmov_b32 	s[sgprSrdB+2], 0                        // Set limit to 0 for last iteration
+s_mov_b32 	s85, s[sgprSrdC+0]
+s_mov_b32 	s86, s[sgprSrdC+1]
+s_mov_b32       s87, s[sgprSrdD+0]
+s_mov_b32       s88, s[sgprSrdD+1]
+
+
+//s_waitcnt lgkmcnt(0)                               // 1wait for local write
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
+s_barrier //4sync for global read
+
+/* iter 0,1 */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4480 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part1
+
+/* iter 1 */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4864 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5248 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part1
+
+
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4224 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4608 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+0:vgprValuC+0+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+0:vgprValuC+0+1] // *= alpha
+v_mul_f64 v[vgprValuC+2:vgprValuC+2+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+2:vgprValuC+2+1] // *= alpha
+v_fma_f64 v[vgprValuC+0:vgprValuC+0+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+0:vgprValuC+0+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+2:vgprValuC+2+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+2:vgprValuC+2+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[0:3], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+12:vgprValuC+12+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+12:vgprValuC+12+1] // *= alpha
+v_mul_f64 v[vgprValuC+14:vgprValuC+14+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+14:vgprValuC+14+1] // *= alpha
+v_fma_f64 v[vgprValuC+12:vgprValuC+12+1], v[vgprG2LB+0:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+12:vgprValuC+12+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+14:vgprValuC+14+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+14:vgprValuC+14+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[12:15], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part2
+
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4992 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5376 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part2
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4736 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+4:vgprValuC+4+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+4:vgprValuC+4+1] // *= alpha
+v_mul_f64 v[vgprValuC+6:vgprValuC+6+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+6:vgprValuC+6+1] // *= alpha
+v_fma_f64 v[vgprValuC+4:vgprValuC+4+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+4:vgprValuC+4+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+6:vgprValuC+6+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+6:vgprValuC+6+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[4:7], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+16:vgprValuC+16+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+16:vgprValuC+16+1] // *= alpha
+v_mul_f64 v[vgprValuC+18:vgprValuC+18+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+18:vgprValuC+18+1] // *= alpha
+v_fma_f64 v[vgprValuC+16:vgprValuC+16+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+16:vgprValuC+16+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+18:vgprValuC+18+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+18:vgprValuC+18+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[16:19], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part3
+
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5120 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:5504 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part3
+
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4480 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+8:vgprValuC+8+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+8:vgprValuC+8+1] // *= alpha
+v_mul_f64 v[vgprValuC+10:vgprValuC+10+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+10:vgprValuC+10+1] // *= alpha
+v_fma_f64 v[vgprValuC+8:vgprValuC+8+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+8:vgprValuC+8+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+10:vgprValuC+10+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+10:vgprValuC+10+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[8:11], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+20:vgprValuC+20+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+20:vgprValuC+20+1] // *= alpha
+v_mul_f64 v[vgprValuC+22:vgprValuC+22+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+22:vgprValuC+22+1] // *= alpha
+v_fma_f64 v[vgprValuC+20:vgprValuC+20+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+20:vgprValuC+20+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+22:vgprValuC+22+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+22:vgprValuC+22+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[20:23], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_mul_i32  s56, s[sgprStridesC+0], 248              // Scale by BPE
+s_add_u32   s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+s_mov_b32   s85, s[sgprSrdC+0]
+s_mov_b32   s86, s[sgprSrdC+1]                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part4
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4864 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+s_lshl_b32   s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32   s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5248 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part4
+
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4224 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+s_mul_i32   s56, s[sgprStridesD+0], 248              // Scale by BPE
+s_add_u32   s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4608 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+24:vgprValuC+24+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+24:vgprValuC+24+1] // *= alpha
+v_mul_f64 v[vgprValuC+26:vgprValuC+26+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+26:vgprValuC+26+1] // *= alpha
+v_fma_f64 v[vgprValuC+24:vgprValuC+24+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+24:vgprValuC+24+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+26:vgprValuC+26+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+26:vgprValuC+26+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[24:27], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_mov_b32       s87, s[sgprSrdD+0]
+s_mov_b32       s88, s[sgprSrdD+1]                 /* local read init pointers b */
+s_lshl_b32      s56, s[sgprStridesD+0], 3         // Scale     s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_add_u32       s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32      s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+36:vgprValuC+36+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+36:vgprValuC+36+1] // *= alpha
+v_mul_f64 v[vgprValuC+38:vgprValuC+38+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+38:vgprValuC+38+1] // *= alpha
+v_fma_f64 v[vgprValuC+36:vgprValuC+36+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+36:vgprValuC+36+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+38:vgprValuC+38+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+38:vgprValuC+38+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[36:39], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0_part5
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4992 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5376 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part5
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4736 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+28:vgprValuC+28+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+28:vgprValuC+28+1] // *= alpha
+v_mul_f64 v[vgprValuC+30:vgprValuC+30+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+30:vgprValuC+30+1] // *= alpha
+v_fma_f64 v[vgprValuC+28:vgprValuC+28+1], v[vgprG2LA+0:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+28:vgprValuC+28+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+30:vgprValuC+30+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+30:vgprValuC+30+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[28:31], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+40:vgprValuC+40+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+40:vgprValuC+40+1] // *= alpha
+v_mul_f64 v[vgprValuC+42:vgprValuC+42+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+42:vgprValuC+42+1] // *= alpha
+v_fma_f64 v[vgprValuC+40:vgprValuC+40+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+40:vgprValuC+40+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+42:vgprValuC+42+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+42:vgprValuC+42+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[40:43], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part6
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5120 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5504 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part6
+
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+32:vgprValuC+32+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+32:vgprValuC+32+1] // *= alpha
+v_mul_f64 v[vgprValuC+34:vgprValuC+34+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+34:vgprValuC+34+1] // *= alpha
+v_fma_f64 v[vgprValuC+32:vgprValuC+32+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+32:vgprValuC+32+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+34:vgprValuC+34+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+34:vgprValuC+34+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[32:35], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_lshl_b32  s56, 	   s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32   s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+
+v_mul_f64 v[vgprValuC+44:vgprValuC+44+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+44:vgprValuC+44+1] // *= alpha
+v_mul_f64 v[vgprValuC+46:vgprValuC+46+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+46:vgprValuC+46+1] // *= alpha
+v_fma_f64 v[vgprValuC+44:vgprValuC+44+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+44:vgprValuC+44+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+46:vgprValuC+46+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+46:vgprValuC+46+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[44:47], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_add_u32            s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+
+
+s_endpgm
+
+label_1002:
+
+/******************************************/
+//branch logic gets executed for edge MT to use legacy alph_beta code
+
+//s_waitcnt lgkmcnt(0)                                 // 1wait for local write
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
+s_barrier //4sync for global read
+
+/* iter 0 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:384 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:512 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:640 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:768 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:896 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt vmcnt(1)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:4096 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 4096
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1024 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:1152 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1280 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 3 writesPerItem=1 */
+s_waitcnt vmcnt(0)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:4096 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 4096
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1408 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0
+
+
+//s_waitcnt lgkmcnt(0)                               // 1wait for local write
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
+s_barrier //4sync for global read
+
+
+/* iter 0 */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4096 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4224 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4352 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4480 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4608 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4736 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4864 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4992 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5120 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:5248 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5376 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5504 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=192 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=192 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0
+s_add_u32 s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+
+s_branch label_0004
+
+label_1003:
+
+//s_waitcnt lgkmcnt(0)                               // 1wait for local write
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
+s_barrier //4sync for global read
+
+
+/* iter 0 */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4096 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4224 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4352 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4480 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4608 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4736 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4864 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4992 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* sched write - iter 2 writesPerItem=1 */
+s_waitcnt vmcnt(1)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:0 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5120 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:5248 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5376 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 3 writesPerItem=1 */
+s_waitcnt vmcnt(0)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:0 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5504 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=192 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=192 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+
+/* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0
+
+s_add_u32 s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+s_cmp_eq_i32 s[sgprLoopCounters+0], -1             // is this the last iteration
+s_cmov_b32 s[sgprSrdA+2], 0                        // Set limit to 0 for last iteration
+s_cmov_b32 s[sgprSrdB+2], 0                        // Set limit to 0 for last iteration
+
+//s_waitcnt lgkmcnt(0)                               // 1wait for local write
+
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
+s_barrier //4sync for global read
+
+/* iter 0 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:384 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:512 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:640 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:768 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:896 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1024 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:1152 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1280 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1408 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0
+s_add_u32 s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+
+label_0004:
+
+
+/******************************************/
+/* Tail Loop                              */
+/******************************************/
+
+
+/* local write reset offsets a */
+
+
+
+/* local write reset offsets b */
+
+
+
+s_cmp_eq_u32 s[sgprOrigLoopCounter], 0             // completely skipped unroll loop?
+s_cselect_b32 s66, 0, s[sgprGlobalReadIncsA]       // force to 0?
+s_cselect_b32 s67, 0, s[sgprGlobalReadIncsB]       // force to 0?
+s_sub_u32  s[sgprSrdA+0], s[sgprSrdA+0], s66       // gra SRD -= inc(lower)
+s_subb_u32  s[sgprSrdA+1], s[sgprSrdA+1], 0        // gra SRD -= inc(upper)
+s_add_u32 s[sgprShadowLimitA+0], s[sgprShadowLimitA+0], s66 // limit -= inc)
+s_addc_u32 s[sgprShadowLimitA+1], s[sgprShadowLimitA+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitA+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdA+2], s[sgprShadowLimitA+0]    // Move shadow to real if we are within 2^32
+
+s_sub_u32  s[sgprSrdB+0], s[sgprSrdB+0], s67       // gra SRD -= inc(lower)
+s_subb_u32  s[sgprSrdB+1], s[sgprSrdB+1], 0        // gra SRD -= inc(upper)
+s_add_u32 s[sgprShadowLimitB+0], s[sgprShadowLimitB+0], s67 // limit -= inc)
+s_addc_u32 s[sgprShadowLimitB+1], s[sgprShadowLimitB+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitB+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdB+2], s[sgprShadowLimitB+0]    // Move shadow to real if we are within 2^32
+
+//numIterL = (((sizeL % LOCAL_DEPTHU) + LOCAL_SPLITU - 1) / LOCAL_SPLITU)
+s_lshr_b32 s66, s[sgprSizesSum+0], 2               // s66 = s[sgprSizesSum+0] / 4
+s_and_b32 s[sgprLoopCounters+0], 3, s[sgprSizesSum+0] // s[sgprLoopCounters+0] = s[sgprSizesSum+0] % 4
+s_cmp_eq_u32 s[sgprLoopCounters+0], 0x0            // numIterL == 0
+s_cbranch_scc1 label_0006                          // skip to end of tail loop b/c numIter==0
+s_sub_u32 s[sgprLoopCounters+0], 0x0, s[sgprLoopCounters+0] // counterL = -sizeL
+
+
+/* global read a */
+
+/* g2l=0, load component 0 */
+buffer_load_dwordx2 v[vgprG2LA+0+0:vgprG2LA+0+0+1], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // load one buffer value
+/* g2l=0, load component 1 */
+buffer_load_dwordx2 v[vgprG2LA+0+2:vgprG2LA+0+2+1], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:8 // load one buffer value
+_v_add_co_u32 v[vgprGlobalReadOffsetA+0], vcc, v[vgprGlobalReadOffsetA+0], 8 // graOffset += 1 * bpe
+
+
+/* global read b */
+
+/* g2l=0, load component 0 */
+buffer_load_dwordx2 v[vgprG2LB+0+0:vgprG2LB+0+0+1], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // load one buffer value
+/* g2l=0, load component 1 */
+buffer_load_dwordx2 v[vgprG2LB+0+2:vgprG2LB+0+2+1], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:8 // load one buffer value
+_v_add_co_u32 v[vgprGlobalReadOffsetB+0], vcc, v[vgprGlobalReadOffsetB+0], 8 // graOffset += 1 * bpe
+
+//s_waitcnt vmcnt(0)                                 // 2wait for global read
+
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
+s_barrier //
+
+/* local write init pointers a */
+
+/* N/A */
+
+
+/* local write init pointers b */
+
+/* N/A */
+
+
+/* local write a */
+
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:0 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 0
+
+
+/* local write b */
+
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:0 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 0
+
+//s_waitcnt lgkmcnt(0)                               // 5wait for local write
+
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
+s_barrier //
+
+
+/* local read reset offsets a */
+
+/* handled internally */
+v_and_b32 v[vgprLocalReadAddrA], 0xfff, v[vgprLocalReadAddrA] // reset Red,Blk -> Red
+
+
+/* local read reset offsets b */
+
+/* handled internally */
+v_and_b32 v[vgprLocalReadAddrB], 0xfff, v[vgprLocalReadAddrB] // reset Red,Blk -> Red
+
+
+/* local read init pointers a */
+
+
+
+/* local read init pointers b */
+
+
+
+/* tail loop: macs */
+
+s_cmp_ge_i32 s[sgprLoopCounters+0], 0x0            // LoopCounterL < EndCounter
+s_cbranch_scc1 label_0006                          // don't enter LoopL
+s_mov_b32 s[sgprOrigLoopCounter], 0                // repurpose to count each localRead increment
+label_0005:
+
+
+/* local read a */
+
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+
+/* local read b */
+
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+
+/* local read inc a */
+
+s_mov_b32 s65, 0x180                               // inc
+_v_add_co_u32 v[vgprLocalReadAddrA], vcc, s65, v[vgprLocalReadAddrA] // lrA += 384 (LSU*(MT+PAD)*bpe)
+
+
+/* local read inc b */
+
+s_mov_b32 s65, 0x200                               // inc
+_v_add_co_u32 v[vgprLocalReadAddrB], vcc, s65, v[vgprLocalReadAddrB] // lrB += 512 (LSU*(MT+PAD)*bpe)
+
+s_waitcnt lgkmcnt(0)                               // 4wait for local read
+
+MAC_6x4_X0
+s_add_u32 s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+s_add_u32 s[sgprOrigLoopCounter], s[sgprOrigLoopCounter], 0x1 // inc counterL
+s_cmp_eq_i32 s[sgprLoopCounters+0], 0x0            // counterL==0
+s_cbranch_scc0 label_0005                          // restart LoopL
+label_0006:
+
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // wait for all summation activity
+
+
+/* shift vector components d0 */
+
+v_mov_b32 v50, s[sgprWorkGroup0]                   //
+v_mul_i32_i24 v50, -0x30, v50                      // wg*MT
+_v_add_co_u32 v50, vcc, s[sgprSizesFree+0], v50    // wgMT = Size - wg*MT
+v_mov_b32 v48, 0x30                                // MT
+v_cmp_lt_u32 s[56:57], v50, v48                    // wgMT < MT
+v_cndmask_b32 v50, v48, v50, s[56:57]              // wgMT = (wgMT < MT) ? wgMT : MT
+v_lshrrev_b32 v52, 1, v50                          // vectorStaticDiv: v52 = v50 / 2
+v_and_b32 v53, 1, v50                              // vectorStaticDiv: v53 = v50 % 2
+v_lshrrev_b32 v54, 3, v52                          // vectorStaticDiv: v54 = v52 / 8
+v_and_b32 v55, 7, v52                              // vectorStaticDiv: v55 = v52 % 8
+v_and_b32 v56, 7, v[vgprSerial]                    // vectorStaticDiv: v56 = v[vgprSerial] % 8
+v_lshrrev_b32 v57, 4, v50                          // vectorStaticDiv: v57 = v50 / 16
+v_and_b32 v58, 1, v50                              // vectorStaticDiv: v58 = v50 % 2
+v_mov_b32 v59, v58                                 // duplicate
+v_lshrrev_b32 v58, 1, v59                          // vectorStaticDiv: v58 = v59 / 2
+_v_add_co_u32 v58, vcc, v57, v58                   // vId = 2 components
+v_cmp_eq_u32 s[56:57], v56, v55                    // mask
+v_mov_b32 v48, s56                                 //
+v_mov_b32 v49, s57                                 //
+v_cmp_eq_u32 vcc, v53, 0x1                         // wgMT%VW == 1
+s_cbranch_vccnz label_0010                         // shift d0 r=1
+s_branch label_0014                                // no shifting
+
+/******************************************/
+/* shift d0 r=1                           */
+/******************************************/
+label_0010:
+v_cmp_eq_u32 vcc, v58, 0x0                         // wgMT/(SG*VW) == 0
+s_cbranch_vccnz label_0011                         // shift d0, r=1, v=0
+v_cmp_eq_u32 vcc, v58, 0x1                         // wgMT/(SG*VW) == 1
+s_cbranch_vccnz label_0012                         // shift d0, r=1, v=1
+v_cmp_eq_u32 vcc, v58, 0x2                         // wgMT/(SG*VW) == 2
+s_cbranch_vccnz label_0013                         // shift d0, r=1, v=2
+
+/* shift d0 r=1 v=0 */
+label_0011:
+v_cmpx_eq_u32 s[56:57], v56, v55                   // serial % SG == (wgMT/VECTOR_WIDTH)%SG
+// src=1, dst=0
+v_mov_b32 v0, v2                                   // rC[0+0*VW+0*TT0I] = rC[1+0*VW+0*TT0I]
+v_mov_b32 v1, v3                                   // rC[0+0*VW+0*TT0I] = rC[1+0*VW+0*TT0I]
+// src=7, dst=6
+v_mov_b32 v12, v14                                 // rC[0+0*VW+1*TT0I] = rC[1+0*VW+1*TT0I]
+v_mov_b32 v13, v15                                 // rC[0+0*VW+1*TT0I] = rC[1+0*VW+1*TT0I]
+// src=13, dst=12
+v_mov_b32 v24, v26                                 // rC[0+0*VW+2*TT0I] = rC[1+0*VW+2*TT0I]
+v_mov_b32 v25, v27                                 // rC[0+0*VW+2*TT0I] = rC[1+0*VW+2*TT0I]
+// src=19, dst=18
+v_mov_b32 v36, v38                                 // rC[0+0*VW+3*TT0I] = rC[1+0*VW+3*TT0I]
+v_mov_b32 v37, v39                                 // rC[0+0*VW+3*TT0I] = rC[1+0*VW+3*TT0I]
+s_mov_b64 s[56:57], 0xFFFFFFFFFFFFFFFF             // to restore all threads active
+s_or_saveexec_b64 vcc, s[56:57]                    // all threads active
+s_branch label_0014                                // done shifting
+
+/* shift d0 r=1 v=1 */
+label_0012:
+v_cmpx_eq_u32 s[56:57], v56, v55                   // serial % SG == (wgMT/VECTOR_WIDTH)%SG
+// src=3, dst=2
+v_mov_b32 v4, v6                                   // rC[0+1*VW+0*TT0I] = rC[1+1*VW+0*TT0I]
+v_mov_b32 v5, v7                                   // rC[0+1*VW+0*TT0I] = rC[1+1*VW+0*TT0I]
+// src=9, dst=8
+v_mov_b32 v16, v18                                 // rC[0+1*VW+1*TT0I] = rC[1+1*VW+1*TT0I]
+v_mov_b32 v17, v19                                 // rC[0+1*VW+1*TT0I] = rC[1+1*VW+1*TT0I]
+// src=15, dst=14
+v_mov_b32 v28, v30                                 // rC[0+1*VW+2*TT0I] = rC[1+1*VW+2*TT0I]
+v_mov_b32 v29, v31                                 // rC[0+1*VW+2*TT0I] = rC[1+1*VW+2*TT0I]
+// src=21, dst=20
+v_mov_b32 v40, v42                                 // rC[0+1*VW+3*TT0I] = rC[1+1*VW+3*TT0I]
+v_mov_b32 v41, v43                                 // rC[0+1*VW+3*TT0I] = rC[1+1*VW+3*TT0I]
+s_mov_b64 s[56:57], 0xFFFFFFFFFFFFFFFF             // to restore all threads active
+s_or_saveexec_b64 vcc, s[56:57]                    // all threads active
+s_branch label_0014                                // done shifting
+
+/* shift d0 r=1 v=2 */
+label_0013:
+v_cmpx_eq_u32 s[56:57], v56, v55                   // serial % SG == (wgMT/VECTOR_WIDTH)%SG
+// src=5, dst=4
+v_mov_b32 v8, v10                                  // rC[0+2*VW+0*TT0I] = rC[1+2*VW+0*TT0I]
+v_mov_b32 v9, v11                                  // rC[0+2*VW+0*TT0I] = rC[1+2*VW+0*TT0I]
+// src=11, dst=10
+v_mov_b32 v20, v22                                 // rC[0+2*VW+1*TT0I] = rC[1+2*VW+1*TT0I]
+v_mov_b32 v21, v23                                 // rC[0+2*VW+1*TT0I] = rC[1+2*VW+1*TT0I]
+// src=17, dst=16
+v_mov_b32 v32, v34                                 // rC[0+2*VW+2*TT0I] = rC[1+2*VW+2*TT0I]
+v_mov_b32 v33, v35                                 // rC[0+2*VW+2*TT0I] = rC[1+2*VW+2*TT0I]
+// src=23, dst=22
+v_mov_b32 v44, v46                                 // rC[0+2*VW+3*TT0I] = rC[1+2*VW+3*TT0I]
+v_mov_b32 v45, v47                                 // rC[0+2*VW+3*TT0I] = rC[1+2*VW+3*TT0I]
+s_mov_b64 s[56:57], 0xFFFFFFFFFFFFFFFF             // to restore all threads active
+s_or_saveexec_b64 vcc, s[56:57]                    // all threads active
+s_branch label_0014                                // done shifting
+label_0014: // end shift0
+
+
+/* shift vector components d1 */
+
+v_mov_b32 v50, s[sgprWorkGroup1]                   //
+v_mul_i32_i24 v50, -0x40, v50                      // wg*MT
+_v_add_co_u32 v50, vcc, s[sgprSizesFree+1], v50    // wgMT = Size - wg*MT
+v_mov_b32 v48, 0x40                                // MT
+v_cmp_lt_u32 s[56:57], v50, v48                    // wgMT < MT
+v_cndmask_b32 v50, v48, v50, s[56:57]              // wgMT = (wgMT < MT) ? wgMT : MT
+v_lshrrev_b32 v52, 1, v50                          // vectorStaticDiv: v52 = v50 / 2
+v_and_b32 v53, 1, v50                              // vectorStaticDiv: v53 = v50 % 2
+v_lshrrev_b32 v54, 4, v52                          // vectorStaticDiv: v54 = v52 / 16
+v_and_b32 v55, 15, v52                             // vectorStaticDiv: v55 = v52 % 16
+v_lshrrev_b32 v56, 3, v[vgprSerial]                // vectorStaticDiv: v56 = v[vgprSerial] / 8
+v_and_b32 v57, 15, v56                             // vectorStaticDiv: v57 = v56 % 16
+v_lshrrev_b32 v56, 5, v50                          // vectorStaticDiv: v56 = v50 / 32
+v_and_b32 v58, 1, v50                              // vectorStaticDiv: v58 = v50 % 2
+v_mov_b32 v59, v58                                 // duplicate
+v_lshrrev_b32 v58, 1, v59                          // vectorStaticDiv: v58 = v59 / 2
+_v_add_co_u32 v58, vcc, v56, v58                   // vId = 2 components
+v_cmp_eq_u32 s[56:57], v57, v55                    // mask
+v_mov_b32 v48, s56                                 //
+v_mov_b32 v49, s57                                 //
+v_cmp_eq_u32 vcc, v53, 0x1                         // wgMT%VW == 1
+s_cbranch_vccnz label_0018                         // shift d1 r=1
+s_branch label_0021                                // no shifting
+
+/******************************************/
+/* shift d1 r=1                           */
+/******************************************/
+label_0018:
+v_cmp_eq_u32 vcc, v58, 0x0                         // wgMT/(SG*VW) == 0
+s_cbranch_vccnz label_0019                         // shift d1, r=1, v=0
+v_cmp_eq_u32 vcc, v58, 0x1                         // wgMT/(SG*VW) == 1
+s_cbranch_vccnz label_0020                         // shift d1, r=1, v=1
+
+/* shift d1 r=1 v=0 */
+label_0019:
+v_cmpx_eq_u32 s[56:57], v57, v55                   // serial % SG == (wgMT/VECTOR_WIDTH)%SG
+// src=6, dst=0
+v_mov_b32 v0, v12                                  // rC[0+0*TT0I*VW+0*TT0I] = rC[0+0*TT0I*VW+1*TT0I]
+v_mov_b32 v1, v13                                  // rC[0+0*TT0I*VW+0*TT0I] = rC[0+0*TT0I*VW+1*TT0I]
+// src=7, dst=1
+v_mov_b32 v2, v14                                  // rC[1+0*TT0I*VW+0*TT0I] = rC[1+0*TT0I*VW+1*TT0I]
+v_mov_b32 v3, v15                                  // rC[1+0*TT0I*VW+0*TT0I] = rC[1+0*TT0I*VW+1*TT0I]
+// src=8, dst=2
+v_mov_b32 v4, v16                                  // rC[2+0*TT0I*VW+0*TT0I] = rC[2+0*TT0I*VW+1*TT0I]
+v_mov_b32 v5, v17                                  // rC[2+0*TT0I*VW+0*TT0I] = rC[2+0*TT0I*VW+1*TT0I]
+// src=9, dst=3
+v_mov_b32 v6, v18                                  // rC[3+0*TT0I*VW+0*TT0I] = rC[3+0*TT0I*VW+1*TT0I]
+v_mov_b32 v7, v19                                  // rC[3+0*TT0I*VW+0*TT0I] = rC[3+0*TT0I*VW+1*TT0I]
+// src=10, dst=4
+v_mov_b32 v8, v20                                  // rC[4+0*TT0I*VW+0*TT0I] = rC[4+0*TT0I*VW+1*TT0I]
+v_mov_b32 v9, v21                                  // rC[4+0*TT0I*VW+0*TT0I] = rC[4+0*TT0I*VW+1*TT0I]
+// src=11, dst=5
+v_mov_b32 v10, v22                                 // rC[5+0*TT0I*VW+0*TT0I] = rC[5+0*TT0I*VW+1*TT0I]
+v_mov_b32 v11, v23                                 // rC[5+0*TT0I*VW+0*TT0I] = rC[5+0*TT0I*VW+1*TT0I]
+s_mov_b64 s[56:57], 0xFFFFFFFFFFFFFFFF             // to restore all threads active
+s_or_saveexec_b64 vcc, s[56:57]                    // all threads active
+s_branch label_0021                                // done shifting
+
+/* shift d1 r=1 v=1 */
+label_0020:
+v_cmpx_eq_u32 s[56:57], v57, v55                   // serial % SG == (wgMT/VECTOR_WIDTH)%SG
+// src=18, dst=12
+v_mov_b32 v24, v36                                 // rC[0+1*TT0I*VW+0*TT0I] = rC[0+1*TT0I*VW+1*TT0I]
+v_mov_b32 v25, v37                                 // rC[0+1*TT0I*VW+0*TT0I] = rC[0+1*TT0I*VW+1*TT0I]
+// src=19, dst=13
+v_mov_b32 v26, v38                                 // rC[1+1*TT0I*VW+0*TT0I] = rC[1+1*TT0I*VW+1*TT0I]
+v_mov_b32 v27, v39                                 // rC[1+1*TT0I*VW+0*TT0I] = rC[1+1*TT0I*VW+1*TT0I]
+// src=20, dst=14
+v_mov_b32 v28, v40                                 // rC[2+1*TT0I*VW+0*TT0I] = rC[2+1*TT0I*VW+1*TT0I]
+v_mov_b32 v29, v41                                 // rC[2+1*TT0I*VW+0*TT0I] = rC[2+1*TT0I*VW+1*TT0I]
+// src=21, dst=15
+v_mov_b32 v30, v42                                 // rC[3+1*TT0I*VW+0*TT0I] = rC[3+1*TT0I*VW+1*TT0I]
+v_mov_b32 v31, v43                                 // rC[3+1*TT0I*VW+0*TT0I] = rC[3+1*TT0I*VW+1*TT0I]
+// src=22, dst=16
+v_mov_b32 v32, v44                                 // rC[4+1*TT0I*VW+0*TT0I] = rC[4+1*TT0I*VW+1*TT0I]
+v_mov_b32 v33, v45                                 // rC[4+1*TT0I*VW+0*TT0I] = rC[4+1*TT0I*VW+1*TT0I]
+// src=23, dst=17
+v_mov_b32 v34, v46                                 // rC[5+1*TT0I*VW+0*TT0I] = rC[5+1*TT0I*VW+1*TT0I]
+v_mov_b32 v35, v47                                 // rC[5+1*TT0I*VW+0*TT0I] = rC[5+1*TT0I*VW+1*TT0I]
+s_mov_b64 s[56:57], 0xFFFFFFFFFFFFFFFF             // to restore all threads active
+s_or_saveexec_b64 vcc, s[56:57]                    // all threads active
+label_0021: // end shift0
+
+
+
+/* not-LocalSplitU: global write indices */
+
+s_mov_b32 s[sgprSrdD+0], s[sgprAddressD+0]         // init SRD base address (lower)
+s_mov_b32 s[sgprSrdD+1], s[sgprAddressD+1]         // init SRD base address (upper) + other fields
+s_mov_b32 s[sgprSrdD+2], 0x80000000                //
+s_mov_b32 s[sgprSrdD+3], Srd127_96                 // Set bits 127_96 in SRD
+s_mov_b32 s[sgprSrdC+0], s[sgprAddressC+0]         // init SRD base address (lower)
+s_mov_b32 s[sgprSrdC+1], s[sgprAddressC+1]         // init SRD base address (upper) + other fields
+s_mov_b32 s[sgprSrdC+2], 0x80000000                //
+s_mov_b32 s[sgprSrdC+3], Srd127_96                 // Set bits 127_96 in SRD
+
+s_mul_i32 s58, 0x40, s[sgprWorkGroup1]             // <- wg1*MT1
+s_mul_hi_u32 s57, s58, s[sgprStridesC+0]           // Scale s58 by Stride
+s_mul_i32 s56, s58, s[sgprStridesC+0]              // Scale s58 by Stride
+s_lshl_b64 s[56:57], s[56:57], 3                   // scale by bpe
+s_add_u32 s[sgprSrdD+0], s[sgprSrdD+0], s56        // add lo to SRD
+s_addc_u32 s[sgprSrdD+1], s[sgprSrdD+1], s57       // add hi to SRD
+s_add_u32 s[sgprSrdC+0], s[sgprSrdC+0], s56        // add lo to SRD
+s_addc_u32 s[sgprSrdC+1], s[sgprSrdC+1], s57       // add hi to SRD
+
+s_mul_hi_u32 s57, s[sgprWorkGroup2], s[sgprStridesC+1] // Scale s[sgprWorkGroup2] by Stride
+s_mul_i32 s56, s[sgprWorkGroup2], s[sgprStridesC+1] // Scale s[sgprWorkGroup2] by Stride
+s_lshl_b64 s[56:57], s[56:57], 3                   // scale by bpe
+s_add_u32 s[sgprSrdD+0], s[sgprSrdD+0], s56        // add lo to SRD
+s_addc_u32 s[sgprSrdD+1], s[sgprSrdD+1], s57       // add hi to SRD
+s_add_u32 s[sgprSrdC+0], s[sgprSrdC+0], s56        // add lo to SRD
+s_addc_u32 s[sgprSrdC+1], s[sgprSrdC+1], s57       // add hi to SRD
+
+v_lshrrev_b32 v49, 3, v[vgprSerial]                // vectorStaticDiv: v49 = v[vgprSerial] / 8
+v_and_b32 v48, 7, v[vgprSerial]                    // vectorStaticDiv: v48 = v[vgprSerial] % 8
+v_lshlrev_b32 v48, 1, v48                          // staticMultiply: v48 = v48 * 2
+v_lshlrev_b32 v49, 1, v49                          // staticMultiply: v49 = v49 * 2
+v_mul_lo_u32 v50, v49, s[sgprStridesC+0]           // rowStart vgpr
+
+s_mul_i32 s56, 0x30, s[sgprWorkGroup0]             // s56 = wg0*MT0
+_v_add_co_u32 v48, vcc, s56, v48                   // coord0 = tid0*VW + wg0*MT0
+s_mul_i32 s58, 0x40, s[sgprWorkGroup1]             // <- wg1*MT1
+_v_add_co_u32 v49, vcc, s58, v49                   // coord1 = tid1*VW + wg1*MT1
+
+//v_mov_b32 v48,v[vgprLocalWriteAddrA]
+//v_mov_b32 v49,v[vgprLocalWriteAddrB]
+//v_mov_b32 v50,v[vgprGlobalReadOffsetB]           // rowStart vgpr
+//_v_add_lshl_u32 v[vgprGlobalReadOffsetA], v[vgprGlobalReadOffsetB], v[vgprLocalWriteAddrA], 0x3                 // init cb addr <-  rowStart + coord0, scaled by BPE
+
+/* not-LocalSplitU: global write */
+
+s_mov_b32 s56, s[sgprBeta+0]                       // tmp = Beta[0]
+s_or_b32 s56, s[sgprBeta+1], s56                   // tmp |= Beta[1]
+s_cmpk_eq_u32 s56, 0x0                             // Beta == 0
+s_cbranch_scc0 label_0030                          // Beta is not zero; so jump to B nonzero
+
+s_mov_b32 s56, 0x0                                 // rMT0=0
+s_add_u32 s58, -0x1, s[sgprNumWorkGroups0]         //
+s_cmp_lt_u32 s[sgprWorkGroup0], s58                // wg0 < nwg0-1
+s_cbranch_scc1 label_0027                          // wg0 < nwg0-1 so skip rMT0 = Size0 % MT0
+/* TODO-packed- compare against product of all packed C0 sizes not just SizesFree+0 */
+s_mov_b32 s61, 0x0                                 // STATIC_DIV: divisior=48
+s_mul_i32 s60, 0xaaa, s[sgprSizesFree+0]           // tmp1 = dividend * magic hi
+s_lshl_b64 s[60:61], s[60:61], 0x10                // left shift 16 bits
+s_mul_i32 s58, s[sgprSizesFree+0], 0xaaab          // tmp0 = dividend * magic lo
+s_add_u32 s60, s58, s60                            // add lo
+s_addc_u32 s61, s61, 0x0                           // add hi
+s_lshr_b64 s[60:61], s[60:61], 0x21                // tmp1 = (dividend * magic) << shift
+s_mov_b32 s58, s60                                 // quotient
+s_mul_i32 s60, s58, 0x30                           // quotient*divisor
+s_sub_u32 s56, s[sgprSizesFree+0], s60             // rReg = dividend - quotient*divisor
+label_0027:
+s_cmpk_gt_u32 s56, 0x0                             // rMT0 > 0
+s_cbranch_scc1 label_0029                          // edges required so jump to E1
+s_mov_b32 s56, 0x0                                 // rMT1=0
+s_add_u32 s58, -0x1, s[sgprNumWorkGroups1]         //
+s_cmp_lt_u32 s[sgprWorkGroup1], s58                // wg1 < nwg1-1
+s_cbranch_scc1 label_0028                          // wg1 < nwg1-1 so skip rMT1 = Size1 % MT1
+s_lshr_b32 s58, s[sgprSizesFree+1], 6              // s58 = s[sgprSizesFree+1] / 64
+s_and_b32 s56, 63, s[sgprSizesFree+1]              // s56 = s[sgprSizesFree+1] % 64
+label_0028:
+s_cmpk_gt_u32 s56, 0x0                             // rMT1 > 0
+s_cbranch_scc1 label_0029                          // edges required so jump to E1
+label_0026:
+
+/******************************************/
+/* Global Write Batch #0 (d1,d0,vc1,vc0) =
+   (0,0,0,0:vw2); (0,1,0,0:vw2); (0,2,0,0:vw2); (0,0,1,0:vw2); (0,1,1,0:vw2); (0,2,1,0:vw2); (1,0,0,0:vw2); (1,1,0,0:vw2); (1,2,0,0:vw2); (1,0,1,0:vw2); (1,1,1,0:vw2); (1,2,1,0:vw2) */
+/******************************************/
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(0,0,0,0) coordOffset1=0 element-rows coordOffset0=0 rows */
+_v_add_lshl_u32 v54, v50, v48, 0x3                 // init cb addr <-  rowStart + coord0, scaled by BPE
+/* (d1,vc1,d0,vc0)=(0,0,1,0) coordOffset1=0 element-rows coordOffset0=16 rows */
+/* (d1,vc1,d0,vc0)=(0,0,2,0) coordOffset1=0 element-rows coordOffset0=32 rows */
+/* (d1,vc1,d0,vc0)=(0,1,0,0) coordOffset1=1 element-rows coordOffset0=0 rows */
+/* (d1,vc1,d0,vc0)=(0,1,1,0) coordOffset1=1 element-rows coordOffset0=16 rows */
+/* (d1,vc1,d0,vc0)=(0,1,2,0) coordOffset1=1 element-rows coordOffset0=32 rows */
+/* (d1,vc1,d0,vc0)=(1,0,0,0) coordOffset1=32 element-rows coordOffset0=0 rows */
+/* (d1,vc1,d0,vc0)=(1,0,1,0) coordOffset1=32 element-rows coordOffset0=16 rows */
+/* (d1,vc1,d0,vc0)=(1,0,2,0) coordOffset1=32 element-rows coordOffset0=32 rows */
+/* (d1,vc1,d0,vc0)=(1,1,0,0) coordOffset1=33 element-rows coordOffset0=0 rows */
+/* (d1,vc1,d0,vc0)=(1,1,1,0) coordOffset1=33 element-rows coordOffset0=16 rows */
+/* (d1,vc1,d0,vc0)=(1,1,2,0) coordOffset1=33 element-rows coordOffset0=32 rows */
+
+/* rC *= alpha batchEements=[(0, 0, 0, 0), (0, 1, 0, 0), (0, 2, 0, 0), (0, 0, 1, 0), (0, 1, 1, 0), (0, 2, 1, 0), (1, 0, 0, 0), (1, 1, 0, 0), (1, 2, 0, 0), (1, 0, 1, 0), (1, 1, 1, 0), (1, 2, 1, 0)] */
+//v_mul_f64 v[vgprValuC+0:vgprValuC+0+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+0:vgprValuC+0+1] // *= alpha
+//v_mul_f64 v[vgprValuC+2:vgprValuC+2+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+2:vgprValuC+2+1] // *= alpha
+//v_mul_f64 v[vgprValuC+4:vgprValuC+4+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+4:vgprValuC+4+1] // *= alpha
+//v_mul_f64 v[vgprValuC+6:vgprValuC+6+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+6:vgprValuC+6+1] // *= alpha
+//v_mul_f64 v[vgprValuC+8:vgprValuC+8+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+8:vgprValuC+8+1] // *= alpha
+//v_mul_f64 v[vgprValuC+10:vgprValuC+10+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+10:vgprValuC+10+1] // *= alpha
+//v_mul_f64 v[vgprValuC+12:vgprValuC+12+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+12:vgprValuC+12+1] // *= alpha
+//v_mul_f64 v[vgprValuC+14:vgprValuC+14+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+14:vgprValuC+14+1] // *= alpha
+//v_mul_f64 v[vgprValuC+16:vgprValuC+16+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+16:vgprValuC+16+1] // *= alpha
+//v_mul_f64 v[vgprValuC+18:vgprValuC+18+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+18:vgprValuC+18+1] // *= alpha
+//v_mul_f64 v[vgprValuC+20:vgprValuC+20+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+20:vgprValuC+20+1] // *= alpha
+//v_mul_f64 v[vgprValuC+22:vgprValuC+22+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+22:vgprValuC+22+1] // *= alpha
+//v_mul_f64 v[vgprValuC+24:vgprValuC+24+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+24:vgprValuC+24+1] // *= alpha
+//v_mul_f64 v[vgprValuC+26:vgprValuC+26+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+26:vgprValuC+26+1] // *= alpha
+//v_mul_f64 v[vgprValuC+28:vgprValuC+28+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+28:vgprValuC+28+1] // *= alpha
+//v_mul_f64 v[vgprValuC+30:vgprValuC+30+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+30:vgprValuC+30+1] // *= alpha
+//v_mul_f64 v[vgprValuC+32:vgprValuC+32+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+32:vgprValuC+32+1] // *= alpha
+//v_mul_f64 v[vgprValuC+34:vgprValuC+34+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+34:vgprValuC+34+1] // *= alpha
+//v_mul_f64 v[vgprValuC+36:vgprValuC+36+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+36:vgprValuC+36+1] // *= alpha
+//v_mul_f64 v[vgprValuC+38:vgprValuC+38+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+38:vgprValuC+38+1] // *= alpha
+//v_mul_f64 v[vgprValuC+40:vgprValuC+40+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+40:vgprValuC+40+1] // *= alpha
+//v_mul_f64 v[vgprValuC+42:vgprValuC+42+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+42:vgprValuC+42+1] // *= alpha
+//v_mul_f64 v[vgprValuC+44:vgprValuC+44+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+44:vgprValuC+44+1] // *= alpha
+//v_mul_f64 v[vgprValuC+46:vgprValuC+46+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+46:vgprValuC+46+1] // *= alpha
+
+/* apply mask, calc new C and issue write */
+buffer_store_dwordx4 v[0:3], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx4 v[4:7], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+buffer_store_dwordx4 v[8:11], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+buffer_store_dwordx4 v[12:15], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx4 v[16:19], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+buffer_store_dwordx4 v[20:23], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_mul_i32 s56, s[sgprStridesC+0], 248              // scale StrideC *= 31 * bpe
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+buffer_store_dwordx4 v[24:27], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx4 v[28:31], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+buffer_store_dwordx4 v[32:35], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+buffer_store_dwordx4 v[36:39], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx4 v[40:43], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+buffer_store_dwordx4 v[44:47], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_branch label_0037                                // jump to end
+label_0029:
+
+/******************************************/
+/* Global Write Edge Batch #0 (d1,d0,vc1,vc0) =
+   (0,0,0,0:vw1); (0,0,0,1:vw1); (0,1,0,0:vw1); (0,1,0,1:vw1); (0,2,0,0:vw1); (0,2,0,1:vw1); (0,0,1,0:vw1); (0,0,1,1:vw1); (0,1,1,0:vw1); (0,1,1,1:vw1); (0,2,1,0:vw1); (0,2,1,1:vw1); (1,0,0,0:vw1); (1,0,0,1:vw1); (1,1,0,0:vw1); (1,1,0,1:vw1); (1,2,0,0:vw1); (1,2,0,1:vw1) */
+/******************************************/
+
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(0,0,0,0) coordOffset1=0 element-rows coordOffset0=0 rows */
+v_mov_b32 v51, v50                                 // rowPtr <- rowStart (first row)
+_v_add_lshl_u32 v54, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[62:63], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v54, -1, v54, s[62:63]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,0,0,1) coordOffset1=0 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v55, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[64:65], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v55, -1, v55, s[64:65]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,0,1,0) coordOffset1=0 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v56, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[66:67], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v56, -1, v56, s[66:67]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,0,1,1) coordOffset1=0 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v57, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[68:69], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v57, -1, v57, s[68:69]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,0,2,0) coordOffset1=0 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v58, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[70:71], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v58, -1, v58, s[70:71]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,0,2,1) coordOffset1=0 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v59, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[72:73], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v59, -1, v59, s[72:73]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,1,0,0) coordOffset1=1 element-rows coordOffset0=0 rows */
+_v_add_co_u32 v53, vcc, v49, 1                     // coord1 += d1*sg1*VW + vc1
+_v_add_co_u32 v51, vcc, v51, s[sgprStridesC+0]     // rowPtr <- move to start of new row
+_v_add_lshl_u32 v60, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[74:75], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v60, -1, v60, s[74:75]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,1,0,1) coordOffset1=1 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v61, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[76:77], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v61, -1, v61, s[76:77]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,1,1,0) coordOffset1=1 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v62, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[78:79], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v62, -1, v62, s[78:79]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,1,1,1) coordOffset1=1 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v63, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[80:81], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v63, -1, v63, s[80:81]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,1,2,0) coordOffset1=1 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v64, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[82:83], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v64, -1, v64, s[82:83]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,1,2,1) coordOffset1=1 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v65, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[84:85], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v65, -1, v65, s[84:85]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,0,0,0) coordOffset1=32 element-rows coordOffset0=0 rows */
+_v_add_co_u32 v53, vcc, v49, 32                    // coord1 += d1*sg1*VW + vc1
+s_mul_i32 s56, s[sgprStridesC+0], 32               // scale StrideC *= coordOffset1(32)
+_v_add_co_u32 v51, vcc, v50, s56                   // rowPtr <- inc for non-0 (tt1+vc1))
+_v_add_lshl_u32 v66, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[86:87], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v66, -1, v66, s[86:87]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,0,0,1) coordOffset1=32 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v67, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[88:89], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v67, -1, v67, s[88:89]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,0,1,0) coordOffset1=32 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v68, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[90:91], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v68, -1, v68, s[90:91]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,0,1,1) coordOffset1=32 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v69, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[92:93], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v69, -1, v69, s[92:93]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,0,2,0) coordOffset1=32 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v70, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[94:95], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v70, -1, v70, s[94:95]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,0,2,1) coordOffset1=32 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v71, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[96:97], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v71, -1, v71, s[96:97]               // clip if OOB. offset
+
+/* rC *= alpha batchEements=[(0, 0, 0, 0), (0, 0, 0, 1), (0, 1, 0, 0), (0, 1, 0, 1), (0, 2, 0, 0), (0, 2, 0, 1), (0, 0, 1, 0), (0, 0, 1, 1), (0, 1, 1, 0), (0, 1, 1, 1), (0, 2, 1, 0), (0, 2, 1, 1), (1, 0, 0, 0), (1, 0, 0, 1), (1, 1, 0, 0), (1, 1, 0, 1), (1, 2, 0, 0), (1, 2, 0, 1)] */
+//v_mul_f64 v[vgprValuC+0:vgprValuC+0+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+0:vgprValuC+0+1] // *= alpha
+//v_mul_f64 v[vgprValuC+2:vgprValuC+2+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+2:vgprValuC+2+1] // *= alpha
+//v_mul_f64 v[vgprValuC+4:vgprValuC+4+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+4:vgprValuC+4+1] // *= alpha
+//v_mul_f64 v[vgprValuC+6:vgprValuC+6+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+6:vgprValuC+6+1] // *= alpha
+//v_mul_f64 v[vgprValuC+8:vgprValuC+8+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+8:vgprValuC+8+1] // *= alpha
+//v_mul_f64 v[vgprValuC+10:vgprValuC+10+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+10:vgprValuC+10+1] // *= alpha
+//v_mul_f64 v[vgprValuC+12:vgprValuC+12+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+12:vgprValuC+12+1] // *= alpha
+//v_mul_f64 v[vgprValuC+14:vgprValuC+14+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+14:vgprValuC+14+1] // *= alpha
+//v_mul_f64 v[vgprValuC+16:vgprValuC+16+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+16:vgprValuC+16+1] // *= alpha
+//v_mul_f64 v[vgprValuC+18:vgprValuC+18+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+18:vgprValuC+18+1] // *= alpha
+//v_mul_f64 v[vgprValuC+20:vgprValuC+20+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+20:vgprValuC+20+1] // *= alpha
+//v_mul_f64 v[vgprValuC+22:vgprValuC+22+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+22:vgprValuC+22+1] // *= alpha
+//v_mul_f64 v[vgprValuC+24:vgprValuC+24+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+24:vgprValuC+24+1] // *= alpha
+//v_mul_f64 v[vgprValuC+26:vgprValuC+26+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+26:vgprValuC+26+1] // *= alpha
+//v_mul_f64 v[vgprValuC+28:vgprValuC+28+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+28:vgprValuC+28+1] // *= alpha
+//v_mul_f64 v[vgprValuC+30:vgprValuC+30+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+30:vgprValuC+30+1] // *= alpha
+//v_mul_f64 v[vgprValuC+32:vgprValuC+32+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+32:vgprValuC+32+1] // *= alpha
+//v_mul_f64 v[vgprValuC+34:vgprValuC+34+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+34:vgprValuC+34+1] // *= alpha
+
+/* apply mask, calc new C and issue write */
+buffer_store_dwordx2 v[0:1], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[2:3], v55, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[4:5], v56, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[6:7], v57, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[8:9], v58, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[10:11], v59, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[12:13], v60, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[14:15], v61, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[16:17], v62, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[18:19], v63, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[20:21], v64, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[22:23], v65, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[24:25], v66, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[26:27], v67, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[28:29], v68, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[30:31], v69, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[32:33], v70, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[34:35], v71, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+/******************************************/
+/* Global Write Edge Batch #1 (d1,d0,vc1,vc0) =
+   (1,0,1,0:vw1); (1,0,1,1:vw1); (1,1,1,0:vw1); (1,1,1,1:vw1); (1,2,1,0:vw1); (1,2,1,1:vw1) */
+/******************************************/
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(1,1,0,0) coordOffset1=33 element-rows coordOffset0=0 rows */
+_v_add_co_u32 v53, vcc, v49, 33                    // coord1 += d1*sg1*VW + vc1
+_v_add_co_u32 v51, vcc, v51, s[sgprStridesC+0]     // rowPtr <- move to start of new row
+_v_add_lshl_u32 v54, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[62:63], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v54, -1, v54, s[62:63]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,1,0,1) coordOffset1=33 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v55, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[64:65], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v55, -1, v55, s[64:65]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,1,1,0) coordOffset1=33 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v56, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[66:67], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v56, -1, v56, s[66:67]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,1,1,1) coordOffset1=33 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v57, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[68:69], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v57, -1, v57, s[68:69]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,1,2,0) coordOffset1=33 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v58, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[70:71], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v58, -1, v58, s[70:71]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,1,2,1) coordOffset1=33 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v59, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[72:73], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v59, -1, v59, s[72:73]               // clip if OOB. offset
+
+/* rC *= alpha batchEements=[(1, 0, 1, 0), (1, 0, 1, 1), (1, 1, 1, 0), (1, 1, 1, 1), (1, 2, 1, 0), (1, 2, 1, 1)] */
+//v_mul_f64 v[vgprValuC+36:vgprValuC+36+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+36:vgprValuC+36+1] // *= alpha
+//v_mul_f64 v[vgprValuC+38:vgprValuC+38+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+38:vgprValuC+38+1] // *= alpha
+//v_mul_f64 v[vgprValuC+40:vgprValuC+40+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+40:vgprValuC+40+1] // *= alpha
+//v_mul_f64 v[vgprValuC+42:vgprValuC+42+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+42:vgprValuC+42+1] // *= alpha
+//v_mul_f64 v[vgprValuC+44:vgprValuC+44+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+44:vgprValuC+44+1] // *= alpha
+//v_mul_f64 v[vgprValuC+46:vgprValuC+46+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+46:vgprValuC+46+1] // *= alpha
+
+/* apply mask, calc new C and issue write */
+buffer_store_dwordx2 v[36:37], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[38:39], v55, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[40:41], v56, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[42:43], v57, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[44:45], v58, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[46:47], v59, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_branch label_0037                                // jump to end
+label_0030:
+s_mov_b32 s56, 0x0                                 // rMT0=0
+s_add_u32 s58, -0x1, s[sgprNumWorkGroups0]         //
+s_cmp_lt_u32 s[sgprWorkGroup0], s58                // wg0 < nwg0-1
+s_cbranch_scc1 label_0034                          // wg0 < nwg0-1 so skip rMT0 = Size0 % MT0
+/* TODO-packed- compare against product of all packed C0 sizes not just SizesFree+0 */
+s_mov_b32 s61, 0x0                                 // STATIC_DIV: divisior=48
+s_mul_i32 s60, 0xaaa, s[sgprSizesFree+0]           // tmp1 = dividend * magic hi
+s_lshl_b64 s[60:61], s[60:61], 0x10                // left shift 16 bits
+s_mul_i32 s58, s[sgprSizesFree+0], 0xaaab          // tmp0 = dividend * magic lo
+s_add_u32 s60, s58, s60                            // add lo
+s_addc_u32 s61, s61, 0x0                           // add hi
+s_lshr_b64 s[60:61], s[60:61], 0x21                // tmp1 = (dividend * magic) << shift
+s_mov_b32 s58, s60                                 // quotient
+s_mul_i32 s60, s58, 0x30                           // quotient*divisor
+s_sub_u32 s56, s[sgprSizesFree+0], s60             // rReg = dividend - quotient*divisor
+label_0034:
+s_cmpk_gt_u32 s56, 0x0                             // rMT0 > 0
+s_cbranch_scc1 label_0036                          // edges required so jump to E1
+s_mov_b32 s56, 0x0                                 // rMT1=0
+s_add_u32 s58, -0x1, s[sgprNumWorkGroups1]         //
+s_cmp_lt_u32 s[sgprWorkGroup1], s58                // wg1 < nwg1-1
+s_cbranch_scc1 label_0035                          // wg1 < nwg1-1 so skip rMT1 = Size1 % MT1
+s_lshr_b32 s58, s[sgprSizesFree+1], 6              // s58 = s[sgprSizesFree+1] / 64
+s_and_b32 s56, 63, s[sgprSizesFree+1]              // s56 = s[sgprSizesFree+1] % 64
+label_0035:
+s_cmpk_gt_u32 s56, 0x0                             // rMT1 > 0
+s_cbranch_scc1 label_0036                          // edges required so jump to E1
+label_0033:
+
+/******************************************/
+/* Global Write Beta Batch #0 (d1,d0,vc1,vc0) =
+   (0,0,0,0:vw2); (0,1,0,0:vw2); (0,2,0,0:vw2); (0,0,1,0:vw2); (0,1,1,0:vw2); (0,2,1,0:vw2) */
+/******************************************/
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(0,0,0,0) coordOffset1=0 element-rows coordOffset0=0 rows */
+_v_add_lshl_u32 v54, v[vgprGlobalReadOffsetB], v48, 0x3                 // init cb addr <-  rowStart + coord0, scaled by BPE
+buffer_load_dwordx4 v[55:58], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,1,0) coordOffset1=0 element-rows coordOffset0=16 rows */
+buffer_load_dwordx4 v[59:62], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,2,0) coordOffset1=0 element-rows coordOffset0=32 rows */
+buffer_load_dwordx4 v[63:66], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,0,0) coordOffset1=1 element-rows coordOffset0=0 rows */
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+buffer_load_dwordx4 v[67:70], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,1,0) coordOffset1=1 element-rows coordOffset0=16 rows */
+buffer_load_dwordx4 v[71:74], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,2,0) coordOffset1=1 element-rows coordOffset0=32 rows */
+buffer_load_dwordx4 v[75:78], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+
+/* rC *= alpha batchEements=[(0, 0, 0, 0), (0, 1, 0, 0), (0, 2, 0, 0), (0, 0, 1, 0), (0, 1, 1, 0), (0, 2, 1, 0)] */
+v_mul_f64 v[vgprValuC+0:vgprValuC+0+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+0:vgprValuC+0+1] // *= alpha
+v_mul_f64 v[vgprValuC+2:vgprValuC+2+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+2:vgprValuC+2+1] // *= alpha
+v_mul_f64 v[vgprValuC+4:vgprValuC+4+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+4:vgprValuC+4+1] // *= alpha
+v_mul_f64 v[vgprValuC+6:vgprValuC+6+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+6:vgprValuC+6+1] // *= alpha
+v_mul_f64 v[vgprValuC+8:vgprValuC+8+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+8:vgprValuC+8+1] // *= alpha
+v_mul_f64 v[vgprValuC+10:vgprValuC+10+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+10:vgprValuC+10+1] // *= alpha
+v_mul_f64 v[vgprValuC+12:vgprValuC+12+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+12:vgprValuC+12+1] // *= alpha
+v_mul_f64 v[vgprValuC+14:vgprValuC+14+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+14:vgprValuC+14+1] // *= alpha
+v_mul_f64 v[vgprValuC+16:vgprValuC+16+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+16:vgprValuC+16+1] // *= alpha
+v_mul_f64 v[vgprValuC+18:vgprValuC+18+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+18:vgprValuC+18+1] // *= alpha
+v_mul_f64 v[vgprValuC+20:vgprValuC+20+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+20:vgprValuC+20+1] // *= alpha
+v_mul_f64 v[vgprValuC+22:vgprValuC+22+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+22:vgprValuC+22+1] // *= alpha
+
+/* apply mask, calc new C and issue write */
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+0:vgprValuC+0+1], v[55:56], s[sgprBeta:sgprBeta+1], v[vgprValuC+0:vgprValuC+0+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+2:vgprValuC+2+1], v[57:58], s[sgprBeta:sgprBeta+1], v[vgprValuC+2:vgprValuC+2+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[0:3], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+4:vgprValuC+4+1], v[59:60], s[sgprBeta:sgprBeta+1], v[vgprValuC+4:vgprValuC+4+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+6:vgprValuC+6+1], v[61:62], s[sgprBeta:sgprBeta+1], v[vgprValuC+6:vgprValuC+6+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[4:7], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+8:vgprValuC+8+1], v[63:64], s[sgprBeta:sgprBeta+1], v[vgprValuC+8:vgprValuC+8+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+10:vgprValuC+10+1], v[65:66], s[sgprBeta:sgprBeta+1], v[vgprValuC+10:vgprValuC+10+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[8:11], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+12:vgprValuC+12+1], v[67:68], s[sgprBeta:sgprBeta+1], v[vgprValuC+12:vgprValuC+12+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+14:vgprValuC+14+1], v[69:70], s[sgprBeta:sgprBeta+1], v[vgprValuC+14:vgprValuC+14+1] // finalSum = sum*alpha + C*beta
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+buffer_store_dwordx4 v[12:15], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+16:vgprValuC+16+1], v[71:72], s[sgprBeta:sgprBeta+1], v[vgprValuC+16:vgprValuC+16+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+18:vgprValuC+18+1], v[73:74], s[sgprBeta:sgprBeta+1], v[vgprValuC+18:vgprValuC+18+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[16:19], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+20:vgprValuC+20+1], v[75:76], s[sgprBeta:sgprBeta+1], v[vgprValuC+20:vgprValuC+20+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+22:vgprValuC+22+1], v[77:78], s[sgprBeta:sgprBeta+1], v[vgprValuC+22:vgprValuC+22+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[20:23], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+
+/******************************************/
+/* Global Write Beta Batch #1 (d1,d0,vc1,vc0) =
+   (1,0,0,0:vw2); (1,1,0,0:vw2); (1,2,0,0:vw2); (1,0,1,0:vw2); (1,1,1,0:vw2); (1,2,1,0:vw2) */
+/******************************************/
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(1,0,0,0) coordOffset1=32 element-rows coordOffset0=0 rows */
+s_mul_i32 s56, s[sgprStridesD+0], 248              // scale StrideC *= 31 * bpe
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+buffer_load_dwordx4 v[55:58], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,1,0) coordOffset1=32 element-rows coordOffset0=16 rows */
+buffer_load_dwordx4 v[59:62], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,2,0) coordOffset1=32 element-rows coordOffset0=32 rows */
+buffer_load_dwordx4 v[63:66], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,0,0) coordOffset1=33 element-rows coordOffset0=0 rows */
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+buffer_load_dwordx4 v[67:70], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,1,0) coordOffset1=33 element-rows coordOffset0=16 rows */
+buffer_load_dwordx4 v[71:74], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,2,0) coordOffset1=33 element-rows coordOffset0=32 rows */
+buffer_load_dwordx4 v[75:78], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+
+/* rC *= alpha batchEements=[(1, 0, 0, 0), (1, 1, 0, 0), (1, 2, 0, 0), (1, 0, 1, 0), (1, 1, 1, 0), (1, 2, 1, 0)] */
+v_mul_f64 v[vgprValuC+24:vgprValuC+24+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+24:vgprValuC+24+1] // *= alpha
+v_mul_f64 v[vgprValuC+26:vgprValuC+26+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+26:vgprValuC+26+1] // *= alpha
+v_mul_f64 v[vgprValuC+28:vgprValuC+28+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+28:vgprValuC+28+1] // *= alpha
+v_mul_f64 v[vgprValuC+30:vgprValuC+30+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+30:vgprValuC+30+1] // *= alpha
+v_mul_f64 v[vgprValuC+32:vgprValuC+32+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+32:vgprValuC+32+1] // *= alpha
+v_mul_f64 v[vgprValuC+34:vgprValuC+34+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+34:vgprValuC+34+1] // *= alpha
+v_mul_f64 v[vgprValuC+36:vgprValuC+36+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+36:vgprValuC+36+1] // *= alpha
+v_mul_f64 v[vgprValuC+38:vgprValuC+38+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+38:vgprValuC+38+1] // *= alpha
+v_mul_f64 v[vgprValuC+40:vgprValuC+40+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+40:vgprValuC+40+1] // *= alpha
+v_mul_f64 v[vgprValuC+42:vgprValuC+42+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+42:vgprValuC+42+1] // *= alpha
+v_mul_f64 v[vgprValuC+44:vgprValuC+44+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+44:vgprValuC+44+1] // *= alpha
+v_mul_f64 v[vgprValuC+46:vgprValuC+46+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+46:vgprValuC+46+1] // *= alpha
+
+/* apply mask, calc new C and issue write */
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+24:vgprValuC+24+1], v[55:56], s[sgprBeta:sgprBeta+1], v[vgprValuC+24:vgprValuC+24+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+26:vgprValuC+26+1], v[57:58], s[sgprBeta:sgprBeta+1], v[vgprValuC+26:vgprValuC+26+1] // finalSum = sum*alpha + C*beta
+s_mul_i32 s56, s[sgprStridesD+0], 248              // scale StrideC *= 31 * bpe
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+buffer_store_dwordx4 v[24:27], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+28:vgprValuC+28+1], v[59:60], s[sgprBeta:sgprBeta+1], v[vgprValuC+28:vgprValuC+28+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+30:vgprValuC+30+1], v[61:62], s[sgprBeta:sgprBeta+1], v[vgprValuC+30:vgprValuC+30+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[28:31], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+32:vgprValuC+32+1], v[63:64], s[sgprBeta:sgprBeta+1], v[vgprValuC+32:vgprValuC+32+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+34:vgprValuC+34+1], v[65:66], s[sgprBeta:sgprBeta+1], v[vgprValuC+34:vgprValuC+34+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[32:35], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+36:vgprValuC+36+1], v[67:68], s[sgprBeta:sgprBeta+1], v[vgprValuC+36:vgprValuC+36+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+38:vgprValuC+38+1], v[69:70], s[sgprBeta:sgprBeta+1], v[vgprValuC+38:vgprValuC+38+1] // finalSum = sum*alpha + C*beta
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+buffer_store_dwordx4 v[36:39], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+40:vgprValuC+40+1], v[71:72], s[sgprBeta:sgprBeta+1], v[vgprValuC+40:vgprValuC+40+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+42:vgprValuC+42+1], v[73:74], s[sgprBeta:sgprBeta+1], v[vgprValuC+42:vgprValuC+42+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[40:43], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+44:vgprValuC+44+1], v[75:76], s[sgprBeta:sgprBeta+1], v[vgprValuC+44:vgprValuC+44+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+46:vgprValuC+46+1], v[77:78], s[sgprBeta:sgprBeta+1], v[vgprValuC+46:vgprValuC+46+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[44:47], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_branch label_0037                                // jump to end
+label_0036:
+
+/******************************************/
+/* Global Write Beta Edge Batch #0 (d1,d0,vc1,vc0) =
+   (0,0,0,0:vw1); (0,0,0,1:vw1); (0,1,0,0:vw1); (0,1,0,1:vw1); (0,2,0,0:vw1); (0,2,0,1:vw1); (0,0,1,0:vw1); (0,0,1,1:vw1) */
+/******************************************/
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(0,0,0,0) coordOffset1=0 element-rows coordOffset0=0 rows */
+v_mov_b32 v51, v50                                 // rowPtr <- rowStart (first row)
+_v_add_lshl_u32 v54, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[62:63], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v54, -1, v54, s[62:63]               // clip if OOB. offset
+buffer_load_dwordx2 v[55:56], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,0,1) coordOffset1=0 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v57, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[64:65], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v57, -1, v57, s[64:65]               // clip if OOB. offset
+buffer_load_dwordx2 v[58:59], v57, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,1,0) coordOffset1=0 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v60, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[66:67], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v60, -1, v60, s[66:67]               // clip if OOB. offset
+buffer_load_dwordx2 v[61:62], v60, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,1,1) coordOffset1=0 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v63, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[68:69], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v63, -1, v63, s[68:69]               // clip if OOB. offset
+buffer_load_dwordx2 v[64:65], v63, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,2,0) coordOffset1=0 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v66, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[70:71], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v66, -1, v66, s[70:71]               // clip if OOB. offset
+buffer_load_dwordx2 v[67:68], v66, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,2,1) coordOffset1=0 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v69, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[72:73], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v69, -1, v69, s[72:73]               // clip if OOB. offset
+buffer_load_dwordx2 v[70:71], v69, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,0,0) coordOffset1=1 element-rows coordOffset0=0 rows */
+_v_add_co_u32 v53, vcc, v49, 1                     // coord1 += d1*sg1*VW + vc1
+_v_add_co_u32 v51, vcc, v51, s[sgprStridesC+0]     // rowPtr <- move to start of new row
+_v_add_lshl_u32 v72, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[74:75], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v72, -1, v72, s[74:75]               // clip if OOB. offset
+buffer_load_dwordx2 v[73:74], v72, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,0,1) coordOffset1=1 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v75, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[76:77], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v75, -1, v75, s[76:77]               // clip if OOB. offset
+buffer_load_dwordx2 v[76:77], v75, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+
+/* rC *= alpha batchEements=[(0, 0, 0, 0), (0, 0, 0, 1), (0, 1, 0, 0), (0, 1, 0, 1), (0, 2, 0, 0), (0, 2, 0, 1), (0, 0, 1, 0), (0, 0, 1, 1)] */
+v_mul_f64 v[vgprValuC+0:vgprValuC+0+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+0:vgprValuC+0+1] // *= alpha
+v_mul_f64 v[vgprValuC+2:vgprValuC+2+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+2:vgprValuC+2+1] // *= alpha
+v_mul_f64 v[vgprValuC+4:vgprValuC+4+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+4:vgprValuC+4+1] // *= alpha
+v_mul_f64 v[vgprValuC+6:vgprValuC+6+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+6:vgprValuC+6+1] // *= alpha
+v_mul_f64 v[vgprValuC+8:vgprValuC+8+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+8:vgprValuC+8+1] // *= alpha
+v_mul_f64 v[vgprValuC+10:vgprValuC+10+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+10:vgprValuC+10+1] // *= alpha
+v_mul_f64 v[vgprValuC+12:vgprValuC+12+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+12:vgprValuC+12+1] // *= alpha
+v_mul_f64 v[vgprValuC+14:vgprValuC+14+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+14:vgprValuC+14+1] // *= alpha
+s_waitcnt vmcnt(0)                                 // wait C
+
+/* apply mask, calc new C and issue write */
+v_fma_f64 v[vgprValuC+0:vgprValuC+0+1], v[55:56], s[sgprBeta:sgprBeta+1], v[vgprValuC+0:vgprValuC+0+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[0:1], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+2:vgprValuC+2+1], v[58:59], s[sgprBeta:sgprBeta+1], v[vgprValuC+2:vgprValuC+2+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[2:3], v57, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+4:vgprValuC+4+1], v[61:62], s[sgprBeta:sgprBeta+1], v[vgprValuC+4:vgprValuC+4+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[4:5], v60, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+6:vgprValuC+6+1], v[64:65], s[sgprBeta:sgprBeta+1], v[vgprValuC+6:vgprValuC+6+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[6:7], v63, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+8:vgprValuC+8+1], v[67:68], s[sgprBeta:sgprBeta+1], v[vgprValuC+8:vgprValuC+8+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[8:9], v66, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+10:vgprValuC+10+1], v[70:71], s[sgprBeta:sgprBeta+1], v[vgprValuC+10:vgprValuC+10+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[10:11], v69, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+12:vgprValuC+12+1], v[73:74], s[sgprBeta:sgprBeta+1], v[vgprValuC+12:vgprValuC+12+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[12:13], v72, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+14:vgprValuC+14+1], v[76:77], s[sgprBeta:sgprBeta+1], v[vgprValuC+14:vgprValuC+14+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[14:15], v75, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+/******************************************/
+/* Global Write Beta Edge Batch #1 (d1,d0,vc1,vc0) =
+   (0,1,1,0:vw1); (0,1,1,1:vw1); (0,2,1,0:vw1); (0,2,1,1:vw1); (1,0,0,0:vw1); (1,0,0,1:vw1); (1,1,0,0:vw1); (1,1,0,1:vw1) */
+/******************************************/
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(0,1,1,0) coordOffset1=1 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v54, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[62:63], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v54, -1, v54, s[62:63]               // clip if OOB. offset
+buffer_load_dwordx2 v[55:56], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,1,1) coordOffset1=1 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v57, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[64:65], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v57, -1, v57, s[64:65]               // clip if OOB. offset
+buffer_load_dwordx2 v[58:59], v57, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,2,0) coordOffset1=1 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v60, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[66:67], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v60, -1, v60, s[66:67]               // clip if OOB. offset
+buffer_load_dwordx2 v[61:62], v60, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,2,1) coordOffset1=1 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v63, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[68:69], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v63, -1, v63, s[68:69]               // clip if OOB. offset
+buffer_load_dwordx2 v[64:65], v63, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,0,0) coordOffset1=32 element-rows coordOffset0=0 rows */
+_v_add_co_u32 v53, vcc, v49, 32                    // coord1 += d1*sg1*VW + vc1
+s_mul_i32 s56, s[sgprStridesC+0], 32               // scale StrideC *= coordOffset1(32)
+_v_add_co_u32 v51, vcc, v50, s56                   // rowPtr <- inc for non-0 (tt1+vc1))
+_v_add_lshl_u32 v66, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[70:71], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v66, -1, v66, s[70:71]               // clip if OOB. offset
+buffer_load_dwordx2 v[67:68], v66, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,0,1) coordOffset1=32 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v69, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[72:73], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v69, -1, v69, s[72:73]               // clip if OOB. offset
+buffer_load_dwordx2 v[70:71], v69, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,1,0) coordOffset1=32 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v72, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[74:75], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v72, -1, v72, s[74:75]               // clip if OOB. offset
+buffer_load_dwordx2 v[73:74], v72, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,1,1) coordOffset1=32 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v75, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[76:77], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v75, -1, v75, s[76:77]               // clip if OOB. offset
+buffer_load_dwordx2 v[76:77], v75, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+
+/* rC *= alpha batchEements=[(0, 1, 1, 0), (0, 1, 1, 1), (0, 2, 1, 0), (0, 2, 1, 1), (1, 0, 0, 0), (1, 0, 0, 1), (1, 1, 0, 0), (1, 1, 0, 1)] */
+v_mul_f64 v[vgprValuC+16:vgprValuC+16+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+16:vgprValuC+16+1] // *= alpha
+v_mul_f64 v[vgprValuC+18:vgprValuC+18+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+18:vgprValuC+18+1] // *= alpha
+v_mul_f64 v[vgprValuC+20:vgprValuC+20+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+20:vgprValuC+20+1] // *= alpha
+v_mul_f64 v[vgprValuC+22:vgprValuC+22+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+22:vgprValuC+22+1] // *= alpha
+v_mul_f64 v[vgprValuC+24:vgprValuC+24+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+24:vgprValuC+24+1] // *= alpha
+v_mul_f64 v[vgprValuC+26:vgprValuC+26+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+26:vgprValuC+26+1] // *= alpha
+v_mul_f64 v[vgprValuC+28:vgprValuC+28+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+28:vgprValuC+28+1] // *= alpha
+v_mul_f64 v[vgprValuC+30:vgprValuC+30+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+30:vgprValuC+30+1] // *= alpha
+s_waitcnt vmcnt(0)                                 // wait C
+
+/* apply mask, calc new C and issue write */
+v_fma_f64 v[vgprValuC+16:vgprValuC+16+1], v[55:56], s[sgprBeta:sgprBeta+1], v[vgprValuC+16:vgprValuC+16+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[16:17], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+18:vgprValuC+18+1], v[58:59], s[sgprBeta:sgprBeta+1], v[vgprValuC+18:vgprValuC+18+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[18:19], v57, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+20:vgprValuC+20+1], v[61:62], s[sgprBeta:sgprBeta+1], v[vgprValuC+20:vgprValuC+20+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[20:21], v60, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+22:vgprValuC+22+1], v[64:65], s[sgprBeta:sgprBeta+1], v[vgprValuC+22:vgprValuC+22+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[22:23], v63, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+24:vgprValuC+24+1], v[67:68], s[sgprBeta:sgprBeta+1], v[vgprValuC+24:vgprValuC+24+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[24:25], v66, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+26:vgprValuC+26+1], v[70:71], s[sgprBeta:sgprBeta+1], v[vgprValuC+26:vgprValuC+26+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[26:27], v69, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+28:vgprValuC+28+1], v[73:74], s[sgprBeta:sgprBeta+1], v[vgprValuC+28:vgprValuC+28+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[28:29], v72, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+30:vgprValuC+30+1], v[76:77], s[sgprBeta:sgprBeta+1], v[vgprValuC+30:vgprValuC+30+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[30:31], v75, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+/******************************************/
+/* Global Write Beta Edge Batch #2 (d1,d0,vc1,vc0) =
+   (1,2,0,0:vw1); (1,2,0,1:vw1); (1,0,1,0:vw1); (1,0,1,1:vw1); (1,1,1,0:vw1); (1,1,1,1:vw1); (1,2,1,0:vw1); (1,2,1,1:vw1) */
+/******************************************/
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(1,0,2,0) coordOffset1=32 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v54, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[62:63], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v54, -1, v54, s[62:63]               // clip if OOB. offset
+buffer_load_dwordx2 v[55:56], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,2,1) coordOffset1=32 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v57, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[64:65], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v57, -1, v57, s[64:65]               // clip if OOB. offset
+buffer_load_dwordx2 v[58:59], v57, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,0,0) coordOffset1=33 element-rows coordOffset0=0 rows */
+_v_add_co_u32 v53, vcc, v49, 33                    // coord1 += d1*sg1*VW + vc1
+_v_add_co_u32 v51, vcc, v51, s[sgprStridesC+0]     // rowPtr <- move to start of new row
+_v_add_lshl_u32 v60, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[66:67], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v60, -1, v60, s[66:67]               // clip if OOB. offset
+buffer_load_dwordx2 v[61:62], v60, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,0,1) coordOffset1=33 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v63, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[68:69], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v63, -1, v63, s[68:69]               // clip if OOB. offset
+buffer_load_dwordx2 v[64:65], v63, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,1,0) coordOffset1=33 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v66, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[70:71], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v66, -1, v66, s[70:71]               // clip if OOB. offset
+buffer_load_dwordx2 v[67:68], v66, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,1,1) coordOffset1=33 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v69, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[72:73], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v69, -1, v69, s[72:73]               // clip if OOB. offset
+buffer_load_dwordx2 v[70:71], v69, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,2,0) coordOffset1=33 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v72, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[74:75], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v72, -1, v72, s[74:75]               // clip if OOB. offset
+buffer_load_dwordx2 v[73:74], v72, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,2,1) coordOffset1=33 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v75, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[76:77], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v75, -1, v75, s[76:77]               // clip if OOB. offset
+buffer_load_dwordx2 v[76:77], v75, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+
+/* rC *= alpha batchEements=[(1, 2, 0, 0), (1, 2, 0, 1), (1, 0, 1, 0), (1, 0, 1, 1), (1, 1, 1, 0), (1, 1, 1, 1), (1, 2, 1, 0), (1, 2, 1, 1)] */
+v_mul_f64 v[vgprValuC+32:vgprValuC+32+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+32:vgprValuC+32+1] // *= alpha
+v_mul_f64 v[vgprValuC+34:vgprValuC+34+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+34:vgprValuC+34+1] // *= alpha
+v_mul_f64 v[vgprValuC+36:vgprValuC+36+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+36:vgprValuC+36+1] // *= alpha
+v_mul_f64 v[vgprValuC+38:vgprValuC+38+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+38:vgprValuC+38+1] // *= alpha
+v_mul_f64 v[vgprValuC+40:vgprValuC+40+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+40:vgprValuC+40+1] // *= alpha
+v_mul_f64 v[vgprValuC+42:vgprValuC+42+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+42:vgprValuC+42+1] // *= alpha
+v_mul_f64 v[vgprValuC+44:vgprValuC+44+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+44:vgprValuC+44+1] // *= alpha
+v_mul_f64 v[vgprValuC+46:vgprValuC+46+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+46:vgprValuC+46+1] // *= alpha
+s_waitcnt vmcnt(0)                                 // wait C
+
+/* apply mask, calc new C and issue write */
+v_fma_f64 v[vgprValuC+32:vgprValuC+32+1], v[55:56], s[sgprBeta:sgprBeta+1], v[vgprValuC+32:vgprValuC+32+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[32:33], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+34:vgprValuC+34+1], v[58:59], s[sgprBeta:sgprBeta+1], v[vgprValuC+34:vgprValuC+34+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[34:35], v57, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+36:vgprValuC+36+1], v[61:62], s[sgprBeta:sgprBeta+1], v[vgprValuC+36:vgprValuC+36+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[36:37], v60, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+38:vgprValuC+38+1], v[64:65], s[sgprBeta:sgprBeta+1], v[vgprValuC+38:vgprValuC+38+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[38:39], v63, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+40:vgprValuC+40+1], v[67:68], s[sgprBeta:sgprBeta+1], v[vgprValuC+40:vgprValuC+40+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[40:41], v66, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+42:vgprValuC+42+1], v[70:71], s[sgprBeta:sgprBeta+1], v[vgprValuC+42:vgprValuC+42+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[42:43], v69, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+44:vgprValuC+44+1], v[73:74], s[sgprBeta:sgprBeta+1], v[vgprValuC+44:vgprValuC+44+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[44:45], v72, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+46:vgprValuC+46+1], v[76:77], s[sgprBeta:sgprBeta+1], v[vgprValuC+46:vgprValuC+46+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[46:47], v75, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_branch label_0037                                // jump to end
+label_0037:
+
+label_0038:  /// KernelEnd
+s_endpgm                                           // Kernel End
+
+

--- a/Tensile/ReplacementKernels-cov3/Cijk_Ailk_Bjlk_DB_MT48x64x4_AF0EM1_ASEM1_FL1_GRVW2_ISA908_PGR1_PLR0_SU0_TT6_4_VAW1_VW2_WG8_16_1_WGM4.s.txt
+++ b/Tensile/ReplacementKernels-cov3/Cijk_Ailk_Bjlk_DB_MT48x64x4_AF0EM1_ASEM1_FL1_GRVW2_ISA908_PGR1_PLR0_SU0_TT6_4_VAW1_VW2_WG8_16_1_WGM4.s.txt
@@ -1090,6 +1090,7 @@ label_0001:
 /* Unroll Loop 1/2 - Begin                */
 /******************************************/
 
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
 s_barrier //4sync for global read
 
 s_cmp_eq_i32 s[sgprLoopCounters+0], -1             // is this the last iteration
@@ -1247,6 +1248,7 @@ s_cbranch_scc1 label_0003                          // exit LoopL
 /* Unroll Loop 2/2 - Begin                */
 /******************************************/
 
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
 s_barrier //4sync for global read
 
 s_cmp_eq_i32 s[sgprLoopCounters+0], -1             // is this the last iteration
@@ -1517,7 +1519,8 @@ s_mov_b32       s87, s[sgprSrdD+0]
 s_mov_b32       s88, s[sgprSrdD+1]
 
 
-s_waitcnt lgkmcnt(0)                               // 1wait for local write
+//s_waitcnt lgkmcnt(0)                               // 1wait for local write
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
 s_barrier //4sync for global read
 
 /* iter 0,1 */
@@ -1845,7 +1848,8 @@ s_cbranch_scc1 label_1002                            // wg1 < nwg1-1 so skip rMT
 
 /******************************************/
 
-s_waitcnt lgkmcnt(0)                                 // 1wait for local write
+//s_waitcnt lgkmcnt(0)                                 // 1wait for local write
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
 s_barrier //4sync for global read
 
 /* iter 0 */
@@ -1960,7 +1964,8 @@ s_mov_b32       s87, s[sgprSrdD+0]
 s_mov_b32       s88, s[sgprSrdD+1]
 
 
-s_waitcnt lgkmcnt(0)                               // 1wait for local write
+//s_waitcnt lgkmcnt(0)                               // 1wait for local write
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
 s_barrier //4sync for global read
 
 /* iter 0,1 */
@@ -2262,7 +2267,8 @@ label_1002:
 /******************************************/
 //branch logic gets executed for edge MT to use legacy alph_beta code
 
-s_waitcnt lgkmcnt(0)                                 // 1wait for local write
+//s_waitcnt lgkmcnt(0)                                 // 1wait for local write
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
 s_barrier //4sync for global read
 
 /* iter 0 */
@@ -2352,7 +2358,8 @@ s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2
 MAC_6x4_X0
 
 
-s_waitcnt lgkmcnt(0)                               // 1wait for local write
+//s_waitcnt lgkmcnt(0)                               // 1wait for local write
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
 s_barrier //4sync for global read
 
 
@@ -2439,7 +2446,8 @@ s_branch label_0004
 
 label_1003:
 
-s_waitcnt lgkmcnt(0)                               // 1wait for local write
+//s_waitcnt lgkmcnt(0)                               // 1wait for local write
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
 s_barrier //4sync for global read
 
 
@@ -2536,8 +2544,9 @@ s_cmp_eq_i32 s[sgprLoopCounters+0], -1             // is this the last iteration
 s_cmov_b32 s[sgprSrdA+2], 0                        // Set limit to 0 for last iteration
 s_cmov_b32 s[sgprSrdB+2], 0                        // Set limit to 0 for last iteration
 
-s_waitcnt lgkmcnt(0)                               // 1wait for local write
+//s_waitcnt lgkmcnt(0)                               // 1wait for local write
 
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
 s_barrier //4sync for global read
 
 /* iter 0 */
@@ -2678,8 +2687,9 @@ buffer_load_dwordx2 v[vgprG2LB+0+0:vgprG2LB+0+0+1], v[vgprGlobalReadOffsetB+0], 
 buffer_load_dwordx2 v[vgprG2LB+0+2:vgprG2LB+0+2+1], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:8 // load one buffer value
 _v_add_co_u32 v[vgprGlobalReadOffsetB+0], vcc, v[vgprGlobalReadOffsetB+0], 8 // graOffset += 1 * bpe
 
-s_waitcnt vmcnt(0)                                 // 2wait for global read
+//s_waitcnt vmcnt(0)                                 // 2wait for global read
 
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
 s_barrier //
 
 /* local write init pointers a */
@@ -2701,8 +2711,9 @@ ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:0 // lwo
 
 ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:0 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 0
 
-s_waitcnt lgkmcnt(0)                               // 5wait for local write
+//s_waitcnt lgkmcnt(0)                               // 5wait for local write
 
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
 s_barrier //
 
 

--- a/Tensile/ReplacementKernels-cov3/Cijk_Alik_Bljk_BBH_MT32x32x32_AF0EM8_ASEM8_FL0_GRVW2_ISA908_MDA2_PGR1_PLR1_SU32_TT2_2_VAW1_VW2_WG16_16_1_WGM8.s.txt
+++ b/Tensile/ReplacementKernels-cov3/Cijk_Alik_Bljk_BBH_MT32x32x32_AF0EM8_ASEM8_FL0_GRVW2_ISA908_MDA2_PGR1_PLR1_SU32_TT2_2_VAW1_VW2_WG16_16_1_WGM8.s.txt
@@ -1,0 +1,1119 @@
+
+
+/******************************************/
+/* Function Prefix                        */
+/******************************************/
+
+
+
+/******************************************/
+/* Begin Kernel                           */
+/******************************************/
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx908+sram-ecc"
+.text
+.protected Cijk_Alik_Bljk_BBH_MT32x32x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGRO1_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG16_16_1_WGM8
+.globl Cijk_Alik_Bljk_BBH_MT32x32x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGRO1_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG16_16_1_WGM8
+.p2align 8
+.type Cijk_Alik_Bljk_BBH_MT32x32x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGRO1_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG16_16_1_WGM8,@function
+.section .rodata,#alloc
+.p2align 6
+.amdhsa_kernel Cijk_Alik_Bljk_BBH_MT32x32x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGRO1_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG16_16_1_WGM8
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_next_free_vgpr 108 // vgprs
+  .amdhsa_next_free_sgpr 98 // sgprs
+  .amdhsa_group_segment_fixed_size 36000 // lds bytes
+  .amdhsa_private_segment_fixed_size 0
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+.text
+
+/******************************************/
+/* Optimizations and Config:              */
+/******************************************/
+/* ThreadTile= 2 x 2 */
+/* SubGroup= 16 x 16 */
+/* VectorWidth=2 */
+/* GlobalLoadVectorWidthA=2, GlobalLoadVectorWidthB=2 */
+/* DirectToLdsA=False */
+/* DirectToLdsB=False */
+/* UseSgprForGRO=1 */
+.amdgpu_metadata
+---
+amdhsa.version:
+  - 1
+  - 0
+amdhsa.kernels:
+  - .name: Cijk_Alik_Bljk_BBH_MT32x32x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGRO1_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG16_16_1_WGM8
+    .symbol: 'Cijk_Alik_Bljk_BBH_MT32x32x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGRO1_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG16_16_1_WGM8.kd'
+    .language:                   OpenCL C
+    .language_version:
+      - 2
+      - 0
+    .args:
+      - .name:            sizeC
+        .size:            8
+        .offset:          0
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            sizeA
+        .size:            8
+        .offset:          8
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            sizeB
+        .size:            8
+        .offset:          16
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            D
+        .size:            8
+        .offset:          24
+        .value_kind:      global_buffer
+        .value_type:      struct
+        .address_space:   generic
+      - .name:            C
+        .size:            8
+        .offset:          32
+        .value_kind:      global_buffer
+        .value_type:      struct
+        .address_space:   generic
+      - .name:            A
+        .size:            8
+        .offset:          40
+        .value_kind:      global_buffer
+        .value_type:      struct
+        .address_space:   generic
+      - .name:            B
+        .size:            8
+        .offset:          48
+        .value_kind:      global_buffer
+        .value_type:      struct
+        .address_space:   generic
+      - .name:            alpha
+        .size:            4
+        .offset:          56
+        .value_kind:      by_value
+        .value_type:      f32
+      - .name:            beta
+        .size:            4
+        .offset:          60
+        .value_kind:      by_value
+        .value_type:      f32
+      - .name:            strideD0
+        .size:            4
+        .offset:          64
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideD1
+        .size:            4
+        .offset:          68
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideC0
+        .size:            4
+        .offset:          72
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideC1
+        .size:            4
+        .offset:          76
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideA0
+        .size:            4
+        .offset:          80
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideA1
+        .size:            4
+        .offset:          84
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideB0
+        .size:            4
+        .offset:          88
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideB1
+        .size:            4
+        .offset:          92
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree0
+        .size:            4
+        .offset:          96
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree1
+        .size:            4
+        .offset:          100
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree2
+        .size:            4
+        .offset:          104
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesSum0
+        .size:            4
+        .offset:          108
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            OrigStaggerUIter
+        .size:            4
+        .offset:          112
+        .value_kind:      by_value
+        .value_type:      i32
+      - .name:            NumWorkGroups0
+        .size:            4
+        .offset:          116
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            NumWorkGroups1
+        .size:            4
+        .offset:          120
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            MagicNumberProblemNumGroupTiles0
+        .size:            4
+        .offset:          124
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            GridNumWorkGroups0
+        .size:            4
+        .offset:          128
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            NumFullBlocks
+        .size:            4
+        .offset:          132
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            WgmRemainder1
+        .size:            4
+        .offset:          136
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            MagicNumberWgmRemainder1
+        .size:            4
+        .offset:          140
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            padding
+        .size:            4
+        .offset:          144
+        .value_kind:      by_value
+        .value_type:      u32
+    .group_segment_fixed_size:   28672
+    .kernarg_segment_align:      8
+    .kernarg_segment_size:       152
+    .max_flat_workgroup_size:    256
+    .private_segment_fixed_size: 0
+    .sgpr_count:                 98
+    .sgpr_spill_count:           0
+    .vgpr_count:                 108
+    .vgpr_spill_count:           0
+    .wavefront_size:             64
+...
+.end_amdgpu_metadata
+Cijk_Alik_Bljk_BBH_MT32x32x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGRO1_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG16_16_1_WGM8:
+
+/******************************************/
+/* Asm syntax workarounds                 */
+/******************************************/
+.macro _v_add_co_u32 dst, cc, src0, src1, dpp=
+   v_add_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+.macro _v_sub_co_u32 dst, cc, src0, src1, dpp=
+   v_sub_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+.macro _v_addc_co_u32 dst, ccOut, src0, ccIn, src1, dpp=
+   v_addc_co_u32 \dst, \ccOut, \src0, \ccIn, \src1 \dpp
+.endm
+.macro _v_add_lshl_u32 dst, src0, src1, shiftCnt
+    v_add_lshl_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+.macro _v_lshl_add_u32 dst, src0, src1, shiftCnt
+    v_lshl_add_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+/******************************************/
+/* Bits 127:96 of SRD.  Set DataFormat = 32 bit */
+/******************************************/
+.set Srd127_96, 0x0020000
+.set BufferOOB, 0x80000000
+/******************************************/
+/* 2GB limit - set offsets to -1 to exceed this and clamp */
+/******************************************/
+.set BufferLimit, 0x80000000
+
+.macro GLOBAL_OFFSET_A vgprAddr vgprOffsetL vgprOffset0I vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStridesA+0], v[\vgprOffset0I] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprTmp+0], v[\vgprOffsetL] // accumulate d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, 0x4, v[\vgprAddr+0] // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/* Global Offset B */
+.macro GLOBAL_OFFSET_B vgprAddr vgprOffset1J vgprOffsetL vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStridesB+0], v[\vgprOffsetL] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprTmp+0], v[\vgprOffset1J] // accumulate d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, 0x4, v[\vgprAddr+0] // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+  //tail-kernel start
+  //tail kernel problem size 64x1024
+  // use 64 CU(s) for tail kernel
+  // tile size = 32x32
+  // 64 CU(s) are split into 2 groups of 32
+  // CU[0-31] = A[0-31]xB[0-1024]  CU[32-63] = A[32-63]xB[0-1024]
+  // B matrix organized as 32 tiles of 32x1024 mapped to CU[0-63], each cU working on 32 columns (y dimension)
+  // A matrix organized as 2 tiles of 32x1024  , each CU[0-31] responsible for 32 rows
+  // Sub-tile/SIMD organization
+  // each 32x32 tile in CU split into 2 groups of 16x16  and simds split into 2 groups
+  // simd(s) use 16x16 mfma instruction to solve 32x32 tile simd[0,1] multiply first [0-15] rows with B[0-31]
+
+   //TODO
+   // convert buffer_load_dword into bufffer_load_dwordx4
+   // Use SGPR for offset to avoid using 4 VALU global fetch pointer increment
+   // move Store C address calculation interleaved with noLoadLoop
+
+//////sreg def/////////////
+.set sgprKernArgAddress , 0
+.set sgprWorkGroup0 , 2
+.set sgprWorkGroup1 , 3
+.set sgprWorkGroup2 , 4
+.set sgprNumWorkGroups0,5
+.set sgprNumWorkGroups1,6
+.set sgprSrdA,8
+.set sgprSrdB,12
+.set sgprSrdC,16
+.set sgprSrdD,20
+.set sgprTensor2dSizeC, 24
+.set sgprTensor2dSizeA, 26
+.set sgprTensor2dSizeB, 28
+.set sgprSaveExecMask, 30
+.set sgprAddressD, 32
+.set sgprAddressC, 34
+.set sgprStridesD, 36
+.set sgprStridesC, 38
+.set sgprAlpha, 40
+.set sgprBeta, 41
+.set sgprSizesFree , 42
+.set sgprSizesSum  , 45
+.set sgprLoopCounters, 46
+.set sgprOrigLoopCounter, 47
+.set sgprStridesA, 48
+.set sgprStridesB, 50
+.set sgprAddressA, 52
+.set sgprAddressB, 54
+.set sgprShadowLimitA, 56
+.set sgprShadowLimitB, 58
+.set sgprOrigStaggerUIter, 60
+.set sgprStaggerUIter, 61
+.set sgprWrapUA, 62
+.set sgprWrapUB, 64
+.set sgprNumFullBlocks, 66
+.set sgprWgmRemainder1, 67
+.set sgprMagicNumberWgmRemainder1, 68
+.set sgprGlobalReadIncsA, 69
+.set sgprGlobalReadIncsB, 70
+.set sgprScalarGlobalReadOffsetA,71
+.set sgprScalarGlobalReadOffsetB,73
+.set sgprLocalWriteAddrA,75
+.set sgprLocalWriteAddrB,77
+.set sgprGlobalFetchSubGrpId,79
+.set sgprWorkGrpIdFlatten , 80
+.set sgprtailWorkGrp0,81
+.set sgprtailWorkGrp1,82
+//sgprs[83-87] used as temp
+.set sgprtailSimdTileX,88
+.set sgprtailSimdTileY,89
+
+/////vreg def////////////////
+
+.set vgprValuC,0
+.set vgprAcc,0
+.set vgprValuA_X0_I0,32
+.set vgprG2LA,48
+.set vgprValuB_X0_I0,52
+.set vgprG2LB,68
+.set vgprLocalWriteAddrA,76
+.set vgprLocalWriteAddrB,78
+.set vgprGlobalReadOfvarA,82
+.set vgprGlobalReadOfvarB,86
+.set vgprLocalReadAddrA,94
+.set vgprLocalReadAddrB,96
+.set vgprSerial,100
+.set vgprGlobalWriteOfvarC,104
+.set vgprTmp,105
+
+//** maxVGPR 112 **/
+.set lds_pad_tail       , 16
+.set lds_pad_qw_tail    , lds_pad_tail >> 2
+.set lds_Asize_per_wr_tail   , 256+lds_pad_tail           //each load inst load one 32X4 block.    need contiunous 32X4X2,256    bytes in LDS
+.set lds_Asize_per_tailwave , lds_Asize_per_wr_tail * 2   //each wave load 2 32X4 block one time.  need contiunous 32X4X4X2,1024 bytes in LDS
+.set lds_Asize_per_tailwg   , lds_Asize_per_tailwave * 4  //WG load 8 32X4 block(64X32) Matrix A to lds for pingpong.
+.set lds_Bsize_per_wr_tail   , 256+lds_pad_tail           //each load inst load one 32X4  block.    need contiunous 32X4X2,256     bytes in LDS
+.set lds_Bsize_per_tailwave , lds_Bsize_per_wr_tail * 2   //each wave load seperate 32X64 block.    need contiunous 32X4X2X2,512 bytes in LDS
+.set lds_Bsize_per_tailwg   , lds_Bsize_per_tailwave * 4  //WG load 64 32X4 block(32X256) Matrix B to lds for pingpong.
+.set A_lds_base_addr    , 0
+.set B_lds_base_addr_tail    , A_lds_base_addr+lds_Asize_per_tailwg * 8  //in bytes
+.set A_lds_simd_offset_tail  , lds_Asize_per_wr_tail*2*2 	//2 loads * 2 SIMD
+
+
+ //****************
+ // start kernel
+
+  s_mov_b32     m0, 0x00003000                          // 000000000000: BEFC00FF 00003000
+  v_mov_b32     v100, v0                                // 000000000008: 7EC80300
+  v_and_b32     v101, 63, v0                            // 00000000000C: 26CA00BF
+  s_load_dword  s26, s[0:1], 0x08                       // 000000000010: C0020680 00000008
+  s_load_dword  s27, s[0:1], 0x0c                       // 000000000018: C00206C0 0000000C
+  s_load_dword  s52, s[0:1], 0x28                       // 000000000020: C0020D00 00000028
+  s_load_dword  s53, s[0:1], 0x2c                       // 000000000028: C0020D40 0000002C
+  s_load_dword  s48, s[0:1], 0x50                       // 000000000030: C0020C00 00000050
+  s_load_dword  s49, s[0:1], 0x54                       // 000000000038: C0020C40 00000054
+  s_load_dword  s50, s[0:1], 0x58                       // 000000000040: C0020C80 00000058
+  s_load_dword  s51, s[0:1], 0x5c                       // 000000000048: C0020CC0 0000005C
+  s_load_dword  s54, s[0:1], 0x30                       // 000000000050: C0020D80 00000030
+  s_load_dword  s55, s[0:1], 0x34                       // 000000000058: C0020DC0 00000034
+  s_load_dword  s28, s[0:1], 0x10                       // 000000000060: C0020700 00000010
+  s_load_dword  s29, s[0:1], 0x14                       // 000000000068: C0020740 00000014
+  v_lshrrev_b32  v2, 6, v100                            // 000000000070: 2004C886
+  v_readfirstlane_b32  s79, v2                          // 000000000074: 7E9E0502
+  s_and_b32     s88, s79, 1                             // 000000000078: 8658814F
+  s_lshr_b32    s89, s79, 1                             // 00000000007C: 8F59814F
+  s_mul_i32     s80, s3, 2                              // 000000000080: 92508203
+  s_add_i32     s80, s2, s80                            // 000000000084: 81505002
+  s_mov_b32     s82, s3                                 // 000000000088: BED20003
+  s_mov_b32     s81, s2                                 // 00000000008C: BED10002
+  v_accvgpr_write  a0, 0                              // 000000000090: D3D94000 18000080
+  v_accvgpr_write  a1, 0                              // 000000000098: D3D94001 18000080
+  v_accvgpr_write  a2, 0                              // 0000000000A0: D3D94002 18000080
+  v_accvgpr_write  a3, 0                              // 0000000000A8: D3D94003 18000080
+  s_waitcnt     lgkmcnt(0)                              // 0000000000B0: BF8CC07F
+  s_mov_b32     s8, s52                                 // 0000000000B4: BE880034
+  s_mov_b32     s9, s53                                 // 0000000000B8: BE890035
+  s_mov_b32     s11, 0x00020000                         // 0000000000BC: BE8B00FF 00020000
+  s_sub_u32     s56, s26, s84                           // 0000000000C4: 80B8541A
+  s_sub_u32     s57, s26, s85                           // 0000000000C8: 80B9551A
+  s_lshl_b64    s[56:57], s[56:57], 1                   // 0000000000CC: 8EB88138
+  s_add_u32     s56, s56, 4                             // 0000000000D0: 80388438
+  s_addc_u32    s57, s57, 0                             // 0000000000D4: 82398039
+  s_cmp_eq_u32  s57, 0                                  // 0000000000D8: BF068039
+  s_cselect_b32  s10, s56, 0x80000000                   // 0000000000DC: 850AFF38 80000000
+  s_mov_b32     s10, 0x80000000                         // 0000000000E4: BE8A00FF 80000000
+  s_mul_i32     s84, s81, 32                            // 0000000000EC: 9254A051
+  s_mul_i32     s84, s48, s84                           // 0000000000F0: 92545430
+  s_lshl_b32    s83, s79, 3                             // 0000000000F4: 8E53834F
+  s_mul_i32     s83, s48, s83                           // 0000000000F8: 92535330
+  s_add_i32     s84, s84, s83                           // 0000000000FC: 81545354
+  v_lshrrev_b32  v0, 4, v101                            // 000000000100: 2000CA84
+  v_mul_lo_u32  v4, s48, v0                             // 000000000104: D2850004 00020030
+  v_and_b32     v1, 15, v101                            // 00000000010C: 2602CA8F
+  v_lshlrev_b32  v1, 1, v1                              // 000000000110: 24020281
+  v_add_co_u32  v82, vcc, v4, v1                        // 000000000114: 32A40304
+  v_add_u32     v82, s84, v82                           // 000000000118: 68A4A454
+  v_lshlrev_b32  v82, 1, v82                            // 00000000011C: 24A4A481
+  s_lshl_b32    s71, s48, 3                             // 000000000120: 8E478330
+  s_sub_u32     s71, s71, 0x00000110                    // 000000000124: 80C7FF47 00000110
+  v_add_u32     v83, s71, v82                           // 00000000012C: 68A6A447
+  s_mov_b32     s75, 0x00000220                         // 000000000130: BECB00FF 00000220
+  s_mul_i32     s75, s79, s75                           // 000000000138: 924B4B4F
+  s_mov_b32     s12, s54                                // 00000000013C: BE8C0036
+  s_mov_b32     s13, s55                                // 000000000140: BE8D0037
+  s_mov_b32     s15, 0x00020000                         // 000000000144: BE8F00FF 00020000
+  s_sub_u32     s58, s28, s84                           // 00000000014C: 80BA541C
+  s_sub_u32     s59, s28, s85                           // 000000000150: 80BB551C
+  s_lshl_b64    s[58:59], s[58:59], 1                   // 000000000154: 8EBA813A
+  s_add_u32     s58, s58, 4                             // 000000000158: 803A843A
+  s_addc_u32    s59, s59, 0                             // 00000000015C: 823B803B
+  s_cmp_eq_u32  s59, 0                                  // 000000000160: BF06803B
+  s_cselect_b32  s14, s58, 0x80000000                   // 000000000164: 850EFF3A 80000000
+  s_mov_b32     s14, 0x80000000                         // 00000000016C: BE8E00FF 80000000
+  s_mul_i32     s84, s82, 32                            // 000000000174: 9254A052
+  s_mul_i32     s84, s50, s84                           // 000000000178: 92545432
+  s_lshl_b32    s83, s79, 3                             // 00000000017C: 8E53834F
+  s_mul_i32     s83, s50, s83                           // 000000000180: 92535332
+  s_add_i32     s84, s84, s83                           // 000000000184: 81545354
+  v_lshrrev_b32  v2, 4, v101                            // 000000000188: 2004CA84
+  v_and_b32     v3, 15, v101                            // 00000000018C: 2606CA8F
+  v_lshlrev_b32  v3, 1, v3                              // 000000000190: 24060681
+  v_mul_lo_u32  v4, s50, v2                             // 000000000194: D2850004 00020432
+  v_add_co_u32  v86, vcc, v4, v3                        // 00000000019C: 32AC0704
+  v_add_u32     v86, s84, v86                           // 0000000001A0: 68ACAC54
+  v_lshlrev_b32  v86, 1, v86                            // 0000000001A4: 24ACAC81
+  s_lshl_b32    s73, s50, 3                             // 0000000001A8: 8E498332
+  s_sub_u32     s73, s73, 0x00000110                    // 0000000001AC: 80C9FF49 00000110
+  v_add_u32     v87, s73, v86                           // 0000000001B4: 68AEAC49
+  s_mov_b32     s77, 0x00000220                         // 0000000001B8: BECD00FF 00000220
+  s_mul_i32     s77, s79, s77                           // 0000000001C0: 924D4D4F
+  s_add_i32     s77, s77, 0x00004400                    // 0000000001C4: 814DFF4D 00004400
+  s_mov_b32     m0, s75                                 // 0000000001CC: BEFC004B
+  s_add_i32     s76, s75, 0x00000880                    // 0000000001D0: 814CFF4B 00000880
+  buffer_load_dword  v48, v82, s[8:11], 0 offen lds     // 0000000001D8: E0511000 80023052
+  buffer_load_dword  v49, v83, s[8:11], 0 offen offset:272 lds // 0000000001E0: E0511110 80023153
+  s_mov_b32     m0, s77                                 // 0000000001E8: BEFC004D
+  s_add_i32     s78, s77, 0x00000880                    // 0000000001EC: 814EFF4D 00000880
+  buffer_load_dword  v68, v86, s[12:15], 0 offen lds    // 0000000001F4: E0511000 80034456
+  buffer_load_dword  v69, v87, s[12:15], 0 offen offset:272 lds // 0000000001FC: E0511110 80034557
+  s_load_dword  s32, s[0:1], 0x18                       // 000000000204: C0020800 00000018
+  s_load_dword  s33, s[0:1], 0x1c                       // 00000000020C: C0020840 0000001C
+  s_load_dword  s34, s[0:1], 0x20                       // 000000000214: C0020880 00000020
+  s_load_dword  s35, s[0:1], 0x24                       // 00000000021C: C00208C0 00000024
+  s_load_dword  s24, s[0:1], 0x00                       // 000000000224: C0020600 00000000
+  s_load_dword  s25, s[0:1], 0x04                       // 00000000022C: C0020640 00000004
+  s_load_dword  s40, s[0:1], 0x38                       // 000000000234: C0020A00 00000038
+  s_load_dword  s36, s[0:1], 0x40                       // 00000000023C: C0020900 00000040
+  s_load_dword  s37, s[0:1], 0x44                       // 000000000244: C0020940 00000044
+  s_load_dword  s38, s[0:1], 0x48                       // 00000000024C: C0020980 00000048
+  s_load_dword  s39, s[0:1], 0x4c                       // 000000000254: C00209C0 0000004C
+  s_load_dword  s42, s[0:1], 0x60                       // 00000000025C: C0020A80 00000060
+  s_load_dword  s43, s[0:1], 0x64                       // 000000000264: C0020AC0 00000064
+  s_load_dword  s44, s[0:1], 0x68                       // 00000000026C: C0020B00 00000068
+  s_load_dword  s45, s[0:1], 0x6c                       // 000000000274: C0020B40 0000006C
+  v_and_b32     v105, v101, 15                          // 00000000027C: D1130069 00011F65
+  v_mul_lo_u32  v94, 16, v105                           // 000000000284: D285005E 0002D290
+  v_lshrrev_b32  v105, 2, v105                          // 00000000028C: 20D2D282
+  v_mul_lo_u32  v105, 4, v105                           // 000000000290: D2850069 0002D284
+  v_add_u32     v94, v105, v94                          // 000000000298: 68BCBD69
+  v_lshrrev_b32  v105, 4, v101                          // 00000000029C: 20D2CA84
+  v_add_u32     v94, v105, v94                          // 0000000002A0: 68BCBD69
+  v_lshlrev_b32  v94, 2, v94                            // 0000000002A4: 24BCBC82
+  v_mov_b32     v96, v94                                // 0000000002A8: 7EC0035E
+  s_mul_i32     s83, s89, 0x00000440                    // 0000000002AC: 9253FF59 00000440
+  v_add_u32     v94, s83, v94                           // 0000000002B4: 68BCBC53
+  v_add_u32     v94, 0, v94                             // 0000000002B8: 68BCBC80
+  v_add_u32     v95, 0x00000880, v94                    // 0000000002BC: 68BEBCFF 00000880
+  s_mul_i32     s83, s88, 0x00000440                    // 0000000002C4: 9253FF58 00000440
+  v_add_u32     v96, s83, v96                           // 0000000002CC: 68C0C053
+  v_add_u32     v96, 0x00004400, v96                    // 0000000002D0: 68C0C0FF 00004400
+  v_add_u32     v97, 0x00000880, v96                    // 0000000002D8: 68C2C0FF 00000880
+  s_mul_i32     s83, 0x00000880, 1                      // 0000000002E0: 925381FF 00000880
+  s_add_i32     m0, s75, s83                            // 0000000002E8: 817C534B
+  v_add_u32     v82, 64, v82                            // 0000000002EC: 68A4A4C0
+  v_add_u32     v83, 64, v83                            // 0000000002F0: 68A6A6C0
+  v_add_u32     v86, 64, v86                            // 0000000002F4: 68ACACC0
+  v_add_u32     v87, 64, v87                            // 0000000002F8: 68AEAEC0
+  buffer_load_dword  v48, v82, s[8:11], 0 offen lds     // 0000000002FC: E0511000 80023052
+  buffer_load_dword  v49, v83, s[8:11], 0 offen offset:272 lds // 000000000304: E0511110 80023153
+  s_add_i32     m0, s77, s83                            // 00000000030C: 817C534D
+  s_nop         0x0000                                  // 000000000310: BF800000
+  buffer_load_dword  v68, v86, s[12:15], 0 offen lds    // 000000000314: E0511000 80034456
+  buffer_load_dword  v69, v87, s[12:15], 0 offen offset:272 lds // 00000000031C: E0511110 80034557
+  s_mul_i32     s83, 0x00000880, 2                      // 000000000324: 925382FF 00000880
+  s_add_i32     m0, s75, s83                            // 00000000032C: 817C534B
+  v_add_u32     v82, 64, v82                            // 000000000330: 68A4A4C0
+  v_add_u32     v83, 64, v83                            // 000000000334: 68A6A6C0
+  v_add_u32     v86, 64, v86                            // 000000000338: 68ACACC0
+  v_add_u32     v87, 64, v87                            // 00000000033C: 68AEAEC0
+  buffer_load_dword  v48, v82, s[8:11], 0 offen lds     // 000000000340: E0511000 80023052
+  buffer_load_dword  v49, v83, s[8:11], 0 offen offset:272 lds // 000000000348: E0511110 80023153
+  s_add_i32     m0, s77, s83                            // 000000000350: 817C534D
+  s_nop         0x0000                                  // 000000000354: BF800000
+  buffer_load_dword  v68, v86, s[12:15], 0 offen lds    // 000000000358: E0511000 80034456
+  buffer_load_dword  v69, v87, s[12:15], 0 offen offset:272 lds // 000000000360: E0511110 80034557
+  s_mul_i32     s83, 0x00000880, 3                      // 000000000368: 925383FF 00000880
+  s_add_i32     m0, s75, s83                            // 000000000370: 817C534B
+  v_add_u32     v82, 64, v82                            // 000000000374: 68A4A4C0
+  v_add_u32     v83, 64, v83                            // 000000000378: 68A6A6C0
+  v_add_u32     v86, 64, v86                            // 00000000037C: 68ACACC0
+  v_add_u32     v87, 64, v87                            // 000000000380: 68AEAEC0
+  buffer_load_dword  v48, v82, s[8:11], 0 offen lds     // 000000000384: E0511000 80023052
+  buffer_load_dword  v49, v83, s[8:11], 0 offen offset:272 lds // 00000000038C: E0511110 80023153
+  s_add_i32     m0, s77, s83                            // 000000000394: 817C534D
+  s_nop         0x0000                                  // 000000000398: BF800000
+  buffer_load_dword  v68, v86, s[12:15], 0 offen lds    // 00000000039C: E0511000 80034456
+  buffer_load_dword  v69, v87, s[12:15], 0 offen offset:272 lds // 0000000003A4: E0511110 80034557
+  s_mul_i32     s83, 0x00000880, 4                      // 0000000003AC: 925384FF 00000880
+  s_add_i32     m0, s75, s83                            // 0000000003B4: 817C534B
+  v_add_u32     v82, 64, v82                            // 0000000003B8: 68A4A4C0
+  v_add_u32     v83, 64, v83                            // 0000000003BC: 68A6A6C0
+  v_add_u32     v86, 64, v86                            // 0000000003C0: 68ACACC0
+  v_add_u32     v87, 64, v87                            // 0000000003C4: 68AEAEC0
+  buffer_load_dword  v48, v82, s[8:11], 0 offen lds     // 0000000003C8: E0511000 80023052
+  buffer_load_dword  v49, v83, s[8:11], 0 offen offset:272 lds // 0000000003D0: E0511110 80023153
+  s_add_i32     m0, s77, s83                            // 0000000003D8: 817C534D
+  s_nop         0x0000                                  // 0000000003DC: BF800000
+  buffer_load_dword  v68, v86, s[12:15], 0 offen lds    // 0000000003E0: E0511000 80034456
+  buffer_load_dword  v69, v87, s[12:15], 0 offen offset:272 lds // 0000000003E8: E0511110 80034557
+  s_mul_i32     s83, 0x00000880, 5                      // 0000000003F0: 925385FF 00000880
+  s_add_i32     m0, s75, s83                            // 0000000003F8: 817C534B
+  v_add_u32     v82, 64, v82                            // 0000000003FC: 68A4A4C0
+  v_add_u32     v83, 64, v83                            // 000000000400: 68A6A6C0
+  v_add_u32     v86, 64, v86                            // 000000000404: 68ACACC0
+  v_add_u32     v87, 64, v87                            // 000000000408: 68AEAEC0
+  buffer_load_dword  v48, v82, s[8:11], 0 offen lds     // 00000000040C: E0511000 80023052
+  buffer_load_dword  v49, v83, s[8:11], 0 offen offset:272 lds // 000000000414: E0511110 80023153
+  s_add_i32     m0, s77, s83                            // 00000000041C: 817C534D
+  s_nop         0x0000                                  // 000000000420: BF800000
+  buffer_load_dword  v68, v86, s[12:15], 0 offen lds    // 000000000424: E0511000 80034456
+  buffer_load_dword  v69, v87, s[12:15], 0 offen offset:272 lds // 00000000042C: E0511110 80034557
+  s_mul_i32     s83, 0x00000880, 6                      // 000000000434: 925386FF 00000880
+  s_add_i32     m0, s75, s83                            // 00000000043C: 817C534B
+  v_add_u32     v82, 64, v82                            // 000000000440: 68A4A4C0
+  v_add_u32     v83, 64, v83                            // 000000000444: 68A6A6C0
+  v_add_u32     v86, 64, v86                            // 000000000448: 68ACACC0
+  v_add_u32     v87, 64, v87                            // 00000000044C: 68AEAEC0
+  buffer_load_dword  v48, v82, s[8:11], 0 offen lds     // 000000000450: E0511000 80023052
+  buffer_load_dword  v49, v83, s[8:11], 0 offen offset:272 lds // 000000000458: E0511110 80023153
+  s_add_i32     m0, s77, s83                            // 000000000460: 817C534D
+  s_nop         0x0000                                  // 000000000464: BF800000
+  buffer_load_dword  v68, v86, s[12:15], 0 offen lds    // 000000000468: E0511000 80034456
+  buffer_load_dword  v69, v87, s[12:15], 0 offen offset:272 lds // 000000000470: E0511110 80034557
+  s_mul_i32     s83, 0x00000880, 7                      // 000000000478: 925387FF 00000880
+  s_add_i32     m0, s75, s83                            // 000000000480: 817C534B
+  v_add_u32     v82, 64, v82                            // 000000000484: 68A4A4C0
+  v_add_u32     v83, 64, v83                            // 000000000488: 68A6A6C0
+  v_add_u32     v86, 64, v86                            // 00000000048C: 68ACACC0
+  v_add_u32     v87, 64, v87                            // 000000000490: 68AEAEC0
+  buffer_load_dword  v48, v82, s[8:11], 0 offen lds     // 000000000494: E0511000 80023052
+  buffer_load_dword  v49, v83, s[8:11], 0 offen offset:272 lds // 00000000049C: E0511110 80023153
+  s_add_i32     m0, s77, s83                            // 0000000004A4: 817C534D
+  s_nop         0x0000                                  // 0000000004A8: BF800000
+  buffer_load_dword  v68, v86, s[12:15], 0 offen lds    // 0000000004AC: E0511000 80034456
+  buffer_load_dword  v69, v87, s[12:15], 0 offen offset:272 lds // 0000000004B4: E0511110 80034557
+  v_add_u32     v82, 64, v82                            // 0000000004BC: 68A4A4C0
+  v_add_u32     v83, 64, v83                            // 0000000004C0: 68A6A6C0
+  v_add_u32     v86, 64, v86                            // 0000000004C4: 68ACACC0
+  v_add_u32     v87, 64, v87                            // 0000000004C8: 68AEAEC0
+  s_waitcnt     lgkmcnt(0)                              // 0000000004CC: BF8CC07F
+  s_waitcnt     vmcnt(30)                               // 0000000004D0: BF8C4F7E
+  s_barrier                                             // 0000000004D4: BF8A0000
+  ds_read_b32   v32, v94                                // 0000000004D8: D86C0000 2000005E
+  ds_read_b32   v33, v94 offset:16                      // 0000000004E0: D86C0010 2100005E
+  ds_read_b32   v34, v94 offset:32                      // 0000000004E8: D86C0020 2200005E
+  ds_read_b32   v35, v94 offset:48                      // 0000000004F0: D86C0030 2300005E
+  s_waitcnt     vmcnt(28)                               // 0000000004F8: BF8C4F7C
+  s_barrier                                             // 0000000004FC: BF8A0000
+  ds_read_b32   v52, v96                                // 000000000500: D86C0000 34000060
+  ds_read_b32   v53, v96 offset:16                      // 000000000508: D86C0010 35000060
+  ds_read_b32   v54, v96 offset:32                      // 000000000510: D86C0020 36000060
+  ds_read_b32   v55, v96 offset:48                      // 000000000518: D86C0030 37000060
+  s_mul_i32     s83, 0x00000880, 1                      // 000000000520: 925381FF 00000880
+  v_add_u32     v105, s83, v94                          // 000000000528: 68D2BC53
+  s_waitcnt     vmcnt(26)                               // 00000000052C: BF8C4F7A
+  s_barrier                                             // 000000000530: BF8A0000
+  ds_read_b32   v36, v105                               // 000000000534: D86C0000 24000069
+  ds_read_b32   v37, v105 offset:16                     // 00000000053C: D86C0010 25000069
+  ds_read_b32   v38, v105 offset:32                     // 000000000544: D86C0020 26000069
+  ds_read_b32   v39, v105 offset:48                     // 00000000054C: D86C0030 27000069
+  v_add_u32     v106, s83, v96                          // 000000000554: 68D4C053
+  s_waitcnt     vmcnt(24)                               // 000000000558: BF8C4F78
+  s_barrier                                             // 00000000055C: BF8A0000
+  ds_read_b32   v56, v106                               // 000000000560: D86C0000 3800006A
+  ds_read_b32   v57, v106 offset:16                     // 000000000568: D86C0010 3900006A
+  ds_read_b32   v58, v106 offset:32                     // 000000000570: D86C0020 3A00006A
+  ds_read_b32   v59, v106 offset:48                     // 000000000578: D86C0030 3B00006A
+  s_mul_i32     s83, 0x00000880, 2                      // 000000000580: 925382FF 00000880
+  v_add_u32     v105, s83, v94                          // 000000000588: 68D2BC53
+  v_add_u32     v106, s83, v96                          // 00000000058C: 68D4C053
+  s_waitcnt     vmcnt(22)                               // 000000000590: BF8C4F76
+  s_barrier                                             // 000000000594: BF8A0000
+  ds_read_b32   v40, v105                               // 000000000598: D86C0000 28000069
+  ds_read_b32   v41, v105 offset:16                     // 0000000005A0: D86C0010 29000069
+  ds_read_b32   v42, v105 offset:32                     // 0000000005A8: D86C0020 2A000069
+  ds_read_b32   v43, v105 offset:48                     // 0000000005B0: D86C0030 2B000069
+  s_waitcnt     vmcnt(20)                               // 0000000005B8: BF8C4F74
+  s_barrier                                             // 0000000005BC: BF8A0000
+  ds_read_b32   v60, v106                               // 0000000005C0: D86C0000 3C00006A
+  ds_read_b32   v61, v106 offset:16                     // 0000000005C8: D86C0010 3D00006A
+  ds_read_b32   v62, v106 offset:32                     // 0000000005D0: D86C0020 3E00006A
+  ds_read_b32   v63, v106 offset:48                     // 0000000005D8: D86C0030 3F00006A
+  s_lshr_b32    s46, s45, 5                             // 0000000005E0: 8F2E852D
+  s_sub_u32     s46, 0, s46                             // 0000000005E4: 80AE2E80
+  s_cmp_eq_u32  s46, 0                                  // 0000000005E8: BF06802E
+  s_cbranch_scc1  label_0447                            // 0000000005EC: BF8502CB
+label_017C:
+  s_waitcnt     0xcf7f                                  // 0000000005F0: BF8CCF7F
+  v_mfma_f32_16x16x8bf16  a[0:3], v32, v52, acc[0:3]          // 0000000005F4: D3ED0000 04026920
+  s_mul_i32     s83, 0x00000880, 0                      // 0000000005FC: 925380FF 00000880
+  s_add_i32     m0, s75, s83                            // 000000000604: 817C534B
+  s_nop         0x0000                                  // 000000000608: BF800000
+  buffer_load_dword  v48, v82, s[8:11], 0 offen lds     // 00000000060C: E0511000 80023052
+  buffer_load_dword  v49, v83, s[8:11], 0 offen offset:272 lds // 000000000614: E0511110 80023153
+  s_add_i32     m0, s77, s83                            // 00000000061C: 817C534D
+  v_add_u32     v82, 64, v82                            // 000000000620: 68A4A4C0
+  v_add_u32     v83, 64, v83                            // 000000000624: 68A6A6C0
+  s_waitcnt     lgkmcnt(12)                             // 000000000628: BF8CCC7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v33, v53, acc[0:3]          // 00000000062C: D3ED0000 04026B21
+  buffer_load_dword  v68, v86, s[12:15], 0 offen lds    // 000000000634: E0511000 80034456
+  buffer_load_dword  v69, v87, s[12:15], 0 offen offset:272 lds // 00000000063C: E0511110 80034557
+  v_add_u32     v86, 64, v86                            // 000000000644: 68ACACC0
+  v_add_u32     v87, 64, v87                            // 000000000648: 68AEAEC0
+  s_waitcnt     lgkmcnt(10)                             // 00000000064C: BF8CCA7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v34, v54, acc[0:3]          // 000000000650: D3ED0000 04026D22
+  s_mul_i32     s83, 0x00000880, 3                      // 000000000658: 925383FF 00000880
+  v_add_u32     v105, s83, v94                          // 000000000660: 68D2BC53
+  s_waitcnt     vmcnt(22)                               // 000000000664: BF8C4F76
+  s_barrier                                             // 000000000668: BF8A0000
+  ds_read_b32   v44, v105                               // 00000000066C: D86C0000 2C000069
+  ds_read_b32   v45, v105 offset:16                     // 000000000674: D86C0010 2D000069
+  ds_read_b32   v46, v105 offset:32                     // 00000000067C: D86C0020 2E000069
+  ds_read_b32   v47, v105 offset:48                     // 000000000684: D86C0030 2F000069
+  s_waitcnt     lgkmcnt(12)                             // 00000000068C: BF8CCC7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v35, v55, acc[0:3]          // 000000000690: D3ED0000 04026F23
+  v_add_u32     v106, s83, v96                          // 000000000698: 68D4C053
+  s_waitcnt     vmcnt(20)                               // 00000000069C: BF8C4F74
+  s_barrier                                             // 0000000006A0: BF8A0000
+  ds_read_b32   v64, v106                               // 0000000006A4: D86C0000 4000006A
+  ds_read_b32   v65, v106 offset:16                     // 0000000006AC: D86C0010 4100006A
+  ds_read_b32   v66, v106 offset:32                     // 0000000006B4: D86C0020 4200006A
+  ds_read_b32   v67, v106 offset:48                     // 0000000006BC: D86C0030 4300006A
+  s_add_u32     s46, s46, 1                             // 0000000006C4: 802E812E
+  s_waitcnt     0xcf7f                                  // 0000000006C8: BF8CCF7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v36, v56, acc[0:3]          // 0000000006CC: D3ED0000 04027124
+  s_mul_i32     s83, 0x00000880, 1                      // 0000000006D4: 925381FF 00000880
+  s_add_i32     m0, s75, s83                            // 0000000006DC: 817C534B
+  s_nop         0x0000                                  // 0000000006E0: BF800000
+  buffer_load_dword  v48, v82, s[8:11], 0 offen lds     // 0000000006E4: E0511000 80023052
+  buffer_load_dword  v49, v83, s[8:11], 0 offen offset:272 lds // 0000000006EC: E0511110 80023153
+  s_add_i32     m0, s77, s83                            // 0000000006F4: 817C534D
+  v_add_u32     v82, 64, v82                            // 0000000006F8: 68A4A4C0
+  v_add_u32     v83, 64, v83                            // 0000000006FC: 68A6A6C0
+  s_waitcnt     lgkmcnt(12)                             // 000000000700: BF8CCC7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v37, v57, acc[0:3]          // 000000000704: D3ED0000 04027325
+  buffer_load_dword  v68, v86, s[12:15], 0 offen lds    // 00000000070C: E0511000 80034456
+  buffer_load_dword  v69, v87, s[12:15], 0 offen offset:272 lds // 000000000714: E0511110 80034557
+  v_add_u32     v86, 64, v86                            // 00000000071C: 68ACACC0
+  v_add_u32     v87, 64, v87                            // 000000000720: 68AEAEC0
+  s_waitcnt     lgkmcnt(10)                             // 000000000724: BF8CCA7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v38, v58, acc[0:3]          // 000000000728: D3ED0000 04027526
+  s_mul_i32     s83, 0x00000880, 4                      // 000000000730: 925384FF 00000880
+  v_add_u32     v105, s83, v94                          // 000000000738: 68D2BC53
+  s_waitcnt     vmcnt(22)                               // 00000000073C: BF8C4F76
+  s_barrier                                             // 000000000740: BF8A0000
+  ds_read_b32   v32, v105                               // 000000000744: D86C0000 20000069
+  ds_read_b32   v33, v105 offset:16                     // 00000000074C: D86C0010 21000069
+  ds_read_b32   v34, v105 offset:32                     // 000000000754: D86C0020 22000069
+  ds_read_b32   v35, v105 offset:48                     // 00000000075C: D86C0030 23000069
+  s_waitcnt     lgkmcnt(12)                             // 000000000764: BF8CCC7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v39, v59, acc[0:3]          // 000000000768: D3ED0000 04027727
+  v_add_u32     v106, s83, v96                          // 000000000770: 68D4C053
+  s_waitcnt     vmcnt(20)                               // 000000000774: BF8C4F74
+  s_barrier                                             // 000000000778: BF8A0000
+  ds_read_b32   v52, v106                               // 00000000077C: D86C0000 3400006A
+  ds_read_b32   v53, v106 offset:16                     // 000000000784: D86C0010 3500006A
+  ds_read_b32   v54, v106 offset:32                     // 00000000078C: D86C0020 3600006A
+  ds_read_b32   v55, v106 offset:48                     // 000000000794: D86C0030 3700006A
+  s_add_u32     s46, s46, 1                             // 00000000079C: 802E812E
+  s_waitcnt     0xcf7f                                  // 0000000007A0: BF8CCF7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v40, v60, acc[0:3]          // 0000000007A4: D3ED0000 04027928
+  s_mul_i32     s83, 0x00000880, 2                      // 0000000007AC: 925382FF 00000880
+  s_add_i32     m0, s75, s83                            // 0000000007B4: 817C534B
+  s_nop         0x0000                                  // 0000000007B8: BF800000
+  buffer_load_dword  v48, v82, s[8:11], 0 offen lds     // 0000000007BC: E0511000 80023052
+  buffer_load_dword  v49, v83, s[8:11], 0 offen offset:272 lds // 0000000007C4: E0511110 80023153
+  s_add_i32     m0, s77, s83                            // 0000000007CC: 817C534D
+  v_add_u32     v82, 64, v82                            // 0000000007D0: 68A4A4C0
+  v_add_u32     v83, 64, v83                            // 0000000007D4: 68A6A6C0
+  s_waitcnt     lgkmcnt(12)                             // 0000000007D8: BF8CCC7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v41, v61, acc[0:3]          // 0000000007DC: D3ED0000 04027B29
+  buffer_load_dword  v68, v86, s[12:15], 0 offen lds    // 0000000007E4: E0511000 80034456
+  buffer_load_dword  v69, v87, s[12:15], 0 offen offset:272 lds // 0000000007EC: E0511110 80034557
+  v_add_u32     v86, 64, v86                            // 0000000007F4: 68ACACC0
+  v_add_u32     v87, 64, v87                            // 0000000007F8: 68AEAEC0
+  s_waitcnt     lgkmcnt(10)                             // 0000000007FC: BF8CCA7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v42, v62, acc[0:3]          // 000000000800: D3ED0000 04027D2A
+  s_mul_i32     s83, 0x00000880, 5                      // 000000000808: 925385FF 00000880
+  v_add_u32     v105, s83, v94                          // 000000000810: 68D2BC53
+  s_waitcnt     vmcnt(22)                               // 000000000814: BF8C4F76
+  s_barrier                                             // 000000000818: BF8A0000
+  ds_read_b32   v36, v105                               // 00000000081C: D86C0000 24000069
+  ds_read_b32   v37, v105 offset:16                     // 000000000824: D86C0010 25000069
+  ds_read_b32   v38, v105 offset:32                     // 00000000082C: D86C0020 26000069
+  ds_read_b32   v39, v105 offset:48                     // 000000000834: D86C0030 27000069
+  s_waitcnt     lgkmcnt(12)                             // 00000000083C: BF8CCC7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v43, v63, acc[0:3]          // 000000000840: D3ED0000 04027F2B
+  v_add_u32     v106, s83, v96                          // 000000000848: 68D4C053
+  s_waitcnt     vmcnt(20)                               // 00000000084C: BF8C4F74
+  s_barrier                                             // 000000000850: BF8A0000
+  ds_read_b32   v56, v106                               // 000000000854: D86C0000 3800006A
+  ds_read_b32   v57, v106 offset:16                     // 00000000085C: D86C0010 3900006A
+  ds_read_b32   v58, v106 offset:32                     // 000000000864: D86C0020 3A00006A
+  ds_read_b32   v59, v106 offset:48                     // 00000000086C: D86C0030 3B00006A
+  s_add_u32     s46, s46, 1                             // 000000000874: 802E812E
+  s_waitcnt     0xcf7f                                  // 000000000878: BF8CCF7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v44, v64, acc[0:3]          // 00000000087C: D3ED0000 0402812C
+  s_mul_i32     s83, 0x00000880, 3                      // 000000000884: 925383FF 00000880
+  s_add_i32     m0, s75, s83                            // 00000000088C: 817C534B
+  s_nop         0x0000                                  // 000000000890: BF800000
+  buffer_load_dword  v48, v82, s[8:11], 0 offen lds     // 000000000894: E0511000 80023052
+  buffer_load_dword  v49, v83, s[8:11], 0 offen offset:272 lds // 00000000089C: E0511110 80023153
+  s_add_i32     m0, s77, s83                            // 0000000008A4: 817C534D
+  v_add_u32     v82, 64, v82                            // 0000000008A8: 68A4A4C0
+  v_add_u32     v83, 64, v83                            // 0000000008AC: 68A6A6C0
+  s_waitcnt     lgkmcnt(12)                             // 0000000008B0: BF8CCC7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v45, v65, acc[0:3]          // 0000000008B4: D3ED0000 0402832D
+  buffer_load_dword  v68, v86, s[12:15], 0 offen lds    // 0000000008BC: E0511000 80034456
+  buffer_load_dword  v69, v87, s[12:15], 0 offen offset:272 lds // 0000000008C4: E0511110 80034557
+  v_add_u32     v86, 64, v86                            // 0000000008CC: 68ACACC0
+  v_add_u32     v87, 64, v87                            // 0000000008D0: 68AEAEC0
+  s_waitcnt     lgkmcnt(10)                             // 0000000008D4: BF8CCA7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v46, v66, acc[0:3]          // 0000000008D8: D3ED0000 0402852E
+  s_mul_i32     s83, 0x00000880, 6                      // 0000000008E0: 925386FF 00000880
+  v_add_u32     v105, s83, v94                          // 0000000008E8: 68D2BC53
+  s_waitcnt     vmcnt(22)                               // 0000000008EC: BF8C4F76
+  s_barrier                                             // 0000000008F0: BF8A0000
+  ds_read_b32   v40, v105                               // 0000000008F4: D86C0000 28000069
+  ds_read_b32   v41, v105 offset:16                     // 0000000008FC: D86C0010 29000069
+  ds_read_b32   v42, v105 offset:32                     // 000000000904: D86C0020 2A000069
+  ds_read_b32   v43, v105 offset:48                     // 00000000090C: D86C0030 2B000069
+  s_waitcnt     lgkmcnt(12)                             // 000000000914: BF8CCC7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v47, v67, acc[0:3]          // 000000000918: D3ED0000 0402872F
+  v_add_u32     v106, s83, v96                          // 000000000920: 68D4C053
+  s_waitcnt     vmcnt(20)                               // 000000000924: BF8C4F74
+  s_barrier                                             // 000000000928: BF8A0000
+  ds_read_b32   v60, v106                               // 00000000092C: D86C0000 3C00006A
+  ds_read_b32   v61, v106 offset:16                     // 000000000934: D86C0010 3D00006A
+  ds_read_b32   v62, v106 offset:32                     // 00000000093C: D86C0020 3E00006A
+  ds_read_b32   v63, v106 offset:48                     // 000000000944: D86C0030 3F00006A
+  s_add_u32     s46, s46, 1                             // 00000000094C: 802E812E
+  s_waitcnt     0xcf7f                                  // 000000000950: BF8CCF7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v32, v52, acc[0:3]          // 000000000954: D3ED0000 04026920
+  s_mul_i32     s83, 0x00000880, 4                      // 00000000095C: 925384FF 00000880
+  s_add_i32     m0, s75, s83                            // 000000000964: 817C534B
+  s_nop         0x0000                                  // 000000000968: BF800000
+  buffer_load_dword  v48, v82, s[8:11], 0 offen lds     // 00000000096C: E0511000 80023052
+  buffer_load_dword  v49, v83, s[8:11], 0 offen offset:272 lds // 000000000974: E0511110 80023153
+  s_add_i32     m0, s77, s83                            // 00000000097C: 817C534D
+  v_add_u32     v82, 64, v82                            // 000000000980: 68A4A4C0
+  v_add_u32     v83, 64, v83                            // 000000000984: 68A6A6C0
+  s_waitcnt     lgkmcnt(12)                             // 000000000988: BF8CCC7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v33, v53, acc[0:3]          // 00000000098C: D3ED0000 04026B21
+  buffer_load_dword  v68, v86, s[12:15], 0 offen lds    // 000000000994: E0511000 80034456
+  buffer_load_dword  v69, v87, s[12:15], 0 offen offset:272 lds // 00000000099C: E0511110 80034557
+  v_add_u32     v86, 64, v86                            // 0000000009A4: 68ACACC0
+  v_add_u32     v87, 64, v87                            // 0000000009A8: 68AEAEC0
+  s_waitcnt     lgkmcnt(10)                             // 0000000009AC: BF8CCA7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v34, v54, acc[0:3]          // 0000000009B0: D3ED0000 04026D22
+  s_mul_i32     s83, 0x00000880, 7                      // 0000000009B8: 925387FF 00000880
+  v_add_u32     v105, s83, v94                          // 0000000009C0: 68D2BC53
+  s_waitcnt     vmcnt(22)                               // 0000000009C4: BF8C4F76
+  s_barrier                                             // 0000000009C8: BF8A0000
+  ds_read_b32   v44, v105                               // 0000000009CC: D86C0000 2C000069
+  ds_read_b32   v45, v105 offset:16                     // 0000000009D4: D86C0010 2D000069
+  ds_read_b32   v46, v105 offset:32                     // 0000000009DC: D86C0020 2E000069
+  ds_read_b32   v47, v105 offset:48                     // 0000000009E4: D86C0030 2F000069
+  s_waitcnt     lgkmcnt(12)                             // 0000000009EC: BF8CCC7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v35, v55, acc[0:3]          // 0000000009F0: D3ED0000 04026F23
+  v_add_u32     v106, s83, v96                          // 0000000009F8: 68D4C053
+  s_waitcnt     vmcnt(20)                               // 0000000009FC: BF8C4F74
+  s_barrier                                             // 000000000A00: BF8A0000
+  ds_read_b32   v64, v106                               // 000000000A04: D86C0000 4000006A
+  ds_read_b32   v65, v106 offset:16                     // 000000000A0C: D86C0010 4100006A
+  ds_read_b32   v66, v106 offset:32                     // 000000000A14: D86C0020 4200006A
+  ds_read_b32   v67, v106 offset:48                     // 000000000A1C: D86C0030 4300006A
+  s_add_u32     s46, s46, 1                             // 000000000A24: 802E812E
+  s_waitcnt     0xcf7f                                  // 000000000A28: BF8CCF7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v36, v56, acc[0:3]          // 000000000A2C: D3ED0000 04027124
+  s_mul_i32     s83, 0x00000880, 5                      // 000000000A34: 925385FF 00000880
+  s_add_i32     m0, s75, s83                            // 000000000A3C: 817C534B
+  s_nop         0x0000                                  // 000000000A40: BF800000
+  buffer_load_dword  v48, v82, s[8:11], 0 offen lds     // 000000000A44: E0511000 80023052
+  buffer_load_dword  v49, v83, s[8:11], 0 offen offset:272 lds // 000000000A4C: E0511110 80023153
+  s_add_i32     m0, s77, s83                            // 000000000A54: 817C534D
+  v_add_u32     v82, 64, v82                            // 000000000A58: 68A4A4C0
+  v_add_u32     v83, 64, v83                            // 000000000A5C: 68A6A6C0
+  s_waitcnt     lgkmcnt(12)                             // 000000000A60: BF8CCC7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v37, v57, acc[0:3]          // 000000000A64: D3ED0000 04027325
+  buffer_load_dword  v68, v86, s[12:15], 0 offen lds    // 000000000A6C: E0511000 80034456
+  buffer_load_dword  v69, v87, s[12:15], 0 offen offset:272 lds // 000000000A74: E0511110 80034557
+  v_add_u32     v86, 64, v86                            // 000000000A7C: 68ACACC0
+  v_add_u32     v87, 64, v87                            // 000000000A80: 68AEAEC0
+  s_waitcnt     lgkmcnt(10)                             // 000000000A84: BF8CCA7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v38, v58, acc[0:3]          // 000000000A88: D3ED0000 04027526
+  s_mul_i32     s83, 0x00000880, 0                      // 000000000A90: 925380FF 00000880
+  v_add_u32     v105, s83, v94                          // 000000000A98: 68D2BC53
+  s_waitcnt     vmcnt(22)                               // 000000000A9C: BF8C4F76
+  s_barrier                                             // 000000000AA0: BF8A0000
+  ds_read_b32   v32, v105                               // 000000000AA4: D86C0000 20000069
+  ds_read_b32   v33, v105 offset:16                     // 000000000AAC: D86C0010 21000069
+  ds_read_b32   v34, v105 offset:32                     // 000000000AB4: D86C0020 22000069
+  ds_read_b32   v35, v105 offset:48                     // 000000000ABC: D86C0030 23000069
+  s_waitcnt     lgkmcnt(12)                             // 000000000AC4: BF8CCC7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v39, v59, acc[0:3]          // 000000000AC8: D3ED0000 04027727
+  v_add_u32     v106, s83, v96                          // 000000000AD0: 68D4C053
+  s_waitcnt     vmcnt(20)                               // 000000000AD4: BF8C4F74
+  s_barrier                                             // 000000000AD8: BF8A0000
+  ds_read_b32   v52, v106                               // 000000000ADC: D86C0000 3400006A
+  ds_read_b32   v53, v106 offset:16                     // 000000000AE4: D86C0010 3500006A
+  ds_read_b32   v54, v106 offset:32                     // 000000000AEC: D86C0020 3600006A
+  ds_read_b32   v55, v106 offset:48                     // 000000000AF4: D86C0030 3700006A
+  s_add_u32     s46, s46, 1                             // 000000000AFC: 802E812E
+  s_waitcnt     0xcf7f                                  // 000000000B00: BF8CCF7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v40, v60, acc[0:3]          // 000000000B04: D3ED0000 04027928
+  s_mul_i32     s83, 0x00000880, 6                      // 000000000B0C: 925386FF 00000880
+  s_add_i32     m0, s75, s83                            // 000000000B14: 817C534B
+  s_nop         0x0000                                  // 000000000B18: BF800000
+  buffer_load_dword  v48, v82, s[8:11], 0 offen lds     // 000000000B1C: E0511000 80023052
+  buffer_load_dword  v49, v83, s[8:11], 0 offen offset:272 lds // 000000000B24: E0511110 80023153
+  s_add_i32     m0, s77, s83                            // 000000000B2C: 817C534D
+  v_add_u32     v82, 64, v82                            // 000000000B30: 68A4A4C0
+  v_add_u32     v83, 64, v83                            // 000000000B34: 68A6A6C0
+  s_waitcnt     lgkmcnt(12)                             // 000000000B38: BF8CCC7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v41, v61, acc[0:3]          // 000000000B3C: D3ED0000 04027B29
+  buffer_load_dword  v68, v86, s[12:15], 0 offen lds    // 000000000B44: E0511000 80034456
+  buffer_load_dword  v69, v87, s[12:15], 0 offen offset:272 lds // 000000000B4C: E0511110 80034557
+  v_add_u32     v86, 64, v86                            // 000000000B54: 68ACACC0
+  v_add_u32     v87, 64, v87                            // 000000000B58: 68AEAEC0
+  s_waitcnt     lgkmcnt(10)                             // 000000000B5C: BF8CCA7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v42, v62, acc[0:3]          // 000000000B60: D3ED0000 04027D2A
+  s_mul_i32     s83, 0x00000880, 1                      // 000000000B68: 925381FF 00000880
+  v_add_u32     v105, s83, v94                          // 000000000B70: 68D2BC53
+  s_waitcnt     vmcnt(22)                               // 000000000B74: BF8C4F76
+  s_barrier                                             // 000000000B78: BF8A0000
+  ds_read_b32   v36, v105                               // 000000000B7C: D86C0000 24000069
+  ds_read_b32   v37, v105 offset:16                     // 000000000B84: D86C0010 25000069
+  ds_read_b32   v38, v105 offset:32                     // 000000000B8C: D86C0020 26000069
+  ds_read_b32   v39, v105 offset:48                     // 000000000B94: D86C0030 27000069
+  s_waitcnt     lgkmcnt(12)                             // 000000000B9C: BF8CCC7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v43, v63, acc[0:3]          // 000000000BA0: D3ED0000 04027F2B
+  v_add_u32     v106, s83, v96                          // 000000000BA8: 68D4C053
+  s_waitcnt     vmcnt(20)                               // 000000000BAC: BF8C4F74
+  s_barrier                                             // 000000000BB0: BF8A0000
+  ds_read_b32   v56, v106                               // 000000000BB4: D86C0000 3800006A
+  ds_read_b32   v57, v106 offset:16                     // 000000000BBC: D86C0010 3900006A
+  ds_read_b32   v58, v106 offset:32                     // 000000000BC4: D86C0020 3A00006A
+  ds_read_b32   v59, v106 offset:48                     // 000000000BCC: D86C0030 3B00006A
+  s_add_u32     s46, s46, 1                             // 000000000BD4: 802E812E
+  s_waitcnt     0xcf7f                                  // 000000000BD8: BF8CCF7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v44, v64, acc[0:3]          // 000000000BDC: D3ED0000 0402812C
+  s_mul_i32     s83, 0x00000880, 7                      // 000000000BE4: 925387FF 00000880
+  s_add_i32     m0, s75, s83                            // 000000000BEC: 817C534B
+  s_nop         0x0000                                  // 000000000BF0: BF800000
+  buffer_load_dword  v48, v82, s[8:11], 0 offen lds     // 000000000BF4: E0511000 80023052
+  buffer_load_dword  v49, v83, s[8:11], 0 offen offset:272 lds // 000000000BFC: E0511110 80023153
+  s_add_i32     m0, s77, s83                            // 000000000C04: 817C534D
+  v_add_u32     v82, 64, v82                            // 000000000C08: 68A4A4C0
+  v_add_u32     v83, 64, v83                            // 000000000C0C: 68A6A6C0
+  s_waitcnt     lgkmcnt(12)                             // 000000000C10: BF8CCC7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v45, v65, acc[0:3]          // 000000000C14: D3ED0000 0402832D
+  buffer_load_dword  v68, v86, s[12:15], 0 offen lds    // 000000000C1C: E0511000 80034456
+  buffer_load_dword  v69, v87, s[12:15], 0 offen offset:272 lds // 000000000C24: E0511110 80034557
+  v_add_u32     v86, 64, v86                            // 000000000C2C: 68ACACC0
+  v_add_u32     v87, 64, v87                            // 000000000C30: 68AEAEC0
+  s_waitcnt     lgkmcnt(10)                             // 000000000C34: BF8CCA7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v46, v66, acc[0:3]          // 000000000C38: D3ED0000 0402852E
+  s_mul_i32     s83, 0x00000880, 2                      // 000000000C40: 925382FF 00000880
+  v_add_u32     v105, s83, v94                          // 000000000C48: 68D2BC53
+  s_waitcnt     vmcnt(22)                               // 000000000C4C: BF8C4F76
+  s_barrier                                             // 000000000C50: BF8A0000
+  ds_read_b32   v40, v105                               // 000000000C54: D86C0000 28000069
+  ds_read_b32   v41, v105 offset:16                     // 000000000C5C: D86C0010 29000069
+  ds_read_b32   v42, v105 offset:32                     // 000000000C64: D86C0020 2A000069
+  ds_read_b32   v43, v105 offset:48                     // 000000000C6C: D86C0030 2B000069
+  s_waitcnt     lgkmcnt(12)                             // 000000000C74: BF8CCC7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v47, v67, acc[0:3]          // 000000000C78: D3ED0000 0402872F
+  v_add_u32     v106, s83, v96                          // 000000000C80: 68D4C053
+  s_waitcnt     vmcnt(20)                               // 000000000C84: BF8C4F74
+  s_barrier                                             // 000000000C88: BF8A0000
+  ds_read_b32   v60, v106                               // 000000000C8C: D86C0000 3C00006A
+  ds_read_b32   v61, v106 offset:16                     // 000000000C94: D86C0010 3D00006A
+  ds_read_b32   v62, v106 offset:32                     // 000000000C9C: D86C0020 3E00006A
+  ds_read_b32   v63, v106 offset:48                     // 000000000CA4: D86C0030 3F00006A
+  s_add_u32     s46, s46, 1                             // 000000000CAC: 802E812E
+  s_cmp_eq_i32  s46, -8                                 // 000000000CB0: BF00C82E
+  s_cbranch_scc0  label_017C                            // 000000000CB4: BF84FE4E
+  s_waitcnt     lgkmcnt(14)                             // 000000000CB8: BF8CCE7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v32, v52, acc[0:3]          // 000000000CBC: D3ED0000 04026920
+  s_waitcnt     lgkmcnt(13)                             // 000000000CC4: BF8CCD7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v33, v53, acc[0:3]          // 000000000CC8: D3ED0000 04026B21
+  s_add_u32     s46, s46, 1                             // 000000000CD0: 802E812E
+  s_waitcnt     lgkmcnt(12)                             // 000000000CD4: BF8CCC7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v34, v54, acc[0:3]          // 000000000CD8: D3ED0000 04026D22
+  s_mul_i32     s83, 0x00000880, 3                      // 000000000CE0: 925383FF 00000880
+  v_add_u32     v105, s83, v94                          // 000000000CE8: 68D2BC53
+  s_waitcnt     vmcnt(18)                               // 000000000CEC: BF8C4F72
+  s_barrier                                             // 000000000CF0: BF8A0000
+  ds_read_b32   v44, v105                               // 000000000CF4: D86C0000 2C000069
+  ds_read_b32   v45, v105 offset:16                     // 000000000CFC: D86C0010 2D000069
+  ds_read_b32   v46, v105 offset:32                     // 000000000D04: D86C0020 2E000069
+  ds_read_b32   v47, v105 offset:48                     // 000000000D0C: D86C0030 2F000069
+  s_waitcnt     0xcf7f                                  // 000000000D14: BF8CCF7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v35, v55, acc[0:3]          // 000000000D18: D3ED0000 04026F23
+  v_add_u32     v106, s83, v96                          // 000000000D20: 68D4C053
+  s_waitcnt     vmcnt(16)                               // 000000000D24: BF8C4F70
+  s_barrier                                             // 000000000D28: BF8A0000
+  ds_read_b32   v64, v106                               // 000000000D2C: D86C0000 4000006A
+  ds_read_b32   v65, v106 offset:16                     // 000000000D34: D86C0010 4100006A
+  ds_read_b32   v66, v106 offset:32                     // 000000000D3C: D86C0020 4200006A
+  ds_read_b32   v67, v106 offset:48                     // 000000000D44: D86C0030 4300006A
+  s_waitcnt     lgkmcnt(14)                             // 000000000D4C: BF8CCE7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v36, v56, acc[0:3]          // 000000000D50: D3ED0000 04027124
+  s_waitcnt     lgkmcnt(13)                             // 000000000D58: BF8CCD7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v37, v57, acc[0:3]          // 000000000D5C: D3ED0000 04027325
+  s_add_u32     s46, s46, 1                             // 000000000D64: 802E812E
+  s_waitcnt     lgkmcnt(12)                             // 000000000D68: BF8CCC7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v38, v58, acc[0:3]          // 000000000D6C: D3ED0000 04027526
+  s_mul_i32     s83, 0x00000880, 4                      // 000000000D74: 925384FF 00000880
+  v_add_u32     v105, s83, v94                          // 000000000D7C: 68D2BC53
+  s_waitcnt     vmcnt(14)                               // 000000000D80: BF8C0F7E
+  s_barrier                                             // 000000000D84: BF8A0000
+  ds_read_b32   v32, v105                               // 000000000D88: D86C0000 20000069
+  ds_read_b32   v33, v105 offset:16                     // 000000000D90: D86C0010 21000069
+  ds_read_b32   v34, v105 offset:32                     // 000000000D98: D86C0020 22000069
+  ds_read_b32   v35, v105 offset:48                     // 000000000DA0: D86C0030 23000069
+  s_waitcnt     0xcf7f                                  // 000000000DA8: BF8CCF7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v39, v59, acc[0:3]          // 000000000DAC: D3ED0000 04027727
+  v_add_u32     v106, s83, v96                          // 000000000DB4: 68D4C053
+  s_waitcnt     vmcnt(12)                               // 000000000DB8: BF8C0F7C
+  s_barrier                                             // 000000000DBC: BF8A0000
+  ds_read_b32   v52, v106                               // 000000000DC0: D86C0000 3400006A
+  ds_read_b32   v53, v106 offset:16                     // 000000000DC8: D86C0010 3500006A
+  ds_read_b32   v54, v106 offset:32                     // 000000000DD0: D86C0020 3600006A
+  ds_read_b32   v55, v106 offset:48                     // 000000000DD8: D86C0030 3700006A
+  s_waitcnt     lgkmcnt(14)                             // 000000000DE0: BF8CCE7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v40, v60, acc[0:3]          // 000000000DE4: D3ED0000 04027928
+  s_waitcnt     lgkmcnt(13)                             // 000000000DEC: BF8CCD7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v41, v61, acc[0:3]          // 000000000DF0: D3ED0000 04027B29
+  s_add_u32     s46, s46, 1                             // 000000000DF8: 802E812E
+  s_waitcnt     lgkmcnt(12)                             // 000000000DFC: BF8CCC7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v42, v62, acc[0:3]          // 000000000E00: D3ED0000 04027D2A
+  s_mul_i32     s83, 0x00000880, 5                      // 000000000E08: 925385FF 00000880
+  v_add_u32     v105, s83, v94                          // 000000000E10: 68D2BC53
+  s_waitcnt     vmcnt(10)                               // 000000000E14: BF8C0F7A
+  s_barrier                                             // 000000000E18: BF8A0000
+  ds_read_b32   v36, v105                               // 000000000E1C: D86C0000 24000069
+  ds_read_b32   v37, v105 offset:16                     // 000000000E24: D86C0010 25000069
+  ds_read_b32   v38, v105 offset:32                     // 000000000E2C: D86C0020 26000069
+  ds_read_b32   v39, v105 offset:48                     // 000000000E34: D86C0030 27000069
+  s_waitcnt     0xcf7f                                  // 000000000E3C: BF8CCF7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v43, v63, acc[0:3]          // 000000000E40: D3ED0000 04027F2B
+  v_add_u32     v106, s83, v96                          // 000000000E48: 68D4C053
+  s_waitcnt     vmcnt(8)                                // 000000000E4C: BF8C0F78
+  s_barrier                                             // 000000000E50: BF8A0000
+  ds_read_b32   v56, v106                               // 000000000E54: D86C0000 3800006A
+  ds_read_b32   v57, v106 offset:16                     // 000000000E5C: D86C0010 3900006A
+  ds_read_b32   v58, v106 offset:32                     // 000000000E64: D86C0020 3A00006A
+  ds_read_b32   v59, v106 offset:48                     // 000000000E6C: D86C0030 3B00006A
+  s_waitcnt     lgkmcnt(14)                             // 000000000E74: BF8CCE7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v44, v64, acc[0:3]          // 000000000E78: D3ED0000 0402812C
+  s_waitcnt     lgkmcnt(13)                             // 000000000E80: BF8CCD7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v45, v65, acc[0:3]          // 000000000E84: D3ED0000 0402832D
+  s_add_u32     s46, s46, 1                             // 000000000E8C: 802E812E
+  s_waitcnt     lgkmcnt(12)                             // 000000000E90: BF8CCC7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v46, v66, acc[0:3]          // 000000000E94: D3ED0000 0402852E
+  s_mul_i32     s83, 0x00000880, 6                      // 000000000E9C: 925386FF 00000880
+  v_add_u32     v105, s83, v94                          // 000000000EA4: 68D2BC53
+  s_waitcnt     vmcnt(6)                                // 000000000EA8: BF8C0F76
+  s_barrier                                             // 000000000EAC: BF8A0000
+  ds_read_b32   v40, v105                               // 000000000EB0: D86C0000 28000069
+  ds_read_b32   v41, v105 offset:16                     // 000000000EB8: D86C0010 29000069
+  ds_read_b32   v42, v105 offset:32                     // 000000000EC0: D86C0020 2A000069
+  ds_read_b32   v43, v105 offset:48                     // 000000000EC8: D86C0030 2B000069
+  s_waitcnt     0xcf7f                                  // 000000000ED0: BF8CCF7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v47, v67, acc[0:3]          // 000000000ED4: D3ED0000 0402872F
+  v_add_u32     v106, s83, v96                          // 000000000EDC: 68D4C053
+  s_waitcnt     vmcnt(4)                                // 000000000EE0: BF8C0F74
+  s_barrier                                             // 000000000EE4: BF8A0000
+  ds_read_b32   v60, v106                               // 000000000EE8: D86C0000 3C00006A
+  ds_read_b32   v61, v106 offset:16                     // 000000000EF0: D86C0010 3D00006A
+  ds_read_b32   v62, v106 offset:32                     // 000000000EF8: D86C0020 3E00006A
+  ds_read_b32   v63, v106 offset:48                     // 000000000F00: D86C0030 3F00006A
+  s_waitcnt     lgkmcnt(14)                             // 000000000F08: BF8CCE7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v32, v52, acc[0:3]          // 000000000F0C: D3ED0000 04026920
+  s_waitcnt     lgkmcnt(13)                             // 000000000F14: BF8CCD7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v33, v53, acc[0:3]          // 000000000F18: D3ED0000 04026B21
+  s_add_u32     s46, s46, 1                             // 000000000F20: 802E812E
+  s_waitcnt     lgkmcnt(12)                             // 000000000F24: BF8CCC7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v34, v54, acc[0:3]          // 000000000F28: D3ED0000 04026D22
+  s_mul_i32     s83, 0x00000880, 7                      // 000000000F30: 925387FF 00000880
+  v_add_u32     v105, s83, v94                          // 000000000F38: 68D2BC53
+  s_waitcnt     vmcnt(2)                                // 000000000F3C: BF8C0F72
+  s_barrier                                             // 000000000F40: BF8A0000
+  ds_read_b32   v44, v105                               // 000000000F44: D86C0000 2C000069
+  ds_read_b32   v45, v105 offset:16                     // 000000000F4C: D86C0010 2D000069
+  ds_read_b32   v46, v105 offset:32                     // 000000000F54: D86C0020 2E000069
+  ds_read_b32   v47, v105 offset:48                     // 000000000F5C: D86C0030 2F000069
+  s_waitcnt     0xcf7f                                  // 000000000F64: BF8CCF7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v35, v55, acc[0:3]          // 000000000F68: D3ED0000 04026F23
+  v_add_u32     v106, s83, v96                          // 000000000F70: 68D4C053
+  s_waitcnt     vmcnt(0)                                // 000000000F74: BF8C0F70
+  s_barrier                                             // 000000000F78: BF8A0000
+  ds_read_b32   v64, v106                               // 000000000F7C: D86C0000 4000006A
+  ds_read_b32   v65, v106 offset:16                     // 000000000F84: D86C0010 4100006A
+  ds_read_b32   v66, v106 offset:32                     // 000000000F8C: D86C0020 4200006A
+  ds_read_b32   v67, v106 offset:48                     // 000000000F94: D86C0030 4300006A
+  s_waitcnt     lgkmcnt(14)                             // 000000000F9C: BF8CCE7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v36, v56, acc[0:3]          // 000000000FA0: D3ED0000 04027124
+  s_waitcnt     lgkmcnt(13)                             // 000000000FA8: BF8CCD7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v37, v57, acc[0:3]          // 000000000FAC: D3ED0000 04027325
+  s_waitcnt     lgkmcnt(12)                             // 000000000FB4: BF8CCC7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v38, v58, acc[0:3]          // 000000000FB8: D3ED0000 04027526
+  s_waitcnt     lgkmcnt(11)                             // 000000000FC0: BF8CCB7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v39, v59, acc[0:3]          // 000000000FC4: D3ED0000 04027727
+  s_waitcnt     lgkmcnt(8)                              // 000000000FCC: BF8CC87F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v40, v60, acc[0:3]          // 000000000FD0: D3ED0000 04027928
+  s_waitcnt     lgkmcnt(7)                              // 000000000FD8: BF8CC77F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v41, v61, acc[0:3]          // 000000000FDC: D3ED0000 04027B29
+  s_waitcnt     lgkmcnt(6)                              // 000000000FE4: BF8CC67F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v42, v62, acc[0:3]          // 000000000FE8: D3ED0000 04027D2A
+  s_waitcnt     lgkmcnt(5)                              // 000000000FF0: BF8CC57F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v43, v63, acc[0:3]          // 000000000FF4: D3ED0000 04027F2B
+  s_waitcnt     lgkmcnt(3)                              // 000000000FFC: BF8CC37F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v44, v64, acc[0:3]          // 000000001000: D3ED0000 0402812C
+  s_waitcnt     lgkmcnt(2)                              // 000000001008: BF8CC27F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v45, v65, acc[0:3]          // 00000000100C: D3ED0000 0402832D
+  s_waitcnt     lgkmcnt(1)                              // 000000001014: BF8CC17F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v46, v66, acc[0:3]          // 000000001018: D3ED0000 0402852E
+  s_waitcnt     lgkmcnt(0)                              // 000000001020: BF8CC07F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v47, v67, acc[0:3]          // 000000001024: D3ED0000 0402872F
+  s_mov_b32     s16, s34                                // 00000000102C: BE900022
+  s_mov_b32     s17, s35                                // 000000001030: BE910023
+  s_mov_b32     s18, 0x80000000                         // 000000001034: BE9200FF 80000000
+  s_mov_b32     s19, 0x00020000                         // 00000000103C: BE9300FF 00020000
+  s_mov_b32     s20, s32                                // 000000001044: BE940020
+  s_mov_b32     s21, s33                                // 000000001048: BE950021
+  s_mov_b32     s22, 0x80000000                         // 00000000104C: BE9600FF 80000000
+  s_mov_b32     s23, 0x00020000                         // 000000001054: BE9700FF 00020000
+  s_mul_hi_u32  s85, s4, s39                            // 00000000105C: 96552704
+  s_mul_i32     s84, s4, s39                            // 000000001060: 92542704
+  s_lshl_b64    s[84:85], s[84:85], 1                   // 000000001064: 8ED48154
+  s_add_u32     s16, s16, s84                           // 000000001068: 80105410
+  s_addc_u32    s17, s17, s85                           // 00000000106C: 82115511
+  s_add_u32     s20, s20, s84                           // 000000001070: 80145414
+  s_addc_u32    s21, s21, s85                           // 000000001074: 82155515
+  s_mul_i32     s86, 32, s82                            // 000000001078: 925652A0
+  s_mul_hi_u32  s85, s86, s38                           // 00000000107C: 96552656
+  s_mul_i32     s84, s86, s38                           // 000000001080: 92542656
+  s_lshl_b64    s[84:85], s[84:85], 1                   // 000000001084: 8ED48154
+  s_add_u32     s16, s16, s84                           // 000000001088: 80105410
+  s_addc_u32    s17, s17, s85                           // 00000000108C: 82115511
+  s_add_u32     s20, s20, s84                           // 000000001090: 80145414
+  s_addc_u32    s21, s21, s85                           // 000000001094: 82155515
+  s_mul_i32     s85, 32, s81                            // 000000001098: 925551A0
+  s_mul_i32     s84, s89, 16                            // 00000000109C: 92549059
+  s_add_i32     s85, s84, s85                           // 0000000010A0: 81555554
+  s_mul_i32     s84, s88, 16                            // 0000000010A4: 92549058
+  s_mul_i32     s83, s84, s38                           // 0000000010A8: 92532654
+  s_add_i32     s85, s85, s83                           // 0000000010AC: 81555355
+  v_and_b32     v3, v101, 15                            // 0000000010B0: D1130003 00011F65
+  v_mul_lo_u32  v5, s38, v3                             // 0000000010B8: D2850005 00020626
+  v_lshrrev_b32  v4, 4, v101                            // 0000000010C0: 2008CA84
+  v_lshlrev_b32  v4, 2, v4                              // 0000000010C4: 24080882
+  v_add_u32     v104, v4, v5                            // 0000000010C8: 68D00B04
+  v_add_u32     v104, s85, v104                         // 0000000010CC: 68D0D055
+  v_lshlrev_b32  v104, 1, v104                          // 0000000010D0: 24D0D081
+  v_accvgpr_read  v0, a0                              // 0000000010D4: D3D84000 18000100
+  v_accvgpr_read  v1, a1                              // 0000000010DC: D3D84001 18000101
+  v_accvgpr_read  v2, a2                              // 0000000010E4: D3D84002 18000102
+  v_accvgpr_read  v3, a3                              // 0000000010EC: D3D84003 18000103
+  v_lshrrev_b32  v0, 16, v0                             // 0000000010F4: 20000090
+  v_lshrrev_b32  v1, 16, v1                             // 0000000010F8: 20020290
+  v_lshlrev_b32  v1, 16, v1                             // 0000000010FC: 24020290
+  v_or_b32      v0, v0, v1                              // 000000001100: 28000300
+  v_lshrrev_b32  v2, 16, v2                             // 000000001104: 20040490
+  v_lshrrev_b32  v3, 16, v3                             // 000000001108: 20060690
+  v_lshlrev_b32  v3, 16, v3                             // 00000000110C: 24060690
+  v_or_b32      v1, v2, v3                              // 000000001110: 28020702
+  buffer_store_dwordx2  v[0:1], v104, s[20:23], 0 offen // 000000001114: E0741000 80050068
+label_0447:
+  s_waitcnt     0x0000                                  // 00000000111C: BF8C0000
+  s_endpgm                                              // 000000001120: BF810000

--- a/Tensile/ReplacementKernels-cov3/Cijk_Alik_Bljk_BBH_MT32x64x64_AF0EM8_ASEM8_FL0_GRVW2_ISA908_MDA2_PGR1_PLR1_SU32_TT2_2_VAW1_VW2_WG16_32_1_WGM8.s.txt
+++ b/Tensile/ReplacementKernels-cov3/Cijk_Alik_Bljk_BBH_MT32x64x64_AF0EM8_ASEM8_FL0_GRVW2_ISA908_MDA2_PGR1_PLR1_SU32_TT2_2_VAW1_VW2_WG16_32_1_WGM8.s.txt
@@ -1,0 +1,929 @@
+
+
+/******************************************/
+/* Function Prefix                        */
+/******************************************/
+
+
+
+/******************************************/
+/* Begin Kernel                           */
+/******************************************/
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx908+sram-ecc"
+.text
+.protected Cijk_Alik_Bljk_BBH_MT32x64x64_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG16_32_1_WGM8
+.globl Cijk_Alik_Bljk_BBH_MT32x64x64_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG16_32_1_WGM8
+.p2align 8
+.type Cijk_Alik_Bljk_BBH_MT32x64x64_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG16_32_1_WGM8,@function
+.section .rodata,#alloc
+.p2align 6
+.amdhsa_kernel Cijk_Alik_Bljk_BBH_MT32x64x64_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG16_32_1_WGM8
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_next_free_vgpr 108 // vgprs
+  .amdhsa_next_free_sgpr 98 // sgprs
+  .amdhsa_group_segment_fixed_size 28672 // lds bytes
+  .amdhsa_private_segment_fixed_size 0
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+.text
+
+/******************************************/
+/* Optimizations and Config:              */
+/******************************************/
+/* ThreadTile= 4 x 4 */
+/* SubGroup= 32 x 16 */
+/* VectorWidth=4 */
+/* GlobalLoadVectorWidthA=4, GlobalLoadVectorWidthB=4 */
+/* DirectToLdsA=False */
+/* DirectToLdsB=False */
+/* UseSgprForGRO=1 */
+.amdgpu_metadata
+---
+amdhsa.version:
+  - 1
+  - 0
+amdhsa.kernels:
+  - .name: Cijk_Alik_Bljk_BBH_MT32x64x64_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG16_32_1_WGM8
+    .symbol: 'Cijk_Alik_Bljk_BBH_MT32x64x64_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG16_32_1_WGM8.kd'
+    .language:                   OpenCL C
+    .language_version:
+      - 2
+      - 0
+    .args:
+      - .name:            sizeC
+        .size:            8
+        .offset:          0
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            sizeA
+        .size:            8
+        .offset:          8
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            sizeB
+        .size:            8
+        .offset:          16
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            D
+        .size:            8
+        .offset:          24
+        .value_kind:      global_buffer
+        .value_type:      struct
+        .address_space:   generic
+      - .name:            C
+        .size:            8
+        .offset:          32
+        .value_kind:      global_buffer
+        .value_type:      struct
+        .address_space:   generic
+      - .name:            A
+        .size:            8
+        .offset:          40
+        .value_kind:      global_buffer
+        .value_type:      struct
+        .address_space:   generic
+      - .name:            B
+        .size:            8
+        .offset:          48
+        .value_kind:      global_buffer
+        .value_type:      struct
+        .address_space:   generic
+      - .name:            alpha
+        .size:            4
+        .offset:          56
+        .value_kind:      by_value
+        .value_type:      f32
+      - .name:            beta
+        .size:            4
+        .offset:          60
+        .value_kind:      by_value
+        .value_type:      f32
+      - .name:            strideD0
+        .size:            4
+        .offset:          64
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideD1
+        .size:            4
+        .offset:          68
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideC0
+        .size:            4
+        .offset:          72
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideC1
+        .size:            4
+        .offset:          76
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideA0
+        .size:            4
+        .offset:          80
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideA1
+        .size:            4
+        .offset:          84
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideB0
+        .size:            4
+        .offset:          88
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideB1
+        .size:            4
+        .offset:          92
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree0
+        .size:            4
+        .offset:          96
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree1
+        .size:            4
+        .offset:          100
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree2
+        .size:            4
+        .offset:          104
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesSum0
+        .size:            4
+        .offset:          108
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            OrigStaggerUIter
+        .size:            4
+        .offset:          112
+        .value_kind:      by_value
+        .value_type:      i32
+      - .name:            NumWorkGroups0
+        .size:            4
+        .offset:          116
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            NumWorkGroups1
+        .size:            4
+        .offset:          120
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            MagicNumberProblemNumGroupTiles0
+        .size:            4
+        .offset:          124
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            GridNumWorkGroups0
+        .size:            4
+        .offset:          128
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            NumFullBlocks
+        .size:            4
+        .offset:          132
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            WgmRemainder1
+        .size:            4
+        .offset:          136
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            MagicNumberWgmRemainder1
+        .size:            4
+        .offset:          140
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            padding
+        .size:            4
+        .offset:          144
+        .value_kind:      by_value
+        .value_type:      u32
+    .group_segment_fixed_size:   28672
+    .kernarg_segment_align:      8
+    .kernarg_segment_size:       152
+    .max_flat_workgroup_size:    512
+    .private_segment_fixed_size: 0
+    .sgpr_count:                 98
+    .sgpr_spill_count:           0
+    .vgpr_count:                 108
+    .vgpr_spill_count:           0
+    .wavefront_size:             64
+...
+.end_amdgpu_metadata
+Cijk_Alik_Bljk_BBH_MT32x64x64_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG16_32_1_WGM8:
+
+/******************************************/
+/* Asm syntax workarounds                 */
+/******************************************/
+.macro _v_add_co_u32 dst, cc, src0, src1, dpp=
+   v_add_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+
+.macro _v_add_u32 dst, src0, src1, dpp=
+   v_add_u32 \dst, \src0, \src1 \dpp
+.endm
+
+.macro _v_sub_co_u32 dst, cc, src0, src1, dpp=
+   v_sub_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+
+.macro _v_sub_u32 dst, src0, src1, dpp=
+   v_sub_u32 \dst, \src0, \src1 \dpp
+.endm
+
+.macro _v_addc_co_u32 dst, ccOut, src0, ccIn, src1, dpp=
+   v_addc_co_u32 \dst, \ccOut, \src0, \ccIn, \src1 \dpp
+.endm
+
+.macro _v_add_lshl_u32 dst, src0, src1, shiftCnt
+    v_add_lshl_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+.macro _v_lshl_add_u32 dst, src0, src1, shiftCnt
+    v_lshl_add_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+/******************************************/
+/* Magic div and mod functions            */
+/******************************************/
+.macro V_MAGIC_DIV dstIdx, dividend, magicNumber, magicShift
+    v_mul_hi_u32 v[\dstIdx+1], \dividend, \magicNumber
+    v_mul_lo_u32 v[\dstIdx+0], \dividend, \magicNumber
+    v_lshrrev_b64 v[\dstIdx:\dstIdx+1], \magicShift, v[\dstIdx:\dstIdx+1]
+.endm
+
+/******************************************/
+/* VGPR Assignments                       */
+/******************************************/
+.set vgprValuC, 0
+/* ValuA/B   Xn=PLR buffer idx,  In=InnerUnroll idx */
+.set vgprValuA_X0_I0, 32
+.set vgprValuA_X1_I0, 34
+.set vgprG2LA, 36
+.set vgprValuB_X0_I0, 40
+.set vgprValuB_X1_I0, 44
+.set vgprG2LB, 48
+.set vgprLocalWriteAddrA, 56
+.set vgprLocalWriteAddrB, 57
+.set vgprGlobalReadOffsetA, 58
+.set vgprGlobalReadOffsetB, 59
+.set vgprLocalReadAddrA, 60
+.set vgprLocalReadAddrB, 61
+.set vgprSerial, 62
+/* Num VGPR=63 */
+
+/******************************************/
+/* SGPR Assignments                       */
+/******************************************/
+.set sgprKernArgAddress, 0
+.set sgprWorkGroup0, 2
+.set sgprWorkGroup1, 3
+.set sgprWorkGroup2, 4
+.set sgprNumWorkGroups0, 5
+.set sgprNumWorkGroups1, 6
+.set sgprSrdA, 8
+.set sgprSrdB, 12
+.set sgprSrdD, 16
+.set sgprSrdC, 20
+.set sgprTensor2dSizeC, 24
+.set sgprTensor2dSizeA, 26
+.set sgprTensor2dSizeB, 28
+.set sgprSaveExecMask, 30
+.set sgprAddressD, 32
+.set sgprAddressC, 34
+.set sgprStridesD, 36
+.set sgprStridesC, 38
+.set sgprAlpha, 40
+.set sgprBeta, 41
+.set sgprSizesFree, 42
+.set sgprSizesSum, 45
+.set sgprLoopCounters, 46
+.set sgprOrigLoopCounter, 47
+.set sgprStridesA, 48
+.set sgprStridesB, 50
+.set sgprAddressA, 52
+.set sgprAddressB, 54
+.set sgprShadowLimitA, 56
+.set sgprShadowLimitB, 58
+.set sgprOrigStaggerUIter, 60
+.set sgprStaggerUIter, 61
+.set sgprWrapUA, 62
+.set sgprWrapUB, 64
+.set sgprNumFullBlocks, 66
+.set sgprWgmRemainder1, 67
+.set sgprMagicNumberWgmRemainder1, 68
+.set sgprGlobalReadIncsA, 69
+.set sgprGlobalReadIncsB, 70
+.set sgprScalarGlobalReadOffsetA, 71
+.set sgprScalarGlobalReadOffsetB, 72
+/* max SGPR=98 */
+
+/* Size Assignments */
+.set sgprSizeD0I, sgprSizesFree+0
+.set sgprSizeD1J, sgprSizesFree+1
+.set sgprSizeDK, sgprSizesFree+2
+.set sgprSizeC0I, sgprSizesFree+0
+.set sgprSizeC1J, sgprSizesFree+1
+.set sgprSizeCK, sgprSizesFree+2
+.set sgprSizeAL, sgprSizesSum+0
+.set sgprSizeA0I, sgprSizesFree+0
+.set sgprSizeAK, sgprSizesFree+2
+.set sgprSizeBL, sgprSizesSum+0
+.set sgprSizeB1J, sgprSizesFree+1
+.set sgprSizeBK, sgprSizesFree+2
+
+/* Stride Assignments */
+.set constStrideD0I, 1
+.set sgprStrideD1J, sgprStridesD+0
+.set sgprStrideDK, sgprStridesD+1
+.set constStrideC0I, 1
+.set sgprStrideC1J, sgprStridesC+0
+.set sgprStrideCK, sgprStridesC+1
+.set constStrideAL, 1
+.set sgprStrideA0I, sgprStridesA+0
+.set sgprStrideAK, sgprStridesA+1
+.set constStrideBL, 1
+.set sgprStrideB1J, sgprStridesB+0
+.set sgprStrideBK, sgprStridesB+1
+
+.set DepthU, 32
+/* Number of elements to shift-left SRD */
+.set SrdShiftLeftA, 4
+.set SrdShiftLeftB, 4
+/* 2GB limit - set offsets to -1 to exceed this and clamp */
+.set BufferLimit, 0x80000000
+/* Bits 127:96 of SRD.  Set DataFormat = 32 bit */
+.set Srd127_96, 0x0020000
+.set BufferOOB, 0x80000000
+
+/* Global Offset A */
+.macro GLOBAL_OFFSET_A vgprAddr vgprOffsetL vgprOffset0I vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStrideA0I], v[\vgprOffset0I] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprOffsetL], v[\vgprTmp+0] // accumulate d1 lower
+_v_add_u32 v[\vgprAddr+0], 0x4, v[\vgprAddr+0]     // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/* Global Offset B */
+.macro GLOBAL_OFFSET_B vgprAddr vgprOffsetL vgprOffset1J vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStrideB1J], v[\vgprOffset1J] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprOffsetL], v[\vgprTmp+0] // accumulate d1 lower
+_v_add_u32 v[\vgprAddr+0], 0x4, v[\vgprAddr+0]     // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/******************************************/
+/* Dynamic Scalar Divide: vQuotient=vDividend/vDivisor; vRemainder=vDividend%vDivisor; */
+/******************************************/
+.macro DYNAMIC_VECTOR_DIVIDE vQuotient vRemainder vDividend vDivisor vTmp0 vTmp1 sTmp
+v_cvt_f32_u32 v[\vQuotient], v[\vDivisor]          //
+v_rcp_f32 v[\vQuotient], v[\vQuotient]             //
+v_mul_f32 v[\vQuotient], 0x4f800000, v[\vQuotient] //
+v_cvt_u32_f32 v[\vQuotient], v[\vQuotient]         //
+v_mul_lo_u32 v[\vRemainder], v[\vDivisor], v[\vQuotient] //
+v_mul_hi_u32 v[\vTmp0], v[\vDivisor], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp1], vcc, 0x0, v[\vRemainder]  //
+v_cmp_ne_i32 s[\sTmp:\sTmp+1], 0x0, v[\vTmp0]      //
+v_cndmask_b32 v[\vRemainder], v[\vTmp1], v[\vRemainder], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vRemainder], v[\vRemainder], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vQuotient], v[\vRemainder] //
+_v_add_co_u32 v[\vQuotient], vcc, v[\vQuotient], v[\vRemainder] //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vTmp0], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vQuotient], v[\vQuotient], v[\vDividend] //
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vDividend], v[\vRemainder] //
+v_cmp_ge_u32 s[\sTmp:\sTmp+1], v[\vDividend], v[\vRemainder] //
+_v_add_co_u32 v[\vRemainder], vcc, 0x1, v[\vQuotient] //
+_v_add_co_u32 v[\vTmp1], vcc, -1, v[\vQuotient]    //
+v_cmp_le_u32 vcc, v[\vDivisor], v[\vTmp0]          //
+s_and_b64 vcc, s[\sTmp:\sTmp+1], vcc               //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vRemainder], vcc //
+v_cndmask_b32 v[\vQuotient], v[\vTmp1], v[\vQuotient], s[\sTmp:\sTmp+1] //
+v_cmp_ne_i32 vcc, 0x0, v[\vDivisor]                //
+v_cndmask_b32 v[\vQuotient], -1, v[\vQuotient], vcc // final result
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vRemainder], vcc, v[\vDividend], v[\vRemainder] // final result
+.endm
+
+/******************************************/
+/* 4x8 thread-tile                        */
+/******************************************/
+.macro MAC_4x8_X0
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[0] iui=0
+s_setprio 1 // Raise priority while processing macs
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[1]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[4]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[5]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[2] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[3]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[6]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[7]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[8] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[9]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[12]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[13]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[10] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[11]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[14]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[15]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[16] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[17]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[20]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[21]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[18] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[19]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[22]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[23]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[24] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[25]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[28]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[29]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[26] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[27]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[30]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[31]
+s_setprio 0 // Reset priority after macs
+.endm
+.macro MAC_4x8_X1
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[0] iui=0
+s_setprio 1 // Raise priority while processing macs
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[1]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[4]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[5]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[2] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[3]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[6]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[7]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[8] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[9]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[12]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[13]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[10] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[11]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[14]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[15]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[16] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[17]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[20]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[21]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[18] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[19]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[22]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[23]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[24] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[25]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[28]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[29]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[26] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[27]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[30]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[31]
+s_setprio 0 // Reset priority after macs
+.endm
+
+
+
+
+/***** program start from here *****/
+
+.long 0xC00A0600, 0x00000008
+.long 0xC00A0D00, 0x00000028
+.long 0xC00A0C00, 0x00000050
+.long 0xC0020B40, 0x0000006C
+.long 0x7EC80300
+.long 0x26CA00BF
+.long 0xB8D0F804
+.long 0xD1130004, 0x0000A0B0
+.long 0x20CC0884
+.long 0x7EA40566
+.long 0xD1130067, 0x0000A08F
+.long 0x7EA20567
+.long 0xBF068151
+.long 0xBF8400EC
+.long 0xBF8CC07F
+.long 0xBE880034
+.long 0xBE890035
+.long 0xBE8A00FF, 0x80000000
+.long 0xBE8B00FF, 0x00020000
+.long 0x96553104
+.long 0x92543104
+.long 0x8ED48154
+.long 0x80085408
+.long 0x82095509
+.long 0x9254A030
+.long 0x92545402
+.long 0x92558830
+.long 0x92555552
+.long 0x81545554
+.long 0x2000CA85
+.long 0xD2850004, 0x00020030
+.long 0x2602CA9F
+.long 0x24020281
+.long 0x32A40304
+.long 0x68A4A454
+.long 0x24A4A481
+.long 0x8E478230
+.long 0x80C7FF47, 0x00000120
+.long 0x68A6A447
+.long 0x68A8A647
+.long 0x68AAA847
+.long 0xBECC00FF, 0x00000480
+.long 0x924C4C52
+.long 0xBE8C0036
+.long 0xBE8D0037
+.long 0xBE8E00FF, 0x80000000
+.long 0xBE8F00FF, 0x00020000
+.long 0x96553304
+.long 0x92543304
+.long 0x8ED48154
+.long 0x800C540C
+.long 0x820D550D
+.long 0x9254C032
+.long 0x92545403
+.long 0x92559032
+.long 0x92555552
+.long 0x81545554
+.long 0x2004CA85
+.long 0xD2850004, 0x00020432
+.long 0x2606CA9F
+.long 0x24060681
+.long 0x32AC0704
+.long 0x68ACAC54
+.long 0x24ACAC81
+.long 0x8E4A8232
+.long 0x80CAFF4A, 0x00000120
+.long 0x68AEAC4A
+.long 0x68B0AE4A
+.long 0x68B2B04A
+.long 0x68B4B24A
+.long 0x68B6B44A
+.long 0x68B8B64A
+.long 0x68BAB84A
+.long 0xBECE00FF, 0x00000900
+.long 0x924E4E52
+.long 0x814EFF4E, 0x00002400
+.long 0xBF8A0000
+.long 0xBEFC004C
+.long 0x814DFF4C, 0x00001200
+.long 0xE0511000, 0x80023052
+.long 0xE0511120, 0x80023153
+.long 0xE0511240, 0x80023254
+.long 0xE0511360, 0x80023355
+.long 0xBEFC004E
+.long 0x814FFF4E, 0x00002400
+.long 0xE0511000, 0x80034456
+.long 0xE0511120, 0x80034557
+.long 0xE0511240, 0x80034658
+.long 0xE0511360, 0x80034759
+.long 0xE0511480, 0x8003485A
+.long 0xE05115A0, 0x8003495B
+.long 0xE05116C0, 0x80034A5C
+.long 0xE05117E0, 0x80034B5D
+.long 0xBEFC004D
+.long 0x8008FF08, 0x00000080
+.long 0x82098009
+.long 0x800CFF0C, 0x00000080
+.long 0x820D800D
+.long 0xE0511000, 0x80023052
+.long 0xE0511120, 0x80023153
+.long 0xE0511240, 0x80023254
+.long 0xE0511360, 0x80023355
+.long 0xBEFC004F
+.long 0xBF800000
+.long 0xE0511000, 0x80034456
+.long 0xE0511120, 0x80034557
+.long 0xE0511240, 0x80034658
+.long 0xE0511360, 0x80034759
+.long 0xE0511480, 0x8003485A
+.long 0xE05115A0, 0x8003495B
+.long 0xE05116C0, 0x80034A5C
+.long 0xE05117E0, 0x80034B5D
+.long 0x8008FF08, 0x00000080
+.long 0x82098009
+.long 0x800CFF0C, 0x00000080
+.long 0x820D800D
+.long 0xBEFC004C
+.long 0xBF8C4F74
+.long 0xBF8A0000
+.long 0xBF8C0F7C
+.long 0xBF8A0000
+.long 0x8F2E862D
+.long 0x80AE2E80
+.long 0xBF03C22E
+.long 0xBF85004F
+.long 0xBF8A0000
+.long 0xE0511000, 0x80023052
+.long 0xE0511120, 0x80023153
+.long 0xE0511240, 0x80023254
+.long 0xE0511360, 0x80023355
+.long 0xBEFC004E
+.long 0xBF800000
+.long 0xE0511000, 0x80034456
+.long 0xE0511120, 0x80034557
+.long 0xE0511240, 0x80034658
+.long 0xE0511360, 0x80034759
+.long 0xE0511480, 0x8003485A
+.long 0xE05115A0, 0x8003495B
+.long 0xE05116C0, 0x80034A5C
+.long 0xE05117E0, 0x80034B5D
+.long 0xBF8C4F74
+.long 0xBF8A0000
+.long 0x8008FF08, 0x00000080
+.long 0x82098009
+.long 0xBF8C0F7C
+.long 0xBF8A0000
+.long 0x800CFF0C, 0x00000080
+.long 0x820D800D
+.long 0xBEFC004D
+.long 0xBF8A0000
+.long 0xE0511000, 0x80023052
+.long 0xE0511120, 0x80023153
+.long 0xE0511240, 0x80023254
+.long 0xE0511360, 0x80023355
+.long 0xBEFC004F
+.long 0xBF800000
+.long 0xE0511000, 0x80034456
+.long 0xE0511120, 0x80034557
+.long 0xE0511240, 0x80034658
+.long 0xE0511360, 0x80034759
+.long 0xE0511480, 0x8003485A
+.long 0xE05115A0, 0x8003495B
+.long 0xE05116C0, 0x80034A5C
+.long 0xE05117E0, 0x80034B5D
+.long 0xBF8C4F74
+.long 0xBF8A0000
+.long 0x8008FF08, 0x00000080
+.long 0x82098009
+.long 0xBF8C0F7C
+.long 0xBF8A0000
+.long 0x800CFF0C, 0x00000080
+.long 0x820D800D
+.long 0xBEFC004C
+.long 0x802E822E
+.long 0xBF03C22E
+.long 0xBF84FFB1
+.long 0xBF8C0F78
+.long 0xBF8A0000
+.long 0xBF8C0F70
+.long 0xBF8A0000
+.long 0xBF810000
+.long 0xC0060700, 0x00000000
+.long 0xC00A0800, 0x00000018
+.long 0xC00A0A00, 0x00000038
+.long 0xC00A0900, 0x00000040
+.long 0xD3D94000, 0x18000080
+.long 0xD3D94001, 0x18000080
+.long 0xD3D94002, 0x18000080
+.long 0xD3D94003, 0x18000080
+.long 0xD3D94004, 0x18000080
+.long 0xD3D94005, 0x18000080
+.long 0xD3D94006, 0x18000080
+.long 0xD3D94007, 0x18000080
+.long 0xD1130001, 0x00011F65
+.long 0xD285005E, 0x000202C0
+.long 0x20040281
+.long 0xD2850002, 0x000204A0
+.long 0x2002CA84
+.long 0x24020283
+.long 0x68BCBD01
+.long 0x24BCBC81
+.long 0x68BCBD02
+.long 0x68BCBC80
+.long 0x68BEBCFF, 0x00001200
+.long 0xBF8A0000
+.long 0xD1130001, 0x00011F65
+.long 0xD2850060, 0x000202C0
+.long 0x20040281
+.long 0xD2850002, 0x000204A0
+.long 0x2002CA84
+.long 0x24020283
+.long 0x68C0C101
+.long 0x24C0C081
+.long 0x68C0C102
+.long 0x9254FF52, 0x00000900
+.long 0x68C0C054
+.long 0x68C0C0FF, 0x00002400
+.long 0x68C2C0FF, 0x00002400
+.long 0xBF8CC07F
+.long 0xBE900022
+.long 0xBE910023
+.long 0xBE9200FF, 0x80000000
+.long 0xBE9300FF, 0x00020000
+.long 0x925603C0
+.long 0x96552656
+.long 0x92542656
+.long 0x8ED48154
+.long 0x80105410
+.long 0x82115511
+.long 0x96552704
+.long 0x92542704
+.long 0x8ED48154
+.long 0x80105410
+.long 0x82115511
+.long 0xD2850004, 0x0002CC90
+.long 0xD2850003, 0x00004D04
+.long 0x2608CA8F
+.long 0xD2850005, 0x00004D04
+.long 0x200CCA84
+.long 0x240C0C82
+.long 0x68D60B03
+.long 0x925402A0
+.long 0x32D40C54
+.long 0xD1FE0068, 0x0206D76A
+.long 0xBE940020
+.long 0xBE950021
+.long 0xBE9600FF, 0x80000000
+.long 0xBE9700FF, 0x00020000
+.long 0x925603C0
+.long 0x96552456
+.long 0x92542456
+.long 0x8ED48154
+.long 0x80145414
+.long 0x82155515
+.long 0x96552504
+.long 0x92542504
+.long 0x8ED48154
+.long 0x80145414
+.long 0x82155515
+.long 0xD2850004, 0x0002CC90
+.long 0xD2850003, 0x00004904
+.long 0x2608CA8F
+.long 0xD2850005, 0x00004904
+.long 0x200CCA84
+.long 0x240C0C82
+.long 0x68D60B03
+.long 0x925402A0
+.long 0x32D40C54
+.long 0xD1FE0069, 0x0206D76A
+.long 0xBF8A0000
+.long 0xD9FE0000, 0x2000005E
+.long 0xD9FE0900, 0x2800005E
+.long 0xD9FE0040, 0x2400005E
+.long 0xD9FE0940, 0x2C00005E
+.long 0xBF8A0000
+.long 0xD9FE0000, 0x44000060
+.long 0xD9FE0040, 0x48000060
+.long 0x8F2E862D
+.long 0x80AE2E80
+.long 0xBF03C22E
+.long 0xBF850065
+.long 0xBF8A0000
+.long 0xBF8CC17F
+.long 0xD3ED0000, 0x04028920
+.long 0xD3ED0004, 0x04128928
+.long 0xD3ED0000, 0x04028B21
+.long 0xD3ED0004, 0x04128B29
+.long 0xD3ED0000, 0x04028D22
+.long 0xBF8A0000
+.long 0xD3ED0004, 0x04128D2A
+.long 0xD9FE0000, 0x3000005F
+.long 0xD3ED0000, 0x04028F23
+.long 0xD9FE0900, 0x3800005F
+.long 0xD3ED0004, 0x04128F2B
+.long 0xD9FE0040, 0x3400005F
+.long 0xBF8CC37F
+.long 0xD3ED0000, 0x04029124
+.long 0xD9FE0940, 0x3C00005F
+.long 0xD3ED0004, 0x0412912C
+.long 0xD3ED0000, 0x04029325
+.long 0xD3ED0004, 0x0412932D
+.long 0xD3ED0000, 0x04029526
+.long 0xD3ED0004, 0x0412952E
+.long 0xBF8A0000
+.long 0xD9FE0000, 0x4C000061
+.long 0xD3ED0000, 0x04029727
+.long 0xD9FE0040, 0x50000061
+.long 0xD3ED0004, 0x0412972F
+.long 0xBF8A0000
+.long 0xBF8CC17F
+.long 0xD3ED0000, 0x04029930
+.long 0xD3ED0004, 0x04129938
+.long 0xD3ED0000, 0x04029B31
+.long 0xD3ED0004, 0x04129B39
+.long 0xD3ED0000, 0x04029D32
+.long 0xBF8A0000
+.long 0xD3ED0004, 0x04129D3A
+.long 0xD9FE0000, 0x2000005E
+.long 0xD3ED0000, 0x04029F33
+.long 0xD9FE0900, 0x2800005E
+.long 0xD3ED0004, 0x04129F3B
+.long 0xD9FE0040, 0x2400005E
+.long 0xBF8CC37F
+.long 0xD3ED0000, 0x0402A134
+.long 0xD9FE0940, 0x2C00005E
+.long 0xD3ED0004, 0x0412A13C
+.long 0xD3ED0000, 0x0402A335
+.long 0xD3ED0004, 0x0412A33D
+.long 0xD3ED0000, 0x0402A536
+.long 0xD3ED0004, 0x0412A53E
+.long 0xBF8A0000
+.long 0xD9FE0000, 0x44000060
+.long 0xD3ED0000, 0x0402A737
+.long 0xD9FE0040, 0x48000060
+.long 0xD3ED0004, 0x0412A73F
+.long 0x802E822E
+.long 0xBF03C22E
+.long 0xBF84FF9B
+.long 0xBF8CC17F
+.long 0xD3ED0000, 0x04028920
+.long 0xE0541000, 0x80041068
+.long 0xE0541020, 0x80041268
+.long 0xD3ED0004, 0x04128928
+.long 0xD3ED0000, 0x04028B21
+.long 0xBF8A0000
+.long 0xD3ED0004, 0x04128B29
+.long 0xD9FE0000, 0x3000005F
+.long 0xD3ED0000, 0x04028D22
+.long 0xD9FE0900, 0x3800005F
+.long 0xD3ED0004, 0x04128D2A
+.long 0xD9FE0040, 0x3400005F
+.long 0xD3ED0000, 0x04028F23
+.long 0xD9FE0940, 0x3C00005F
+.long 0xD3ED0004, 0x04128F2B
+.long 0xBF8CC37F
+.long 0xD3ED0000, 0x04029124
+.long 0xD3ED0004, 0x0412912C
+.long 0xD3ED0000, 0x04029325
+.long 0xD3ED0004, 0x0412932D
+.long 0xD3ED0000, 0x04029526
+.long 0xBF8A0000
+.long 0xD9FE0000, 0x4C000061
+.long 0xD3ED0004, 0x0412952E
+.long 0xD9FE0040, 0x50000061
+.long 0xD3ED0000, 0x04029727
+.long 0xD3ED0004, 0x0412972F
+.long 0xBF8CC17F
+.long 0xD3ED0000, 0x04029930
+.long 0xD3ED0004, 0x04129938
+.long 0xD3ED0000, 0x04029B31
+.long 0xD3ED0004, 0x04129B39
+.long 0xD3ED0000, 0x04029D32
+.long 0xD3ED0004, 0x04129D3A
+.long 0xD3ED0000, 0x04029F33
+.long 0xD3ED0004, 0x04129F3B
+.long 0xBF8CC07F
+.long 0xD3ED0000, 0x0402A134
+.long 0xD3ED0000, 0x0402A335
+.long 0xD3ED0000, 0x0402A536
+.long 0xD3ED0000, 0x0402A737
+.long 0xD3ED0004, 0x0412A13C
+.long 0xD3ED0004, 0x0412A33D
+.long 0xD3ED0004, 0x0412A53E
+.long 0xD3ED0004, 0x0412A73F
+.long 0x7ED602FF, 0xFFFF0000
+.long 0xD3D84000, 0x18000100
+.long 0x0A000028
+.long 0xD3D84001, 0x18000101
+.long 0x0A020228
+.long 0xD3D84002, 0x18000102
+.long 0x0A040428
+.long 0xD3D84003, 0x18000103
+.long 0x0A060628
+.long 0xBF8C0F71
+.long 0x24D42090
+.long 0xD1CB0000, 0x0400536A
+.long 0x26D420FF, 0xFFFF0000
+.long 0xD1CB0001, 0x0404536A
+.long 0x20000090
+.long 0xD2010000, 0x0402D701
+.long 0x24D42290
+.long 0xD1CB0002, 0x0408536A
+.long 0x26D422FF, 0xFFFF0000
+.long 0xD1CB0003, 0x040C536A
+.long 0x20040490
+.long 0xD2010001, 0x040AD703
+.long 0xE0741000, 0x80050069
+.long 0xD3D84004, 0x18000104
+.long 0x0A080828
+.long 0xD3D84005, 0x18000105
+.long 0x0A0A0A28
+.long 0xD3D84006, 0x18000106
+.long 0x0A0C0C28
+.long 0xD3D84007, 0x18000107
+.long 0x0A0E0E28
+.long 0xBF8C0F71
+.long 0x24D42490
+.long 0xD1CB0004, 0x0410536A
+.long 0x26D424FF, 0xFFFF0000
+.long 0xD1CB0005, 0x0414536A
+.long 0x20080890
+.long 0xD2010002, 0x0412D705
+.long 0x24D42690
+.long 0xD1CB0006, 0x0418536A
+.long 0x26D426FF, 0xFFFF0000
+.long 0xD1CB0007, 0x041C536A
+.long 0x200C0C90
+.long 0xD2010003, 0x041AD707
+.long 0xE0741020, 0x80050269
+.long 0xBF8C0000
+.long 0xBF810000

--- a/Tensile/ReplacementKernels-cov3/Cijk_Alik_Bljk_BBH_MT64x128x32_AF0EM8_ASEM8_FL0_GRVW4_ISA908_MDA2_PGR1_PLR1_SU32_TT4_8_VAW1_VW4_WG16_16_1_WGM8.s.txt
+++ b/Tensile/ReplacementKernels-cov3/Cijk_Alik_Bljk_BBH_MT64x128x32_AF0EM8_ASEM8_FL0_GRVW4_ISA908_MDA2_PGR1_PLR1_SU32_TT4_8_VAW1_VW4_WG16_16_1_WGM8.s.txt
@@ -1,0 +1,930 @@
+
+
+/******************************************/
+/* Function Prefix                        */
+/******************************************/
+
+
+
+/******************************************/
+/* Begin Kernel                           */
+/******************************************/
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx908+sram-ecc"
+.text
+.protected Cijk_Alik_Bljk_BBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT4_8_TLDS0_USFGRO1_VAW1_VS1_VW4_WSGRA0_WSGRB0_WG16_16_1_WGM8
+.globl Cijk_Alik_Bljk_BBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT4_8_TLDS0_USFGRO1_VAW1_VS1_VW4_WSGRA0_WSGRB0_WG16_16_1_WGM8
+.p2align 8
+.type Cijk_Alik_Bljk_BBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT4_8_TLDS0_USFGRO1_VAW1_VS1_VW4_WSGRA0_WSGRB0_WG16_16_1_WGM8,@function
+.section .rodata,#alloc
+.p2align 6
+.amdhsa_kernel Cijk_Alik_Bljk_BBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT4_8_TLDS0_USFGRO1_VAW1_VS1_VW4_WSGRA0_WSGRB0_WG16_16_1_WGM8
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_next_free_vgpr 108 // vgprs
+  .amdhsa_next_free_sgpr 98 // sgprs
+  .amdhsa_group_segment_fixed_size 28672 // lds bytes
+  .amdhsa_private_segment_fixed_size 0
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+.text
+
+/******************************************/
+/* Optimizations and Config:              */
+/******************************************/
+/* ThreadTile= 4 x 8 */
+/* SubGroup= 16 x 16 */
+/* VectorWidth=4 */
+/* GlobalLoadVectorWidthA=4, GlobalLoadVectorWidthB=4 */
+/* DirectToLdsA=False */
+/* DirectToLdsB=False */
+/* UseSgprForGRO=1 */
+.amdgpu_metadata
+---
+amdhsa.version:
+  - 1
+  - 0
+amdhsa.kernels:
+  - .name: Cijk_Alik_Bljk_BBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT4_8_TLDS0_USFGRO1_VAW1_VS1_VW4_WSGRA0_WSGRB0_WG16_16_1_WGM8
+    .symbol: 'Cijk_Alik_Bljk_BBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT4_8_TLDS0_USFGRO1_VAW1_VS1_VW4_WSGRA0_WSGRB0_WG16_16_1_WGM8.kd'
+    .language:                   OpenCL C
+    .language_version:
+      - 2
+      - 0
+    .args:
+      - .name:            sizeC
+        .size:            8
+        .offset:          0
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            sizeA
+        .size:            8
+        .offset:          8
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            sizeB
+        .size:            8
+        .offset:          16
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            D
+        .size:            8
+        .offset:          24
+        .value_kind:      global_buffer
+        .value_type:      struct
+        .address_space:   generic
+      - .name:            C
+        .size:            8
+        .offset:          32
+        .value_kind:      global_buffer
+        .value_type:      struct
+        .address_space:   generic
+      - .name:            A
+        .size:            8
+        .offset:          40
+        .value_kind:      global_buffer
+        .value_type:      struct
+        .address_space:   generic
+      - .name:            B
+        .size:            8
+        .offset:          48
+        .value_kind:      global_buffer
+        .value_type:      struct
+        .address_space:   generic
+      - .name:            alpha
+        .size:            4
+        .offset:          56
+        .value_kind:      by_value
+        .value_type:      f32
+      - .name:            beta
+        .size:            4
+        .offset:          60
+        .value_kind:      by_value
+        .value_type:      f32
+      - .name:            strideD0
+        .size:            4
+        .offset:          64
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideD1
+        .size:            4
+        .offset:          68
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideC0
+        .size:            4
+        .offset:          72
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideC1
+        .size:            4
+        .offset:          76
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideA0
+        .size:            4
+        .offset:          80
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideA1
+        .size:            4
+        .offset:          84
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideB0
+        .size:            4
+        .offset:          88
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideB1
+        .size:            4
+        .offset:          92
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree0
+        .size:            4
+        .offset:          96
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree1
+        .size:            4
+        .offset:          100
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree2
+        .size:            4
+        .offset:          104
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesSum0
+        .size:            4
+        .offset:          108
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            OrigStaggerUIter
+        .size:            4
+        .offset:          112
+        .value_kind:      by_value
+        .value_type:      i32
+      - .name:            NumWorkGroups0
+        .size:            4
+        .offset:          116
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            NumWorkGroups1
+        .size:            4
+        .offset:          120
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            MagicNumberProblemNumGroupTiles0
+        .size:            4
+        .offset:          124
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            GridNumWorkGroups0
+        .size:            4
+        .offset:          128
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            NumFullBlocks
+        .size:            4
+        .offset:          132
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            WgmRemainder1
+        .size:            4
+        .offset:          136
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            MagicNumberWgmRemainder1
+        .size:            4
+        .offset:          140
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            padding
+        .size:            4
+        .offset:          144
+        .value_kind:      by_value
+        .value_type:      u32
+    .group_segment_fixed_size:   28672
+    .kernarg_segment_align:      8
+    .kernarg_segment_size:       152
+    .max_flat_workgroup_size:    256
+    .private_segment_fixed_size: 0
+    .sgpr_count:                 98
+    .sgpr_spill_count:           0
+    .vgpr_count:                 108
+    .vgpr_spill_count:           0
+    .wavefront_size:             64
+...
+.end_amdgpu_metadata
+Cijk_Alik_Bljk_BBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT4_8_TLDS0_USFGRO1_VAW1_VS1_VW4_WSGRA0_WSGRB0_WG16_16_1_WGM8:
+
+/******************************************/
+/* Asm syntax workarounds                 */
+/******************************************/
+.macro _v_add_co_u32 dst, cc, src0, src1, dpp=
+   v_add_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+.macro _v_sub_co_u32 dst, cc, src0, src1, dpp=
+   v_sub_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+.macro _v_addc_co_u32 dst, ccOut, src0, ccIn, src1, dpp=
+   v_addc_co_u32 \dst, \ccOut, \src0, \ccIn, \src1 \dpp
+.endm
+.macro _v_add_lshl_u32 dst, src0, src1, shiftCnt
+    v_add_lshl_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+.macro _v_lshl_add_u32 dst, src0, src1, shiftCnt
+    v_lshl_add_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+/******************************************/
+/* Magic div and mod functions            */
+/******************************************/
+.macro V_MAGIC_DIV dstIdx, dividend, magicNumber, magicShift
+    v_mul_lo_u32 v[\dstIdx+0], \dividend, \magicNumber
+    v_mul_hi_u32 v[\dstIdx+1], \dividend, \magicNumber
+    v_lshrrev_b64 v[\dstIdx:\dstIdx+1], \magicShift, v[\dstIdx:\dstIdx+1]
+.endm
+
+/******************************************/
+/* VGPR Assignments                       */
+/******************************************/
+.set vgprValuC, 0
+/* ValuA/B   Xn=PLR buffer idx,  In=InnerUnroll idx */
+.set vgprValuA_X0_I0, 32
+.set vgprValuA_X1_I0, 34
+.set vgprG2LA, 36
+.set vgprValuB_X0_I0, 40
+.set vgprValuB_X1_I0, 44
+.set vgprG2LB, 48
+.set vgprLocalWriteAddrA, 56
+.set vgprLocalWriteAddrB, 57
+.set vgprGlobalReadOffsetA, 58
+.set vgprGlobalReadOffsetB, 60
+.set vgprLocalReadAddrA, 64
+.set vgprLocalReadAddrB, 65
+.set vgprSerial, 66
+/* Num VGPR=67 */
+
+/******************************************/
+/* SGPR Assignments                       */
+/******************************************/
+.set sgprKernArgAddress, 0
+.set sgprWorkGroup0, 2
+.set sgprWorkGroup1, 3
+.set sgprWorkGroup2, 4
+.set sgprNumWorkGroups0, 5
+.set sgprNumWorkGroups1, 6
+.set sgprSrdA, 8
+.set sgprSrdB, 12
+.set sgprSrdD, 16
+.set sgprSrdC, 20
+.set sgprTensor2dSizeC, 24
+.set sgprTensor2dSizeA, 26
+.set sgprTensor2dSizeB, 28
+.set sgprSaveExecMask, 30
+.set sgprAddressD, 32
+.set sgprAddressC, 34
+.set sgprStridesD, 36
+.set sgprStridesC, 38
+.set sgprAlpha, 40
+.set sgprSizesFree, 41
+.set sgprSizesSum, 44
+.set sgprLoopCounters, 45
+.set sgprOrigLoopCounter, 46
+.set sgprStridesA, 47
+.set sgprStridesB, 49
+.set sgprAddressA, 51
+.set sgprAddressB, 53
+.set sgprShadowLimitA, 56
+.set sgprShadowLimitB, 58
+.set sgprOrigStaggerUIter, 60
+.set sgprStaggerUIter, 61
+.set sgprWrapUA, 62
+.set sgprWrapUB, 64
+.set sgprNumFullBlocks, 66
+.set sgprWgmRemainder1, 67
+.set sgprMagicNumberWgmRemainder1, 68
+.set sgprGlobalReadIncsA, 69
+.set sgprGlobalReadIncsB, 70
+/* max SGPR=98 */
+
+/******************************************/
+/* 2GB limit - set offsets to -1 to exceed this and clamp */
+/******************************************/
+.set BufferLimit, 0x80000000
+
+/******************************************/
+/* Bits 127:96 of SRD.  Set DataFormat = 32 bit */
+/******************************************/
+.set Srd127_96, 0x0020000
+.set BufferOOB, 0x80000000
+
+/* Global Offset A */
+.macro GLOBAL_OFFSET_A vgprAddr vgprOffsetL vgprOffset0I vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStridesA+0], v[\vgprOffset0I] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprTmp+0], v[\vgprOffsetL] // accumulate d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, 0x4, v[\vgprAddr+0] // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/* Global Offset B */
+.macro GLOBAL_OFFSET_B vgprAddr vgprOffset1J vgprOffsetL vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStridesB+0], v[\vgprOffsetL] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprTmp+0], v[\vgprOffset1J] // accumulate d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, 0x4, v[\vgprAddr+0] // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+ //****************
+ // start kernel
+
+.long 0xC0020680, 0x00000008
+.long 0xC00206C0, 0x0000000C
+.long 0xC0020D00, 0x00000028
+.long 0xC0020D40, 0x0000002C
+.long 0xC0020C00, 0x00000050
+.long 0xC0020C40, 0x00000054
+.long 0xBEFC00FF, 0x00003000
+.long 0x7EC80300
+.long 0x26CA00BF
+.long 0x2004C886
+.long 0x7E9C0502
+.long 0xBF8CC07F
+.long 0xC0020C80, 0x00000058
+.long 0xC0020CC0, 0x0000005C
+.long 0xC0020D80, 0x00000030
+.long 0xC0020DC0, 0x00000034
+.long 0xC0020700, 0x00000010
+.long 0xC0020740, 0x00000014
+.long 0xBE880034
+.long 0xBE890035
+.long 0xBE8B00FF, 0x00020000
+.long 0xBE8A00FF, 0x80000000
+.long 0x9254C030
+.long 0x92545402
+.long 0x8E55844E
+.long 0x92533055
+.long 0x81545354
+.long 0x2000CA84
+.long 0xD2850004, 0x00020030
+.long 0x2602CA8F
+.long 0x24020281
+.long 0x32A40304
+.long 0x68A4A454
+.long 0x24A4A481
+.long 0x8E478330
+.long 0x80C7FF47, 0x00000108
+.long 0x68A6A447
+.long 0x68A8A647
+.long 0x68AAA847
+.long 0xBED800FF, 0x00000420
+.long 0x9258584E
+.long 0xBEFC0058
+.long 0x8159FF58, 0x00001080
+.long 0xE0511000, 0x80023052
+.long 0xE0511108, 0x80023153
+.long 0xE0511210, 0x80023254
+.long 0xE0511318, 0x80023355
+.long 0xBF8CC07F
+.long 0xBE8C0036
+.long 0xBE8D0037
+.long 0xBE8F00FF, 0x00020000
+.long 0xBE8E00FF, 0x80000000
+.long 0x9254FF32, 0x00000080
+.long 0x92545403
+.long 0x925532A0
+.long 0x9255554E
+.long 0x81545554
+.long 0x2004CA84
+.long 0x2606CA8F
+.long 0x24060681
+.long 0xD2850004, 0x00020432
+.long 0x32AC0704
+.long 0x68ACAC54
+.long 0x24ACAC81
+.long 0x8E4A8332
+.long 0x80CAFF4A, 0x00000108
+.long 0x68AEAC4A
+.long 0x68B0AE4A
+.long 0x68B2B04A
+.long 0x68B4B24A
+.long 0x68B6B44A
+.long 0x68B8B64A
+.long 0x68BAB84A
+.long 0xBEDA00FF, 0x00000840
+.long 0x925A5A4E
+.long 0x815AFF5A, 0x00002100
+.long 0xBEFC005A
+.long 0x815BFF5A, 0x00002100
+.long 0xE0511000, 0x80034456
+.long 0xE0511108, 0x80034557
+.long 0xE0511210, 0x80034658
+.long 0xE0511318, 0x80034759
+.long 0xE0511420, 0x8003485A
+.long 0xE0511528, 0x8003495B
+.long 0xE0511630, 0x80034A5C
+.long 0xE0511738, 0x80034B5D
+.long 0xC0020800, 0x00000018
+.long 0xC0020840, 0x0000001C
+.long 0xC0020880, 0x00000020
+.long 0xC00208C0, 0x00000024
+.long 0xC0020600, 0x00000000
+.long 0xC0020640, 0x00000004
+.long 0xC0020A00, 0x00000038
+.long 0xC0020900, 0x00000040
+.long 0xC0020940, 0x00000044
+.long 0xC0020980, 0x00000048
+.long 0xC00209C0, 0x0000004C
+.long 0xC0020A80, 0x00000060
+.long 0xC0020AC0, 0x00000064
+.long 0xC0020B00, 0x00000068
+.long 0xC0020B40, 0x0000006C
+.long 0xD1130001, 0x00013F65
+.long 0xD285005E, 0x00020290
+.long 0x20020282
+.long 0xD2850001, 0x00020282
+.long 0x68BCBD01
+.long 0x2002CA85
+.long 0x68BCBD01
+.long 0x24BCBC82
+.long 0x68BCBC80
+.long 0x68BEBCFF, 0x00001080
+.long 0xD1130001, 0x00013F65
+.long 0xD2850060, 0x00020290
+.long 0x20020282
+.long 0xD2850001, 0x00020282
+.long 0x68C0C101
+.long 0x2002CA85
+.long 0x68C0C101
+.long 0x24C0C082
+.long 0x9254FF4E, 0x00000840
+.long 0x68C0C054
+.long 0x68C0C0FF, 0x00002100
+.long 0x68C2C0FF, 0x00002100
+.long 0x925488FF, 0x00000108
+.long 0x815C545A
+.long 0x815D545B
+.long 0x68A4A4C0
+.long 0x68A6A6C0
+.long 0x68A8A8C0
+.long 0x68AAAAC0
+.long 0xBE900022
+.long 0xBE910023
+.long 0xBE9200FF, 0x80000000
+.long 0xBE9300FF, 0x00020000
+.long 0xBE940020
+.long 0xBE950021
+.long 0xBE9600FF, 0x80000000
+.long 0xBE9700FF, 0x00020000
+.long 0x925603FF, 0x00000080
+.long 0x96552656
+.long 0x92542656
+.long 0x8ED48154
+.long 0x80105410
+.long 0x82115511
+.long 0x80145414
+.long 0x82155515
+.long 0x96552704
+.long 0x92542704
+.long 0x8ED48154
+.long 0x80105410
+.long 0x82115511
+.long 0x80145414
+.long 0x82155515
+.long 0x2008C886
+.long 0xD2850004, 0x000208A0
+.long 0xD2850003, 0x00004D04
+.long 0x2608C89F
+.long 0xD2850005, 0x00004D04
+.long 0x2608C8BF
+.long 0x200C0885
+.long 0x240C0C82
+.long 0x68440B03
+.long 0x925402C0
+.long 0x32400C54
+.long 0xD1FE0068, 0x02064520
+.long 0xBEFC0059
+.long 0xD3D94000, 0x18000080
+.long 0xD3D94001, 0x18000080
+.long 0xD3D94002, 0x18000080
+.long 0xD3D94003, 0x18000080
+.long 0xD3D94004, 0x18000080
+.long 0xD3D94005, 0x18000080
+.long 0xD3D94006, 0x18000080
+.long 0xD3D94007, 0x18000080
+.long 0xD3D94008, 0x18000080
+.long 0xD3D94009, 0x18000080
+.long 0xD3D9400A, 0x18000080
+.long 0xD3D9400B, 0x18000080
+.long 0xD3D9400C, 0x18000080
+.long 0xD3D9400D, 0x18000080
+.long 0xD3D9400E, 0x18000080
+.long 0xD3D9400F, 0x18000080
+.long 0xE0511000, 0x80023052
+.long 0xE0511108, 0x80023153
+.long 0xE0511210, 0x80023254
+.long 0xE0511318, 0x80023355
+.long 0xBEFC005B
+.long 0x68ACACC0
+.long 0x68AEAEC0
+.long 0x68B0B0C0
+.long 0x68B2B2C0
+.long 0x68B4B4C0
+.long 0x68B6B6C0
+.long 0x68B8B8C0
+.long 0x68BABAC0
+.long 0xE0511000, 0x80034456
+.long 0xE0511108, 0x80034557
+.long 0xE0511210, 0x80034658
+.long 0xE0511318, 0x80034759
+.long 0xD3D94010, 0x18000080
+.long 0xD3D94011, 0x18000080
+.long 0xD3D94012, 0x18000080
+.long 0xD3D94013, 0x18000080
+.long 0xD3D94014, 0x18000080
+.long 0xD3D94015, 0x18000080
+.long 0xD3D94016, 0x18000080
+.long 0xD3D94017, 0x18000080
+.long 0xD3D94018, 0x18000080
+.long 0xD3D94019, 0x18000080
+.long 0xD3D9401A, 0x18000080
+.long 0xD3D9401B, 0x18000080
+.long 0xD3D9401C, 0x18000080
+.long 0xD3D9401D, 0x18000080
+.long 0xD3D9401E, 0x18000080
+.long 0xD3D9401F, 0x18000080
+.long 0xE0511420, 0x8003485A
+.long 0xE0511528, 0x8003495B
+.long 0xE0511630, 0x80034A5C
+.long 0xE0511738, 0x80034B5D
+.long 0xBF8CC07F
+.long 0xBF8C4F74
+.long 0xBF8C0070
+.long 0xBF8A0000
+.long 0xD86C0000, 0x2000005E
+.long 0xD86C0840, 0x2100005E
+.long 0xD86C0008, 0x2200005E
+.long 0xD86C0848, 0x2300005E
+.long 0xBF8C0F7C
+.long 0xD86C0000, 0x34000060
+.long 0xD86C0008, 0x35000060
+.long 0xD86C0010, 0x36000060
+.long 0xD86C0018, 0x37000060
+.long 0x8F2E852D
+.long 0x80AE2E80
+.long 0xBF06802E
+.long 0xBF850234
+.long 0xBF8CC27F
+.long 0xD3EC0000, 0x04026920
+.long 0xD86C0010, 0x2400005E
+.long 0xD86C0850, 0x2500005E
+.long 0xD86C0018, 0x2600005E
+.long 0xD86C0858, 0x2700005E
+.long 0xD3EC0010, 0x04426921
+.long 0xD86C0020, 0x2800005E
+.long 0xD86C0860, 0x2900005E
+.long 0xD86C0020, 0x38000060
+.long 0xD86C0028, 0x39000060
+.long 0xBEFC0058
+.long 0xD3EC0000, 0x04026B22
+.long 0xD86C0028, 0x2A00005E
+.long 0xD86C0868, 0x2B00005E
+.long 0xD86C0030, 0x3A000060
+.long 0xD86C0038, 0x3B000060
+.long 0xD3EC0010, 0x04426B23
+.long 0xD86C0038, 0x2E00005E
+.long 0xD86C0878, 0x2F00005E
+.long 0xD86C0030, 0x2C00005E
+.long 0xD86C0870, 0x2D00005E
+.long 0xBF8CCE7F
+.long 0xD3EC0000, 0x04026D24
+.long 0x68A4A4C0
+.long 0x68A6A6C0
+.long 0x68A8A8C0
+.long 0x68AAAAC0
+.long 0xD3EC0010, 0x04426D25
+.long 0x68ACACC0
+.long 0x68AEAEC0
+.long 0x68B0B0C0
+.long 0x68B2B2C0
+.long 0xBF8CCC7F
+.long 0xD3EC0000, 0x04026F26
+.long 0x68B4B4C0
+.long 0x68B6B6C0
+.long 0x68B8B8C0
+.long 0x68BABAC0
+.long 0xD3EC0010, 0x04426F27
+.long 0xBF8CC87F
+.long 0xD3EC0000, 0x04027128
+.long 0xE0511000, 0x80023052
+.long 0xE0511108, 0x80023153
+.long 0xD3EC0010, 0x04427129
+.long 0xE0511210, 0x80023254
+.long 0xE0511318, 0x80023355
+.long 0xBEFC005A
+.long 0xBF8CC47F
+.long 0xD3EC0000, 0x0402732A
+.long 0xE0511000, 0x80034456
+.long 0xE0511108, 0x80034557
+.long 0xE0511210, 0x80034658
+.long 0xD3EC0010, 0x0442732B
+.long 0xE0511318, 0x80034759
+.long 0xE0511420, 0x8003485A
+.long 0xE0511528, 0x8003495B
+.long 0xBF8CC07F
+.long 0xD3EC0000, 0x0402752C
+.long 0xE0511630, 0x80034A5C
+.long 0xE0511738, 0x80034B5D
+.long 0xD3EC0010, 0x0442752D
+.long 0xBF8C4F74
+.long 0xBF8C0070
+.long 0xBF8A0000
+.long 0xD3EC0000, 0x0402772E
+.long 0xD86C0000, 0x2000005F
+.long 0xD86C0840, 0x2100005F
+.long 0xD86C0008, 0x2200005F
+.long 0xD86C0848, 0x2300005F
+.long 0xD3EC0010, 0x0442772F
+.long 0xBF8C0F7C
+.long 0xD86C0000, 0x3C000061
+.long 0xD86C0008, 0x3D000061
+.long 0xD86C0010, 0x3E000061
+.long 0xD86C0018, 0x3F000061
+.long 0x802E812E
+.long 0xBF8CC27F
+.long 0xD3EC0000, 0x04027920
+.long 0xD86C0010, 0x2400005F
+.long 0xD86C0850, 0x2500005F
+.long 0xD86C0018, 0x2600005F
+.long 0xD86C0858, 0x2700005F
+.long 0xD3EC0010, 0x04427921
+.long 0xD86C0020, 0x2800005F
+.long 0xD86C0860, 0x2900005F
+.long 0xD86C0020, 0x40000061
+.long 0xD86C0028, 0x41000061
+.long 0xBEFC0059
+.long 0xD3EC0000, 0x04027B22
+.long 0xD86C0028, 0x2A00005F
+.long 0xD86C0868, 0x2B00005F
+.long 0xD86C0030, 0x42000061
+.long 0xD86C0038, 0x43000061
+.long 0xD3EC0010, 0x04427B23
+.long 0xD86C0038, 0x2E00005F
+.long 0xD86C0878, 0x2F00005F
+.long 0xD86C0030, 0x2C00005F
+.long 0xD86C0870, 0x2D00005F
+.long 0xBF8CCE7F
+.long 0xD3EC0000, 0x04027D24
+.long 0x68A4A4C0
+.long 0x68A6A6C0
+.long 0x68A8A8C0
+.long 0x68AAAAC0
+.long 0xD3EC0010, 0x04427D25
+.long 0x68ACACC0
+.long 0x68AEAEC0
+.long 0x68B0B0C0
+.long 0x68B2B2C0
+.long 0xBF8CCC7F
+.long 0xD3EC0000, 0x04027F26
+.long 0x68B4B4C0
+.long 0x68B6B6C0
+.long 0x68B8B8C0
+.long 0x68BABAC0
+.long 0xD3EC0010, 0x04427F27
+.long 0xBF8CC87F
+.long 0xD3EC0000, 0x04028128
+.long 0xE0511000, 0x80023052
+.long 0xE0511108, 0x80023153
+.long 0xD3EC0010, 0x04428129
+.long 0xE0511210, 0x80023254
+.long 0xE0511318, 0x80023355
+.long 0xBEFC005B
+.long 0xBF8CC47F
+.long 0xD3EC0000, 0x0402832A
+.long 0xE0511000, 0x80034456
+.long 0xE0511108, 0x80034557
+.long 0xE0511210, 0x80034658
+.long 0xD3EC0010, 0x0442832B
+.long 0xE0511318, 0x80034759
+.long 0xE0511420, 0x8003485A
+.long 0xE0511528, 0x8003495B
+.long 0xBF8CC07F
+.long 0xD3EC0000, 0x0402852C
+.long 0xE0511630, 0x80034A5C
+.long 0xE0511738, 0x80034B5D
+.long 0xD3EC0010, 0x0442852D
+.long 0xBF8C4F74
+.long 0xBF8C0070
+.long 0xBF8A0000
+.long 0xD3EC0000, 0x0402872E
+.long 0xD86C0000, 0x2000005E
+.long 0xD86C0840, 0x2100005E
+.long 0xD86C0008, 0x2200005E
+.long 0xD86C0848, 0x2300005E
+.long 0xD3EC0010, 0x0442872F
+.long 0xBF8C0F7C
+.long 0xD86C0000, 0x34000060
+.long 0xD86C0008, 0x35000060
+.long 0xD86C0010, 0x36000060
+.long 0xD86C0018, 0x37000060
+.long 0x802E812E
+.long 0xBF00C22E
+.long 0xBF84FEFC
+.long 0xBF8CC27F
+.long 0xD3EC0000, 0x04026920
+.long 0xD86C0010, 0x2400005E
+.long 0xD86C0850, 0x2500005E
+.long 0xD86C0018, 0x2600005E
+.long 0xD86C0858, 0x2700005E
+.long 0xD3EC0010, 0x04426921
+.long 0xD86C0020, 0x2800005E
+.long 0xD86C0860, 0x2900005E
+.long 0xD86C0020, 0x38000060
+.long 0xD86C0028, 0x39000060
+.long 0xD3EC0000, 0x04026B22
+.long 0xD86C0028, 0x2A00005E
+.long 0xD86C0868, 0x2B00005E
+.long 0xD86C0030, 0x3A000060
+.long 0xD86C0038, 0x3B000060
+.long 0xD3EC0010, 0x04426B23
+.long 0xD86C0030, 0x2C00005E
+.long 0xD86C0870, 0x2D00005E
+.long 0xD86C0038, 0x2E00005E
+.long 0xD86C0878, 0x2F00005E
+.long 0xBF8CCE7F
+.long 0xD3EC0000, 0x04026D24
+.long 0xD3EC0010, 0x04426D25
+.long 0xBF8CCC7F
+.long 0xD3EC0000, 0x04026F26
+.long 0xD3EC0010, 0x04426F27
+.long 0xBF8CC87F
+.long 0xD3EC0000, 0x04027128
+.long 0xD3EC0010, 0x04427129
+.long 0xBF8CC47F
+.long 0xD3EC0000, 0x0402732A
+.long 0xD3EC0010, 0x0442732B
+.long 0xBF8CC07F
+.long 0xD3EC0000, 0x0402752C
+.long 0xD3EC0010, 0x0442752D
+.long 0xBF8C0F78
+.long 0xBF8C0070
+.long 0xBF8A0000
+.long 0xD3EC0000, 0x0402772E
+.long 0xD86C0000, 0x2000005F
+.long 0xD86C0840, 0x2100005F
+.long 0xD86C0008, 0x2200005F
+.long 0xD86C0848, 0x2300005F
+.long 0xD3EC0010, 0x0442772F
+.long 0xBF8C0F70
+.long 0xD86C0000, 0x3C000061
+.long 0xD86C0008, 0x3D000061
+.long 0xD86C0010, 0x3E000061
+.long 0xD86C0018, 0x3F000061
+.long 0xBF8CC27F
+.long 0xD3EC0000, 0x04027920
+.long 0xD86C0010, 0x2400005F
+.long 0xD86C0850, 0x2500005F
+.long 0xD86C0018, 0x2600005F
+.long 0xD86C0858, 0x2700005F
+.long 0xD3EC0010, 0x04427921
+.long 0xD86C0020, 0x2800005F
+.long 0xD86C0860, 0x2900005F
+.long 0xD86C0020, 0x40000061
+.long 0xD86C0028, 0x41000061
+.long 0xD3EC0000, 0x04027B22
+.long 0xD86C0028, 0x2A00005F
+.long 0xD86C0868, 0x2B00005F
+.long 0xD86C0030, 0x42000061
+.long 0xD86C0038, 0x43000061
+.long 0xD3EC0010, 0x04427B23
+.long 0xD86C0030, 0x2C00005F
+.long 0xD86C0870, 0x2D00005F
+.long 0xD86C0038, 0x2E00005F
+.long 0xD86C0878, 0x2F00005F
+.long 0xBF8CCE7F
+.long 0xD3EC0000, 0x04027D24
+.long 0xD3EC0010, 0x04427D25
+.long 0xBF8CCC7F
+.long 0xD3EC0000, 0x04027F26
+.long 0xD3EC0010, 0x04427F27
+.long 0xBF8CC87F
+.long 0xD3EC0000, 0x04028128
+.long 0xD3EC0010, 0x04428129
+.long 0xBF8CC47F
+.long 0xD3EC0000, 0x0402832A
+.long 0xD3EC0010, 0x0442832B
+.long 0xBF8CC07F
+.long 0xD3EC0000, 0x0402852C
+.long 0xD3EC0010, 0x0442852D
+.long 0xD3EC0000, 0x0402872E
+.long 0xD3EC0010, 0x0442872F
+.long 0xD3D84000, 0x18000100
+.long 0xD3D84001, 0x18000101
+.long 0xD3D84002, 0x18000102
+.long 0xD3D84003, 0x18000103
+.long 0xD3D84004, 0x18000104
+.long 0xD3D84005, 0x18000105
+.long 0xD3D84006, 0x18000106
+.long 0xD3D84007, 0x18000107
+.long 0xD3D84008, 0x18000108
+.long 0xD3D84009, 0x18000109
+.long 0xD3D8400A, 0x1800010A
+.long 0xD3D8400B, 0x1800010B
+.long 0xD3D8400C, 0x1800010C
+.long 0xD3D8400D, 0x1800010D
+.long 0xD3D8400E, 0x1800010E
+.long 0xD3D8400F, 0x1800010F
+.long 0x20000090
+.long 0x20020290
+.long 0x24020290
+.long 0x28000300
+.long 0x20040490
+.long 0x20060690
+.long 0x24060690
+.long 0x28020702
+.long 0x20080890
+.long 0x200A0A90
+.long 0x240A0A90
+.long 0x28040B04
+.long 0x200C0C90
+.long 0x200E0E90
+.long 0x240E0E90
+.long 0x28060F06
+.long 0x20101090
+.long 0x20121290
+.long 0x24121290
+.long 0x28081308
+.long 0x20141490
+.long 0x20161690
+.long 0x24161690
+.long 0x280A170A
+.long 0x20181890
+.long 0x201A1A90
+.long 0x241A1A90
+.long 0x280C1B0C
+.long 0x201C1C90
+.long 0x201E1E90
+.long 0x241E1E90
+.long 0x280E1F0E
+.long 0xE0741000, 0x80050068
+.long 0xE0741010, 0x80050268
+.long 0xE0741020, 0x80050468
+.long 0xE0741030, 0x80050668
+.long 0xD3D84000, 0x18000110
+.long 0xD3D84001, 0x18000111
+.long 0xD3D84002, 0x18000112
+.long 0xD3D84003, 0x18000113
+.long 0xD3D84004, 0x18000114
+.long 0xD3D84005, 0x18000115
+.long 0xD3D84006, 0x18000116
+.long 0xD3D84007, 0x18000117
+.long 0xD3D84008, 0x18000118
+.long 0xD3D84009, 0x18000119
+.long 0xD3D8400A, 0x1800011A
+.long 0xD3D8400B, 0x1800011B
+.long 0xD3D8400C, 0x1800011C
+.long 0xD3D8400D, 0x1800011D
+.long 0xD3D8400E, 0x1800011E
+.long 0xD3D8400F, 0x1800011F
+.long 0x20000090
+.long 0x20020290
+.long 0x24020290
+.long 0x28000300
+.long 0x20040490
+.long 0x20060690
+.long 0x24060690
+.long 0x28020702
+.long 0x20080890
+.long 0x200A0A90
+.long 0x240A0A90
+.long 0x28040B04
+.long 0x200C0C90
+.long 0x200E0E90
+.long 0x240E0E90
+.long 0x28060F06
+.long 0x20101090
+.long 0x20121290
+.long 0x24121290
+.long 0x28081308
+.long 0x20141490
+.long 0x20161690
+.long 0x24161690
+.long 0x280A170A
+.long 0x20181890
+.long 0x201A1A90
+.long 0x241A1A90
+.long 0x280C1B0C
+.long 0x201C1C90
+.long 0x201E1E90
+.long 0x241E1E90
+.long 0x280E1F0E
+.long 0xE0741040, 0x80050068
+.long 0xE0741050, 0x80050268
+.long 0xE0741060, 0x80050468
+.long 0xE0741070, 0x80050668
+.long 0xBF8C0000
+.long 0xBF810000

--- a/Tensile/ReplacementKernels-cov3/Cijk_Alik_Bljk_BBH_MT64x128x64_AF0EM8_ASEM8_FL0_GRVW4_ISA908_MDA2_PGR1_PLR1_SU32_TT4_4_VAW1_VW4_WG16_32_1_WGM8.s.txt
+++ b/Tensile/ReplacementKernels-cov3/Cijk_Alik_Bljk_BBH_MT64x128x64_AF0EM8_ASEM8_FL0_GRVW4_ISA908_MDA2_PGR1_PLR1_SU32_TT4_4_VAW1_VW4_WG16_32_1_WGM8.s.txt
@@ -1,0 +1,1743 @@
+
+
+/******************************************/
+/* Function Prefix                        */
+/******************************************/
+
+
+
+/******************************************/
+/* Begin Kernel                           */
+/******************************************/
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx908+sram-ecc"
+.text
+.protected Cijk_Alik_Bljk_BBH_MT64x128x64_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT4_4_TLDS0_USFGROn1_VAW1_VSn1_VW4_WSGRA0_WSGRB0_WG16_32_1_WGM8
+.globl Cijk_Alik_Bljk_BBH_MT64x128x64_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT4_4_TLDS0_USFGROn1_VAW1_VSn1_VW4_WSGRA0_WSGRB0_WG16_32_1_WGM8
+.p2align 8
+.type Cijk_Alik_Bljk_BBH_MT64x128x64_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT4_4_TLDS0_USFGROn1_VAW1_VSn1_VW4_WSGRA0_WSGRB0_WG16_32_1_WGM8,@function
+.section .rodata,#alloc
+.p2align 6
+.amdhsa_kernel Cijk_Alik_Bljk_BBH_MT64x128x64_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT4_4_TLDS0_USFGROn1_VAW1_VSn1_VW4_WSGRA0_WSGRB0_WG16_32_1_WGM8
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_next_free_vgpr 108 // vgprs
+  .amdhsa_next_free_sgpr 98 // sgprs
+  .amdhsa_group_segment_fixed_size 28672 // lds bytes
+  .amdhsa_private_segment_fixed_size 0
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+.text
+
+/******************************************/
+/* Optimizations and Config:              */
+/******************************************/
+/* ThreadTile= 4 x 4 */
+/* SubGroup= 32 x 16 */
+/* VectorWidth=4 */
+/* GlobalLoadVectorWidthA=4, GlobalLoadVectorWidthB=4 */
+/* DirectToLdsA=False */
+/* DirectToLdsB=False */
+/* UseSgprForGRO=1 */
+.amdgpu_metadata
+---
+amdhsa.version:
+  - 1
+  - 0
+amdhsa.kernels:
+  - .name: Cijk_Alik_Bljk_BBH_MT64x128x64_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT4_4_TLDS0_USFGROn1_VAW1_VSn1_VW4_WSGRA0_WSGRB0_WG16_32_1_WGM8
+    .symbol: 'Cijk_Alik_Bljk_BBH_MT64x128x64_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT4_4_TLDS0_USFGROn1_VAW1_VSn1_VW4_WSGRA0_WSGRB0_WG16_32_1_WGM8.kd'
+    .language:                   OpenCL C
+    .language_version:
+      - 2
+      - 0
+    .args:
+      - .name:            sizeC
+        .size:            8
+        .offset:          0
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            sizeA
+        .size:            8
+        .offset:          8
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            sizeB
+        .size:            8
+        .offset:          16
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            D
+        .size:            8
+        .offset:          24
+        .value_kind:      global_buffer
+        .value_type:      struct
+        .address_space:   generic
+      - .name:            C
+        .size:            8
+        .offset:          32
+        .value_kind:      global_buffer
+        .value_type:      struct
+        .address_space:   generic
+      - .name:            A
+        .size:            8
+        .offset:          40
+        .value_kind:      global_buffer
+        .value_type:      struct
+        .address_space:   generic
+      - .name:            B
+        .size:            8
+        .offset:          48
+        .value_kind:      global_buffer
+        .value_type:      struct
+        .address_space:   generic
+      - .name:            alpha
+        .size:            4
+        .offset:          56
+        .value_kind:      by_value
+        .value_type:      f32
+      - .name:            beta
+        .size:            4
+        .offset:          60
+        .value_kind:      by_value
+        .value_type:      f32
+      - .name:            strideD0
+        .size:            4
+        .offset:          64
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideD1
+        .size:            4
+        .offset:          68
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideC0
+        .size:            4
+        .offset:          72
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideC1
+        .size:            4
+        .offset:          76
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideA0
+        .size:            4
+        .offset:          80
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideA1
+        .size:            4
+        .offset:          84
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideB0
+        .size:            4
+        .offset:          88
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideB1
+        .size:            4
+        .offset:          92
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree0
+        .size:            4
+        .offset:          96
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree1
+        .size:            4
+        .offset:          100
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree2
+        .size:            4
+        .offset:          104
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesSum0
+        .size:            4
+        .offset:          108
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            OrigStaggerUIter
+        .size:            4
+        .offset:          112
+        .value_kind:      by_value
+        .value_type:      i32
+      - .name:            NumWorkGroups0
+        .size:            4
+        .offset:          116
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            NumWorkGroups1
+        .size:            4
+        .offset:          120
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            MagicNumberProblemNumGroupTiles0
+        .size:            4
+        .offset:          124
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            GridNumWorkGroups0
+        .size:            4
+        .offset:          128
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            NumFullBlocks
+        .size:            4
+        .offset:          132
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            WgmRemainder1
+        .size:            4
+        .offset:          136
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            MagicNumberWgmRemainder1
+        .size:            4
+        .offset:          140
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            padding
+        .size:            4
+        .offset:          144
+        .value_kind:      by_value
+        .value_type:      u32
+    .group_segment_fixed_size:   28672
+    .kernarg_segment_align:      8
+    .kernarg_segment_size:       152
+    .max_flat_workgroup_size:    256
+    .private_segment_fixed_size: 0
+    .sgpr_count:                 98
+    .sgpr_spill_count:           0
+    .vgpr_count:                 108
+    .vgpr_spill_count:           0
+    .wavefront_size:             64
+...
+.end_amdgpu_metadata
+Cijk_Alik_Bljk_BBH_MT64x128x64_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT4_4_TLDS0_USFGROn1_VAW1_VSn1_VW4_WSGRA0_WSGRB0_WG16_32_1_WGM8:
+
+.set BufferOOB, 0x80000000
+
+///////////////implementation description///////////////////////
+/////1. 2wave/simd solution.  8 waves/wg split into 2 groups of 4waves
+/////   one group (called fetch group) dedeicated fetching elements for A&B for macro-tile
+/////   other group does math for macro-tile
+/////2. each thread group generate a 64X128. by multiply block A(64XK) and block B (KX128).
+/////3. each thread group's input block A addressed by thread gourp idy,  block B addressed by thread gourp idx.
+/////4. each thread group has 4 waves.
+/////5. each wave generate a 64X32,  by multiply block A(64XK) and block B (KX32)
+/////6. in each loop, each wave multiply block A(64X32) and block B (32X32),  wave mem data load as belowing:
+///           Matrix A (K)                       Matrix B (N)
+///           ---------32              --------4-------8------12-------16---------32---------- 64------------128----------
+///           0   w0Ab0                -       |       |       |       |          |            |              |             |            |
+///           4   w0Ab1                -       |       |       |       |          |            |              |             |            |
+///           8   w0Ab2                -       |       |       |       |          |            |              |             |            |
+///          12   w0Ab3                -       |       |       |       |          |            |              |             |            |
+///      (M) 16   w1Ab0           (K)  - w0Bb0 | w0Bb1 | w0Bb2 | w0Bb3 | w0Bb[4-7]| w1Bb[0-7] |  w2Bb[0-7]  | w3Bb[0-7]
+///           -                        -       |       |       |       |          |            |              |             |            |
+///          ...                       -       |       |       |       |          |            |              |             |            |
+///          32   w2Ab0                -       |       |       |       |          |            |              |             |            |
+///          ...                      32       |       |       |       |          |            |              |             |            |
+///          48   w3Ab0
+///          ..
+///          60   w3Ab3
+///      5.1  Ab means Matrix A block M(4)*K(32),  Bb means Matrix B block K(32)*N(4).
+///      5.2  w0Ab0 means wave 0 Matrix A first loading block.
+/////6. all of the data in step 5 are loaded into LDS directly with buffer_load lds:1.
+/////   in lds, the data stored location followed the order:  w0 -> w1 -> w2-> w3.
+
+//////sreg def/////////////
+
+.set sgprKernArgAddress ,0
+.set sgprWorkGroup0 ,2
+.set sgprWorkGroup1 ,3
+.set sgprWorkGroup2 ,4
+.set sgprNumWorkGroups0,5
+.set sgprNumWorkGroups1,6
+.set sgprSrdA,8
+.set sgprSrdB,12
+.set sgprSrdC,16
+.set sgprSrdD,20
+.set sgprTensor2dSizeC,24
+.set sgprTensor2dSizeA,26
+.set sgprTensor2dSizeB,28
+.set sgprSaveExecMask,30
+.set sgprAddressD,32
+.set sgprAddressC,34
+.set sgprStridesD,36
+.set sgprStridesC,38
+.set sgprAlpha,40
+.set sgprBeta,41
+.set sgprSizesFree ,42
+.set sgprSizesSum  ,45
+.set sgprLoopCounters,46
+.set sgprOrigLoopCounter,47
+.set sgprStridesA,48
+.set sgprStridesB,50
+.set sgprAddressA,52
+.set sgprAddressB,54
+.set sgprShadowLimitA,56
+.set sgprShadowLimitB,58
+.set sgprOrigStaggerUIter,60
+.set sgprStaggerUIter,61
+.set sgprWrapUA,62
+.set sgprWrapUB,64
+.set sgprNumFullBlocks,66
+.set sgprWgmRemainder1,67
+.set sgprMagicNumberWgmRemainder1,68
+.set sgprGlobalReadIncsA,69
+.set sgprGlobalReadIncsB,70
+.set sgprScalarGlobalReadOffsetA,71
+.set sgprScalarGlobalReadOffsetB,74
+.set sgprLocalWriteAddrA,88
+.set sgprLocalWriteAddrB,90
+.set sgprLoopIdx ,94
+.set hw_id ,95
+
+
+/////vreg def////////////////
+
+.set vgprValuC,0
+.set vgprAcc,0
+.set vgprValuA_X0_I0,32
+.set vgprG2LA,48
+.set vgprValuB_X0_I0,52
+.set vgprG2LB,68
+.set vgprLocalWriteAddrA,76
+.set vgprLocalWriteAddrB,78
+.set vgprGlobalReadOfvarA,82
+.set vgprGlobalReadOfvarB,86
+.set vgprLocalReadAddrA,94
+.set vgprLocalReadAddrB,96
+.set vgprSerial,100
+.set vgprGlobalWriteOfvarC,104
+.set vgprTmp,106
+
+////constant def/////////////
+.set varlds_pad            , 8
+.set varlds_pad_qw         , varlds_pad >> 2
+.set varlds_Asize_per_wr   , 256+varlds_pad                  //each load inst load one 32X4 block.    need contiunous 32X4X2=256    bytes in LDS
+.set varlds_Asize_per_wave , varlds_Asize_per_wr * 4   //each wave load 4 32X4 block one time.  need contiunous 32X4X4X2=1024 bytes in LDS
+.set varlds_Asize_per_wg   , varlds_Asize_per_wave * 4 //WG load 16 32X4 block(64X32) Matrix A to lds for pingpong.
+.set M_row_per_WG          , 64       //each WG process 64 row
+.set varlds_Bsize_per_wr   , 256+varlds_pad             //each load inst load one 32X4  block.    need contiunous 32X4X2=256     bytes in LDS
+.set varlds_Bsize_per_wave , varlds_Bsize_per_wr * 8   //each wave load seperate 32X64 block.    need contiunous 32X4X8X2=2048 bytes in LDS
+.set varlds_Bsize_per_wg   , varlds_Bsize_per_wave * 4  //WG load 64 32X4 block(32X256) Matrix B to lds for pingpong.
+.set varA_lds_base_addr    , 0
+.set varB_lds_base_addr    , varA_lds_base_addr+varlds_Asize_per_wg * 2  //in bytes
+
+/******************************************/
+/* 2GB limit - set offsets to -1 to exceed this and clamp */
+/******************************************/
+.set BufferLimit,0x80000000
+
+/******************************************/
+/* Bits 127:96 of SRD.  Set DataFormat = 32 bit */
+/******************************************/
+.set Srd127_96,0x0020000
+
+.long 0xC00A0D00, 0x00000028
+.long 0xC00A0C00, 0x00000050
+.long 0xC00A0600, 0x00000008
+.long 0xC0020B40, 0x0000006C
+.long 0xBEFC00FF, 0x00003000
+.long 0x7EC80300
+.long 0x26CA00BF
+.long 0x2004C886
+.long 0xB8D0F804
+.long 0xD1130004, 0x0000A0B0
+.long 0x20CC0884
+.long 0x7EA40566
+.long 0xD1130067, 0x0000A08F
+.long 0x7EA20567
+.long 0xBF068151
+.long 0xBF840118
+.long 0xBF8CC07F
+.long 0xBE880034
+.long 0xBE890035
+.long 0xBE8B00FF, 0x00020000
+.long 0x80B85418
+.long 0x80B95518
+.long 0x8EB88138
+.long 0x80388438
+.long 0x82398039
+.long 0xBF068039
+.long 0x850AFF38, 0x80000000
+.long 0xBE8A00FF, 0x80000000
+.long 0x9254C030
+.long 0x92545402
+.long 0x8E558452
+.long 0x92533055
+.long 0x92553104
+.long 0x81545354
+.long 0x81545554
+.long 0x2000CA84
+.long 0xD2850004, 0x00020030
+.long 0x2602CA8F
+.long 0x24020281
+.long 0x32A40304
+.long 0x68A4A454
+.long 0x24A4A481
+.long 0x8E478330
+.long 0x80C7FF47, 0x00000108
+.long 0x68A6A447
+.long 0x68A8A647
+.long 0x68AAA847
+.long 0xBECC00FF, 0x00000420
+.long 0x924C4C52
+.long 0xBE8C0036
+.long 0xBE8D0037
+.long 0xBE8F00FF, 0x00020000
+.long 0x80BA541A
+.long 0x80BB551A
+.long 0x8EBA813A
+.long 0x803A843A
+.long 0x823B803B
+.long 0xBF06803B
+.long 0x850EFF3A, 0x80000000
+.long 0xBE8E00FF, 0x80000000
+.long 0x9254FF32, 0x00000080
+.long 0x92545403
+.long 0x925532A0
+.long 0x92555552
+.long 0x81545554
+.long 0x92553304
+.long 0x81545554
+.long 0x2004CA84
+.long 0x2606CA8F
+.long 0x24060681
+.long 0xD2850004, 0x00020432
+.long 0x32AC0704
+.long 0x68ACAC54
+.long 0x24ACAC81
+.long 0x8E4A8332
+.long 0x80CAFF4A, 0x00000108
+.long 0x68AEAC4A
+.long 0x68B0AE4A
+.long 0x68B2B04A
+.long 0x68B4B24A
+.long 0x68B6B44A
+.long 0x68B8B64A
+.long 0x68BAB84A
+.long 0xBECE00FF, 0x00000840
+.long 0x924E4E52
+.long 0x814EFF4E, 0x00002100
+.long 0xBF8A0000
+.long 0xBEFC004C
+.long 0x814DFF4C, 0x00001080
+.long 0xE0511000, 0x80023052
+.long 0xE0511108, 0x80023153
+.long 0xE0511210, 0x80023254
+.long 0xE0511318, 0x80023355
+.long 0xBEFC004E
+.long 0x814FFF4E, 0x00002100
+.long 0xE0511000, 0x80034456
+.long 0xE0511108, 0x80034557
+.long 0xE0511210, 0x80034658
+.long 0xE0511318, 0x80034759
+.long 0xE0511420, 0x8003485A
+.long 0xE0511528, 0x8003495B
+.long 0xE0511630, 0x80034A5C
+.long 0xE0511738, 0x80034B5D
+.long 0xBEFC004D
+.long 0x68A4A4C0
+.long 0x68A6A6C0
+.long 0x68A8A8C0
+.long 0x68AAAAC0
+.long 0x68ACACC0
+.long 0x68AEAEC0
+.long 0x68B0B0C0
+.long 0x68B2B2C0
+.long 0x68B4B4C0
+.long 0x68B6B6C0
+.long 0x68B8B8C0
+.long 0x68BABAC0
+.long 0xE0511000, 0x80023052
+.long 0xE0511108, 0x80023153
+.long 0xE0511210, 0x80023254
+.long 0xE0511318, 0x80023355
+.long 0xBEFC004F
+.long 0xBF800000
+.long 0xE0511000, 0x80034456
+.long 0xE0511108, 0x80034557
+.long 0xE0511210, 0x80034658
+.long 0xE0511318, 0x80034759
+.long 0xE0511420, 0x8003485A
+.long 0xE0511528, 0x8003495B
+.long 0xE0511630, 0x80034A5C
+.long 0xE0511738, 0x80034B5D
+.long 0x68A4A4C0
+.long 0x68A6A6C0
+.long 0x68A8A8C0
+.long 0x68AAAAC0
+.long 0x68ACACC0
+.long 0x68AEAEC0
+.long 0x68B0B0C0
+.long 0x68B2B2C0
+.long 0x68B4B4C0
+.long 0x68B6B6C0
+.long 0x68B8B8C0
+.long 0x68BABAC0
+.long 0xBEFC004C
+.long 0xBF8C4F74
+.long 0xBF8A0000
+.long 0xBF8C0F7C
+.long 0xBF8A0000
+.long 0x8F2E852D
+.long 0x80AE2E80
+.long 0xBF06802E
+.long 0xBF850064
+.long 0xBF8A0000
+.long 0xE0511000, 0x80023052
+.long 0xE0511108, 0x80023153
+.long 0xE0511210, 0x80023254
+.long 0xE0511318, 0x80023355
+.long 0xBEFC004E
+.long 0xBF800000
+.long 0xE0511000, 0x80034456
+.long 0xE0511108, 0x80034557
+.long 0xE0511210, 0x80034658
+.long 0xE0511318, 0x80034759
+.long 0xE0511420, 0x8003485A
+.long 0xE0511528, 0x8003495B
+.long 0xE0511630, 0x80034A5C
+.long 0xE0511738, 0x80034B5D
+.long 0xBF8C4F74
+.long 0xBF8F0001
+.long 0xBF8A0000
+.long 0x68A4A4C0
+.long 0x68A6A6C0
+.long 0x68A8A8C0
+.long 0x68AAAAC0
+.long 0x68ACACC0
+.long 0x68AEAEC0
+.long 0x68B0B0C0
+.long 0x68B2B2C0
+.long 0xBF8F0000
+.long 0xBF8C0F7C
+.long 0xBF8F0001
+.long 0xBF8A0000
+.long 0x68B4B4C0
+.long 0x68B6B6C0
+.long 0x68B8B8C0
+.long 0x68BABAC0
+.long 0xBF8F0000
+.long 0xBEFC004D
+.long 0x802E812E
+.long 0xBF8A0000
+.long 0xE0511000, 0x80023052
+.long 0xE0511108, 0x80023153
+.long 0xE0511210, 0x80023254
+.long 0xE0511318, 0x80023355
+.long 0xBEFC004F
+.long 0xBF800000
+.long 0xE0511000, 0x80034456
+.long 0xE0511108, 0x80034557
+.long 0xE0511210, 0x80034658
+.long 0xE0511318, 0x80034759
+.long 0xE0511420, 0x8003485A
+.long 0xE0511528, 0x8003495B
+.long 0xE0511630, 0x80034A5C
+.long 0xE0511738, 0x80034B5D
+.long 0xBF8C4F74
+.long 0xBF8A0000
+.long 0xBF8F0001
+.long 0x68A4A4C0
+.long 0x68A6A6C0
+.long 0x68A8A8C0
+.long 0x68AAAAC0
+.long 0x68ACACC0
+.long 0x68AEAEC0
+.long 0x68B0B0C0
+.long 0x68B2B2C0
+.long 0xBF8F0000
+.long 0xBF8C0F7C
+.long 0xBF8A0000
+.long 0xBF8F0001
+.long 0x68B4B4C0
+.long 0x68B6B6C0
+.long 0x68B8B8C0
+.long 0x68BABAC0
+.long 0xBF8F0000
+.long 0xBEFC004C
+.long 0x802E812E
+.long 0xBF00C22E
+.long 0xBF84FF9C
+.long 0xBF8C0F78
+.long 0xBF8A0000
+.long 0xBF8C0F70
+.long 0xBF8A0000
+.long 0xBF810000
+.long 0xD3D94000, 0x18000080
+.long 0xD3D94001, 0x18000080
+.long 0xD3D94002, 0x18000080
+.long 0xD3D94003, 0x18000080
+.long 0xD3D94004, 0x18000080
+.long 0xD3D94005, 0x18000080
+.long 0xD3D94006, 0x18000080
+.long 0xD3D94007, 0x18000080
+.long 0xD3D94008, 0x18000080
+.long 0xD3D94009, 0x18000080
+.long 0xD3D9400A, 0x18000080
+.long 0xD3D9400B, 0x18000080
+.long 0xD3D9400C, 0x18000080
+.long 0xD3D9400D, 0x18000080
+.long 0xD3D9400E, 0x18000080
+.long 0xD3D9400F, 0x18000080
+.long 0xD3D94010, 0x18000080
+.long 0xD3D94011, 0x18000080
+.long 0xD3D94012, 0x18000080
+.long 0xD3D94013, 0x18000080
+.long 0xD3D94014, 0x18000080
+.long 0xD3D94015, 0x18000080
+.long 0xD3D94016, 0x18000080
+.long 0xD3D94017, 0x18000080
+.long 0xD3D94018, 0x18000080
+.long 0xD3D94019, 0x18000080
+.long 0xD3D9401A, 0x18000080
+.long 0xD3D9401B, 0x18000080
+.long 0xD3D9401C, 0x18000080
+.long 0xD3D9401D, 0x18000080
+.long 0xD3D9401E, 0x18000080
+.long 0xD3D9401F, 0x18000080
+.long 0xC0060700, 0x00000000
+.long 0xC00A0900, 0x00000040
+.long 0xC0020A00, 0x00000038
+.long 0xC0020A40, 0x0000003C
+.long 0xC00A0800, 0x00000018
+.long 0xD1130001, 0x00013F65
+.long 0xD285005E, 0x00020290
+.long 0x20020282
+.long 0xD2850001, 0x00020282
+.long 0x68BCBD01
+.long 0x2002CA85
+.long 0x68BCBD01
+.long 0x24BCBC82
+.long 0x68BCBC80
+.long 0x68BEBCFF, 0x00001080
+.long 0xBF8A0000
+.long 0xD1130001, 0x00013F65
+.long 0xD2850060, 0x00020290
+.long 0x20020282
+.long 0xD2850001, 0x00020282
+.long 0x68C0C101
+.long 0x2002CA85
+.long 0x68C0C101
+.long 0x24C0C082
+.long 0x9254FF52, 0x00000840
+.long 0x68C0C054
+.long 0x68C0C0FF, 0x00002100
+.long 0x68C2C0FF, 0x00002100
+.long 0xBF8CC07F
+.long 0xBE900022
+.long 0xBE910023
+.long 0xBE9200FF, 0x80000000
+.long 0xBE9300FF, 0x00020000
+.long 0xBE940020
+.long 0xBE950021
+.long 0xBE9600FF, 0x80000000
+.long 0xBE9700FF, 0x00020000
+.long 0x925603FF, 0x00000080
+.long 0x96552656
+.long 0x92542656
+.long 0x8ED48154
+.long 0x80105410
+.long 0x82115511
+.long 0x80145414
+.long 0x82155515
+.long 0x96552704
+.long 0x92542704
+.long 0x8ED48154
+.long 0x80105410
+.long 0x82115511
+.long 0x80145414
+.long 0x82155515
+.long 0x24C8CC86
+.long 0x68C8C965
+.long 0xD2850004, 0x0002CCA0
+.long 0xD2850003, 0x00004D04
+.long 0x2608C89F
+.long 0xD2850005, 0x00004D04
+.long 0x2608C8BF
+.long 0x200C0885
+.long 0x240C0C82
+.long 0x68D60B03
+.long 0x925402C0
+.long 0x32D40C54
+.long 0xD1FE0068, 0x0206D76A
+.long 0xBF8A0000
+.long 0xD86C0000, 0x2000005E
+.long 0xD86C0840, 0x2100005E
+.long 0xD86C0008, 0x2200005E
+.long 0xD86C0848, 0x2300005E
+.long 0xD86C0010, 0x2400005E
+.long 0xD86C0850, 0x2500005E
+.long 0xD86C0018, 0x2600005E
+.long 0xD86C0858, 0x2700005E
+.long 0xD86C0020, 0x2800005E
+.long 0xD86C0860, 0x2900005E
+.long 0xD86C0028, 0x2A00005E
+.long 0xD86C0868, 0x2B00005E
+.long 0xD86C0030, 0x2C00005E
+.long 0xD86C0870, 0x2D00005E
+.long 0xD86C0038, 0x2E00005E
+.long 0xD86C0878, 0x2F00005E
+.long 0xBF8A0000
+.long 0xD86C0000, 0x44000060
+.long 0xD86C0008, 0x45000060
+.long 0xD86C0010, 0x46000060
+.long 0xD86C0018, 0x47000060
+.long 0x8F2E852D
+.long 0x80AE2E80
+.long 0xBF06802E
+.long 0xBF850714
+.long 0xBF8CC37F
+.long 0xD3EC0000, 0x04028920
+.long 0xD86C0020, 0x48000060
+.long 0xD86C0028, 0x49000060
+.long 0xD86C0030, 0x4A000060
+.long 0xD86C0038, 0x4B000060
+.long 0xD3EC0010, 0x04428921
+.long 0xBF8A0000
+.long 0xBF8CC67F
+.long 0xD3EC0000, 0x04028B22
+.long 0xD3EC0010, 0x04428B23
+.long 0xBF8CC57F
+.long 0xD3EC0000, 0x04028D24
+.long 0xD3EC0010, 0x04428D25
+.long 0xBF8CC47F
+.long 0xD3EC0000, 0x04028F26
+.long 0xD3EC0010, 0x04428F27
+.long 0xBF8CC07F
+.long 0xD3EC0000, 0x04029128
+.long 0xD3EC0010, 0x04429129
+.long 0xBF8F0000
+.long 0xD3EC0000, 0x0402932A
+.long 0xBF8A0000
+.long 0xD86C0000, 0x3000005F
+.long 0xD86C0840, 0x3100005F
+.long 0xD3EC0010, 0x0442932B
+.long 0xD86C0008, 0x3200005F
+.long 0xD86C0848, 0x3300005F
+.long 0xD86C0010, 0x3400005F
+.long 0xD86C0850, 0x3500005F
+.long 0xD3EC0000, 0x0402952C
+.long 0xD86C0018, 0x3600005F
+.long 0xD86C0858, 0x3700005F
+.long 0xD86C0020, 0x3800005F
+.long 0xD86C0860, 0x3900005F
+.long 0xD86C0028, 0x3A00005F
+.long 0xD3EC0010, 0x0442952D
+.long 0xD86C0868, 0x3B00005F
+.long 0xD86C0030, 0x3C00005F
+.long 0xD86C0870, 0x3D00005F
+.long 0xD86C0038, 0x3E00005F
+.long 0xD86C0878, 0x3F00005F
+.long 0xD3EC0000, 0x0402972E
+.long 0xBF8A0000
+.long 0xD86C0000, 0x4C000061
+.long 0xD86C0008, 0x4D000061
+.long 0xD3EC0010, 0x0442972F
+.long 0xD86C0010, 0x4E000061
+.long 0xD86C0018, 0x4F000061
+.long 0xD86C0020, 0x50000061
+.long 0xD86C0028, 0x51000061
+.long 0xBF8F0001
+.long 0x802E812E
+.long 0xBF8CC57F
+.long 0xD3EC0000, 0x04029930
+.long 0xD86C0030, 0x52000061
+.long 0xD86C0038, 0x53000061
+.long 0xD3EC0010, 0x04429931
+.long 0xBF8A0000
+.long 0xBF8CC67F
+.long 0xD3EC0000, 0x04029B32
+.long 0xD3EC0010, 0x04429B33
+.long 0xBF8CC57F
+.long 0xD3EC0000, 0x04029D34
+.long 0xD3EC0010, 0x04429D35
+.long 0xBF8CC47F
+.long 0xD3EC0000, 0x04029F36
+.long 0xD3EC0010, 0x04429F37
+.long 0xBF8CC07F
+.long 0xD3EC0000, 0x0402A138
+.long 0xD3EC0010, 0x0442A139
+.long 0xBF8F0000
+.long 0xD3EC0000, 0x0402A33A
+.long 0xBF8A0000
+.long 0xD86C0000, 0x2000005E
+.long 0xD86C0840, 0x2100005E
+.long 0xD3EC0010, 0x0442A33B
+.long 0xD86C0008, 0x2200005E
+.long 0xD86C0848, 0x2300005E
+.long 0xD86C0010, 0x2400005E
+.long 0xD86C0850, 0x2500005E
+.long 0xD86C0018, 0x2600005E
+.long 0xD3EC0000, 0x0402A53C
+.long 0xD86C0858, 0x2700005E
+.long 0xD86C0020, 0x2800005E
+.long 0xD86C0860, 0x2900005E
+.long 0xD86C0028, 0x2A00005E
+.long 0xD3EC0010, 0x0442A53D
+.long 0xD86C0868, 0x2B00005E
+.long 0xD86C0030, 0x2C00005E
+.long 0xD86C0870, 0x2D00005E
+.long 0xD86C0038, 0x2E00005E
+.long 0xD86C0878, 0x2F00005E
+.long 0xD3EC0000, 0x0402A73E
+.long 0xBF8A0000
+.long 0xD86C0000, 0x44000060
+.long 0xD86C0008, 0x45000060
+.long 0xD3EC0010, 0x0442A73F
+.long 0xD86C0018, 0x47000060
+.long 0xD86C0020, 0x48000060
+.long 0xD86C0028, 0x49000060
+.long 0xD86C0010, 0x46000060
+.long 0xBF8F0001
+.long 0x802E812E
+.long 0xBF8CC57F
+.long 0xD3EC0000, 0x04028920
+.long 0xD86C0030, 0x4A000060
+.long 0xD86C0038, 0x4B000060
+.long 0xD3EC0010, 0x04428921
+.long 0xBF8A0000
+.long 0xBF8CC67F
+.long 0xD3EC0000, 0x04028B22
+.long 0xD3EC0010, 0x04428B23
+.long 0xBF8CC57F
+.long 0xD3EC0000, 0x04028D24
+.long 0xD3EC0010, 0x04428D25
+.long 0xBF8CC47F
+.long 0xD3EC0000, 0x04028F26
+.long 0xD3EC0010, 0x04428F27
+.long 0xBF8CC07F
+.long 0xD3EC0000, 0x04029128
+.long 0xD3EC0010, 0x04429129
+.long 0xBF8F0000
+.long 0xD3EC0000, 0x0402932A
+.long 0xBF8A0000
+.long 0xD86C0000, 0x3000005F
+.long 0xD86C0840, 0x3100005F
+.long 0xD3EC0010, 0x0442932B
+.long 0xD86C0008, 0x3200005F
+.long 0xD86C0848, 0x3300005F
+.long 0xD86C0010, 0x3400005F
+.long 0xD86C0850, 0x3500005F
+.long 0xD3EC0000, 0x0402952C
+.long 0xD86C0018, 0x3600005F
+.long 0xD86C0858, 0x3700005F
+.long 0xD86C0020, 0x3800005F
+.long 0xD86C0860, 0x3900005F
+.long 0xD86C0028, 0x3A00005F
+.long 0xD3EC0010, 0x0442952D
+.long 0xD86C0868, 0x3B00005F
+.long 0xD86C0030, 0x3C00005F
+.long 0xD86C0870, 0x3D00005F
+.long 0xD86C0038, 0x3E00005F
+.long 0xD86C0878, 0x3F00005F
+.long 0xD3EC0000, 0x0402972E
+.long 0xBF8A0000
+.long 0xD86C0000, 0x4C000061
+.long 0xD86C0008, 0x4D000061
+.long 0xD3EC0010, 0x0442972F
+.long 0xD86C0010, 0x4E000061
+.long 0xD86C0018, 0x4F000061
+.long 0xD86C0020, 0x50000061
+.long 0xD86C0028, 0x51000061
+.long 0xBF8F0001
+.long 0x802E812E
+.long 0xBF8CC57F
+.long 0xD3EC0000, 0x04029930
+.long 0xD86C0030, 0x52000061
+.long 0xD86C0038, 0x53000061
+.long 0xD3EC0010, 0x04429931
+.long 0xBF8A0000
+.long 0xBF8CC67F
+.long 0xD3EC0000, 0x04029B32
+.long 0xD3EC0010, 0x04429B33
+.long 0xBF8CC57F
+.long 0xD3EC0000, 0x04029D34
+.long 0xD3EC0010, 0x04429D35
+.long 0xBF8CC47F
+.long 0xD3EC0000, 0x04029F36
+.long 0xD3EC0010, 0x04429F37
+.long 0xBF8CC07F
+.long 0xD3EC0000, 0x0402A138
+.long 0xD3EC0010, 0x0442A139
+.long 0xBF8F0000
+.long 0xD3EC0000, 0x0402A33A
+.long 0xBF8A0000
+.long 0xD86C0000, 0x2000005E
+.long 0xD86C0840, 0x2100005E
+.long 0xD3EC0010, 0x0442A33B
+.long 0xD86C0008, 0x2200005E
+.long 0xD86C0848, 0x2300005E
+.long 0xD86C0010, 0x2400005E
+.long 0xD86C0850, 0x2500005E
+.long 0xD3EC0000, 0x0402A53C
+.long 0xD86C0018, 0x2600005E
+.long 0xD86C0858, 0x2700005E
+.long 0xD86C0020, 0x2800005E
+.long 0xD86C0860, 0x2900005E
+.long 0xD86C0028, 0x2A00005E
+.long 0xD3EC0010, 0x0442A53D
+.long 0xD86C0868, 0x2B00005E
+.long 0xD86C0030, 0x2C00005E
+.long 0xD86C0870, 0x2D00005E
+.long 0xD86C0038, 0x2E00005E
+.long 0xD86C0878, 0x2F00005E
+.long 0xD3EC0000, 0x0402A73E
+.long 0xBF8A0000
+.long 0xD86C0000, 0x44000060
+.long 0xD86C0008, 0x45000060
+.long 0xD3EC0010, 0x0442A73F
+.long 0xD86C0010, 0x46000060
+.long 0xD86C0018, 0x47000060
+.long 0xD86C0020, 0x48000060
+.long 0xD86C0028, 0x49000060
+.long 0xBF8F0001
+.long 0x802E812E
+.long 0xBF00C22E
+.long 0xBF84FF48
+.long 0xBF8CC57F
+.long 0xD3EC0000, 0x04028920
+.long 0xD86C0030, 0x4A000060
+.long 0xD86C0038, 0x4B000060
+.long 0xB4290000
+.long 0xBF840326
+.long 0xD3EC0010, 0x04428921
+.long 0xB4280001
+.long 0xBF8400FD
+.long 0xBF8CC67F
+.long 0xD3EC0000, 0x04028B22
+.long 0xD3EC0010, 0x04428B23
+.long 0xBF8CC57F
+.long 0xD3EC0000, 0x04028D24
+.long 0xD3EC0010, 0x04428D25
+.long 0xBF8CC47F
+.long 0xD3EC0000, 0x04028F26
+.long 0xD3EC0010, 0x04428F27
+.long 0xBF8CC07F
+.long 0xD3EC0000, 0x04029128
+.long 0xD3EC0010, 0x04429129
+.long 0xD3EC0000, 0x0402932A
+.long 0xBF8A0000
+.long 0xD86C0000, 0x3000005F
+.long 0xD86C0840, 0x3100005F
+.long 0xD3EC0010, 0x0442932B
+.long 0xD86C0008, 0x3200005F
+.long 0xD86C0848, 0x3300005F
+.long 0xD86C0010, 0x3400005F
+.long 0xD86C0850, 0x3500005F
+.long 0xD3EC0000, 0x0402952C
+.long 0xD86C0018, 0x3600005F
+.long 0xD86C0858, 0x3700005F
+.long 0xD86C0020, 0x3800005F
+.long 0xD86C0860, 0x3900005F
+.long 0xD86C0028, 0x3A00005F
+.long 0xD3EC0010, 0x0442952D
+.long 0xD86C0868, 0x3B00005F
+.long 0xD86C0030, 0x3C00005F
+.long 0xD86C0870, 0x3D00005F
+.long 0xD86C0038, 0x3E00005F
+.long 0xD86C0878, 0x3F00005F
+.long 0xD3EC0000, 0x0402972E
+.long 0xBF8A0000
+.long 0xD86C0000, 0x4C000061
+.long 0xD86C0008, 0x4D000061
+.long 0xD3EC0010, 0x0442972F
+.long 0xD86C0010, 0x4E000061
+.long 0xD86C0018, 0x4F000061
+.long 0xD86C0020, 0x50000061
+.long 0xD86C0028, 0x51000061
+.long 0xBF8CC57F
+.long 0xD3EC0000, 0x04029930
+.long 0xD86C0030, 0x52000061
+.long 0xD86C0038, 0x53000061
+.long 0xD3EC0010, 0x04429931
+.long 0xBF8CC67F
+.long 0xD3EC0000, 0x04029B32
+.long 0xD3EC0010, 0x04429B33
+.long 0xBF8CC57F
+.long 0xD3EC0000, 0x04029D34
+.long 0xD3EC0010, 0x04429D35
+.long 0xBF8CC47F
+.long 0xD3EC0000, 0x04029F36
+.long 0xD3EC0010, 0x04429F37
+.long 0xBF8CC07F
+.long 0xD3EC0000, 0x0402A138
+.long 0xD3EC0000, 0x0402A33A
+.long 0xD3EC0000, 0x0402A53C
+.long 0xD3EC0000, 0x0402A73E
+.long 0xBED400FF, 0xFFFF0000
+.long 0x2AD6D56A
+.long 0x28D6D654
+.long 0xD3EC0010, 0x0442A139
+.long 0xD3D84000, 0x18000100
+.long 0xD3D84001, 0x18000101
+.long 0xD3D84002, 0x18000102
+.long 0xD3D84003, 0x18000103
+.long 0xD3D84004, 0x18000104
+.long 0xD3D84005, 0x18000105
+.long 0xD3D84006, 0x18000106
+.long 0xD3D84007, 0x18000107
+.long 0x20000090
+.long 0xD2010000, 0x0402D701
+.long 0x20040490
+.long 0xD2010001, 0x040AD703
+.long 0x20080890
+.long 0xD2010002, 0x0412D705
+.long 0xD3EC0010, 0x0442A33B
+.long 0xE0741000, 0x80050068
+.long 0x200C0C90
+.long 0xD2010003, 0x041AD707
+.long 0xD3EC0010, 0x0442A53D
+.long 0xE0741010, 0x80050268
+.long 0xD3D84008, 0x18000108
+.long 0xD3D84009, 0x18000109
+.long 0xD3D8400A, 0x1800010A
+.long 0xD3D8400B, 0x1800010B
+.long 0xD3EC0010, 0x0442A73F
+.long 0x20101090
+.long 0xD2010004, 0x0422D709
+.long 0x20141490
+.long 0xD2010005, 0x042AD70B
+.long 0xE0741020, 0x80050468
+.long 0xD3D8400C, 0x1800010C
+.long 0xD3D8400D, 0x1800010D
+.long 0xD3D8400E, 0x1800010E
+.long 0xD3D8400F, 0x1800010F
+.long 0x20181890
+.long 0xD2010006, 0x0432D70D
+.long 0x201C1C90
+.long 0xD2010007, 0x043AD70F
+.long 0xE0741030, 0x80050668
+.long 0xD3D84000, 0x18000110
+.long 0xD3D84001, 0x18000111
+.long 0xD3D84002, 0x18000112
+.long 0xD3D84003, 0x18000113
+.long 0xD3D84004, 0x18000114
+.long 0xD3D84005, 0x18000115
+.long 0xD3D84006, 0x18000116
+.long 0xD3D84007, 0x18000117
+.long 0x20000090
+.long 0xD2010000, 0x0402D701
+.long 0x20040490
+.long 0xD2010001, 0x040AD703
+.long 0x20080890
+.long 0xD2010002, 0x0412D705
+.long 0xE0741040, 0x80050068
+.long 0x200C0C90
+.long 0xD2010003, 0x041AD707
+.long 0xD3D84008, 0x18000118
+.long 0xD3D84009, 0x18000119
+.long 0xD3D8400A, 0x1800011A
+.long 0xD3D8400B, 0x1800011B
+.long 0xE0741050, 0x80050268
+.long 0x20101090
+.long 0xD2010004, 0x0422D709
+.long 0x20141490
+.long 0xD2010005, 0x042AD70B
+.long 0xD3D8400C, 0x1800011C
+.long 0xD3D8400D, 0x1800011D
+.long 0xD3D8400E, 0x1800011E
+.long 0xD3D8400F, 0x1800011F
+.long 0xE0741060, 0x80050468
+.long 0x20181890
+.long 0xD2010006, 0x0432D70D
+.long 0x201C1C90
+.long 0xD2010007, 0x043AD70F
+.long 0xE0741070, 0x80050668
+.long 0xBF8C0000
+.long 0xBF810000
+.long 0xBF8CC67F
+.long 0xD3EC0000, 0x04028B22
+.long 0xB4290000
+.long 0xBF840220
+.long 0xD3EC0010, 0x04428B23
+.long 0xD3EC0000, 0x04028D24
+.long 0xD3EC0010, 0x04428D25
+.long 0xBF8CC47F
+.long 0xD3EC0000, 0x04028F26
+.long 0xD3EC0010, 0x04428F27
+.long 0xBF8CC07F
+.long 0xD3EC0000, 0x04029128
+.long 0xD3EC0010, 0x04429129
+.long 0xD3EC0000, 0x0402932A
+.long 0xBF8A0000
+.long 0xD86C0000, 0x3000005F
+.long 0xD86C0840, 0x3100005F
+.long 0xD3EC0010, 0x0442932B
+.long 0xD86C0008, 0x3200005F
+.long 0xD86C0848, 0x3300005F
+.long 0xD86C0010, 0x3400005F
+.long 0xD86C0850, 0x3500005F
+.long 0xD3EC0000, 0x0402952C
+.long 0xD86C0018, 0x3600005F
+.long 0xD86C0858, 0x3700005F
+.long 0xD86C0020, 0x3800005F
+.long 0xD86C0860, 0x3900005F
+.long 0xD86C0028, 0x3A00005F
+.long 0xD3EC0010, 0x0442952D
+.long 0xD86C0868, 0x3B00005F
+.long 0xD86C0030, 0x3C00005F
+.long 0xD86C0870, 0x3D00005F
+.long 0xD86C0038, 0x3E00005F
+.long 0xD86C0878, 0x3F00005F
+.long 0xD3EC0000, 0x0402972E
+.long 0xBF8A0000
+.long 0xD86C0000, 0x4C000061
+.long 0xD86C0008, 0x4D000061
+.long 0xD3EC0010, 0x0442972F
+.long 0xD86C0010, 0x4E000061
+.long 0xD86C0018, 0x4F000061
+.long 0xD86C0020, 0x50000061
+.long 0xD86C0028, 0x51000061
+.long 0xBF8CC57F
+.long 0xD3EC0000, 0x04029930
+.long 0xD86C0030, 0x52000061
+.long 0xD86C0038, 0x53000061
+.long 0xD3EC0010, 0x04429931
+.long 0xBF8CC67F
+.long 0xD3EC0000, 0x04029B32
+.long 0xD3EC0010, 0x04429B33
+.long 0xBF8CC57F
+.long 0xD3EC0000, 0x04029D34
+.long 0xD3EC0010, 0x04429D35
+.long 0xBF8CC47F
+.long 0xD3EC0000, 0x04029F36
+.long 0xD3EC0010, 0x04429F37
+.long 0xBF8CC07F
+.long 0xD3EC0000, 0x0402A138
+.long 0xD3EC0000, 0x0402A33A
+.long 0xD3EC0000, 0x0402A53C
+.long 0xD3EC0000, 0x0402A73E
+.long 0xD3EC0010, 0x0442A139
+.long 0xD3EC0010, 0x0442A33B
+.long 0xD3EC0010, 0x0442A53D
+.long 0xD3EC0010, 0x0442A73F
+.long 0xBED400FF, 0xFFFF0000
+.long 0x2AD6D56A
+.long 0x28D6D654
+.long 0x7E7602FF, 0xFFFF0000
+.long 0x7E7802FF, 0x7FFF0000
+.long 0x7E7A02FF, 0x00007FFF
+.long 0xBF8C0F70
+.long 0xD3D84000, 0x18000100
+.long 0xD3D84001, 0x18000101
+.long 0xD3D84002, 0x18000102
+.long 0xD3D84003, 0x18000103
+.long 0xD3D84004, 0x18000104
+.long 0xD3D84005, 0x18000105
+.long 0xD3D84006, 0x18000106
+.long 0xD3D84007, 0x18000107
+.long 0x0A000028
+.long 0x0A020228
+.long 0x0A040428
+.long 0x0A060628
+.long 0x0A080828
+.long 0x0A0A0A28
+.long 0xD0480036, 0x00020100
+.long 0xD1C8003A, 0x02052100
+.long 0xD1FF003A, 0x04F67500
+.long 0xD1000000, 0x00DA793A
+.long 0x20000090
+.long 0xD0480036, 0x00020301
+.long 0xD1C8003A, 0x02052101
+.long 0xD1FF003A, 0x04F67501
+.long 0xD1000001, 0x00DA793A
+.long 0xD2010000, 0x04027701
+.long 0xD0480036, 0x00020502
+.long 0xD1C8003A, 0x02052102
+.long 0xD1FF003A, 0x04F67502
+.long 0xD1000002, 0x00DA793A
+.long 0xD0480036, 0x00020703
+.long 0xD1C8003A, 0x02052103
+.long 0xD1FF003A, 0x04F67503
+.long 0xD1000003, 0x00DA793A
+.long 0x20040490
+.long 0xD2010001, 0x040A7703
+.long 0xD0480036, 0x00020904
+.long 0xD1C8003A, 0x02052104
+.long 0xD1FF003A, 0x04F67504
+.long 0xD1000004, 0x00DA793A
+.long 0xD0480036, 0x00020B05
+.long 0xD1C8003A, 0x02052105
+.long 0xD1FF003A, 0x04F67505
+.long 0xD1000005, 0x00DA793A
+.long 0x20080890
+.long 0xD2010002, 0x04127705
+.long 0xE0741000, 0x80050068
+.long 0x0A0C0C28
+.long 0x0A0E0E28
+.long 0xD0480036, 0x00020D06
+.long 0xD1C8003A, 0x02052106
+.long 0xD1FF003A, 0x04F67506
+.long 0xD1000006, 0x00DA793A
+.long 0xD0480036, 0x00020F07
+.long 0xD1C8003A, 0x02052107
+.long 0xD1FF003A, 0x04F67507
+.long 0xD1000007, 0x00DA793A
+.long 0x200C0C90
+.long 0xD2010003, 0x041A7707
+.long 0xE0741010, 0x80050268
+.long 0xD3D84008, 0x18000108
+.long 0xD3D84009, 0x18000109
+.long 0xD3D8400A, 0x1800010A
+.long 0xD3D8400B, 0x1800010B
+.long 0x0A101028
+.long 0x0A121228
+.long 0x0A141428
+.long 0x0A161628
+.long 0xD0480036, 0x00021108
+.long 0xD1C8003A, 0x02052108
+.long 0xD1FF003A, 0x04F67508
+.long 0xD1000008, 0x00DA793A
+.long 0xD0480036, 0x00021309
+.long 0xD1C8003A, 0x02052109
+.long 0xD1FF003A, 0x04F67509
+.long 0xD1000009, 0x00DA793A
+.long 0x20101090
+.long 0xD2010004, 0x04227709
+.long 0xD0480036, 0x0002150A
+.long 0xD1C8003A, 0x0205210A
+.long 0xD1FF003A, 0x04F6750A
+.long 0xD100000A, 0x00DA793A
+.long 0xD0480036, 0x0002170B
+.long 0xD1C8003A, 0x0205210B
+.long 0xD1FF003A, 0x04F6750B
+.long 0xD100000B, 0x00DA793A
+.long 0x20141490
+.long 0xD2010005, 0x042A770B
+.long 0xE0741020, 0x80050468
+.long 0xD3D8400C, 0x1800010C
+.long 0xD3D8400D, 0x1800010D
+.long 0xD3D8400E, 0x1800010E
+.long 0xD3D8400F, 0x1800010F
+.long 0x0A181828
+.long 0x0A1A1A28
+.long 0x0A1C1C28
+.long 0x0A1E1E28
+.long 0xD0480036, 0x0002190C
+.long 0xD1C8003A, 0x0205210C
+.long 0xD1FF003A, 0x04F6750C
+.long 0xD100000C, 0x00DA793A
+.long 0xD0480036, 0x00021B0D
+.long 0xD1C8003A, 0x0205210D
+.long 0xD1FF003A, 0x04F6750D
+.long 0xD100000D, 0x00DA793A
+.long 0x20181890
+.long 0xD2010006, 0x0432770D
+.long 0xD0480036, 0x00021D0E
+.long 0xD1C8003A, 0x0205210E
+.long 0xD1FF003A, 0x04F6750E
+.long 0xD100000E, 0x00DA793A
+.long 0xD0480036, 0x00021F0F
+.long 0xD1C8003A, 0x0205210F
+.long 0xD1FF003A, 0x04F6750F
+.long 0xD100000F, 0x00DA793A
+.long 0x201C1C90
+.long 0xD2010007, 0x043A770F
+.long 0xE0741030, 0x80050668
+.long 0xD3D84000, 0x18000110
+.long 0xD3D84001, 0x18000111
+.long 0xD3D84002, 0x18000112
+.long 0xD3D84003, 0x18000113
+.long 0xD3D84004, 0x18000114
+.long 0xD3D84005, 0x18000115
+.long 0xD3D84006, 0x18000116
+.long 0xD3D84007, 0x18000117
+.long 0x0A000028
+.long 0x0A020228
+.long 0x0A040428
+.long 0x0A060628
+.long 0x0A080828
+.long 0x0A0A0A28
+.long 0xD0480036, 0x00020100
+.long 0xD1C8003A, 0x02052100
+.long 0xD1FF003A, 0x04F67500
+.long 0xD1000000, 0x00DA793A
+.long 0x20000090
+.long 0xD0480036, 0x00020301
+.long 0xD1C8003A, 0x02052101
+.long 0xD1FF003A, 0x04F67501
+.long 0xD1000001, 0x00DA793A
+.long 0xD2010000, 0x04027701
+.long 0xD0480036, 0x00020502
+.long 0xD1C8003A, 0x02052102
+.long 0xD1FF003A, 0x04F67502
+.long 0xD1000002, 0x00DA793A
+.long 0xD0480036, 0x00020703
+.long 0xD1C8003A, 0x02052103
+.long 0xD1FF003A, 0x04F67503
+.long 0xD1000003, 0x00DA793A
+.long 0x20040490
+.long 0xD2010001, 0x040A7703
+.long 0xD0480036, 0x00020904
+.long 0xD1C8003A, 0x02052104
+.long 0xD1FF003A, 0x04F67504
+.long 0xD1000004, 0x00DA793A
+.long 0xD0480036, 0x00020B05
+.long 0xD1C8003A, 0x02052105
+.long 0xD1FF003A, 0x04F67505
+.long 0xD1000005, 0x00DA793A
+.long 0x20080890
+.long 0xD2010002, 0x04127705
+.long 0xE0741040, 0x80050068
+.long 0x0A0C0C28
+.long 0x0A0E0E28
+.long 0xD0480036, 0x00020D06
+.long 0xD1C8003A, 0x02052106
+.long 0xD1FF003A, 0x04F67506
+.long 0xD1000006, 0x00DA793A
+.long 0xD0480036, 0x00020F07
+.long 0xD1C8003A, 0x02052107
+.long 0xD1FF003A, 0x04F67507
+.long 0xD1000007, 0x00DA793A
+.long 0x200C0C90
+.long 0xD2010003, 0x041A7707
+.long 0xE0741050, 0x80050268
+.long 0xD3D84008, 0x18000118
+.long 0xD3D84009, 0x18000119
+.long 0xD3D8400A, 0x1800011A
+.long 0xD3D8400B, 0x1800011B
+.long 0x0A101028
+.long 0x0A121228
+.long 0x0A141428
+.long 0x0A161628
+.long 0xD0480036, 0x00021108
+.long 0xD1C8003A, 0x02052108
+.long 0xD1FF003A, 0x04F67508
+.long 0xD1000008, 0x00DA793A
+.long 0xD0480036, 0x00021309
+.long 0xD1C8003A, 0x02052109
+.long 0xD1FF003A, 0x04F67509
+.long 0xD1000009, 0x00DA793A
+.long 0x20101090
+.long 0xD2010004, 0x04227709
+.long 0xD0480036, 0x0002150A
+.long 0xD1C8003A, 0x0205210A
+.long 0xD1FF003A, 0x04F6750A
+.long 0xD100000A, 0x00DA793A
+.long 0xD0480036, 0x0002170B
+.long 0xD1C8003A, 0x0205210B
+.long 0xD1FF003A, 0x04F6750B
+.long 0xD100000B, 0x00DA793A
+.long 0x20141490
+.long 0xD2010005, 0x042A770B
+.long 0xE0741060, 0x80050468
+.long 0xD3D8400C, 0x1800011C
+.long 0xD3D8400D, 0x1800011D
+.long 0xD3D8400E, 0x1800011E
+.long 0xD3D8400F, 0x1800011F
+.long 0x0A181828
+.long 0x0A1A1A28
+.long 0x0A1C1C28
+.long 0x0A1E1E28
+.long 0xD0480036, 0x0002190C
+.long 0xD1C8003A, 0x0205210C
+.long 0xD1FF003A, 0x04F6750C
+.long 0xD100000C, 0x00DA793A
+.long 0xD0480036, 0x00021B0D
+.long 0xD1C8003A, 0x0205210D
+.long 0xD1FF003A, 0x04F6750D
+.long 0xD100000D, 0x00DA793A
+.long 0x20181890
+.long 0xD2010006, 0x0432770D
+.long 0xD0480036, 0x00021D0E
+.long 0xD1C8003A, 0x0205210E
+.long 0xD1FF003A, 0x04F6750E
+.long 0xD100000E, 0x00DA793A
+.long 0xD0480036, 0x00021F0F
+.long 0xD1C8003A, 0x0205210F
+.long 0xD1FF003A, 0x04F6750F
+.long 0xD100000F, 0x00DA793A
+.long 0x201C1C90
+.long 0xD2010007, 0x043A770F
+.long 0xE0741070, 0x80050668
+.long 0xBF8C0000
+.long 0xBF810000
+.long 0xD3EC0010, 0x04428921
+.long 0xE0541000, 0x80041068
+.long 0xE0541010, 0x80041268
+.long 0xE0541020, 0x80041468
+.long 0xBF8CC67F
+.long 0xD3EC0000, 0x04028B22
+.long 0xE0541030, 0x80041668
+.long 0xE0541040, 0x80041868
+.long 0xE0541050, 0x80041A68
+.long 0xD3EC0010, 0x04428B23
+.long 0xE0541060, 0x80041C68
+.long 0xE0541070, 0x80041E68
+.long 0xD3EC0000, 0x04028D24
+.long 0xD3EC0010, 0x04428D25
+.long 0xBF8CC47F
+.long 0xD3EC0000, 0x04028F26
+.long 0xD3EC0010, 0x04428F27
+.long 0xBF8CC07F
+.long 0xD3EC0000, 0x04029128
+.long 0xD3EC0010, 0x04429129
+.long 0xD3EC0000, 0x0402932A
+.long 0xBF8A0000
+.long 0xD86C0000, 0x3000005F
+.long 0xD86C0840, 0x3100005F
+.long 0xD3EC0010, 0x0442932B
+.long 0xD86C0008, 0x3200005F
+.long 0xD86C0848, 0x3300005F
+.long 0xD86C0010, 0x3400005F
+.long 0xD86C0850, 0x3500005F
+.long 0xD3EC0000, 0x0402952C
+.long 0xD86C0018, 0x3600005F
+.long 0xD86C0858, 0x3700005F
+.long 0xD86C0020, 0x3800005F
+.long 0xD86C0860, 0x3900005F
+.long 0xD86C0028, 0x3A00005F
+.long 0xD3EC0010, 0x0442952D
+.long 0xD86C0868, 0x3B00005F
+.long 0xD86C0030, 0x3C00005F
+.long 0xD86C0870, 0x3D00005F
+.long 0xD86C0038, 0x3E00005F
+.long 0xD86C0878, 0x3F00005F
+.long 0xD3EC0000, 0x0402972E
+.long 0xBF8A0000
+.long 0xD86C0000, 0x4C000061
+.long 0xD86C0008, 0x4D000061
+.long 0xD3EC0010, 0x0442972F
+.long 0xD86C0010, 0x4E000061
+.long 0xD86C0018, 0x4F000061
+.long 0xD86C0020, 0x50000061
+.long 0xD86C0028, 0x51000061
+.long 0xBF8CC57F
+.long 0xD3EC0000, 0x04029930
+.long 0xD86C0030, 0x52000061
+.long 0xD86C0038, 0x53000061
+.long 0xD3EC0010, 0x04429931
+.long 0xBF8CC67F
+.long 0xD3EC0000, 0x04029B32
+.long 0xD3EC0010, 0x04429B33
+.long 0xBF8CC57F
+.long 0xD3EC0000, 0x04029D34
+.long 0xD3EC0010, 0x04429D35
+.long 0xBF8CC47F
+.long 0xD3EC0000, 0x04029F36
+.long 0xD3EC0010, 0x04429F37
+.long 0xBF8CC07F
+.long 0xD3EC0000, 0x0402A138
+.long 0xD3EC0000, 0x0402A33A
+.long 0xD3EC0000, 0x0402A53C
+.long 0xD3EC0000, 0x0402A73E
+.long 0xD3EC0010, 0x0442A139
+.long 0xD3EC0010, 0x0442A33B
+.long 0xD3EC0010, 0x0442A53D
+.long 0xD3EC0010, 0x0442A73F
+.long 0xBED400FF, 0xFFFF0000
+.long 0x2AD6D56A
+.long 0x28D6D654
+.long 0x7E7602FF, 0xFFFF0000
+.long 0x7E7802FF, 0x7FFF0000
+.long 0x7E7A02FF, 0x00007FFF
+.long 0xBF8C0F70
+.long 0xD3D84000, 0x18000100
+.long 0xD3D84001, 0x18000101
+.long 0xD3D84002, 0x18000102
+.long 0xD3D84003, 0x18000103
+.long 0xD3D84004, 0x18000104
+.long 0xD3D84005, 0x18000105
+.long 0xD3D84006, 0x18000106
+.long 0xD3D84007, 0x18000107
+.long 0x0A000028
+.long 0x0A020228
+.long 0x24402090
+.long 0x2642216B
+.long 0x2C004029
+.long 0x2C024229
+.long 0x0A040428
+.long 0x0A060628
+.long 0x24402290
+.long 0x2642236B
+.long 0x2C044029
+.long 0x2C064229
+.long 0x0A080828
+.long 0x0A0A0A28
+.long 0x24402490
+.long 0x2642256B
+.long 0x2C084029
+.long 0x2C0A4229
+.long 0xD0480036, 0x00020100
+.long 0xD1C8003A, 0x02052100
+.long 0xD1FF003A, 0x04F67500
+.long 0xD1000000, 0x00DA793A
+.long 0x20000090
+.long 0xD0480036, 0x00020301
+.long 0xD1C8003A, 0x02052101
+.long 0xD1FF003A, 0x04F67501
+.long 0xD1000001, 0x00DA793A
+.long 0xD2010000, 0x04027701
+.long 0xD0480036, 0x00020502
+.long 0xD1C8003A, 0x02052102
+.long 0xD1FF003A, 0x04F67502
+.long 0xD1000002, 0x00DA793A
+.long 0xD0480036, 0x00020703
+.long 0xD1C8003A, 0x02052103
+.long 0xD1FF003A, 0x04F67503
+.long 0xD1000003, 0x00DA793A
+.long 0x20040490
+.long 0xD2010001, 0x040A7703
+.long 0xD0480036, 0x00020904
+.long 0xD1C8003A, 0x02052104
+.long 0xD1FF003A, 0x04F67504
+.long 0xD1000004, 0x00DA793A
+.long 0xD0480036, 0x00020B05
+.long 0xD1C8003A, 0x02052105
+.long 0xD1FF003A, 0x04F67505
+.long 0xD1000005, 0x00DA793A
+.long 0x20080890
+.long 0xD2010002, 0x04127705
+.long 0xE0741000, 0x80050068
+.long 0x0A0C0C28
+.long 0x0A0E0E28
+.long 0x24402690
+.long 0x2642276B
+.long 0x2C0C4029
+.long 0x2C0E4229
+.long 0xD0480036, 0x00020D06
+.long 0xD1C8003A, 0x02052106
+.long 0xD1FF003A, 0x04F67506
+.long 0xD1000006, 0x00DA793A
+.long 0xD0480036, 0x00020F07
+.long 0xD1C8003A, 0x02052107
+.long 0xD1FF003A, 0x04F67507
+.long 0xD1000007, 0x00DA793A
+.long 0x200C0C90
+.long 0xD2010003, 0x041A7707
+.long 0xE0741010, 0x80050268
+.long 0xD3D84008, 0x18000108
+.long 0xD3D84009, 0x18000109
+.long 0xD3D8400A, 0x1800010A
+.long 0xD3D8400B, 0x1800010B
+.long 0x0A101028
+.long 0x0A121228
+.long 0x24402890
+.long 0x2642296B
+.long 0x2C104029
+.long 0x2C124229
+.long 0x0A141428
+.long 0x0A161628
+.long 0x24402A90
+.long 0x26422B6B
+.long 0x2C144029
+.long 0x2C164229
+.long 0xD0480036, 0x00021108
+.long 0xD1C8003A, 0x02052108
+.long 0xD1FF003A, 0x04F67508
+.long 0xD1000008, 0x00DA793A
+.long 0xD0480036, 0x00021309
+.long 0xD1C8003A, 0x02052109
+.long 0xD1FF003A, 0x04F67509
+.long 0xD1000009, 0x00DA793A
+.long 0x20101090
+.long 0xD2010004, 0x04227709
+.long 0xD0480036, 0x0002150A
+.long 0xD1C8003A, 0x0205210A
+.long 0xD1FF003A, 0x04F6750A
+.long 0xD100000A, 0x00DA793A
+.long 0xD0480036, 0x0002170B
+.long 0xD1C8003A, 0x0205210B
+.long 0xD1FF003A, 0x04F6750B
+.long 0xD100000B, 0x00DA793A
+.long 0x20141490
+.long 0xD2010005, 0x042A770B
+.long 0xE0741020, 0x80050468
+.long 0xD3D8400C, 0x1800010C
+.long 0xD3D8400D, 0x1800010D
+.long 0xD3D8400E, 0x1800010E
+.long 0xD3D8400F, 0x1800010F
+.long 0x0A181828
+.long 0x0A1A1A28
+.long 0x24402C90
+.long 0x26422D6B
+.long 0x2C184029
+.long 0x2C1A4229
+.long 0x0A1C1C28
+.long 0x0A1E1E28
+.long 0x24402E90
+.long 0x26422F6B
+.long 0x2C1C4029
+.long 0x2C1E4229
+.long 0xD0480036, 0x0002190C
+.long 0xD1C8003A, 0x0205210C
+.long 0xD1FF003A, 0x04F6750C
+.long 0xD100000C, 0x00DA793A
+.long 0xD0480036, 0x00021B0D
+.long 0xD1C8003A, 0x0205210D
+.long 0xD1FF003A, 0x04F6750D
+.long 0xD100000D, 0x00DA793A
+.long 0x20181890
+.long 0xD2010006, 0x0432770D
+.long 0xD0480036, 0x00021D0E
+.long 0xD1C8003A, 0x0205210E
+.long 0xD1FF003A, 0x04F6750E
+.long 0xD100000E, 0x00DA793A
+.long 0xD0480036, 0x00021F0F
+.long 0xD1C8003A, 0x0205210F
+.long 0xD1FF003A, 0x04F6750F
+.long 0xD100000F, 0x00DA793A
+.long 0x201C1C90
+.long 0xD2010007, 0x043A770F
+.long 0xE0741030, 0x80050668
+.long 0xD3D84000, 0x18000110
+.long 0xD3D84001, 0x18000111
+.long 0xD3D84002, 0x18000112
+.long 0xD3D84003, 0x18000113
+.long 0xD3D84004, 0x18000114
+.long 0xD3D84005, 0x18000115
+.long 0xD3D84006, 0x18000116
+.long 0xD3D84007, 0x18000117
+.long 0x0A000028
+.long 0x0A020228
+.long 0x24403090
+.long 0x2642316B
+.long 0x2C004029
+.long 0x2C024229
+.long 0x0A040428
+.long 0x0A060628
+.long 0x24403290
+.long 0x2642336B
+.long 0x2C044029
+.long 0x2C064229
+.long 0x0A080828
+.long 0x0A0A0A28
+.long 0x24403490
+.long 0x2642356B
+.long 0x2C084029
+.long 0x2C0A4229
+.long 0xD0480036, 0x00020100
+.long 0xD1C8003A, 0x02052100
+.long 0xD1FF003A, 0x04F67500
+.long 0xD1000000, 0x00DA793A
+.long 0x20000090
+.long 0xD0480036, 0x00020301
+.long 0xD1C8003A, 0x02052101
+.long 0xD1FF003A, 0x04F67501
+.long 0xD1000001, 0x00DA793A
+.long 0xD2010000, 0x04027701
+.long 0xD0480036, 0x00020502
+.long 0xD1C8003A, 0x02052102
+.long 0xD1FF003A, 0x04F67502
+.long 0xD1000002, 0x00DA793A
+.long 0xD0480036, 0x00020703
+.long 0xD1C8003A, 0x02052103
+.long 0xD1FF003A, 0x04F67503
+.long 0xD1000003, 0x00DA793A
+.long 0x20040490
+.long 0xD2010001, 0x040A7703
+.long 0xD0480036, 0x00020904
+.long 0xD1C8003A, 0x02052104
+.long 0xD1FF003A, 0x04F67504
+.long 0xD1000004, 0x00DA793A
+.long 0xD0480036, 0x00020B05
+.long 0xD1C8003A, 0x02052105
+.long 0xD1FF003A, 0x04F67505
+.long 0xD1000005, 0x00DA793A
+.long 0x20080890
+.long 0xD2010002, 0x04127705
+.long 0xE0741040, 0x80050068
+.long 0x0A0C0C28
+.long 0x0A0E0E28
+.long 0x24403690
+.long 0x2642376B
+.long 0x2C0C4029
+.long 0x2C0E4229
+.long 0xD0480036, 0x00020D06
+.long 0xD1C8003A, 0x02052106
+.long 0xD1FF003A, 0x04F67506
+.long 0xD1000006, 0x00DA793A
+.long 0xD0480036, 0x00020F07
+.long 0xD1C8003A, 0x02052107
+.long 0xD1FF003A, 0x04F67507
+.long 0xD1000007, 0x00DA793A
+.long 0x200C0C90
+.long 0xD2010003, 0x041A7707
+.long 0xE0741050, 0x80050268
+.long 0xD3D84008, 0x18000118
+.long 0xD3D84009, 0x18000119
+.long 0xD3D8400A, 0x1800011A
+.long 0xD3D8400B, 0x1800011B
+.long 0x0A101028
+.long 0x0A121228
+.long 0x24403890
+.long 0x2642396B
+.long 0x2C104029
+.long 0x2C124229
+.long 0x0A141428
+.long 0x0A161628
+.long 0x24403A90
+.long 0x26423B6B
+.long 0x2C144029
+.long 0x2C164229
+.long 0xD0480036, 0x00021108
+.long 0xD1C8003A, 0x02052108
+.long 0xD1FF003A, 0x04F67508
+.long 0xD1000008, 0x00DA793A
+.long 0xD0480036, 0x00021309
+.long 0xD1C8003A, 0x02052109
+.long 0xD1FF003A, 0x04F67509
+.long 0xD1000009, 0x00DA793A
+.long 0x20101090
+.long 0xD2010004, 0x04227709
+.long 0xD0480036, 0x0002150A
+.long 0xD1C8003A, 0x0205210A
+.long 0xD1FF003A, 0x04F6750A
+.long 0xD100000A, 0x00DA793A
+.long 0xD0480036, 0x0002170B
+.long 0xD1C8003A, 0x0205210B
+.long 0xD1FF003A, 0x04F6750B
+.long 0xD100000B, 0x00DA793A
+.long 0x20141490
+.long 0xD2010005, 0x042A770B
+.long 0xE0741060, 0x80050468
+.long 0xD3D8400C, 0x1800011C
+.long 0xD3D8400D, 0x1800011D
+.long 0xD3D8400E, 0x1800011E
+.long 0xD3D8400F, 0x1800011F
+.long 0x0A181828
+.long 0x0A1A1A28
+.long 0x24403C90
+.long 0x26423D6B
+.long 0x2C184029
+.long 0x2C1A4229
+.long 0x0A1C1C28
+.long 0x0A1E1E28
+.long 0x24403E90
+.long 0x26423F6B
+.long 0x2C1C4029
+.long 0x2C1E4229
+.long 0xD0480036, 0x0002190C
+.long 0xD1C8003A, 0x0205210C
+.long 0xD1FF003A, 0x04F6750C
+.long 0xD100000C, 0x00DA793A
+.long 0xD0480036, 0x00021B0D
+.long 0xD1C8003A, 0x0205210D
+.long 0xD1FF003A, 0x04F6750D
+.long 0xD100000D, 0x00DA793A
+.long 0x20181890
+.long 0xD2010006, 0x0432770D
+.long 0xD0480036, 0x00021D0E
+.long 0xD1C8003A, 0x0205210E
+.long 0xD1FF003A, 0x04F6750E
+.long 0xD100000E, 0x00DA793A
+.long 0xD0480036, 0x00021F0F
+.long 0xD1C8003A, 0x0205210F
+.long 0xD1FF003A, 0x04F6750F
+.long 0xD100000F, 0x00DA793A
+.long 0x201C1C90
+.long 0xD2010007, 0x043A770F
+.long 0xE0741070, 0x80050668
+.long 0xBF8C0000
+.long 0xBF810000

--- a/Tensile/ReplacementKernels-cov3/Cijk_Alik_Bljk_BBH_MT64x32x64_AF0EM8_ASEM8_FL0_GRVW2_ISA908_MDA2_PGR1_PLR1_SU32_TT2_2_VAW1_VW2_WG32_16_1_WGM8.s.txt
+++ b/Tensile/ReplacementKernels-cov3/Cijk_Alik_Bljk_BBH_MT64x32x64_AF0EM8_ASEM8_FL0_GRVW2_ISA908_MDA2_PGR1_PLR1_SU32_TT2_2_VAW1_VW2_WG32_16_1_WGM8.s.txt
@@ -1,0 +1,931 @@
+
+
+/******************************************/
+/* Function Prefix                        */
+/******************************************/
+
+
+
+/******************************************/
+/* Begin Kernel                           */
+/******************************************/
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx908+sram-ecc"
+.text
+.protected  Cijk_Alik_Bljk_BBH_MT64x32x64_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG32_16_1_WGM8
+.globl  Cijk_Alik_Bljk_BBH_MT64x32x64_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG32_16_1_WGM8
+.p2align 8
+.type  Cijk_Alik_Bljk_BBH_MT64x32x64_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG32_16_1_WGM8,@function
+.section .rodata,#alloc
+.p2align 6
+.amdhsa_kernel  Cijk_Alik_Bljk_BBH_MT64x32x64_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG32_16_1_WGM8
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_next_free_vgpr 108 // vgprs
+  .amdhsa_next_free_sgpr 98 // sgprs
+  .amdhsa_group_segment_fixed_size 28672 // lds bytes
+  .amdhsa_private_segment_fixed_size 0
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+.text
+
+/******************************************/
+/* Optimizations and Config:              */
+/******************************************/
+/* ThreadTile= 4 x 4 */
+/* SubGroup= 32 x 16 */
+/* VectorWidth=4 */
+/* GlobalLoadVectorWidthA=4, GlobalLoadVectorWidthB=4 */
+/* DirectToLdsA=False */
+/* DirectToLdsB=False */
+/* UseSgprForGRO=1 */
+.amdgpu_metadata
+---
+amdhsa.version:
+  - 1
+  - 0
+amdhsa.kernels:
+  - .name:  Cijk_Alik_Bljk_BBH_MT64x32x64_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG32_16_1_WGM8
+    .symbol: 'Cijk_Alik_Bljk_BBH_MT64x32x64_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG32_16_1_WGM8.kd'
+    .language:                   OpenCL C
+    .language_version:
+      - 2
+      - 0
+    .args:
+      - .name:            sizeC
+        .size:            8
+        .offset:          0
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            sizeA
+        .size:            8
+        .offset:          8
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            sizeB
+        .size:            8
+        .offset:          16
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            D
+        .size:            8
+        .offset:          24
+        .value_kind:      global_buffer
+        .value_type:      struct
+        .address_space:   generic
+      - .name:            C
+        .size:            8
+        .offset:          32
+        .value_kind:      global_buffer
+        .value_type:      struct
+        .address_space:   generic
+      - .name:            A
+        .size:            8
+        .offset:          40
+        .value_kind:      global_buffer
+        .value_type:      struct
+        .address_space:   generic
+      - .name:            B
+        .size:            8
+        .offset:          48
+        .value_kind:      global_buffer
+        .value_type:      struct
+        .address_space:   generic
+      - .name:            alpha
+        .size:            4
+        .offset:          56
+        .value_kind:      by_value
+        .value_type:      f32
+      - .name:            beta
+        .size:            4
+        .offset:          60
+        .value_kind:      by_value
+        .value_type:      f32
+      - .name:            strideD0
+        .size:            4
+        .offset:          64
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideD1
+        .size:            4
+        .offset:          68
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideC0
+        .size:            4
+        .offset:          72
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideC1
+        .size:            4
+        .offset:          76
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideA0
+        .size:            4
+        .offset:          80
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideA1
+        .size:            4
+        .offset:          84
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideB0
+        .size:            4
+        .offset:          88
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideB1
+        .size:            4
+        .offset:          92
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree0
+        .size:            4
+        .offset:          96
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree1
+        .size:            4
+        .offset:          100
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree2
+        .size:            4
+        .offset:          104
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesSum0
+        .size:            4
+        .offset:          108
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            OrigStaggerUIter
+        .size:            4
+        .offset:          112
+        .value_kind:      by_value
+        .value_type:      i32
+      - .name:            NumWorkGroups0
+        .size:            4
+        .offset:          116
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            NumWorkGroups1
+        .size:            4
+        .offset:          120
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            MagicNumberProblemNumGroupTiles0
+        .size:            4
+        .offset:          124
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            GridNumWorkGroups0
+        .size:            4
+        .offset:          128
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            NumFullBlocks
+        .size:            4
+        .offset:          132
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            WgmRemainder1
+        .size:            4
+        .offset:          136
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            MagicNumberWgmRemainder1
+        .size:            4
+        .offset:          140
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            padding
+        .size:            4
+        .offset:          144
+        .value_kind:      by_value
+        .value_type:      u32
+    .group_segment_fixed_size:   28672
+    .kernarg_segment_align:      8
+    .kernarg_segment_size:       152
+    .max_flat_workgroup_size:    512
+    .private_segment_fixed_size: 0
+    .sgpr_count:                 98
+    .sgpr_spill_count:           0
+    .vgpr_count:                 108
+    .vgpr_spill_count:           0
+    .wavefront_size:             64
+...
+.end_amdgpu_metadata
+Cijk_Alik_Bljk_BBH_MT64x32x64_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG32_16_1_WGM8:
+
+/******************************************/
+/* Asm syntax workarounds                 */
+/******************************************/
+.macro _v_add_co_u32 dst, cc, src0, src1, dpp=
+   v_add_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+
+.macro _v_add_u32 dst, src0, src1, dpp=
+   v_add_u32 \dst, \src0, \src1 \dpp
+.endm
+
+.macro _v_sub_co_u32 dst, cc, src0, src1, dpp=
+   v_sub_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+
+.macro _v_sub_u32 dst, src0, src1, dpp=
+   v_sub_u32 \dst, \src0, \src1 \dpp
+.endm
+
+.macro _v_addc_co_u32 dst, ccOut, src0, ccIn, src1, dpp=
+   v_addc_co_u32 \dst, \ccOut, \src0, \ccIn, \src1 \dpp
+.endm
+
+.macro _v_add_lshl_u32 dst, src0, src1, shiftCnt
+    v_add_lshl_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+.macro _v_lshl_add_u32 dst, src0, src1, shiftCnt
+    v_lshl_add_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+/******************************************/
+/* Magic div and mod functions            */
+/******************************************/
+.macro V_MAGIC_DIV dstIdx, dividend, magicNumber, magicShift
+    v_mul_hi_u32 v[\dstIdx+1], \dividend, \magicNumber
+    v_mul_lo_u32 v[\dstIdx+0], \dividend, \magicNumber
+    v_lshrrev_b64 v[\dstIdx:\dstIdx+1], \magicShift, v[\dstIdx:\dstIdx+1]
+.endm
+
+/******************************************/
+/* VGPR Assignments                       */
+/******************************************/
+.set vgprValuC, 0
+/* ValuA/B   Xn=PLR buffer idx,  In=InnerUnroll idx */
+.set vgprValuA_X0_I0, 32
+.set vgprValuA_X1_I0, 34
+.set vgprG2LA, 36
+.set vgprValuB_X0_I0, 40
+.set vgprValuB_X1_I0, 44
+.set vgprG2LB, 48
+.set vgprLocalWriteAddrA, 56
+.set vgprLocalWriteAddrB, 57
+.set vgprGlobalReadOffsetA, 58
+.set vgprGlobalReadOffsetB, 59
+.set vgprLocalReadAddrA, 60
+.set vgprLocalReadAddrB, 61
+.set vgprSerial, 62
+/* Num VGPR=63 */
+
+/******************************************/
+/* SGPR Assignments                       */
+/******************************************/
+.set sgprKernArgAddress, 0
+.set sgprWorkGroup0, 2
+.set sgprWorkGroup1, 3
+.set sgprWorkGroup2, 4
+.set sgprNumWorkGroups0, 5
+.set sgprNumWorkGroups1, 6
+.set sgprSrdA, 8
+.set sgprSrdB, 12
+.set sgprSrdD, 16
+.set sgprSrdC, 20
+.set sgprTensor2dSizeC, 24
+.set sgprTensor2dSizeA, 26
+.set sgprTensor2dSizeB, 28
+.set sgprSaveExecMask, 30
+.set sgprAddressD, 32
+.set sgprAddressC, 34
+.set sgprStridesD, 36
+.set sgprStridesC, 38
+.set sgprAlpha, 40
+.set sgprBeta, 41
+.set sgprSizesFree, 42
+.set sgprSizesSum, 45
+.set sgprLoopCounters, 46
+.set sgprOrigLoopCounter, 47
+.set sgprStridesA, 48
+.set sgprStridesB, 50
+.set sgprAddressA, 52
+.set sgprAddressB, 54
+.set sgprShadowLimitA, 56
+.set sgprShadowLimitB, 58
+.set sgprOrigStaggerUIter, 60
+.set sgprStaggerUIter, 61
+.set sgprWrapUA, 62
+.set sgprWrapUB, 64
+.set sgprNumFullBlocks, 66
+.set sgprWgmRemainder1, 67
+.set sgprMagicNumberWgmRemainder1, 68
+.set sgprGlobalReadIncsA, 69
+.set sgprGlobalReadIncsB, 70
+.set sgprScalarGlobalReadOffsetA, 71
+.set sgprScalarGlobalReadOffsetB, 72
+/* max SGPR=98 */
+
+/* Size Assignments */
+.set sgprSizeD0I, sgprSizesFree+0
+.set sgprSizeD1J, sgprSizesFree+1
+.set sgprSizeDK, sgprSizesFree+2
+.set sgprSizeC0I, sgprSizesFree+0
+.set sgprSizeC1J, sgprSizesFree+1
+.set sgprSizeCK, sgprSizesFree+2
+.set sgprSizeAL, sgprSizesSum+0
+.set sgprSizeA0I, sgprSizesFree+0
+.set sgprSizeAK, sgprSizesFree+2
+.set sgprSizeBL, sgprSizesSum+0
+.set sgprSizeB1J, sgprSizesFree+1
+.set sgprSizeBK, sgprSizesFree+2
+
+/* Stride Assignments */
+.set constStrideD0I, 1
+.set sgprStrideD1J, sgprStridesD+0
+.set sgprStrideDK, sgprStridesD+1
+.set constStrideC0I, 1
+.set sgprStrideC1J, sgprStridesC+0
+.set sgprStrideCK, sgprStridesC+1
+.set constStrideAL, 1
+.set sgprStrideA0I, sgprStridesA+0
+.set sgprStrideAK, sgprStridesA+1
+.set constStrideBL, 1
+.set sgprStrideB1J, sgprStridesB+0
+.set sgprStrideBK, sgprStridesB+1
+
+.set DepthU, 32
+/* Number of elements to shift-left SRD */
+.set SrdShiftLeftA, 4
+.set SrdShiftLeftB, 4
+/* 2GB limit - set offsets to -1 to exceed this and clamp */
+.set BufferLimit, 0x80000000
+/* Bits 127:96 of SRD.  Set DataFormat = 32 bit */
+.set Srd127_96, 0x0020000
+.set BufferOOB, 0x80000000
+
+/* Global Offset A */
+.macro GLOBAL_OFFSET_A vgprAddr vgprOffsetL vgprOffset0I vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStrideA0I], v[\vgprOffset0I] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprOffsetL], v[\vgprTmp+0] // accumulate d1 lower
+_v_add_u32 v[\vgprAddr+0], 0x4, v[\vgprAddr+0]     // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/* Global Offset B */
+.macro GLOBAL_OFFSET_B vgprAddr vgprOffsetL vgprOffset1J vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStrideB1J], v[\vgprOffset1J] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprOffsetL], v[\vgprTmp+0] // accumulate d1 lower
+_v_add_u32 v[\vgprAddr+0], 0x4, v[\vgprAddr+0]     // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/******************************************/
+/* Dynamic Scalar Divide: vQuotient=vDividend/vDivisor; vRemainder=vDividend%vDivisor; */
+/******************************************/
+.macro DYNAMIC_VECTOR_DIVIDE vQuotient vRemainder vDividend vDivisor vTmp0 vTmp1 sTmp
+v_cvt_f32_u32 v[\vQuotient], v[\vDivisor]          //
+v_rcp_f32 v[\vQuotient], v[\vQuotient]             //
+v_mul_f32 v[\vQuotient], 0x4f800000, v[\vQuotient] //
+v_cvt_u32_f32 v[\vQuotient], v[\vQuotient]         //
+v_mul_lo_u32 v[\vRemainder], v[\vDivisor], v[\vQuotient] //
+v_mul_hi_u32 v[\vTmp0], v[\vDivisor], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp1], vcc, 0x0, v[\vRemainder]  //
+v_cmp_ne_i32 s[\sTmp:\sTmp+1], 0x0, v[\vTmp0]      //
+v_cndmask_b32 v[\vRemainder], v[\vTmp1], v[\vRemainder], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vRemainder], v[\vRemainder], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vQuotient], v[\vRemainder] //
+_v_add_co_u32 v[\vQuotient], vcc, v[\vQuotient], v[\vRemainder] //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vTmp0], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vQuotient], v[\vQuotient], v[\vDividend] //
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vDividend], v[\vRemainder] //
+v_cmp_ge_u32 s[\sTmp:\sTmp+1], v[\vDividend], v[\vRemainder] //
+_v_add_co_u32 v[\vRemainder], vcc, 0x1, v[\vQuotient] //
+_v_add_co_u32 v[\vTmp1], vcc, -1, v[\vQuotient]    //
+v_cmp_le_u32 vcc, v[\vDivisor], v[\vTmp0]          //
+s_and_b64 vcc, s[\sTmp:\sTmp+1], vcc               //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vRemainder], vcc //
+v_cndmask_b32 v[\vQuotient], v[\vTmp1], v[\vQuotient], s[\sTmp:\sTmp+1] //
+v_cmp_ne_i32 vcc, 0x0, v[\vDivisor]                //
+v_cndmask_b32 v[\vQuotient], -1, v[\vQuotient], vcc // final result
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vRemainder], vcc, v[\vDividend], v[\vRemainder] // final result
+.endm
+
+/******************************************/
+/* 4x8 thread-tile                        */
+/******************************************/
+.macro MAC_4x8_X0
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[0] iui=0
+s_setprio 1 // Raise priority while processing macs
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[1]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[4]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[5]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[2] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[3]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[6]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[7]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[8] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[9]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[12]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[13]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[10] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[11]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[14]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[15]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[16] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[17]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[20]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[21]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[18] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[19]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[22]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[23]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[24] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[25]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[28]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[29]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[26] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[27]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[30]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[31]
+s_setprio 0 // Reset priority after macs
+.endm
+.macro MAC_4x8_X1
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[0] iui=0
+s_setprio 1 // Raise priority while processing macs
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[1]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[4]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[5]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[2] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[3]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[6]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[7]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[8] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[9]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[12]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[13]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[10] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[11]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[14]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[15]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[16] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[17]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[20]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[21]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[18] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[19]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[22]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[23]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[24] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[25]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[28]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[29]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[26] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[27]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[30]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[31]
+s_setprio 0 // Reset priority after macs
+.endm
+
+
+
+
+/***** program start from here *****/
+
+.long 0xC00A0600, 0x00000008
+.long 0xC00A0D00, 0x00000028
+.long 0xC00A0C00, 0x00000050
+.long 0xC0020B40, 0x0000006C
+.long 0x7ECC0300
+.long 0x26CE00BF
+.long 0xB8D0F804
+.long 0xD1130004, 0x0000A0B0
+.long 0x20D00884
+.long 0x7EA40568
+.long 0xD1130069, 0x0000A08F
+.long 0x7EA20569
+.long 0xBF068151
+.long 0xBF8400EC
+.long 0xBF8CC07F
+.long 0xBE880034
+.long 0xBE890035
+.long 0xBE8A00FF, 0x80000000
+.long 0xBE8B00FF, 0x00020000
+.long 0x96553104
+.long 0x92543104
+.long 0x8ED48154
+.long 0x80085408
+.long 0x82095509
+.long 0x9254C030
+.long 0x92545402
+.long 0x92559030
+.long 0x92555552
+.long 0x81545554
+.long 0x2000CE85
+.long 0xD2850004, 0x00020030
+.long 0x2602CE9F
+.long 0x24020281
+.long 0x32180304
+.long 0x68181854
+.long 0x24181881
+.long 0x8E478230
+.long 0x80C7FF47, 0x00000120
+.long 0x681A1847
+.long 0x681C1A47
+.long 0x681E1C47
+.long 0x68201E47
+.long 0x68222047
+.long 0x68242247
+.long 0x68262447
+.long 0xBECC00FF, 0x00000900
+.long 0x924C4C52
+.long 0xBE8C0036
+.long 0xBE8D0037
+.long 0xBE8E00FF, 0x80000000
+.long 0xBE8F00FF, 0x00020000
+.long 0x96553304
+.long 0x92543304
+.long 0x8ED48154
+.long 0x800C540C
+.long 0x820D550D
+.long 0x9254A032
+.long 0x92545403
+.long 0x92558832
+.long 0x92555552
+.long 0x81545554
+.long 0x2004CE85
+.long 0xD2850004, 0x00020432
+.long 0x2606CE9F
+.long 0x24060681
+.long 0x32280704
+.long 0x68282854
+.long 0x24282881
+.long 0x8E4A8232
+.long 0x80CAFF4A, 0x00000120
+.long 0x682A284A
+.long 0x682C2A4A
+.long 0x682E2C4A
+.long 0xBECE00FF, 0x00000480
+.long 0x924E4E52
+.long 0x814EFF4E, 0x00004800
+.long 0xBF8A0000
+.long 0xBEFC004E
+.long 0x814FFF4E, 0x00001200
+.long 0xE0511000, 0x80030814
+.long 0xE0511120, 0x80030915
+.long 0xE0511240, 0x80030A16
+.long 0xE0511360, 0x80030B17
+.long 0xBEFC004C
+.long 0x814DFF4C, 0x00002400
+.long 0xE0511000, 0x8002000C
+.long 0xE0511120, 0x8002010D
+.long 0xE0511240, 0x8002020E
+.long 0xE0511360, 0x8002030F
+.long 0xE0511480, 0x80020410
+.long 0xE05115A0, 0x80020511
+.long 0xE05116C0, 0x80020612
+.long 0xE05117E0, 0x80020713
+.long 0xBEFC004F
+.long 0x800CFF0C, 0x00000080
+.long 0x820D800D
+.long 0x8008FF08, 0x00000080
+.long 0x82098009
+.long 0xE0511000, 0x80030814
+.long 0xE0511120, 0x80030915
+.long 0xE0511240, 0x80030A16
+.long 0xE0511360, 0x80030B17
+.long 0xBEFC004D
+.long 0xBF800000
+.long 0xE0511000, 0x8002000C
+.long 0xE0511120, 0x8002010D
+.long 0xE0511240, 0x8002020E
+.long 0xE0511360, 0x8002030F
+.long 0xE0511480, 0x80020410
+.long 0xE05115A0, 0x80020511
+.long 0xE05116C0, 0x80020612
+.long 0xE05117E0, 0x80020713
+.long 0x800CFF0C, 0x00000080
+.long 0x820D800D
+.long 0x8008FF08, 0x00000080
+.long 0x82098009
+.long 0xBEFC004E
+.long 0xBF8C4F74
+.long 0xBF8A0000
+.long 0xBF8C0F7C
+.long 0xBF8A0000
+.long 0x8F2E862D
+.long 0x80AE2E80
+.long 0xBF03C22E
+.long 0xBF85004F
+.long 0xBF8A0000
+.long 0xE0511000, 0x80030814
+.long 0xE0511120, 0x80030915
+.long 0xE0511240, 0x80030A16
+.long 0xE0511360, 0x80030B17
+.long 0xBEFC004C
+.long 0xBF800000
+.long 0xE0511000, 0x8002000C
+.long 0xE0511120, 0x8002010D
+.long 0xE0511240, 0x8002020E
+.long 0xE0511360, 0x8002030F
+.long 0xE0511480, 0x80020410
+.long 0xE05115A0, 0x80020511
+.long 0xE05116C0, 0x80020612
+.long 0xE05117E0, 0x80020713
+.long 0xBF8C4F74
+.long 0xBF8A0000
+.long 0x800CFF0C, 0x00000080
+.long 0x820D800D
+.long 0xBF8C0F7C
+.long 0xBF8A0000
+.long 0x8008FF08, 0x00000080
+.long 0x82098009
+.long 0xBEFC004F
+.long 0xBF8A0000
+.long 0xE0511000, 0x80030814
+.long 0xE0511120, 0x80030915
+.long 0xE0511240, 0x80030A16
+.long 0xE0511360, 0x80030B17
+.long 0xBEFC004D
+.long 0xBF800000
+.long 0xE0511000, 0x8002000C
+.long 0xE0511120, 0x8002010D
+.long 0xE0511240, 0x8002020E
+.long 0xE0511360, 0x8002030F
+.long 0xE0511480, 0x80020410
+.long 0xE05115A0, 0x80020511
+.long 0xE05116C0, 0x80020612
+.long 0xE05117E0, 0x80020713
+.long 0xBF8C4F74
+.long 0xBF8A0000
+.long 0x800CFF0C, 0x00000080
+.long 0x820D800D
+.long 0xBF8C0F7C
+.long 0xBF8A0000
+.long 0x8008FF08, 0x00000080
+.long 0x82098009
+.long 0xBEFC004E
+.long 0x802E822E
+.long 0xBF03C22E
+.long 0xBF84FFB1
+.long 0xBF8C0F78
+.long 0xBF8A0000
+.long 0xBF8C0F70
+.long 0xBF8A0000
+.long 0xBF810000
+.long 0xC0060700, 0x00000000
+.long 0xC00A0800, 0x00000018
+.long 0xC00A0A00, 0x00000038
+.long 0xC00A0900, 0x00000040
+.long 0xD3D94000, 0x18000080
+.long 0xD3D94001, 0x18000080
+.long 0xD3D94002, 0x18000080
+.long 0xD3D94003, 0x18000080
+.long 0xD3D94004, 0x18000080
+.long 0xD3D94005, 0x18000080
+.long 0xD3D94006, 0x18000080
+.long 0xD3D94007, 0x18000080
+.long 0xD1130001, 0x00011F67
+.long 0xD2850040, 0x000202C0
+.long 0x20040281
+.long 0xD2850002, 0x000204A0
+.long 0x2002CE84
+.long 0x24020283
+.long 0x68808101
+.long 0x24808081
+.long 0x68808102
+.long 0x9254FF52, 0x00000900
+.long 0x68808054
+.long 0x68808080
+.long 0x688280FF, 0x00002400
+.long 0xBF8A0000
+.long 0xD1130001, 0x00011F67
+.long 0xD2850042, 0x000202C0
+.long 0x20040281
+.long 0xD2850002, 0x000204A0
+.long 0x2002CE84
+.long 0x24020283
+.long 0x68848501
+.long 0x24848481
+.long 0x68848502
+.long 0x688484FF, 0x00004800
+.long 0x688684FF, 0x00001200
+.long 0xBF8CC07F
+.long 0xBE900022
+.long 0xBE910023
+.long 0xBE9200FF, 0x80000000
+.long 0xBE9300FF, 0x00020000
+.long 0x925603A0
+.long 0x96552656
+.long 0x92542656
+.long 0x8ED48154
+.long 0x80105410
+.long 0x82115511
+.long 0x96552704
+.long 0x92542704
+.long 0x8ED48154
+.long 0x80105410
+.long 0x82115511
+.long 0xD2850003, 0x0002D090
+.long 0x2608CE8F
+.long 0xD2850005, 0x00004D04
+.long 0x200CCE84
+.long 0x240C0C82
+.long 0x68D60B03
+.long 0x925402C0
+.long 0x32D40C54
+.long 0xD1FE0044, 0x0206D76A
+.long 0x925426A0
+.long 0x688A8854
+.long 0xBE940020
+.long 0xBE950021
+.long 0xBE9600FF, 0x80000000
+.long 0xBE9700FF, 0x00020000
+.long 0x925603A0
+.long 0x96552456
+.long 0x92542456
+.long 0x8ED48154
+.long 0x80145414
+.long 0x82155515
+.long 0x96552504
+.long 0x92542504
+.long 0x8ED48154
+.long 0x80145414
+.long 0x82155515
+.long 0xD2850003, 0x0002D090
+.long 0x2608CE8F
+.long 0xD2850005, 0x00004904
+.long 0x200CCE84
+.long 0x240C0C82
+.long 0x68D60B03
+.long 0x925402C0
+.long 0x32D40C54
+.long 0xD1FE0046, 0x0206D76A
+.long 0x925426A0
+.long 0x688E8C54
+.long 0xBF8A0000
+.long 0xD9FE0000, 0x20000042
+.long 0xD9FE0900, 0x28000042
+.long 0xD9FE0040, 0x24000042
+.long 0xD9FE0940, 0x2C000042
+.long 0xBF8A0000
+.long 0xD9FE0000, 0x10000040
+.long 0xD9FE0040, 0x14000040
+.long 0x8F2E862D
+.long 0x80AE2E80
+.long 0xBF03C22E
+.long 0xBF850065
+.long 0xBF8A0000
+.long 0xBF8CC17F
+.long 0xD3ED0000, 0x04024110
+.long 0xD3ED0004, 0x04125110
+.long 0xD3ED0000, 0x04024311
+.long 0xD3ED0004, 0x04125311
+.long 0xD3ED0000, 0x04024512
+.long 0xBF8A0000
+.long 0xD3ED0004, 0x04125512
+.long 0xD9FE0000, 0x30000043
+.long 0xD3ED0000, 0x04024713
+.long 0xD9FE0900, 0x38000043
+.long 0xD3ED0004, 0x04125713
+.long 0xD9FE0040, 0x34000043
+.long 0xBF8CC37F
+.long 0xD3ED0000, 0x04024914
+.long 0xD9FE0940, 0x3C000043
+.long 0xD3ED0004, 0x04125914
+.long 0xD3ED0000, 0x04024B15
+.long 0xD3ED0004, 0x04125B15
+.long 0xD3ED0000, 0x04024D16
+.long 0xD3ED0004, 0x04125D16
+.long 0xBF8A0000
+.long 0xD9FE0000, 0x18000041
+.long 0xD3ED0000, 0x04024F17
+.long 0xD9FE0040, 0x1C000041
+.long 0xD3ED0004, 0x04125F17
+.long 0xBF8A0000
+.long 0xBF8CC17F
+.long 0xD3ED0000, 0x04026118
+.long 0xD3ED0004, 0x04127118
+.long 0xD3ED0000, 0x04026319
+.long 0xD3ED0004, 0x04127319
+.long 0xD3ED0000, 0x0402651A
+.long 0xBF8A0000
+.long 0xD3ED0004, 0x0412751A
+.long 0xD9FE0000, 0x20000042
+.long 0xD3ED0000, 0x0402671B
+.long 0xD9FE0900, 0x28000042
+.long 0xD3ED0004, 0x0412771B
+.long 0xD9FE0040, 0x24000042
+.long 0xBF8CC37F
+.long 0xD3ED0000, 0x0402691C
+.long 0xD9FE0940, 0x2C000042
+.long 0xD3ED0004, 0x0412791C
+.long 0xD3ED0000, 0x04026B1D
+.long 0xD3ED0004, 0x04127B1D
+.long 0xD3ED0000, 0x04026D1E
+.long 0xD3ED0004, 0x04127D1E
+.long 0xBF8A0000
+.long 0xD9FE0000, 0x10000040
+.long 0xD3ED0000, 0x04026F1F
+.long 0xD9FE0040, 0x14000040
+.long 0xD3ED0004, 0x04127F1F
+.long 0x802E822E
+.long 0xBF03C22E
+.long 0xBF84FF9B
+.long 0xBF8CC17F
+.long 0xD3ED0000, 0x04024110
+.long 0xE0541000, 0x80040844
+.long 0xE0541000, 0x80040A45
+.long 0xD3ED0004, 0x04125110
+.long 0xD3ED0000, 0x04024311
+.long 0xBF8A0000
+.long 0xD3ED0004, 0x04125311
+.long 0xD9FE0000, 0x30000043
+.long 0xD3ED0000, 0x04024512
+.long 0xD9FE0900, 0x38000043
+.long 0xD3ED0004, 0x04125512
+.long 0xD9FE0040, 0x34000043
+.long 0xD3ED0000, 0x04024713
+.long 0xD9FE0940, 0x3C000043
+.long 0xD3ED0004, 0x04125713
+.long 0xBF8CC37F
+.long 0xD3ED0000, 0x04024914
+.long 0xD3ED0004, 0x04125914
+.long 0xD3ED0000, 0x04024B15
+.long 0xD3ED0004, 0x04125B15
+.long 0xD3ED0000, 0x04024D16
+.long 0xBF8A0000
+.long 0xD9FE0000, 0x18000041
+.long 0xD3ED0004, 0x04125D16
+.long 0xD9FE0040, 0x1C000041
+.long 0xD3ED0000, 0x04024F17
+.long 0xD3ED0004, 0x04125F17
+.long 0xBF8CC17F
+.long 0xD3ED0000, 0x04026118
+.long 0xD3ED0004, 0x04127118
+.long 0xD3ED0000, 0x04026319
+.long 0xD3ED0004, 0x04127319
+.long 0xD3ED0000, 0x0402651A
+.long 0xD3ED0004, 0x0412751A
+.long 0xD3ED0000, 0x0402671B
+.long 0xD3ED0004, 0x0412771B
+.long 0xBF8CC07F
+.long 0xD3ED0000, 0x0402691C
+.long 0xD3ED0000, 0x04026B1D
+.long 0xD3ED0000, 0x04026D1E
+.long 0xD3ED0000, 0x04026F1F
+.long 0xD3ED0004, 0x0412791C
+.long 0xD3ED0004, 0x04127B1D
+.long 0xD3ED0004, 0x04127D1E
+.long 0xD3ED0004, 0x04127F1F
+.long 0x7ED602FF, 0xFFFF0000
+.long 0xD3D84000, 0x18000100
+.long 0x0A000028
+.long 0xD3D84001, 0x18000101
+.long 0x0A020228
+.long 0xD3D84002, 0x18000102
+.long 0x0A040428
+.long 0xD3D84003, 0x18000103
+.long 0x0A060628
+.long 0xBF8C0F71
+.long 0x24D41090
+.long 0xD1CB0000, 0x0400536A
+.long 0x26D410FF, 0xFFFF0000
+.long 0xD1CB0001, 0x0404536A
+.long 0x20000090
+.long 0xD2010000, 0x0402D701
+.long 0x24D41290
+.long 0xD1CB0002, 0x0408536A
+.long 0x26D412FF, 0xFFFF0000
+.long 0xD1CB0003, 0x040C536A
+.long 0x20040490
+.long 0xD2010001, 0x040AD703
+.long 0xE0741000, 0x80050046
+.long 0xD3D84004, 0x18000104
+.long 0x0A080828
+.long 0xD3D84005, 0x18000105
+.long 0x0A0A0A28
+.long 0xD3D84006, 0x18000106
+.long 0x0A0C0C28
+.long 0xD3D84007, 0x18000107
+.long 0x0A0E0E28
+.long 0xBF8C0F71
+.long 0x24D41490
+.long 0xD1CB0004, 0x0410536A
+.long 0x26D414FF, 0xFFFF0000
+.long 0xD1CB0005, 0x0414536A
+.long 0x20080890
+.long 0xD2010002, 0x0412D705
+.long 0x24D41690
+.long 0xD1CB0006, 0x0418536A
+.long 0x26D416FF, 0xFFFF0000
+.long 0xD1CB0007, 0x041C536A
+.long 0x200C0C90
+.long 0xD2010003, 0x041AD707
+.long 0xE0741000, 0x80050247
+.long 0xBF8C0000
+.long 0xBF810000

--- a/Tensile/ReplacementKernels-cov3/Cijk_Alik_Bljk_HBH_MT128x256x32_AF0EM8_ASEM8_FL0_GRVW8_ISA908_MDA2_PGR1_PLR1_SU32_TT8_8_VAW2_VW8_WG16_32_1_WGM8.s.txt
+++ b/Tensile/ReplacementKernels-cov3/Cijk_Alik_Bljk_HBH_MT128x256x32_AF0EM8_ASEM8_FL0_GRVW8_ISA908_MDA2_PGR1_PLR1_SU32_TT8_8_VAW2_VW8_WG16_32_1_WGM8.s.txt
@@ -1,0 +1,1854 @@
+
+
+/******************************************/
+/* Function Prefix                        */
+/******************************************/
+
+
+
+/******************************************/
+/* Begin Kernel                           */
+/******************************************/
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx908+sram-ecc"
+.text
+.protected Cijk_Alik_Bljk_HBH_MT128x256x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW8_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT8_8_TLDS0_USFGROn1_VAW2_VS1_VW8_WSGRA0_WSGRB0_WG16_32_1_WGM8
+.globl Cijk_Alik_Bljk_HBH_MT128x256x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW8_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT8_8_TLDS0_USFGROn1_VAW2_VS1_VW8_WSGRA0_WSGRB0_WG16_32_1_WGM8
+.p2align 8
+.type Cijk_Alik_Bljk_HBH_MT128x256x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW8_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT8_8_TLDS0_USFGROn1_VAW2_VS1_VW8_WSGRA0_WSGRB0_WG16_32_1_WGM8,@function
+.section .rodata,#alloc
+.p2align 6
+.amdhsa_kernel Cijk_Alik_Bljk_HBH_MT128x256x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW8_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT8_8_TLDS0_USFGROn1_VAW2_VS1_VW8_WSGRA0_WSGRB0_WG16_32_1_WGM8
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_next_free_vgpr 128 // vgprs
+  .amdhsa_next_free_sgpr 98 // sgprs
+  .amdhsa_group_segment_fixed_size 57344 // lds bytes
+  .amdhsa_private_segment_fixed_size 0
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+.text
+
+/******************************************/
+/* Optimizations and Config:              */
+/******************************************/
+/* ThreadTile= 8 x 8 */
+/* SubGroup= 16 x 32 */
+/* VectorWidth=8 */
+/* GlobalLoadVectorWidthA=8, GlobalLoadVectorWidthB=8 */
+/* DirectToLdsA=False */
+/* DirectToLdsB=False */
+/* UseSgprForGRO=1 */
+.amdgpu_metadata
+---
+amdhsa.version:
+  - 1
+  - 0
+amdhsa.kernels:
+  - .name: Cijk_Alik_Bljk_HBH_MT128x256x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW8_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT8_8_TLDS0_USFGROn1_VAW2_VS1_VW8_WSGRA0_WSGRB0_WG16_32_1_WGM8
+    .symbol: 'Cijk_Alik_Bljk_HBH_MT128x256x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW8_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT8_8_TLDS0_USFGROn1_VAW2_VS1_VW8_WSGRA0_WSGRB0_WG16_32_1_WGM8.kd'
+    .language:                   OpenCL C
+    .language_version:
+      - 2
+      - 0
+    .args:
+      - .name:            sizeC
+        .size:            8
+        .offset:          0
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            sizeA
+        .size:            8
+        .offset:          8
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            sizeB
+        .size:            8
+        .offset:          16
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            D
+        .size:            8
+        .offset:          24
+        .value_kind:      global_buffer
+        .value_type:      struct
+        .address_space:   generic
+      - .name:            C
+        .size:            8
+        .offset:          32
+        .value_kind:      global_buffer
+        .value_type:      struct
+        .address_space:   generic
+      - .name:            A
+        .size:            8
+        .offset:          40
+        .value_kind:      global_buffer
+        .value_type:      struct
+        .address_space:   generic
+      - .name:            B
+        .size:            8
+        .offset:          48
+        .value_kind:      global_buffer
+        .value_type:      struct
+        .address_space:   generic
+      - .name:            alpha
+        .size:            4
+        .offset:          56
+        .value_kind:      by_value
+        .value_type:      f16
+      - .name:            beta
+        .size:            4
+        .offset:          60
+        .value_kind:      by_value
+        .value_type:      f16
+      - .name:            strideD0
+        .size:            4
+        .offset:          64
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideD1
+        .size:            4
+        .offset:          68
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideC0
+        .size:            4
+        .offset:          72
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideC1
+        .size:            4
+        .offset:          76
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideA0
+        .size:            4
+        .offset:          80
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideA1
+        .size:            4
+        .offset:          84
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideB0
+        .size:            4
+        .offset:          88
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideB1
+        .size:            4
+        .offset:          92
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree0
+        .size:            4
+        .offset:          96
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree1
+        .size:            4
+        .offset:          100
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree2
+        .size:            4
+        .offset:          104
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesSum0
+        .size:            4
+        .offset:          108
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            OrigStaggerUIter
+        .size:            4
+        .offset:          112
+        .value_kind:      by_value
+        .value_type:      i32
+      - .name:            NumWorkGroups0
+        .size:            4
+        .offset:          116
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            NumWorkGroups1
+        .size:            4
+        .offset:          120
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            MagicNumberProblemNumGroupTiles0
+        .size:            4
+        .offset:          124
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            GridNumWorkGroups0
+        .size:            4
+        .offset:          128
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            NumFullBlocks
+        .size:            4
+        .offset:          132
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            WgmRemainder1
+        .size:            4
+        .offset:          136
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            MagicNumberWgmRemainder1
+        .size:            4
+        .offset:          140
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            padding
+        .size:            4
+        .offset:          144
+        .value_kind:      by_value
+        .value_type:      u32
+    .group_segment_fixed_size:   57344
+    .kernarg_segment_align:      8
+    .kernarg_segment_size:       152
+    .max_flat_workgroup_size:    512
+    .private_segment_fixed_size: 0
+    .sgpr_count:                 98
+    .sgpr_spill_count:           0
+    .vgpr_count:                 128
+    .vgpr_spill_count:           0
+    .wavefront_size:             64
+...
+.end_amdgpu_metadata
+Cijk_Alik_Bljk_HBH_MT128x256x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW8_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT8_8_TLDS0_USFGROn1_VAW2_VS1_VW8_WSGRA0_WSGRB0_WG16_32_1_WGM8:
+
+/******************************************/
+/* Asm syntax workarounds                 */
+/******************************************/
+.macro _v_add_co_u32 dst, cc, src0, src1, dpp=
+   v_add_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+
+.macro _v_add_u32 dst, src0, src1, dpp=
+   v_add_u32 \dst, \src0, \src1 \dpp
+.endm
+
+.macro _v_sub_co_u32 dst, cc, src0, src1, dpp=
+   v_sub_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+
+.macro _v_sub_u32 dst, src0, src1, dpp=
+   v_sub_u32 \dst, \src0, \src1 \dpp
+.endm
+
+.macro _v_addc_co_u32 dst, ccOut, src0, ccIn, src1, dpp=
+   v_addc_co_u32 \dst, \ccOut, \src0, \ccIn, \src1 \dpp
+.endm
+
+.macro _v_add_lshl_u32 dst, src0, src1, shiftCnt
+    v_add_lshl_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+.macro _v_lshl_add_u32 dst, src0, src1, shiftCnt
+    v_lshl_add_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+/******************************************/
+/* Magic div and mod functions            */
+/******************************************/
+.macro V_MAGIC_DIV dstIdx, dividend, magicNumber, magicShift
+    v_mul_hi_u32 v[\dstIdx+1], \dividend, \magicNumber
+    v_mul_lo_u32 v[\dstIdx+0], \dividend, \magicNumber
+    v_lshrrev_b64 v[\dstIdx:\dstIdx+1], \magicShift, v[\dstIdx:\dstIdx+1]
+.endm
+
+/******************************************/
+/* VGPR Assignments                       */
+/******************************************/
+.set vgprValuC, 0
+/* ValuA/B   Xn=PLR buffer idx,  In=InnerUnroll idx */
+.set vgprValuA_X0_I0, 32
+.set vgprValuA_X1_I0, 34
+.set vgprG2LA, 36
+.set vgprValuB_X0_I0, 40
+.set vgprValuB_X1_I0, 44
+.set vgprG2LB, 48
+.set vgprLocalWriteAddrA, 56
+.set vgprLocalWriteAddrB, 57
+.set vgprGlobalReadOffsetA, 58
+.set vgprGlobalReadOffsetB, 59
+.set vgprLocalReadAddrA, 60
+.set vgprLocalReadAddrB, 61
+.set vgprSerial, 62
+/* Num VGPR=63 */
+
+/******************************************/
+/* SGPR Assignments                       */
+/******************************************/
+.set sgprKernArgAddress, 0
+.set sgprWorkGroup0, 2
+.set sgprWorkGroup1, 3
+.set sgprWorkGroup2, 4
+.set sgprNumWorkGroups0, 5
+.set sgprNumWorkGroups1, 6
+.set sgprSrdA, 8
+.set sgprSrdB, 12
+.set sgprSrdD, 16
+.set sgprSrdC, 20
+.set sgprTensor2dSizeC, 24
+.set sgprTensor2dSizeA, 26
+.set sgprTensor2dSizeB, 28
+.set sgprSaveExecMask, 30
+.set sgprAddressD, 32
+.set sgprAddressC, 34
+.set sgprStridesD, 36
+.set sgprStridesC, 38
+.set sgprAlpha, 40
+.set sgprBeta, 41
+.set sgprSizesFree, 42
+.set sgprSizesSum, 45
+.set sgprLoopCounters, 46
+.set sgprOrigLoopCounter, 47
+.set sgprStridesA, 48
+.set sgprStridesB, 50
+.set sgprAddressA, 52
+.set sgprAddressB, 54
+.set sgprShadowLimitA, 56
+.set sgprShadowLimitB, 58
+.set sgprOrigStaggerUIter, 60
+.set sgprStaggerUIter, 61
+.set sgprWrapUA, 62
+.set sgprWrapUB, 64
+.set sgprNumFullBlocks, 66
+.set sgprWgmRemainder1, 67
+.set sgprMagicNumberWgmRemainder1, 68
+.set sgprGlobalReadIncsA, 69
+.set sgprGlobalReadIncsB, 70
+.set sgprScalarGlobalReadOffsetA, 71
+.set sgprScalarGlobalReadOffsetB, 72
+/* max SGPR=98 */
+
+/* Size Assignments */
+.set sgprSizeD0I, sgprSizesFree+0
+.set sgprSizeD1J, sgprSizesFree+1
+.set sgprSizeDK, sgprSizesFree+2
+.set sgprSizeC0I, sgprSizesFree+0
+.set sgprSizeC1J, sgprSizesFree+1
+.set sgprSizeCK, sgprSizesFree+2
+.set sgprSizeAL, sgprSizesSum+0
+.set sgprSizeA0I, sgprSizesFree+0
+.set sgprSizeAK, sgprSizesFree+2
+.set sgprSizeBL, sgprSizesSum+0
+.set sgprSizeB1J, sgprSizesFree+1
+.set sgprSizeBK, sgprSizesFree+2
+
+/* Stride Assignments */
+.set constStrideD0I, 1
+.set sgprStrideD1J, sgprStridesD+0
+.set sgprStrideDK, sgprStridesD+1
+.set constStrideC0I, 1
+.set sgprStrideC1J, sgprStridesC+0
+.set sgprStrideCK, sgprStridesC+1
+.set constStrideAL, 1
+.set sgprStrideA0I, sgprStridesA+0
+.set sgprStrideAK, sgprStridesA+1
+.set constStrideBL, 1
+.set sgprStrideB1J, sgprStridesB+0
+.set sgprStrideBK, sgprStridesB+1
+
+.set DepthU, 32
+/* Number of elements to shift-left SRD */
+.set SrdShiftLeftA, 4
+.set SrdShiftLeftB, 4
+/* 2GB limit - set offsets to -1 to exceed this and clamp */
+.set BufferLimit, 0x80000000
+/* Bits 127:96 of SRD.  Set DataFormat = 32 bit */
+.set Srd127_96, 0x0020000
+.set BufferOOB, 0x80000000
+
+/* Global Offset A */
+.macro GLOBAL_OFFSET_A vgprAddr vgprOffsetL vgprOffset0I vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStrideA0I], v[\vgprOffset0I] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprOffsetL], v[\vgprTmp+0] // accumulate d1 lower
+_v_add_u32 v[\vgprAddr+0], 0x4, v[\vgprAddr+0]     // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/* Global Offset B */
+.macro GLOBAL_OFFSET_B vgprAddr vgprOffsetL vgprOffset1J vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStrideB1J], v[\vgprOffset1J] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprOffsetL], v[\vgprTmp+0] // accumulate d1 lower
+_v_add_u32 v[\vgprAddr+0], 0x4, v[\vgprAddr+0]     // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/******************************************/
+/* Dynamic Scalar Divide: vQuotient=vDividend/vDivisor; vRemainder=vDividend%vDivisor; */
+/******************************************/
+.macro DYNAMIC_VECTOR_DIVIDE vQuotient vRemainder vDividend vDivisor vTmp0 vTmp1 sTmp
+v_cvt_f32_u32 v[\vQuotient], v[\vDivisor]          //
+v_rcp_f32 v[\vQuotient], v[\vQuotient]             //
+v_mul_f32 v[\vQuotient], 0x4f800000, v[\vQuotient] //
+v_cvt_u32_f32 v[\vQuotient], v[\vQuotient]         //
+v_mul_lo_u32 v[\vRemainder], v[\vDivisor], v[\vQuotient] //
+v_mul_hi_u32 v[\vTmp0], v[\vDivisor], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp1], vcc, 0x0, v[\vRemainder]  //
+v_cmp_ne_i32 s[\sTmp:\sTmp+1], 0x0, v[\vTmp0]      //
+v_cndmask_b32 v[\vRemainder], v[\vTmp1], v[\vRemainder], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vRemainder], v[\vRemainder], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vQuotient], v[\vRemainder] //
+_v_add_co_u32 v[\vQuotient], vcc, v[\vQuotient], v[\vRemainder] //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vTmp0], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vQuotient], v[\vQuotient], v[\vDividend] //
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vDividend], v[\vRemainder] //
+v_cmp_ge_u32 s[\sTmp:\sTmp+1], v[\vDividend], v[\vRemainder] //
+_v_add_co_u32 v[\vRemainder], vcc, 0x1, v[\vQuotient] //
+_v_add_co_u32 v[\vTmp1], vcc, -1, v[\vQuotient]    //
+v_cmp_le_u32 vcc, v[\vDivisor], v[\vTmp0]          //
+s_and_b64 vcc, s[\sTmp:\sTmp+1], vcc               //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vRemainder], vcc //
+v_cndmask_b32 v[\vQuotient], v[\vTmp1], v[\vQuotient], s[\sTmp:\sTmp+1] //
+v_cmp_ne_i32 vcc, 0x0, v[\vDivisor]                //
+v_cndmask_b32 v[\vQuotient], -1, v[\vQuotient], vcc // final result
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vRemainder], vcc, v[\vDividend], v[\vRemainder] // final result
+.endm
+
+/******************************************/
+/* 4x8 thread-tile                        */
+/******************************************/
+.macro MAC_4x8_X0
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[0] iui=0
+s_setprio 1 // Raise priority while processing macs
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[1]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[4]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[5]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[2] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[3]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[6]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[7]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[8] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[9]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[12]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[13]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[10] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[11]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[14]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[15]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[16] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[17]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[20]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[21]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[18] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[19]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[22]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[23]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[24] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[25]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[28]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[29]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[26] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[27]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[30]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[31]
+s_setprio 0 // Reset priority after macs
+.endm
+.macro MAC_4x8_X1
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[0] iui=0
+s_setprio 1 // Raise priority while processing macs
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[1]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[4]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[5]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[2] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[3]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[6]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[7]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[8] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[9]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[12]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[13]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[10] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[11]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[14]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[15]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[16] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[17]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[20]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[21]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[18] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[19]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[22]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[23]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[24] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[25]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[28]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[29]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[26] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[27]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[30]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[31]
+s_setprio 0 // Reset priority after macs
+.endm
+
+
+
+
+/***** program start from here *****/
+
+.long 0xC00A0D00, 0x00000028
+.long 0xC00A0C00, 0x00000050
+.long 0xC00A0600, 0x00000008
+.long 0xC0020B40, 0x0000006C
+.long 0xC0020140, 0x00000074
+.long 0xBEFC00FF, 0x0000FFFF
+.long 0x7ECA0300
+.long 0x26CC00BF
+.long 0x2004CA86
+.long 0xB8D0F804
+.long 0xD1130004, 0x0000A0B0
+.long 0x20CE0884
+.long 0x7EA40567
+.long 0xD1130068, 0x0000A08F
+.long 0x7EA20568
+.long 0xBF068151
+.long 0xBF8400F3
+.long 0xBF8CC07F
+.long 0xBE880034
+.long 0xBE890035
+.long 0xBE8B00FF, 0x00020000
+.long 0xBE8A00FF, 0x80000000
+.long 0x9254FF30, 0x00000080
+.long 0x92545402
+.long 0x9255A052
+.long 0x92533055
+.long 0x92553104
+.long 0x81545354
+.long 0x80545554
+.long 0x2000CC82
+.long 0xD2850004, 0x00020030
+.long 0x2602CC83
+.long 0x24020283
+.long 0x32AC0304
+.long 0x68ACAC54
+.long 0x24ACAC81
+.long 0x8E478530
+.long 0x68AEAC47
+.long 0xBECC00FF, 0x00000880
+.long 0x924C4C52
+.long 0xBE8C0036
+.long 0xBE8D0037
+.long 0xBE8F00FF, 0x00020000
+.long 0xBE8E00FF, 0x80000000
+.long 0x9254FF32, 0x00000100
+.long 0x92545403
+.long 0x9255C052
+.long 0x92533255
+.long 0x92553304
+.long 0x81545354
+.long 0x80545554
+.long 0x2004CC82
+.long 0xD2850004, 0x00020432
+.long 0x2606CC83
+.long 0x24060683
+.long 0x32B40704
+.long 0x68B4B454
+.long 0x24B4B481
+.long 0x8E4A8532
+.long 0x68B6B44A
+.long 0x68B8B64A
+.long 0x68BAB84A
+.long 0xBECE00FF, 0x00001100
+.long 0x924E4E52
+.long 0x814EFF4E, 0x00004400
+.long 0xBF8A0000
+.long 0x814DFF4C, 0x00002200
+.long 0x24A0CC84
+.long 0x68A0A04C
+.long 0x24A2CC84
+.long 0x68A2A24D
+.long 0x814FFF4E, 0x00004400
+.long 0x24A4CC84
+.long 0x68A4A44E
+.long 0x24A6CC84
+.long 0x68A6A64F
+.long 0x2002CC83
+.long 0xD2850001, 0x00020288
+.long 0x68A0A101
+.long 0x68A2A301
+.long 0x68A4A501
+.long 0x68A6A701
+.long 0xD1340058, 0x00018156
+.long 0xD1340059, 0x00018157
+.long 0xD134005E, 0x0001815A
+.long 0xD134005F, 0x0001815B
+.long 0xD1340060, 0x0001815C
+.long 0xD1340061, 0x0001815D
+.long 0xE05E1000, 0x80022056
+.long 0xE05E1000, 0x80022457
+.long 0xE05E1000, 0x8003305A
+.long 0xE05E1000, 0x8003345B
+.long 0xE05E1000, 0x8003385C
+.long 0xE05E1000, 0x80033C5D
+.long 0xE05E1000, 0x80022858
+.long 0xE05E1000, 0x80022C59
+.long 0xE05E1000, 0x8003405E
+.long 0xE05E1000, 0x8003445F
+.long 0xE05E1000, 0x80034860
+.long 0xE05E1000, 0x80034C61
+.long 0x68ACACFF, 0x00000080
+.long 0x68AEAEFF, 0x00000080
+.long 0x8F2E852D
+.long 0x80AE2E80
+.long 0xBF06802E
+.long 0xBF850059
+.long 0xBF8C0F7A
+.long 0xD9BE0000, 0x00002050
+.long 0xD9BE0440, 0x00002450
+.long 0xBF8CC07F
+.long 0xE05E1000, 0x80022056
+.long 0xE05E1000, 0x80022457
+.long 0xBF8C0F78
+.long 0xD9BE0000, 0x00003052
+.long 0xD9BE0440, 0x00003452
+.long 0xD9BE0880, 0x00003852
+.long 0xD9BE0CC0, 0x00003C52
+.long 0x68ACACFF, 0x00000080
+.long 0x68AEAEFF, 0x00000080
+.long 0x68B4B4FF, 0x00000080
+.long 0x68B6B6FF, 0x00000080
+.long 0x68B8B8FF, 0x00000080
+.long 0x68BABAFF, 0x00000080
+.long 0x68B0B0FF, 0x00000080
+.long 0x68B2B2FF, 0x00000080
+.long 0x68BCBCFF, 0x00000080
+.long 0x68BEBEFF, 0x00000080
+.long 0x68C0C0FF, 0x00000080
+.long 0x68C2C2FF, 0x00000080
+.long 0xBF8CC07F
+.long 0xE05E1000, 0x8003305A
+.long 0xE05E1000, 0x8003345B
+.long 0xE05E1000, 0x8003385C
+.long 0xE05E1000, 0x80033C5D
+.long 0xBF8C0F7A
+.long 0xD9BE0000, 0x00002851
+.long 0xD9BE0440, 0x00002C51
+.long 0xBF8CC07F
+.long 0xE05E1000, 0x80022858
+.long 0xE05E1000, 0x80022C59
+.long 0xBF8C0F78
+.long 0xD9BE0000, 0x00004053
+.long 0xD9BE0440, 0x00004453
+.long 0xD9BE0880, 0x00004853
+.long 0xD9BE0CC0, 0x00004C53
+.long 0xBF8CC07F
+.long 0xBF8A0000
+.long 0xBF800018
+.long 0xE05E1000, 0x8003405E
+.long 0xBF80000B
+.long 0xE05E1000, 0x8003445F
+.long 0xBF80000B
+.long 0xE05E1000, 0x80034860
+.long 0xBF80000B
+.long 0xE05E1000, 0x80034C61
+.long 0xBF8A0000
+.long 0x802E822E
+.long 0xBF00C22E
+.long 0xBF84FFA7
+.long 0xBF8C0F7A
+.long 0xD9BE0000, 0x00002050
+.long 0xD9BE0440, 0x00002450
+.long 0xBF8C0F76
+.long 0xD9BE0000, 0x00003052
+.long 0xD9BE0440, 0x00003452
+.long 0xD9BE0880, 0x00003852
+.long 0xD9BE0CC0, 0x00003C52
+.long 0xBF8C0F74
+.long 0xD9BE0000, 0x00002851
+.long 0xD9BE0440, 0x00002C51
+.long 0xBF8C0F70
+.long 0xD9BE0000, 0x00004053
+.long 0xD9BE0440, 0x00004453
+.long 0xD9BE0880, 0x00004853
+.long 0xD9BE0CC0, 0x00004C53
+.long 0xBF8CC07F
+.long 0xBF8A0000
+.long 0xBF810000
+.long 0xD3D94000, 0x18000080
+.long 0xD3D94001, 0x18000080
+.long 0xD3D94002, 0x18000080
+.long 0xD3D94003, 0x18000080
+.long 0xD3D94004, 0x18000080
+.long 0xD3D94005, 0x18000080
+.long 0xD3D94006, 0x18000080
+.long 0xD3D94007, 0x18000080
+.long 0xD3D94008, 0x18000080
+.long 0xD3D94009, 0x18000080
+.long 0xD3D9400A, 0x18000080
+.long 0xD3D9400B, 0x18000080
+.long 0xD3D9400C, 0x18000080
+.long 0xD3D9400D, 0x18000080
+.long 0xD3D9400E, 0x18000080
+.long 0xD3D9400F, 0x18000080
+.long 0xD3D94010, 0x18000080
+.long 0xD3D94011, 0x18000080
+.long 0xD3D94012, 0x18000080
+.long 0xD3D94013, 0x18000080
+.long 0xD3D94014, 0x18000080
+.long 0xD3D94015, 0x18000080
+.long 0xD3D94016, 0x18000080
+.long 0xD3D94017, 0x18000080
+.long 0xD3D94018, 0x18000080
+.long 0xD3D94019, 0x18000080
+.long 0xD3D9401A, 0x18000080
+.long 0xD3D9401B, 0x18000080
+.long 0xD3D9401C, 0x18000080
+.long 0xD3D9401D, 0x18000080
+.long 0xD3D9401E, 0x18000080
+.long 0xD3D9401F, 0x18000080
+.long 0xD3D94020, 0x18000080
+.long 0xD3D94021, 0x18000080
+.long 0xD3D94022, 0x18000080
+.long 0xD3D94023, 0x18000080
+.long 0xD3D94024, 0x18000080
+.long 0xD3D94025, 0x18000080
+.long 0xD3D94026, 0x18000080
+.long 0xD3D94027, 0x18000080
+.long 0xD3D94028, 0x18000080
+.long 0xD3D94029, 0x18000080
+.long 0xD3D9402A, 0x18000080
+.long 0xD3D9402B, 0x18000080
+.long 0xD3D9402C, 0x18000080
+.long 0xD3D9402D, 0x18000080
+.long 0xD3D9402E, 0x18000080
+.long 0xD3D9402F, 0x18000080
+.long 0xD3D94030, 0x18000080
+.long 0xD3D94031, 0x18000080
+.long 0xD3D94032, 0x18000080
+.long 0xD3D94033, 0x18000080
+.long 0xD3D94034, 0x18000080
+.long 0xD3D94035, 0x18000080
+.long 0xD3D94036, 0x18000080
+.long 0xD3D94037, 0x18000080
+.long 0xD3D94038, 0x18000080
+.long 0xD3D94039, 0x18000080
+.long 0xD3D9403A, 0x18000080
+.long 0xD3D9403B, 0x18000080
+.long 0xD3D9403C, 0x18000080
+.long 0xD3D9403D, 0x18000080
+.long 0xD3D9403E, 0x18000080
+.long 0xD3D9403F, 0x18000080
+.long 0xD3D94040, 0x18000080
+.long 0xD3D94041, 0x18000080
+.long 0xD3D94042, 0x18000080
+.long 0xD3D94043, 0x18000080
+.long 0xD3D94044, 0x18000080
+.long 0xD3D94045, 0x18000080
+.long 0xD3D94046, 0x18000080
+.long 0xD3D94047, 0x18000080
+.long 0xD3D94048, 0x18000080
+.long 0xD3D94049, 0x18000080
+.long 0xD3D9404A, 0x18000080
+.long 0xD3D9404B, 0x18000080
+.long 0xD3D9404C, 0x18000080
+.long 0xD3D9404D, 0x18000080
+.long 0xD3D9404E, 0x18000080
+.long 0xD3D9404F, 0x18000080
+.long 0xD3D94050, 0x18000080
+.long 0xD3D94051, 0x18000080
+.long 0xD3D94052, 0x18000080
+.long 0xD3D94053, 0x18000080
+.long 0xD3D94054, 0x18000080
+.long 0xD3D94055, 0x18000080
+.long 0xD3D94056, 0x18000080
+.long 0xD3D94057, 0x18000080
+.long 0xD3D94058, 0x18000080
+.long 0xD3D94059, 0x18000080
+.long 0xD3D9405A, 0x18000080
+.long 0xD3D9405B, 0x18000080
+.long 0xD3D9405C, 0x18000080
+.long 0xD3D9405D, 0x18000080
+.long 0xD3D9405E, 0x18000080
+.long 0xD3D9405F, 0x18000080
+.long 0xD3D94060, 0x18000080
+.long 0xD3D94061, 0x18000080
+.long 0xD3D94062, 0x18000080
+.long 0xD3D94063, 0x18000080
+.long 0xD3D94064, 0x18000080
+.long 0xD3D94065, 0x18000080
+.long 0xD3D94066, 0x18000080
+.long 0xD3D94067, 0x18000080
+.long 0xD3D94068, 0x18000080
+.long 0xD3D94069, 0x18000080
+.long 0xD3D9406A, 0x18000080
+.long 0xD3D9406B, 0x18000080
+.long 0xD3D9406C, 0x18000080
+.long 0xD3D9406D, 0x18000080
+.long 0xD3D9406E, 0x18000080
+.long 0xD3D9406F, 0x18000080
+.long 0xD3D94070, 0x18000080
+.long 0xD3D94071, 0x18000080
+.long 0xD3D94072, 0x18000080
+.long 0xD3D94073, 0x18000080
+.long 0xD3D94074, 0x18000080
+.long 0xD3D94075, 0x18000080
+.long 0xD3D94076, 0x18000080
+.long 0xD3D94077, 0x18000080
+.long 0xD3D94078, 0x18000080
+.long 0xD3D94079, 0x18000080
+.long 0xD3D9407A, 0x18000080
+.long 0xD3D9407B, 0x18000080
+.long 0xD3D9407C, 0x18000080
+.long 0xD3D9407D, 0x18000080
+.long 0xD3D9407E, 0x18000080
+.long 0xD3D9407F, 0x18000080
+.long 0xC0060700, 0x00000000
+.long 0xC00A0A00, 0x00000038
+.long 0xC00A0900, 0x00000040
+.long 0xC00A0800, 0x00000018
+.long 0xC00A0A00, 0x00000038
+.long 0xD1130001, 0x00013F66
+.long 0xD2850061, 0x000202A0
+.long 0x20040281
+.long 0xD2850002, 0x00020488
+.long 0x2002CC85
+.long 0x24020282
+.long 0x68C2C301
+.long 0x24C2C281
+.long 0x68C2C302
+.long 0x86548152
+.long 0x9254FF54, 0x00001100
+.long 0x68C2C254
+.long 0x68C2C280
+.long 0x68C4C2FF, 0x00002200
+.long 0xBF8A0000
+.long 0xD1130001, 0x00013F66
+.long 0xD2850063, 0x000202A0
+.long 0x20040281
+.long 0xD2850002, 0x00020488
+.long 0x2002CC85
+.long 0x24020282
+.long 0x68C6C701
+.long 0x24C6C681
+.long 0x68C6C702
+.long 0x86548252
+.long 0x8F548154
+.long 0x9254FF54, 0x00002200
+.long 0x68C6C654
+.long 0x68C6C6FF, 0x00004400
+.long 0x68C8C6FF, 0x00004400
+.long 0xBF8CC07F
+.long 0xBE900022
+.long 0xBE910023
+.long 0xBE9200FF, 0x80000000
+.long 0xBE9300FF, 0x00020000
+.long 0xBE940020
+.long 0xBE950021
+.long 0xBE9600FF, 0x80000000
+.long 0xBE9700FF, 0x00020000
+.long 0x925603FF, 0x00000100
+.long 0x96552656
+.long 0x92542656
+.long 0x8ED48154
+.long 0x80105410
+.long 0x82115511
+.long 0x80145414
+.long 0x82155515
+.long 0x96552704
+.long 0x92542704
+.long 0x8ED48154
+.long 0x80105410
+.long 0x82115511
+.long 0x80145414
+.long 0x82155515
+.long 0x24CACE86
+.long 0x68CACB66
+.long 0x2608CE82
+.long 0x20080881
+.long 0x24080887
+.long 0xD2850003, 0x00004D04
+.long 0x2608CE81
+.long 0xD2850004, 0x000208C0
+.long 0x68060903
+.long 0x2608CA9F
+.long 0xD2850005, 0x00004D04
+.long 0x68D40B03
+.long 0x2608CABF
+.long 0x200C0885
+.long 0x240C0C82
+.long 0x925402FF, 0x00000080
+.long 0x32D20C54
+.long 0xD1FE0060, 0x0206D569
+.long 0x7ED20228
+.long 0x7ED21769
+.long 0x7E500569
+.long 0x7ED20229
+.long 0x7ED21769
+.long 0x7E520569
+.long 0xBF8A0000
+.long 0xD8EC0000, 0x00000061
+.long 0xD8EC0000, 0x20000063
+.long 0xD8EC0010, 0x02000061
+.long 0xD8EC0010, 0x22000063
+.long 0xBF8CC27F
+.long 0xD3CC0000, 0x04024100
+.long 0xD8EC0020, 0x04000061
+.long 0xD8EC0020, 0x24000063
+.long 0xD8EC0030, 0x06000061
+.long 0xD8EC0030, 0x26000063
+.long 0xBF8CC47F
+.long 0xD3CC0000, 0x04024502
+.long 0xD8EC0000, 0x10000062
+.long 0xD8EC0000, 0x40000064
+.long 0xD8EC0010, 0x12000062
+.long 0xD8EC0010, 0x42000064
+.long 0xD3CC0000, 0x04024904
+.long 0xD8EC0020, 0x14000062
+.long 0xD8EC0020, 0x44000064
+.long 0xD8EC0030, 0x16000062
+.long 0xD8EC0030, 0x46000064
+.long 0xD3CC0000, 0x04024D06
+.long 0xD8EC0880, 0x08000061
+.long 0xD8EC0880, 0x28000063
+.long 0xD8EC0890, 0x0A000061
+.long 0xD8EC0890, 0x2A000063
+.long 0xD3CC0000, 0x04028110
+.long 0xD8EC08A0, 0x0C000061
+.long 0xD8EC08A0, 0x2C000063
+.long 0xD8EC08B0, 0x0E000061
+.long 0xD8EC08B0, 0x2E000063
+.long 0xD3CC0000, 0x04028512
+.long 0xD8EC0880, 0x18000062
+.long 0xD8EC0890, 0x1A000062
+.long 0xD8EC08A0, 0x1C000062
+.long 0xD8EC08B0, 0x1E000062
+.long 0xD3CC0000, 0x04028914
+.long 0xD8EC0880, 0x48000064
+.long 0xD8EC0890, 0x4A000064
+.long 0xD8EC08A0, 0x4C000064
+.long 0xD8EC08B0, 0x4E000064
+.long 0xD3CC0000, 0x04028D16
+.long 0xD8EC1100, 0x30000063
+.long 0xD8EC1110, 0x32000063
+.long 0xD8EC1120, 0x34000063
+.long 0xD8EC1130, 0x36000063
+.long 0xD3CC0010, 0x04424108
+.long 0xD8EC1980, 0x38000063
+.long 0xD8EC1990, 0x3A000063
+.long 0xD8EC19A0, 0x3C000063
+.long 0xD8EC19B0, 0x3E000063
+.long 0xD3CC0010, 0x0442450A
+.long 0xD8EC1100, 0x50000064
+.long 0xD8EC1110, 0x52000064
+.long 0xD8EC1120, 0x54000064
+.long 0xD8EC1130, 0x56000064
+.long 0xD3CC0010, 0x0442490C
+.long 0xD8EC1980, 0x58000064
+.long 0xD8EC1990, 0x5A000064
+.long 0xD8EC19A0, 0x5C000064
+.long 0xD8EC19B0, 0x5E000064
+.long 0x8F2E852D
+.long 0x80AE2E80
+.long 0xBF06802E
+.long 0xBF850119
+.long 0xD3CC0010, 0x04424D0E
+.long 0xBF8CC07F
+.long 0xBF8A0000
+.long 0xD3CC0010, 0x04428118
+.long 0xBF80000C
+.long 0xD3CC0010, 0x0442851A
+.long 0xBF80000C
+.long 0xD3CC0010, 0x0442891C
+.long 0xBF80000C
+.long 0xD3CC0010, 0x04428D1E
+.long 0xBF80000C
+.long 0xD3CC0020, 0x04825100
+.long 0xBF80000C
+.long 0xD3CC0020, 0x04825502
+.long 0xBF80000C
+.long 0xD3CC0020, 0x04825904
+.long 0xBF80000C
+.long 0xD3CC0020, 0x04825D06
+.long 0xBF80000C
+.long 0xD3CC0020, 0x04829110
+.long 0xBF80000C
+.long 0xD3CC0020, 0x04829512
+.long 0xBF80000C
+.long 0xD3CC0020, 0x04829914
+.long 0xBF80000C
+.long 0xD3CC0020, 0x04829D16
+.long 0xBF80000C
+.long 0xD3CC0030, 0x04C25108
+.long 0xBF80000C
+.long 0xD3CC0030, 0x04C2550A
+.long 0xBF80000C
+.long 0xD3CC0030, 0x04C2590C
+.long 0xBF80000C
+.long 0xD3CC0030, 0x04C25D0E
+.long 0xBF80000C
+.long 0xD3CC0030, 0x04C29118
+.long 0xBF80000C
+.long 0xD3CC0030, 0x04C2951A
+.long 0xBF80000C
+.long 0xD3CC0030, 0x04C2991C
+.long 0xBF80000C
+.long 0xD3CC0030, 0x04C29D1E
+.long 0xBF80000C
+.long 0xD3CC0040, 0x05026100
+.long 0xBF80000C
+.long 0xD3CC0040, 0x05026502
+.long 0xBF80000C
+.long 0xD3CC0040, 0x05026904
+.long 0xBF80000C
+.long 0xD3CC0040, 0x05026D06
+.long 0xBF80000C
+.long 0xD3CC0040, 0x0502A110
+.long 0xBF80000C
+.long 0xD3CC0040, 0x0502A512
+.long 0xBF80000C
+.long 0xD3CC0040, 0x0502A914
+.long 0xBF80000C
+.long 0xD3CC0040, 0x0502AD16
+.long 0xBF80000C
+.long 0xD3CC0050, 0x05426108
+.long 0xBF80000C
+.long 0xD3CC0050, 0x0542650A
+.long 0xBF80000C
+.long 0xD3CC0050, 0x0542690C
+.long 0xBF80000C
+.long 0xD3CC0050, 0x05426D0E
+.long 0xBF80000C
+.long 0xD3CC0050, 0x0542A118
+.long 0xBF80000C
+.long 0xD3CC0050, 0x0542A51A
+.long 0xBF80000C
+.long 0xD3CC0050, 0x0542A91C
+.long 0xBF80000C
+.long 0xD3CC0050, 0x0542AD1E
+.long 0xBF80000C
+.long 0xD3CC0060, 0x05827100
+.long 0xBF80000C
+.long 0xD3CC0060, 0x05827502
+.long 0xBF80000C
+.long 0xD3CC0060, 0x05827904
+.long 0xBF80000C
+.long 0xD3CC0060, 0x05827D06
+.long 0xBF80000C
+.long 0xD3CC0060, 0x0582B110
+.long 0xBF80000C
+.long 0xD3CC0060, 0x0582B512
+.long 0xBF80000C
+.long 0xD3CC0060, 0x0582B914
+.long 0xBF80000C
+.long 0xD3CC0060, 0x0582BD16
+.long 0xBF80000C
+.long 0xD3CC0070, 0x05C27108
+.long 0xBF80000C
+.long 0xD3CC0070, 0x05C2750A
+.long 0xBF80000C
+.long 0xD3CC0070, 0x05C2790C
+.long 0xBF80000C
+.long 0xD3CC0070, 0x05C27D0E
+.long 0xBF80000C
+.long 0xD3CC0070, 0x05C2B118
+.long 0xBF80000C
+.long 0xD3CC0070, 0x05C2B51A
+.long 0xBF80000C
+.long 0xD3CC0070, 0x05C2B91C
+.long 0xBF8A0000
+.long 0xD8EC0000, 0x00000061
+.long 0xD8EC0000, 0x20000063
+.long 0xD8EC0010, 0x02000061
+.long 0xD8EC0010, 0x22000063
+.long 0xD3CC0070, 0x05C2BD1E
+.long 0xD8EC0020, 0x04000061
+.long 0xD8EC0020, 0x24000063
+.long 0xD8EC0030, 0x06000061
+.long 0xD8EC0030, 0x26000063
+.long 0xBF8CC67F
+.long 0xD3CC0000, 0x04024100
+.long 0xD8EC0000, 0x10000062
+.long 0xD8EC0000, 0x40000064
+.long 0xD8EC0010, 0x12000062
+.long 0xD8EC0010, 0x42000064
+.long 0xD3CC0000, 0x04024502
+.long 0xD8EC0020, 0x14000062
+.long 0xD8EC0020, 0x44000064
+.long 0xD8EC0030, 0x16000062
+.long 0xD8EC0030, 0x46000064
+.long 0xD3CC0000, 0x04024904
+.long 0xD8EC0880, 0x08000061
+.long 0xD8EC0880, 0x28000063
+.long 0xD8EC0890, 0x0A000061
+.long 0xD8EC0890, 0x2A000063
+.long 0xD3CC0000, 0x04024D06
+.long 0xD8EC08A0, 0x0C000061
+.long 0xD8EC08A0, 0x2C000063
+.long 0xD8EC08B0, 0x0E000061
+.long 0xD8EC08B0, 0x2E000063
+.long 0xD3CC0000, 0x04028110
+.long 0xD8EC0880, 0x18000062
+.long 0xD8EC0890, 0x1A000062
+.long 0xD8EC08A0, 0x1C000062
+.long 0xD8EC08B0, 0x1E000062
+.long 0xD3CC0000, 0x04028512
+.long 0xD8EC0880, 0x48000064
+.long 0xD8EC0890, 0x4A000064
+.long 0xD8EC08A0, 0x4C000064
+.long 0xD8EC08B0, 0x4E000064
+.long 0xD3CC0000, 0x04028914
+.long 0xD8EC1100, 0x30000063
+.long 0xD8EC1110, 0x32000063
+.long 0xD8EC1120, 0x34000063
+.long 0xD8EC1130, 0x36000063
+.long 0xD3CC0000, 0x04028D16
+.long 0xD8EC1980, 0x38000063
+.long 0xD8EC1990, 0x3A000063
+.long 0xD8EC19A0, 0x3C000063
+.long 0xD8EC19B0, 0x3E000063
+.long 0xD3CC0010, 0x04424108
+.long 0xD8EC1100, 0x50000064
+.long 0xD8EC1110, 0x52000064
+.long 0xD8EC1120, 0x54000064
+.long 0xD8EC1130, 0x56000064
+.long 0xD3CC0010, 0x0442450A
+.long 0xD8EC1980, 0x58000064
+.long 0xD8EC1990, 0x5A000064
+.long 0xD8EC19A0, 0x5C000064
+.long 0xD8EC19B0, 0x5E000064
+.long 0xD3CC0010, 0x0442490C
+.long 0x802E822E
+.long 0xBF00C22E
+.long 0xBF84FEE7
+.long 0x9254C026
+.long 0xD3CC0010, 0x04424D0E
+.long 0xE0541000, 0x80046160
+.long 0xE0541010, 0x80046360
+.long 0xE0541020, 0x80046560
+.long 0xE0541030, 0x80046760
+.long 0xD3D84069, 0x18000100
+.long 0xD3D8406A, 0x18000101
+.long 0xD3D8406B, 0x18000102
+.long 0xD3D8406C, 0x18000103
+.long 0xD3D8406D, 0x18000104
+.long 0xD3D8406E, 0x18000105
+.long 0xD3D8406F, 0x18000106
+.long 0xD3D84070, 0x18000107
+.long 0xD3CC0010, 0x04428118
+.long 0xBF8C0F73
+.long 0x0AD2D228
+.long 0x0AD4D428
+.long 0xD3A00069, 0x15A6C229
+.long 0xD3A0106A, 0x15AAC229
+.long 0x7ED21569
+.long 0x7ED4156A
+.long 0xD2000069, 0x05A5216A
+.long 0x0AD6D628
+.long 0x0AD8D828
+.long 0xD3A0006B, 0x15AEC429
+.long 0xD3A0106C, 0x15B2C429
+.long 0x7ED6156B
+.long 0x7ED8156C
+.long 0xD200006A, 0x05AD216C
+.long 0xD3CC0010, 0x0442851A
+.long 0xE0741000, 0x80056960
+.long 0xBF8C0F73
+.long 0x0ADADA28
+.long 0x0ADCDC28
+.long 0xD3A0006D, 0x15B6C629
+.long 0xD3A0106E, 0x15BAC629
+.long 0x7EDA156D
+.long 0x7EDC156E
+.long 0xD200006B, 0x05B5216E
+.long 0x0ADEDE28
+.long 0x0AE0E028
+.long 0xD3A0006F, 0x15BEC829
+.long 0xD3A01070, 0x15C2C829
+.long 0x7EDE156F
+.long 0x7EE01570
+.long 0xD200006C, 0x05BD2170
+.long 0xD3CC0010, 0x0442891C
+.long 0xD3D84071, 0x18000108
+.long 0xD3D84072, 0x18000109
+.long 0xD3D84073, 0x1800010A
+.long 0xD3D84074, 0x1800010B
+.long 0xD3CC0010, 0x04428D1E
+.long 0xE0741010, 0x80056B60
+.long 0xBF8C0F73
+.long 0x0AE2E228
+.long 0x0AE4E428
+.long 0xD3A00071, 0x15C6CA29
+.long 0xD3A01072, 0x15CACA29
+.long 0x7EE21571
+.long 0x7EE41572
+.long 0xD200006D, 0x05C52172
+.long 0x0AE6E628
+.long 0x0AE8E828
+.long 0xD3A00073, 0x15CECC29
+.long 0xD3A01074, 0x15D2CC29
+.long 0x7EE61573
+.long 0x7EE81574
+.long 0xD200006E, 0x05CD2174
+.long 0xD3CC0020, 0x04825100
+.long 0xD3D84075, 0x1800010C
+.long 0xD3D84076, 0x1800010D
+.long 0xD3D84077, 0x1800010E
+.long 0xD3D84078, 0x1800010F
+.long 0xE0741020, 0x80056D60
+.long 0xBF8C0F73
+.long 0x0AEAEA28
+.long 0x0AECEC28
+.long 0xD3A00075, 0x15D6CE29
+.long 0xD3A01076, 0x15DACE29
+.long 0x7EEA1575
+.long 0x7EEC1576
+.long 0xD200006F, 0x05D52176
+.long 0x0AEEEE28
+.long 0x0AF0F028
+.long 0xD3A00077, 0x15DED029
+.long 0xD3A01078, 0x15E2D029
+.long 0x7EEE1577
+.long 0x7EF01578
+.long 0xD2000070, 0x05DD2178
+.long 0xD3CC0020, 0x04825502
+.long 0xE0741030, 0x80056F60
+.long 0xE0541040, 0x80046160
+.long 0xE0541050, 0x80046360
+.long 0xE0541060, 0x80046560
+.long 0xE0541070, 0x80046760
+.long 0xD3D84069, 0x18000110
+.long 0xD3D8406A, 0x18000111
+.long 0xD3D8406B, 0x18000112
+.long 0xD3D8406C, 0x18000113
+.long 0xD3D8406D, 0x18000114
+.long 0xD3D8406E, 0x18000115
+.long 0xD3D8406F, 0x18000116
+.long 0xD3D84070, 0x18000117
+.long 0xD3CC0020, 0x04825904
+.long 0xBF8C0F73
+.long 0x0AD2D228
+.long 0x0AD4D428
+.long 0xD3A00069, 0x15A6C229
+.long 0xD3A0106A, 0x15AAC229
+.long 0x7ED21569
+.long 0x7ED4156A
+.long 0xD2000069, 0x05A5216A
+.long 0x0AD6D628
+.long 0x0AD8D828
+.long 0xD3A0006B, 0x15AEC429
+.long 0xD3A0106C, 0x15B2C429
+.long 0x7ED6156B
+.long 0x7ED8156C
+.long 0xD200006A, 0x05AD216C
+.long 0xD3CC0020, 0x04825D06
+.long 0xE0741040, 0x80056960
+.long 0xBF8C0F73
+.long 0x0ADADA28
+.long 0x0ADCDC28
+.long 0xD3A0006D, 0x15B6C629
+.long 0xD3A0106E, 0x15BAC629
+.long 0x7EDA156D
+.long 0x7EDC156E
+.long 0xD200006B, 0x05B5216E
+.long 0x0ADEDE28
+.long 0x0AE0E028
+.long 0xD3A0006F, 0x15BEC829
+.long 0xD3A01070, 0x15C2C829
+.long 0x7EDE156F
+.long 0x7EE01570
+.long 0xD200006C, 0x05BD2170
+.long 0xD3CC0020, 0x04829110
+.long 0xD3D84071, 0x18000118
+.long 0xD3D84072, 0x18000119
+.long 0xD3D84073, 0x1800011A
+.long 0xD3D84074, 0x1800011B
+.long 0xE0741050, 0x80056B60
+.long 0xD3CC0020, 0x04829512
+.long 0xBF8C0F73
+.long 0x0AE2E228
+.long 0x0AE4E428
+.long 0xD3A00071, 0x15C6CA29
+.long 0xD3A01072, 0x15CACA29
+.long 0x7EE21571
+.long 0x7EE41572
+.long 0xD200006D, 0x05C52172
+.long 0x0AE6E628
+.long 0x0AE8E828
+.long 0xD3A00073, 0x15CECC29
+.long 0xD3A01074, 0x15D2CC29
+.long 0x7EE61573
+.long 0x7EE81574
+.long 0xD200006E, 0x05CD2174
+.long 0xD3CC0020, 0x04829914
+.long 0xD3D84075, 0x1800011C
+.long 0xD3D84076, 0x1800011D
+.long 0xD3D84077, 0x1800011E
+.long 0xD3D84078, 0x1800011F
+.long 0xE0741060, 0x80056D60
+.long 0xD3CC0020, 0x04829D16
+.long 0xBF8C0F73
+.long 0x0AEAEA28
+.long 0x0AECEC28
+.long 0xD3A00075, 0x15D6CE29
+.long 0xD3A01076, 0x15DACE29
+.long 0x7EEA1575
+.long 0x7EEC1576
+.long 0xD200006F, 0x05D52176
+.long 0x0AEEEE28
+.long 0x0AF0F028
+.long 0xD3A00077, 0x15DED029
+.long 0xD3A01078, 0x15E2D029
+.long 0x7EEE1577
+.long 0x7EF01578
+.long 0xD2000070, 0x05DD2178
+.long 0xD3CC0030, 0x04C25108
+.long 0xE0741070, 0x80056F60
+.long 0xD3CC0030, 0x04C2550A
+.long 0xD1340060, 0x0000A960
+.long 0xE0541000, 0x80046160
+.long 0xE0541010, 0x80046360
+.long 0xE0541020, 0x80046560
+.long 0xE0541030, 0x80046760
+.long 0xD3D84069, 0x18000120
+.long 0xD3D8406A, 0x18000121
+.long 0xD3D8406B, 0x18000122
+.long 0xD3D8406C, 0x18000123
+.long 0xD3D8406D, 0x18000124
+.long 0xD3D8406E, 0x18000125
+.long 0xD3D8406F, 0x18000126
+.long 0xD3D84070, 0x18000127
+.long 0xBF8C0F73
+.long 0x0AD2D228
+.long 0x0AD4D428
+.long 0xD3A00069, 0x15A6C229
+.long 0xD3A0106A, 0x15AAC229
+.long 0x7ED21569
+.long 0x7ED4156A
+.long 0xD2000069, 0x05A5216A
+.long 0x0AD6D628
+.long 0x0AD8D828
+.long 0xD3A0006B, 0x15AEC429
+.long 0xD3A0106C, 0x15B2C429
+.long 0x7ED6156B
+.long 0x7ED8156C
+.long 0xD200006A, 0x05AD216C
+.long 0xD3CC0030, 0x04C2590C
+.long 0xE0741000, 0x80056960
+.long 0xD3CC0030, 0x04C25D0E
+.long 0xBF8C0F73
+.long 0x0ADADA28
+.long 0x0ADCDC28
+.long 0xD3A0006D, 0x15B6C629
+.long 0xD3A0106E, 0x15BAC629
+.long 0x7EDA156D
+.long 0x7EDC156E
+.long 0xD200006B, 0x05B5216E
+.long 0x0ADEDE28
+.long 0x0AE0E028
+.long 0xD3A0006F, 0x15BEC829
+.long 0xD3A01070, 0x15C2C829
+.long 0x7EDE156F
+.long 0x7EE01570
+.long 0xD200006C, 0x05BD2170
+.long 0xD3CC0030, 0x04C29118
+.long 0xD3D84071, 0x18000128
+.long 0xD3D84072, 0x18000129
+.long 0xD3D84073, 0x1800012A
+.long 0xD3D84074, 0x1800012B
+.long 0xE0741010, 0x80056B60
+.long 0xD3CC0030, 0x04C2951A
+.long 0xBF8C0F73
+.long 0x0AE2E228
+.long 0x0AE4E428
+.long 0xD3A00071, 0x15C6CA29
+.long 0xD3A01072, 0x15CACA29
+.long 0x7EE21571
+.long 0x7EE41572
+.long 0xD200006D, 0x05C52172
+.long 0x0AE6E628
+.long 0x0AE8E828
+.long 0xD3A00073, 0x15CECC29
+.long 0xD3A01074, 0x15D2CC29
+.long 0x7EE61573
+.long 0x7EE81574
+.long 0xD200006E, 0x05CD2174
+.long 0xD3CC0030, 0x04C2991C
+.long 0xD3D84075, 0x1800012C
+.long 0xD3D84076, 0x1800012D
+.long 0xD3D84077, 0x1800012E
+.long 0xD3D84078, 0x1800012F
+.long 0xE0741020, 0x80056D60
+.long 0xD3CC0030, 0x04C29D1E
+.long 0xBF8C0F73
+.long 0x0AEAEA28
+.long 0x0AECEC28
+.long 0xD3A00075, 0x15D6CE29
+.long 0xD3A01076, 0x15DACE29
+.long 0x7EEA1575
+.long 0x7EEC1576
+.long 0xD200006F, 0x05D52176
+.long 0x0AEEEE28
+.long 0x0AF0F028
+.long 0xD3A00077, 0x15DED029
+.long 0xD3A01078, 0x15E2D029
+.long 0x7EEE1577
+.long 0x7EF01578
+.long 0xD2000070, 0x05DD2178
+.long 0xD3CC0040, 0x05026100
+.long 0xE0741030, 0x80056F60
+.long 0xD3CC0040, 0x05026502
+.long 0xE0541040, 0x80046160
+.long 0xE0541050, 0x80046360
+.long 0xE0541060, 0x80046560
+.long 0xE0541070, 0x80046760
+.long 0xD3D84069, 0x18000130
+.long 0xD3D8406A, 0x18000131
+.long 0xD3D8406B, 0x18000132
+.long 0xD3D8406C, 0x18000133
+.long 0xD3D8406D, 0x18000134
+.long 0xD3D8406E, 0x18000135
+.long 0xD3D8406F, 0x18000136
+.long 0xD3D84070, 0x18000137
+.long 0xBF8C0F73
+.long 0x0AD2D228
+.long 0x0AD4D428
+.long 0xD3A00069, 0x15A6C229
+.long 0xD3A0106A, 0x15AAC229
+.long 0x7ED21569
+.long 0x7ED4156A
+.long 0xD2000069, 0x05A5216A
+.long 0x0AD6D628
+.long 0x0AD8D828
+.long 0xD3A0006B, 0x15AEC429
+.long 0xD3A0106C, 0x15B2C429
+.long 0x7ED6156B
+.long 0x7ED8156C
+.long 0xD200006A, 0x05AD216C
+.long 0xD3CC0040, 0x05026904
+.long 0xE0741040, 0x80056960
+.long 0xD3CC0040, 0x05026D06
+.long 0xBF8C0F73
+.long 0x0ADADA28
+.long 0x0ADCDC28
+.long 0xD3A0006D, 0x15B6C629
+.long 0xD3A0106E, 0x15BAC629
+.long 0x7EDA156D
+.long 0x7EDC156E
+.long 0xD200006B, 0x05B5216E
+.long 0x0ADEDE28
+.long 0x0AE0E028
+.long 0xD3A0006F, 0x15BEC829
+.long 0xD3A01070, 0x15C2C829
+.long 0x7EDE156F
+.long 0x7EE01570
+.long 0xD200006C, 0x05BD2170
+.long 0xD3CC0040, 0x0502A110
+.long 0xD3D84071, 0x18000138
+.long 0xD3D84072, 0x18000139
+.long 0xD3D84073, 0x1800013A
+.long 0xD3D84074, 0x1800013B
+.long 0xE0741050, 0x80056B60
+.long 0xD3CC0040, 0x0502A512
+.long 0xBF8C0F73
+.long 0x0AE2E228
+.long 0x0AE4E428
+.long 0xD3A00071, 0x15C6CA29
+.long 0xD3A01072, 0x15CACA29
+.long 0x7EE21571
+.long 0x7EE41572
+.long 0xD200006D, 0x05C52172
+.long 0x0AE6E628
+.long 0x0AE8E828
+.long 0xD3A00073, 0x15CECC29
+.long 0xD3A01074, 0x15D2CC29
+.long 0x7EE61573
+.long 0x7EE81574
+.long 0xD200006E, 0x05CD2174
+.long 0xD3CC0040, 0x0502A914
+.long 0xD3D84075, 0x1800013C
+.long 0xD3D84076, 0x1800013D
+.long 0xD3D84077, 0x1800013E
+.long 0xD3D84078, 0x1800013F
+.long 0xE0741060, 0x80056D60
+.long 0xD3CC0040, 0x0502AD16
+.long 0xBF8C0F73
+.long 0x0AEAEA28
+.long 0x0AECEC28
+.long 0xD3A00075, 0x15D6CE29
+.long 0xD3A01076, 0x15DACE29
+.long 0x7EEA1575
+.long 0x7EEC1576
+.long 0xD200006F, 0x05D52176
+.long 0x0AEEEE28
+.long 0x0AF0F028
+.long 0xD3A00077, 0x15DED029
+.long 0xD3A01078, 0x15E2D029
+.long 0x7EEE1577
+.long 0x7EF01578
+.long 0xD2000070, 0x05DD2178
+.long 0xD3CC0050, 0x05426108
+.long 0xE0741070, 0x80056F60
+.long 0xD3CC0050, 0x0542650A
+.long 0xD1340060, 0x0000A960
+.long 0xE0541000, 0x80046160
+.long 0xE0541010, 0x80046360
+.long 0xE0541020, 0x80046560
+.long 0xE0541030, 0x80046760
+.long 0xD3D84069, 0x18000140
+.long 0xD3D8406A, 0x18000141
+.long 0xD3D8406B, 0x18000142
+.long 0xD3D8406C, 0x18000143
+.long 0xD3D8406D, 0x18000144
+.long 0xD3D8406E, 0x18000145
+.long 0xD3D8406F, 0x18000146
+.long 0xD3D84070, 0x18000147
+.long 0xBF8C0F73
+.long 0x0AD2D228
+.long 0x0AD4D428
+.long 0xD3A00069, 0x15A6C229
+.long 0xD3A0106A, 0x15AAC229
+.long 0x7ED21569
+.long 0x7ED4156A
+.long 0xD2000069, 0x05A5216A
+.long 0x0AD6D628
+.long 0x0AD8D828
+.long 0xD3A0006B, 0x15AEC429
+.long 0xD3A0106C, 0x15B2C429
+.long 0x7ED6156B
+.long 0x7ED8156C
+.long 0xD200006A, 0x05AD216C
+.long 0xD3CC0050, 0x0542690C
+.long 0xE0741000, 0x80056960
+.long 0xD3CC0050, 0x05426D0E
+.long 0xBF8C0F73
+.long 0x0ADADA28
+.long 0x0ADCDC28
+.long 0xD3A0006D, 0x15B6C629
+.long 0xD3A0106E, 0x15BAC629
+.long 0x7EDA156D
+.long 0x7EDC156E
+.long 0xD200006B, 0x05B5216E
+.long 0x0ADEDE28
+.long 0x0AE0E028
+.long 0xD3A0006F, 0x15BEC829
+.long 0xD3A01070, 0x15C2C829
+.long 0x7EDE156F
+.long 0x7EE01570
+.long 0xD200006C, 0x05BD2170
+.long 0xD3CC0050, 0x0542A118
+.long 0xD3D84071, 0x18000148
+.long 0xD3D84072, 0x18000149
+.long 0xD3D84073, 0x1800014A
+.long 0xD3D84074, 0x1800014B
+.long 0xE0741010, 0x80056B60
+.long 0xD3CC0050, 0x0542A51A
+.long 0xBF8C0F73
+.long 0x0AE2E228
+.long 0x0AE4E428
+.long 0xD3A00071, 0x15C6CA29
+.long 0xD3A01072, 0x15CACA29
+.long 0x7EE21571
+.long 0x7EE41572
+.long 0xD200006D, 0x05C52172
+.long 0x0AE6E628
+.long 0x0AE8E828
+.long 0xD3A00073, 0x15CECC29
+.long 0xD3A01074, 0x15D2CC29
+.long 0x7EE61573
+.long 0x7EE81574
+.long 0xD200006E, 0x05CD2174
+.long 0xD3CC0050, 0x0542A91C
+.long 0xD3D84075, 0x1800014C
+.long 0xD3D84076, 0x1800014D
+.long 0xD3D84077, 0x1800014E
+.long 0xD3D84078, 0x1800014F
+.long 0xE0741020, 0x80056D60
+.long 0xD3CC0050, 0x0542AD1E
+.long 0xBF8C0F73
+.long 0x0AEAEA28
+.long 0x0AECEC28
+.long 0xD3A00075, 0x15D6CE29
+.long 0xD3A01076, 0x15DACE29
+.long 0x7EEA1575
+.long 0x7EEC1576
+.long 0xD200006F, 0x05D52176
+.long 0x0AEEEE28
+.long 0x0AF0F028
+.long 0xD3A00077, 0x15DED029
+.long 0xD3A01078, 0x15E2D029
+.long 0x7EEE1577
+.long 0x7EF01578
+.long 0xD2000070, 0x05DD2178
+.long 0xD3CC0060, 0x05827100
+.long 0xE0741030, 0x80056F60
+.long 0xD3CC0060, 0x05827502
+.long 0xE0541040, 0x80046160
+.long 0xE0541050, 0x80046360
+.long 0xE0541060, 0x80046560
+.long 0xE0541070, 0x80046760
+.long 0xD3D84069, 0x18000150
+.long 0xD3D8406A, 0x18000151
+.long 0xD3D8406B, 0x18000152
+.long 0xD3D8406C, 0x18000153
+.long 0xD3D8406D, 0x18000154
+.long 0xD3D8406E, 0x18000155
+.long 0xD3D8406F, 0x18000156
+.long 0xD3D84070, 0x18000157
+.long 0xBF8C0F73
+.long 0x0AD2D228
+.long 0x0AD4D428
+.long 0xD3A00069, 0x15A6C229
+.long 0xD3A0106A, 0x15AAC229
+.long 0x7ED21569
+.long 0x7ED4156A
+.long 0xD2000069, 0x05A5216A
+.long 0x0AD6D628
+.long 0x0AD8D828
+.long 0xD3A0006B, 0x15AEC429
+.long 0xD3A0106C, 0x15B2C429
+.long 0x7ED6156B
+.long 0x7ED8156C
+.long 0xD200006A, 0x05AD216C
+.long 0xD3CC0060, 0x05827904
+.long 0xE0741040, 0x80056960
+.long 0xD3CC0060, 0x05827D06
+.long 0xBF8C0F73
+.long 0x0ADADA28
+.long 0x0ADCDC28
+.long 0xD3A0006D, 0x15B6C629
+.long 0xD3A0106E, 0x15BAC629
+.long 0x7EDA156D
+.long 0x7EDC156E
+.long 0xD200006B, 0x05B5216E
+.long 0x0ADEDE28
+.long 0x0AE0E028
+.long 0xD3A0006F, 0x15BEC829
+.long 0xD3A01070, 0x15C2C829
+.long 0x7EDE156F
+.long 0x7EE01570
+.long 0xD200006C, 0x05BD2170
+.long 0xD3CC0060, 0x0582B110
+.long 0xD3D84071, 0x18000158
+.long 0xD3D84072, 0x18000159
+.long 0xD3D84073, 0x1800015A
+.long 0xD3D84074, 0x1800015B
+.long 0xE0741050, 0x80056B60
+.long 0xD3CC0060, 0x0582B512
+.long 0xBF8C0F73
+.long 0x0AE2E228
+.long 0x0AE4E428
+.long 0xD3A00071, 0x15C6CA29
+.long 0xD3A01072, 0x15CACA29
+.long 0x7EE21571
+.long 0x7EE41572
+.long 0xD200006D, 0x05C52172
+.long 0x0AE6E628
+.long 0x0AE8E828
+.long 0xD3A00073, 0x15CECC29
+.long 0xD3A01074, 0x15D2CC29
+.long 0x7EE61573
+.long 0x7EE81574
+.long 0xD200006E, 0x05CD2174
+.long 0xD3CC0060, 0x0582B914
+.long 0xD3D84075, 0x1800015C
+.long 0xD3D84076, 0x1800015D
+.long 0xD3D84077, 0x1800015E
+.long 0xD3D84078, 0x1800015F
+.long 0xE0741060, 0x80056D60
+.long 0xD3CC0060, 0x0582BD16
+.long 0xBF8C0F73
+.long 0x0AEAEA28
+.long 0x0AECEC28
+.long 0xD3A00075, 0x15D6CE29
+.long 0xD3A01076, 0x15DACE29
+.long 0x7EEA1575
+.long 0x7EEC1576
+.long 0xD200006F, 0x05D52176
+.long 0x0AEEEE28
+.long 0x0AF0F028
+.long 0xD3A00077, 0x15DED029
+.long 0xD3A01078, 0x15E2D029
+.long 0x7EEE1577
+.long 0x7EF01578
+.long 0xD2000070, 0x05DD2178
+.long 0xD3CC0070, 0x05C27108
+.long 0xE0741070, 0x80056F60
+.long 0xD3CC0070, 0x05C2750A
+.long 0xD1340060, 0x0000A960
+.long 0xE0541000, 0x80046160
+.long 0xE0541010, 0x80046360
+.long 0xE0541020, 0x80046560
+.long 0xE0541030, 0x80046760
+.long 0xD3D84069, 0x18000160
+.long 0xD3D8406A, 0x18000161
+.long 0xD3D8406B, 0x18000162
+.long 0xD3D8406C, 0x18000163
+.long 0xD3D8406D, 0x18000164
+.long 0xD3D8406E, 0x18000165
+.long 0xD3D8406F, 0x18000166
+.long 0xD3D84070, 0x18000167
+.long 0xBF8C0F73
+.long 0x0AD2D228
+.long 0x0AD4D428
+.long 0xD3A00069, 0x15A6C229
+.long 0xD3A0106A, 0x15AAC229
+.long 0x7ED21569
+.long 0x7ED4156A
+.long 0xD2000069, 0x05A5216A
+.long 0x0AD6D628
+.long 0x0AD8D828
+.long 0xD3A0006B, 0x15AEC429
+.long 0xD3A0106C, 0x15B2C429
+.long 0x7ED6156B
+.long 0x7ED8156C
+.long 0xD200006A, 0x05AD216C
+.long 0xD3CC0070, 0x05C2790C
+.long 0xE0741000, 0x80056960
+.long 0xD3CC0070, 0x05C27D0E
+.long 0xBF8C0F73
+.long 0x0ADADA28
+.long 0x0ADCDC28
+.long 0xD3A0006D, 0x15B6C629
+.long 0xD3A0106E, 0x15BAC629
+.long 0x7EDA156D
+.long 0x7EDC156E
+.long 0xD200006B, 0x05B5216E
+.long 0x0ADEDE28
+.long 0x0AE0E028
+.long 0xD3A0006F, 0x15BEC829
+.long 0xD3A01070, 0x15C2C829
+.long 0x7EDE156F
+.long 0x7EE01570
+.long 0xD200006C, 0x05BD2170
+.long 0xD3CC0070, 0x05C2B118
+.long 0xD3D84071, 0x18000168
+.long 0xD3D84072, 0x18000169
+.long 0xD3D84073, 0x1800016A
+.long 0xD3D84074, 0x1800016B
+.long 0xE0741010, 0x80056B60
+.long 0xD3CC0070, 0x05C2B51A
+.long 0xBF8C0F73
+.long 0x0AE2E228
+.long 0x0AE4E428
+.long 0xD3A00071, 0x15C6CA29
+.long 0xD3A01072, 0x15CACA29
+.long 0x7EE21571
+.long 0x7EE41572
+.long 0xD200006D, 0x05C52172
+.long 0x0AE6E628
+.long 0x0AE8E828
+.long 0xD3A00073, 0x15CECC29
+.long 0xD3A01074, 0x15D2CC29
+.long 0x7EE61573
+.long 0x7EE81574
+.long 0xD200006E, 0x05CD2174
+.long 0xD3CC0070, 0x05C2B91C
+.long 0xD3D84075, 0x1800016C
+.long 0xD3D84076, 0x1800016D
+.long 0xD3D84077, 0x1800016E
+.long 0xD3D84078, 0x1800016F
+.long 0xE0741020, 0x80056D60
+.long 0xD3CC0070, 0x05C2BD1E
+.long 0xBF800007
+.long 0xBF8C0F73
+.long 0x0AEAEA28
+.long 0x0AECEC28
+.long 0xD3A00075, 0x15D6CE29
+.long 0xD3A01076, 0x15DACE29
+.long 0x7EEA1575
+.long 0x7EEC1576
+.long 0xD200006F, 0x05D52176
+.long 0x0AEEEE28
+.long 0x0AF0F028
+.long 0xD3A00077, 0x15DED029
+.long 0xD3A01078, 0x15E2D029
+.long 0x7EEE1577
+.long 0x7EF01578
+.long 0xD2000070, 0x05DD2178
+.long 0xE0741030, 0x80056F60
+.long 0xE0541040, 0x80046160
+.long 0xE0541050, 0x80046360
+.long 0xE0541060, 0x80046560
+.long 0xE0541070, 0x80046760
+.long 0xD3D84069, 0x18000170
+.long 0xD3D8406A, 0x18000171
+.long 0xD3D8406B, 0x18000172
+.long 0xD3D8406C, 0x18000173
+.long 0xD3D8406D, 0x18000174
+.long 0xD3D8406E, 0x18000175
+.long 0xD3D8406F, 0x18000176
+.long 0xD3D84070, 0x18000177
+.long 0xBF8C0F73
+.long 0x0AD2D228
+.long 0x0AD4D428
+.long 0xD3A00069, 0x15A6C229
+.long 0xD3A0106A, 0x15AAC229
+.long 0x7ED21569
+.long 0x7ED4156A
+.long 0xD2000069, 0x05A5216A
+.long 0x0AD6D628
+.long 0x0AD8D828
+.long 0xD3A0006B, 0x15AEC429
+.long 0xD3A0106C, 0x15B2C429
+.long 0x7ED6156B
+.long 0x7ED8156C
+.long 0xD200006A, 0x05AD216C
+.long 0xE0741040, 0x80056960
+.long 0xBF8C0F73
+.long 0x0ADADA28
+.long 0x0ADCDC28
+.long 0xD3A0006D, 0x15B6C629
+.long 0xD3A0106E, 0x15BAC629
+.long 0x7EDA156D
+.long 0x7EDC156E
+.long 0xD200006B, 0x05B5216E
+.long 0x0ADEDE28
+.long 0x0AE0E028
+.long 0xD3A0006F, 0x15BEC829
+.long 0xD3A01070, 0x15C2C829
+.long 0x7EDE156F
+.long 0x7EE01570
+.long 0xD200006C, 0x05BD2170
+.long 0xD3D84071, 0x18000178
+.long 0xD3D84072, 0x18000179
+.long 0xD3D84073, 0x1800017A
+.long 0xD3D84074, 0x1800017B
+.long 0xE0741050, 0x80056B60
+.long 0xBF8C0F73
+.long 0x0AE2E228
+.long 0x0AE4E428
+.long 0xD3A00071, 0x15C6CA29
+.long 0xD3A01072, 0x15CACA29
+.long 0x7EE21571
+.long 0x7EE41572
+.long 0xD200006D, 0x05C52172
+.long 0x0AE6E628
+.long 0x0AE8E828
+.long 0xD3A00073, 0x15CECC29
+.long 0xD3A01074, 0x15D2CC29
+.long 0x7EE61573
+.long 0x7EE81574
+.long 0xD200006E, 0x05CD2174
+.long 0xD3D84075, 0x1800017C
+.long 0xD3D84076, 0x1800017D
+.long 0xD3D84077, 0x1800017E
+.long 0xD3D84078, 0x1800017F
+.long 0xE0741060, 0x80056D60
+.long 0xBF8C0F73
+.long 0x0AEAEA28
+.long 0x0AECEC28
+.long 0xD3A00075, 0x15D6CE29
+.long 0xD3A01076, 0x15DACE29
+.long 0x7EEA1575
+.long 0x7EEC1576
+.long 0xD200006F, 0x05D52176
+.long 0x0AEEEE28
+.long 0x0AF0F028
+.long 0xD3A00077, 0x15DED029
+.long 0xD3A01078, 0x15E2D029
+.long 0x7EEE1577
+.long 0x7EF01578
+.long 0xD2000070, 0x05DD2178
+.long 0xE0741070, 0x80056F60
+.long 0xBF8C0000
+.long 0xBF810000

--- a/Tensile/ReplacementKernels-cov3/Cijk_Alik_Bljk_HBH_MT64x128x32_AF0EM8_ASEM8_FL0_GRVW4_ISA908_MDA2_PGR1_PLR1_SU32_TT4_4_VAW2_VW4_WG16_32_1_WGM8.s.txt
+++ b/Tensile/ReplacementKernels-cov3/Cijk_Alik_Bljk_HBH_MT64x128x32_AF0EM8_ASEM8_FL0_GRVW4_ISA908_MDA2_PGR1_PLR1_SU32_TT4_4_VAW2_VW4_WG16_32_1_WGM8.s.txt
@@ -1,0 +1,1027 @@
+
+
+/******************************************/
+/* Function Prefix                        */
+/******************************************/
+
+
+
+/******************************************/
+/* Begin Kernel                           */
+/******************************************/
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx908+sram-ecc"
+.text
+.protected Cijk_Alik_Bljk_HBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT4_4_TLDS0_USFGROn1_VAW2_VS1_VW4_WSGRA0_WSGRB0_WG16_32_1_WGM8
+.globl Cijk_Alik_Bljk_HBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT4_4_TLDS0_USFGROn1_VAW2_VS1_VW4_WSGRA0_WSGRB0_WG16_32_1_WGM8
+.p2align 8
+.type Cijk_Alik_Bljk_HBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT4_4_TLDS0_USFGROn1_VAW2_VS1_VW4_WSGRA0_WSGRB0_WG16_32_1_WGM8,@function
+.section .rodata,#alloc
+.p2align 6
+.amdhsa_kernel Cijk_Alik_Bljk_HBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT4_4_TLDS0_USFGROn1_VAW2_VS1_VW4_WSGRA0_WSGRB0_WG16_32_1_WGM8
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_next_free_vgpr 108 // vgprs
+  .amdhsa_next_free_sgpr 98 // sgprs
+  .amdhsa_group_segment_fixed_size 30000 // lds bytes
+  .amdhsa_private_segment_fixed_size 0
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+.text
+
+/******************************************/
+/* Optimizations and Config:              */
+/******************************************/
+/* ThreadTile= 4 x 4 */
+/* SubGroup= 16 x 32 */
+/* VectorWidth=4 */
+/* GlobalLoadVectorWidthA=4, GlobalLoadVectorWidthB=4 */
+/* DirectToLdsA=False */
+/* DirectToLdsB=False */
+/* UseSgprForGRO=1 */
+.amdgpu_metadata
+---
+amdhsa.version:
+  - 1
+  - 0
+amdhsa.kernels:
+  - .name: Cijk_Alik_Bljk_HBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT4_4_TLDS0_USFGROn1_VAW2_VS1_VW4_WSGRA0_WSGRB0_WG16_32_1_WGM8
+    .symbol: 'Cijk_Alik_Bljk_HBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT4_4_TLDS0_USFGROn1_VAW2_VS1_VW4_WSGRA0_WSGRB0_WG16_32_1_WGM8.kd'
+    .language:                   OpenCL C
+    .language_version:
+      - 2
+      - 0
+    .args:
+      - .name:            sizeC
+        .size:            8
+        .offset:          0
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            sizeA
+        .size:            8
+        .offset:          8
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            sizeB
+        .size:            8
+        .offset:          16
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            D
+        .size:            8
+        .offset:          24
+        .value_kind:      global_buffer
+        .value_type:      struct
+        .address_space:   generic
+      - .name:            C
+        .size:            8
+        .offset:          32
+        .value_kind:      global_buffer
+        .value_type:      struct
+        .address_space:   generic
+      - .name:            A
+        .size:            8
+        .offset:          40
+        .value_kind:      global_buffer
+        .value_type:      struct
+        .address_space:   generic
+      - .name:            B
+        .size:            8
+        .offset:          48
+        .value_kind:      global_buffer
+        .value_type:      struct
+        .address_space:   generic
+      - .name:            alpha
+        .size:            4
+        .offset:          56
+        .value_kind:      by_value
+        .value_type:      f16
+      - .name:            beta
+        .size:            4
+        .offset:          60
+        .value_kind:      by_value
+        .value_type:      f16
+      - .name:            strideD0
+        .size:            4
+        .offset:          64
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideD1
+        .size:            4
+        .offset:          68
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideC0
+        .size:            4
+        .offset:          72
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideC1
+        .size:            4
+        .offset:          76
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideA0
+        .size:            4
+        .offset:          80
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideA1
+        .size:            4
+        .offset:          84
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideB0
+        .size:            4
+        .offset:          88
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideB1
+        .size:            4
+        .offset:          92
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree0
+        .size:            4
+        .offset:          96
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree1
+        .size:            4
+        .offset:          100
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree2
+        .size:            4
+        .offset:          104
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesSum0
+        .size:            4
+        .offset:          108
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            OrigStaggerUIter
+        .size:            4
+        .offset:          112
+        .value_kind:      by_value
+        .value_type:      i32
+      - .name:            NumWorkGroups0
+        .size:            4
+        .offset:          116
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            NumWorkGroups1
+        .size:            4
+        .offset:          120
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            MagicNumberProblemNumGroupTiles0
+        .size:            4
+        .offset:          124
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            GridNumWorkGroups0
+        .size:            4
+        .offset:          128
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            NumFullBlocks
+        .size:            4
+        .offset:          132
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            WgmRemainder1
+        .size:            4
+        .offset:          136
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            MagicNumberWgmRemainder1
+        .size:            4
+        .offset:          140
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            padding
+        .size:            4
+        .offset:          144
+        .value_kind:      by_value
+        .value_type:      u32
+    .group_segment_fixed_size:   28672
+    .kernarg_segment_align:      8
+    .kernarg_segment_size:       152
+    .max_flat_workgroup_size:    512
+    .private_segment_fixed_size: 0
+    .sgpr_count:                 98
+    .sgpr_spill_count:           0
+    .vgpr_count:                 108
+    .vgpr_spill_count:           0
+    .wavefront_size:             64
+...
+.end_amdgpu_metadata
+Cijk_Alik_Bljk_HBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT4_4_TLDS0_USFGROn1_VAW2_VS1_VW4_WSGRA0_WSGRB0_WG16_32_1_WGM8:
+
+/******************************************/
+/* Asm syntax workarounds                 */
+/******************************************/
+.macro _v_add_co_u32 dst, cc, src0, src1, dpp=
+   v_add_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+
+.macro _v_add_u32 dst, src0, src1, dpp=
+   v_add_u32 \dst, \src0, \src1 \dpp
+.endm
+
+.macro _v_sub_co_u32 dst, cc, src0, src1, dpp=
+   v_sub_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+
+.macro _v_sub_u32 dst, src0, src1, dpp=
+   v_sub_u32 \dst, \src0, \src1 \dpp
+.endm
+
+.macro _v_addc_co_u32 dst, ccOut, src0, ccIn, src1, dpp=
+   v_addc_co_u32 \dst, \ccOut, \src0, \ccIn, \src1 \dpp
+.endm
+
+.macro _v_add_lshl_u32 dst, src0, src1, shiftCnt
+    v_add_lshl_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+.macro _v_lshl_add_u32 dst, src0, src1, shiftCnt
+    v_lshl_add_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+/******************************************/
+/* Magic div and mod functions            */
+/******************************************/
+.macro V_MAGIC_DIV dstIdx, dividend, magicNumber, magicShift
+    v_mul_hi_u32 v[\dstIdx+1], \dividend, \magicNumber
+    v_mul_lo_u32 v[\dstIdx+0], \dividend, \magicNumber
+    v_lshrrev_b64 v[\dstIdx:\dstIdx+1], \magicShift, v[\dstIdx:\dstIdx+1]
+.endm
+
+/******************************************/
+/* VGPR Assignments                       */
+/******************************************/
+.set vgprValuC, 0
+/* ValuA/B   Xn=PLR buffer idx,  In=InnerUnroll idx */
+.set vgprValuA_X0_I0, 32
+.set vgprValuA_X1_I0, 34
+.set vgprG2LA, 36
+.set vgprValuB_X0_I0, 40
+.set vgprValuB_X1_I0, 44
+.set vgprG2LB, 48
+.set vgprLocalWriteAddrA, 56
+.set vgprLocalWriteAddrB, 57
+.set vgprGlobalReadOffsetA, 58
+.set vgprGlobalReadOffsetB, 59
+.set vgprLocalReadAddrA, 60
+.set vgprLocalReadAddrB, 61
+.set vgprSerial, 62
+/* Num VGPR=63 */
+
+/******************************************/
+/* SGPR Assignments                       */
+/******************************************/
+.set sgprKernArgAddress, 0
+.set sgprWorkGroup0, 2
+.set sgprWorkGroup1, 3
+.set sgprWorkGroup2, 4
+.set sgprNumWorkGroups0, 5
+.set sgprNumWorkGroups1, 6
+.set sgprSrdA, 8
+.set sgprSrdB, 12
+.set sgprSrdD, 16
+.set sgprSrdC, 20
+.set sgprTensor2dSizeC, 24
+.set sgprTensor2dSizeA, 26
+.set sgprTensor2dSizeB, 28
+.set sgprSaveExecMask, 30
+.set sgprAddressD, 32
+.set sgprAddressC, 34
+.set sgprStridesD, 36
+.set sgprStridesC, 38
+.set sgprAlpha, 40
+.set sgprBeta, 41
+.set sgprSizesFree, 42
+.set sgprSizesSum, 45
+.set sgprLoopCounters, 46
+.set sgprOrigLoopCounter, 47
+.set sgprStridesA, 48
+.set sgprStridesB, 50
+.set sgprAddressA, 52
+.set sgprAddressB, 54
+.set sgprShadowLimitA, 56
+.set sgprShadowLimitB, 58
+.set sgprOrigStaggerUIter, 60
+.set sgprStaggerUIter, 61
+.set sgprWrapUA, 62
+.set sgprWrapUB, 64
+.set sgprNumFullBlocks, 66
+.set sgprWgmRemainder1, 67
+.set sgprMagicNumberWgmRemainder1, 68
+.set sgprGlobalReadIncsA, 69
+.set sgprGlobalReadIncsB, 70
+.set sgprScalarGlobalReadOffsetA, 71
+.set sgprScalarGlobalReadOffsetB, 72
+/* max SGPR=98 */
+
+/* Size Assignments */
+.set sgprSizeD0I, sgprSizesFree+0
+.set sgprSizeD1J, sgprSizesFree+1
+.set sgprSizeDK, sgprSizesFree+2
+.set sgprSizeC0I, sgprSizesFree+0
+.set sgprSizeC1J, sgprSizesFree+1
+.set sgprSizeCK, sgprSizesFree+2
+.set sgprSizeAL, sgprSizesSum+0
+.set sgprSizeA0I, sgprSizesFree+0
+.set sgprSizeAK, sgprSizesFree+2
+.set sgprSizeBL, sgprSizesSum+0
+.set sgprSizeB1J, sgprSizesFree+1
+.set sgprSizeBK, sgprSizesFree+2
+
+/* Stride Assignments */
+.set constStrideD0I, 1
+.set sgprStrideD1J, sgprStridesD+0
+.set sgprStrideDK, sgprStridesD+1
+.set constStrideC0I, 1
+.set sgprStrideC1J, sgprStridesC+0
+.set sgprStrideCK, sgprStridesC+1
+.set constStrideAL, 1
+.set sgprStrideA0I, sgprStridesA+0
+.set sgprStrideAK, sgprStridesA+1
+.set constStrideBL, 1
+.set sgprStrideB1J, sgprStridesB+0
+.set sgprStrideBK, sgprStridesB+1
+
+.set DepthU, 32
+/* Number of elements to shift-left SRD */
+.set SrdShiftLeftA, 4
+.set SrdShiftLeftB, 4
+/* 2GB limit - set offsets to -1 to exceed this and clamp */
+.set BufferLimit, 0x80000000
+/* Bits 127:96 of SRD.  Set DataFormat = 32 bit */
+.set Srd127_96, 0x0020000
+.set BufferOOB, 0x80000000
+
+/* Global Offset A */
+.macro GLOBAL_OFFSET_A vgprAddr vgprOffsetL vgprOffset0I vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStrideA0I], v[\vgprOffset0I] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprOffsetL], v[\vgprTmp+0] // accumulate d1 lower
+_v_add_u32 v[\vgprAddr+0], 0x4, v[\vgprAddr+0]     // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/* Global Offset B */
+.macro GLOBAL_OFFSET_B vgprAddr vgprOffsetL vgprOffset1J vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStrideB1J], v[\vgprOffset1J] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprOffsetL], v[\vgprTmp+0] // accumulate d1 lower
+_v_add_u32 v[\vgprAddr+0], 0x4, v[\vgprAddr+0]     // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/******************************************/
+/* Dynamic Scalar Divide: vQuotient=vDividend/vDivisor; vRemainder=vDividend%vDivisor; */
+/******************************************/
+.macro DYNAMIC_VECTOR_DIVIDE vQuotient vRemainder vDividend vDivisor vTmp0 vTmp1 sTmp
+v_cvt_f32_u32 v[\vQuotient], v[\vDivisor]          //
+v_rcp_f32 v[\vQuotient], v[\vQuotient]             //
+v_mul_f32 v[\vQuotient], 0x4f800000, v[\vQuotient] //
+v_cvt_u32_f32 v[\vQuotient], v[\vQuotient]         //
+v_mul_lo_u32 v[\vRemainder], v[\vDivisor], v[\vQuotient] //
+v_mul_hi_u32 v[\vTmp0], v[\vDivisor], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp1], vcc, 0x0, v[\vRemainder]  //
+v_cmp_ne_i32 s[\sTmp:\sTmp+1], 0x0, v[\vTmp0]      //
+v_cndmask_b32 v[\vRemainder], v[\vTmp1], v[\vRemainder], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vRemainder], v[\vRemainder], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vQuotient], v[\vRemainder] //
+_v_add_co_u32 v[\vQuotient], vcc, v[\vQuotient], v[\vRemainder] //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vTmp0], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vQuotient], v[\vQuotient], v[\vDividend] //
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vDividend], v[\vRemainder] //
+v_cmp_ge_u32 s[\sTmp:\sTmp+1], v[\vDividend], v[\vRemainder] //
+_v_add_co_u32 v[\vRemainder], vcc, 0x1, v[\vQuotient] //
+_v_add_co_u32 v[\vTmp1], vcc, -1, v[\vQuotient]    //
+v_cmp_le_u32 vcc, v[\vDivisor], v[\vTmp0]          //
+s_and_b64 vcc, s[\sTmp:\sTmp+1], vcc               //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vRemainder], vcc //
+v_cndmask_b32 v[\vQuotient], v[\vTmp1], v[\vQuotient], s[\sTmp:\sTmp+1] //
+v_cmp_ne_i32 vcc, 0x0, v[\vDivisor]                //
+v_cndmask_b32 v[\vQuotient], -1, v[\vQuotient], vcc // final result
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vRemainder], vcc, v[\vDividend], v[\vRemainder] // final result
+.endm
+
+/******************************************/
+/* 4x8 thread-tile                        */
+/******************************************/
+.macro MAC_4x8_X0
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[0] iui=0
+s_setprio 1 // Raise priority while processing macs
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[1]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[4]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[5]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[2] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[3]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[6]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[7]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[8] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[9]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[12]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[13]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[10] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[11]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[14]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[15]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[16] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[17]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[20]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[21]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[18] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[19]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[22]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[23]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[24] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[25]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[28]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[29]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[26] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[27]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[30]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[31]
+s_setprio 0 // Reset priority after macs
+.endm
+.macro MAC_4x8_X1
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[0] iui=0
+s_setprio 1 // Raise priority while processing macs
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[1]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[4]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[5]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[2] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[3]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[6]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[7]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[8] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[9]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[12]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[13]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[10] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[11]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[14]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[15]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[16] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[17]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[20]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[21]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[18] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[19]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[22]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[23]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[24] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[25]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[28]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[29]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[26] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[27]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[30]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[31]
+s_setprio 0 // Reset priority after macs
+.endm
+
+
+
+
+/***** program start from here *****/
+
+.long 0xC00A0D00, 0x00000028
+.long 0xC00A0C00, 0x00000050
+.long 0xC00A0600, 0x00000008
+.long 0xC0020B40, 0x0000006C
+.long 0xBEFC00FF, 0x00006600
+.long 0x7EC80300
+.long 0x26CA00BF
+.long 0x2004C886
+.long 0xB8D0F804
+.long 0xD1130004, 0x0000A0B0
+.long 0x20CC0884
+.long 0x7EA40566
+.long 0xD1130067, 0x0000A08F
+.long 0x7EA20567
+.long 0xBF068151
+.long 0xBF8400AD
+.long 0xBF8CC07F
+.long 0xBE880034
+.long 0xBE890035
+.long 0xBE8B00FF, 0x00020000
+.long 0xBE8A00FF, 0x80000000
+.long 0x9254C030
+.long 0x92545402
+.long 0x92559052
+.long 0x92533055
+.long 0x92553104
+.long 0x81545354
+.long 0x80545554
+.long 0x2000CA82
+.long 0xD2850004, 0x00020030
+.long 0x2602CA83
+.long 0x24020283
+.long 0x32A40304
+.long 0x68A4A454
+.long 0x24A4A481
+.long 0xBECC00FF, 0x00000440
+.long 0x924C4C52
+.long 0xBE8C0036
+.long 0xBE8D0037
+.long 0xBE8F00FF, 0x00020000
+.long 0xBE8E00FF, 0x80000000
+.long 0x9254FF32, 0x00000080
+.long 0x92545403
+.long 0x9255A052
+.long 0x92533255
+.long 0x92553304
+.long 0x81545354
+.long 0x80545554
+.long 0x2004CA82
+.long 0xD2850004, 0x00020432
+.long 0x2606CA83
+.long 0x24060683
+.long 0x32AC0704
+.long 0x68ACAC54
+.long 0x24ACAC81
+.long 0x8E4A8532
+.long 0x68AEAC4A
+.long 0xBECE00FF, 0x00000880
+.long 0x924E4E52
+.long 0x814EFF4E, 0x00002200
+.long 0x814DFF4C, 0x00001100
+.long 0x2498CA84
+.long 0x6898984C
+.long 0x249ACA84
+.long 0x689A9A4D
+.long 0x814FFF4E, 0x00002200
+.long 0x249CCA84
+.long 0x689C9C4E
+.long 0x249ECA84
+.long 0x689E9E4F
+.long 0x2002CA83
+.long 0xD2850001, 0x00020288
+.long 0x68989901
+.long 0x689A9B01
+.long 0x689C9D01
+.long 0x689E9F01
+.long 0xD1340054, 0x00018152
+.long 0xD1340058, 0x00018156
+.long 0xD1340059, 0x00018157
+.long 0xBF8A0000
+.long 0xE05C1000, 0x80022052
+.long 0xE05C1000, 0x80033056
+.long 0xE05C1000, 0x80033457
+.long 0xE05C1000, 0x80022854
+.long 0xE05C1000, 0x80033858
+.long 0xE05C1000, 0x80033C59
+.long 0x68A4A4FF, 0x00000080
+.long 0x68ACACFF, 0x00000080
+.long 0x68AEAEFF, 0x00000080
+.long 0x8F2E852D
+.long 0x80AE2E80
+.long 0xBF06C22E
+.long 0xBF850034
+.long 0xBF8C0F75
+.long 0xD9BE0000, 0x0000204C
+.long 0xBF8C0F73
+.long 0xD9BE0000, 0x0000304E
+.long 0xD9BE0440, 0x0000344E
+.long 0xBF8CC27F
+.long 0xE05C1000, 0x80022052
+.long 0xBF8CC17F
+.long 0xE05C1000, 0x80033056
+.long 0xBF8CC07F
+.long 0xE05C1000, 0x80033457
+.long 0xBF8F0001
+.long 0x68A4A4FF, 0x00000080
+.long 0x68ACACFF, 0x00000080
+.long 0x68AEAEFF, 0x00000080
+.long 0x68A8A8FF, 0x00000080
+.long 0x68B0B0FF, 0x00000080
+.long 0x68B2B2FF, 0x00000080
+.long 0xBF8F0000
+.long 0xBF8C0F75
+.long 0xD9BE0000, 0x0000284D
+.long 0xBF8C0F73
+.long 0xD9BE0000, 0x0000384F
+.long 0xD9BE0440, 0x00003C4F
+.long 0xBF8CC27F
+.long 0xE05C1000, 0x80022854
+.long 0xBF8CC07F
+.long 0xBF8A0000
+.long 0xE05C1000, 0x80033858
+.long 0xE05C1000, 0x80033C59
+.long 0xBF8A0000
+.long 0x802E822E
+.long 0xBF00C22E
+.long 0xBF84FFCC
+.long 0xBF8C0F75
+.long 0xD9BE0000, 0x0000204C
+.long 0xBF8C0F73
+.long 0xD9BE0000, 0x0000304E
+.long 0xD9BE0440, 0x0000344E
+.long 0xBF8C0F72
+.long 0xD9BE0000, 0x0000284D
+.long 0xBF8C0F70
+.long 0xD9BE0000, 0x0000384F
+.long 0xD9BE0440, 0x00003C4F
+.long 0xBF8CC07F
+.long 0xBF8A0000
+.long 0xBF810000
+.long 0xD3D94000, 0x18000080
+.long 0xD3D94001, 0x18000080
+.long 0xD3D94002, 0x18000080
+.long 0xD3D94003, 0x18000080
+.long 0xD3D94004, 0x18000080
+.long 0xD3D94005, 0x18000080
+.long 0xD3D94006, 0x18000080
+.long 0xD3D94007, 0x18000080
+.long 0xD3D94008, 0x18000080
+.long 0xD3D94009, 0x18000080
+.long 0xD3D9400A, 0x18000080
+.long 0xD3D9400B, 0x18000080
+.long 0xD3D9400C, 0x18000080
+.long 0xD3D9400D, 0x18000080
+.long 0xD3D9400E, 0x18000080
+.long 0xD3D9400F, 0x18000080
+.long 0xD3D94010, 0x18000080
+.long 0xD3D94011, 0x18000080
+.long 0xD3D94012, 0x18000080
+.long 0xD3D94013, 0x18000080
+.long 0xD3D94014, 0x18000080
+.long 0xD3D94015, 0x18000080
+.long 0xD3D94016, 0x18000080
+.long 0xD3D94017, 0x18000080
+.long 0xD3D94018, 0x18000080
+.long 0xD3D94019, 0x18000080
+.long 0xD3D9401A, 0x18000080
+.long 0xD3D9401B, 0x18000080
+.long 0xD3D9401C, 0x18000080
+.long 0xD3D9401D, 0x18000080
+.long 0xD3D9401E, 0x18000080
+.long 0xD3D9401F, 0x18000080
+.long 0xC0060700, 0x00000000
+.long 0xC00A0A00, 0x00000038
+.long 0xC00A0900, 0x00000040
+.long 0xC00A0800, 0x00000018
+.long 0xD1130001, 0x00013F65
+.long 0xD2850060, 0x000202A0
+.long 0x20040281
+.long 0xD2850002, 0x00020488
+.long 0x2002CA85
+.long 0x24020282
+.long 0x68C0C101
+.long 0x24C0C081
+.long 0x68C0C102
+.long 0x68C0C080
+.long 0x68C2C0FF, 0x00001100
+.long 0xBF8A0000
+.long 0xD1130001, 0x00013F65
+.long 0xD2850062, 0x000202A0
+.long 0x20040281
+.long 0xD2850002, 0x00020488
+.long 0x2002CA85
+.long 0x24020282
+.long 0x68C4C501
+.long 0x24C4C481
+.long 0x68C4C502
+.long 0x9254FF52, 0x00000880
+.long 0x68C4C454
+.long 0x68C4C4FF, 0x00002200
+.long 0x68C6C4FF, 0x00002200
+.long 0xBF8CC07F
+.long 0xBE900022
+.long 0xBE910023
+.long 0xBE9200FF, 0x80000000
+.long 0xBE9300FF, 0x00020000
+.long 0xBE940020
+.long 0xBE950021
+.long 0xBE9600FF, 0x80000000
+.long 0xBE9700FF, 0x00020000
+.long 0x925603FF, 0x00000080
+.long 0x96552656
+.long 0x92542656
+.long 0x8ED48154
+.long 0x80105410
+.long 0x82115511
+.long 0x80145414
+.long 0x82155515
+.long 0x96552704
+.long 0x92542704
+.long 0x8ED48154
+.long 0x80105410
+.long 0x82115511
+.long 0x80145414
+.long 0x82155515
+.long 0x24C8CC86
+.long 0x68C8C965
+.long 0xD2850004, 0x0002CCA0
+.long 0xD2850003, 0x00004D04
+.long 0x2608C89F
+.long 0xD2850005, 0x00004D04
+.long 0x2608C8BF
+.long 0x200C0885
+.long 0x240C0C82
+.long 0x68D60B03
+.long 0x925402C0
+.long 0x32D40C54
+.long 0xD1FE0068, 0x0206D76A
+.long 0x7ED40228
+.long 0x7ED4176A
+.long 0x7E50056A
+.long 0x7ED40229
+.long 0x7ED4176A
+.long 0x7E52056A
+.long 0xBF8A0000
+.long 0xD8EC0000, 0x20000060
+.long 0xD8EC0000, 0x40000062
+.long 0xD8EC0000, 0x30000061
+.long 0xD8EC0000, 0x48000063
+.long 0xBF8CC27F
+.long 0xD3CC0000, 0x04028120
+.long 0xD8EC0010, 0x22000060
+.long 0xD8EC0010, 0x42000062
+.long 0xD8EC0010, 0x32000061
+.long 0xD8EC0010, 0x4A000063
+.long 0xBF8CC47F
+.long 0xD3CC0000, 0x04029130
+.long 0xD8EC0020, 0x24000060
+.long 0xD8EC0020, 0x44000062
+.long 0xD8EC0020, 0x34000061
+.long 0xD8EC0020, 0x4C000063
+.long 0xE0541000, 0x80041068
+.long 0xE0541010, 0x80041268
+.long 0xBF8CC67F
+.long 0xD3CC0000, 0x04028522
+.long 0xD8EC0030, 0x26000060
+.long 0xD8EC0030, 0x46000062
+.long 0xD8EC0030, 0x36000061
+.long 0xD8EC0030, 0x4E000063
+.long 0xE0541020, 0x80041468
+.long 0xE0541030, 0x80041668
+.long 0xBF8CC87F
+.long 0xD3CC0000, 0x04029532
+.long 0xD8EC0880, 0x28000060
+.long 0xD8EC0880, 0x38000061
+.long 0xD8EC0890, 0x2A000060
+.long 0xD8EC0890, 0x3A000061
+.long 0xBF8CCA7F
+.long 0xD3CC0000, 0x04028924
+.long 0xD8EC08A0, 0x2C000060
+.long 0xD8EC08A0, 0x3C000061
+.long 0xD8EC08B0, 0x2E000060
+.long 0xD8EC08B0, 0x3E000061
+.long 0xBF8CCC7F
+.long 0xD3CC0000, 0x04029934
+.long 0xBF8CCE7F
+.long 0xD3CC0000, 0x04028D26
+.long 0xBF8CC07F
+.long 0xBF8A0000
+.long 0x8F2E852D
+.long 0x80AE2E80
+.long 0xBF06C22E
+.long 0xBF850064
+.long 0xD3CC0000, 0x04029D36
+.long 0xBF80000C
+.long 0xD3CC0010, 0x04428128
+.long 0xBF80000C
+.long 0xD3CC0010, 0x04429138
+.long 0xBF80000C
+.long 0xD3CC0010, 0x0442852A
+.long 0xBF80000C
+.long 0xD3CC0010, 0x0442953A
+.long 0xBF80000C
+.long 0xD3CC0010, 0x0442892C
+.long 0xBF80000C
+.long 0xD3CC0010, 0x0442993C
+.long 0xBF80000C
+.long 0xD3CC0010, 0x04428D2E
+.long 0xBF8A0000
+.long 0xD8EC0000, 0x20000060
+.long 0xD8EC0000, 0x40000062
+.long 0xD8EC0000, 0x30000061
+.long 0xD8EC0000, 0x48000063
+.long 0xD3CC0010, 0x04429D3E
+.long 0xD8EC0010, 0x22000060
+.long 0xD8EC0010, 0x42000062
+.long 0xD8EC0010, 0x32000061
+.long 0xD8EC0010, 0x4A000063
+.long 0xBF8CC67F
+.long 0xD3CC0000, 0x04028120
+.long 0xD8EC0020, 0x24000060
+.long 0xD8EC0020, 0x44000062
+.long 0xD8EC0020, 0x34000061
+.long 0xD8EC0020, 0x4C000063
+.long 0xBF8CC87F
+.long 0xD3CC0000, 0x04029130
+.long 0xD8EC0030, 0x26000060
+.long 0xD8EC0030, 0x46000062
+.long 0xD8EC0030, 0x36000061
+.long 0xD8EC0030, 0x4E000063
+.long 0xBF8CCA7F
+.long 0xD3CC0000, 0x04028522
+.long 0xD8EC0880, 0x28000060
+.long 0xD8EC0880, 0x38000061
+.long 0xD8EC0890, 0x2A000060
+.long 0xD8EC0890, 0x3A000061
+.long 0xBF8CCC7F
+.long 0xD3CC0000, 0x04029532
+.long 0xD8EC08A0, 0x2C000060
+.long 0xD8EC08A0, 0x3C000061
+.long 0xD8EC08B0, 0x2E000060
+.long 0xD8EC08B0, 0x3E000061
+.long 0xBF8CCE7F
+.long 0xD3CC0000, 0x04028924
+.long 0xBF80000C
+.long 0xBF8CCC7F
+.long 0xD3CC0000, 0x04029934
+.long 0xBF8CC07F
+.long 0xBF8A0000
+.long 0xD3CC0000, 0x04028D26
+.long 0x802E822E
+.long 0xBF00C22E
+.long 0xBF84FF9C
+.long 0xE0541040, 0x80041868
+.long 0xE0541050, 0x80041A68
+.long 0xD3CC0000, 0x04029D36
+.long 0xE0541060, 0x80041C68
+.long 0xE0541070, 0x80041E68
+.long 0xD3CC0010, 0x04428128
+.long 0xD3D84000, 0x18000100
+.long 0xD3D84001, 0x18000101
+.long 0xD3D84002, 0x18000102
+.long 0xD3D84003, 0x18000103
+.long 0xD3D84004, 0x18000104
+.long 0xD3D84005, 0x18000105
+.long 0xD3D84006, 0x18000106
+.long 0xD3D84007, 0x18000107
+.long 0xD3CC0010, 0x04429138
+.long 0xBF8C0F77
+.long 0x0A000028
+.long 0x0A020228
+.long 0xD3A00000, 0x14022029
+.long 0xD3A01001, 0x14062029
+.long 0x7E001500
+.long 0x7E021501
+.long 0xD2000000, 0x04012101
+.long 0x0A040428
+.long 0x0A060628
+.long 0xD3A00002, 0x140A2229
+.long 0xD3A01003, 0x140E2229
+.long 0x7E041502
+.long 0x7E061503
+.long 0xD2000001, 0x04092103
+.long 0xE0741000, 0x80050068
+.long 0xD3CC0010, 0x0442852A
+.long 0xBF8C0F77
+.long 0x0A080828
+.long 0x0A0A0A28
+.long 0xD3A00004, 0x14122429
+.long 0xD3A01005, 0x14162429
+.long 0x7E081504
+.long 0x7E0A1505
+.long 0xD2000002, 0x04112105
+.long 0x0A0C0C28
+.long 0x0A0E0E28
+.long 0xD3A00006, 0x141A2629
+.long 0xD3A01007, 0x141E2629
+.long 0x7E0C1506
+.long 0x7E0E1507
+.long 0xD2000003, 0x04192107
+.long 0xD3CC0010, 0x0442953A
+.long 0xE0741010, 0x80050268
+.long 0xD3CC0010, 0x0442892C
+.long 0xD3D84008, 0x18000108
+.long 0xD3D84009, 0x18000109
+.long 0xD3D8400A, 0x1800010A
+.long 0xD3D8400B, 0x1800010B
+.long 0xBF8C0F77
+.long 0x0A101028
+.long 0x0A121228
+.long 0xD3A00008, 0x14222829
+.long 0xD3A01009, 0x14262829
+.long 0x7E101508
+.long 0x7E121509
+.long 0xD2000004, 0x04212109
+.long 0x0A141428
+.long 0x0A161628
+.long 0xD3A0000A, 0x142A2A29
+.long 0xD3A0100B, 0x142E2A29
+.long 0x7E14150A
+.long 0x7E16150B
+.long 0xD2000005, 0x0429210B
+.long 0xD3CC0010, 0x0442993C
+.long 0xE0741020, 0x80050468
+.long 0xD3CC0010, 0x04428D2E
+.long 0xD3D8400C, 0x1800010C
+.long 0xD3D8400D, 0x1800010D
+.long 0xD3D8400E, 0x1800010E
+.long 0xD3D8400F, 0x1800010F
+.long 0xBF8C0F77
+.long 0x0A181828
+.long 0x0A1A1A28
+.long 0xD3A0000C, 0x14322C29
+.long 0xD3A0100D, 0x14362C29
+.long 0x7E18150C
+.long 0x7E1A150D
+.long 0xD2000006, 0x0431210D
+.long 0x0A1C1C28
+.long 0x0A1E1E28
+.long 0xD3A0000E, 0x143A2E29
+.long 0xD3A0100F, 0x143E2E29
+.long 0x7E1C150E
+.long 0x7E1E150F
+.long 0xD2000007, 0x0439210F
+.long 0xD3CC0010, 0x04429D3E
+.long 0xBF800008
+.long 0xE0741030, 0x80050668
+.long 0xD3D84000, 0x18000110
+.long 0xD3D84001, 0x18000111
+.long 0xD3D84002, 0x18000112
+.long 0xD3D84003, 0x18000113
+.long 0xD3D84004, 0x18000114
+.long 0xD3D84005, 0x18000115
+.long 0xD3D84006, 0x18000116
+.long 0xD3D84007, 0x18000117
+.long 0xBF8C0F77
+.long 0x0A000028
+.long 0x0A020228
+.long 0xD3A00000, 0x14023029
+.long 0xD3A01001, 0x14063029
+.long 0x7E001500
+.long 0x7E021501
+.long 0xD2000000, 0x04012101
+.long 0x0A040428
+.long 0x0A060628
+.long 0xD3A00002, 0x140A3229
+.long 0xD3A01003, 0x140E3229
+.long 0x7E041502
+.long 0x7E061503
+.long 0xD2000001, 0x04092103
+.long 0xE0741040, 0x80050068
+.long 0xBF8C0F77
+.long 0x0A080828
+.long 0x0A0A0A28
+.long 0xD3A00004, 0x14123429
+.long 0xD3A01005, 0x14163429
+.long 0x7E081504
+.long 0x7E0A1505
+.long 0xD2000002, 0x04112105
+.long 0x0A0C0C28
+.long 0x0A0E0E28
+.long 0xD3A00006, 0x141A3629
+.long 0xD3A01007, 0x141E3629
+.long 0x7E0C1506
+.long 0x7E0E1507
+.long 0xD2000003, 0x04192107
+.long 0xD3D84008, 0x18000118
+.long 0xD3D84009, 0x18000119
+.long 0xD3D8400A, 0x1800011A
+.long 0xD3D8400B, 0x1800011B
+.long 0xE0741050, 0x80050268
+.long 0xBF8C0F77
+.long 0x0A101028
+.long 0x0A121228
+.long 0xD3A00008, 0x14223829
+.long 0xD3A01009, 0x14263829
+.long 0x7E101508
+.long 0x7E121509
+.long 0xD2000004, 0x04212109
+.long 0x0A141428
+.long 0x0A161628
+.long 0xD3A0000A, 0x142A3A29
+.long 0xD3A0100B, 0x142E3A29
+.long 0x7E14150A
+.long 0x7E16150B
+.long 0xD2000005, 0x0429210B
+.long 0xD3D8400C, 0x1800011C
+.long 0xD3D8400D, 0x1800011D
+.long 0xD3D8400E, 0x1800011E
+.long 0xD3D8400F, 0x1800011F
+.long 0xE0741060, 0x80050468
+.long 0xBF8C0F77
+.long 0x0A181828
+.long 0x0A1A1A28
+.long 0xD3A0000C, 0x14323C29
+.long 0xD3A0100D, 0x14363C29
+.long 0x7E18150C
+.long 0x7E1A150D
+.long 0xD2000006, 0x0431210D
+.long 0x0A1C1C28
+.long 0x0A1E1E28
+.long 0xD3A0000E, 0x143A3E29
+.long 0xD3A0100F, 0x143E3E29
+.long 0x7E1C150E
+.long 0x7E1E150F
+.long 0xD2000007, 0x0439210F
+.long 0xE0741070, 0x80050668
+.long 0xBF8C0000
+.long 0xBF810000

--- a/Tensile/ReplacementKernels-cov3/Cijk_Alik_Bljk_SB_MT32x64x32_AF0EM8_ASEM8_FL0_GRVW2_ISA908_MDA2_PGR1_PLR1_SU32_TT2_2_VAW1_VW2_WG16_32_1_WGM8.s.txt
+++ b/Tensile/ReplacementKernels-cov3/Cijk_Alik_Bljk_SB_MT32x64x32_AF0EM8_ASEM8_FL0_GRVW2_ISA908_MDA2_PGR1_PLR1_SU32_TT2_2_VAW1_VW2_WG16_32_1_WGM8.s.txt
@@ -1,0 +1,910 @@
+
+
+/******************************************/
+/* Function Prefix                        */
+/******************************************/
+
+
+
+/******************************************/
+/* Begin Kernel                           */
+/******************************************/
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx908+sram-ecc"
+.text
+.protected Cijk_Alik_Bljk_SB_MT32x64x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG16_32_1_WGM8
+.globl Cijk_Alik_Bljk_SB_MT32x64x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG16_32_1_WGM8
+.p2align 8
+.type Cijk_Alik_Bljk_SB_MT32x64x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG16_32_1_WGM8,@function
+.section .rodata,#alloc
+.p2align 6
+.amdhsa_kernel Cijk_Alik_Bljk_SB_MT32x64x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG16_32_1_WGM8
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_next_free_vgpr 108 // vgprs
+  .amdhsa_next_free_sgpr 98 // sgprs
+  .amdhsa_group_segment_fixed_size 28672 // lds bytes
+  .amdhsa_private_segment_fixed_size 0
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+.text
+
+/******************************************/
+/* Optimizations and Config:              */
+/******************************************/
+/* ThreadTile= 4 x 4 */
+/* SubGroup= 16 x 32 */
+/* VectorWidth=4 */
+/* GlobalLoadVectorWidthA=4, GlobalLoadVectorWidthB=4 */
+/* DirectToLdsA=False */
+/* DirectToLdsB=False */
+/* UseSgprForGRO=1 */
+.amdgpu_metadata
+---
+amdhsa.version:
+  - 1
+  - 0
+amdhsa.kernels:
+  - .name: Cijk_Alik_Bljk_SB_MT32x64x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG16_32_1_WGM8
+    .symbol: 'Cijk_Alik_Bljk_SB_MT32x64x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG16_32_1_WGM8.kd'
+    .language:                   OpenCL C
+    .language_version:
+      - 2
+      - 0
+    .args:
+      - .name:            sizeC
+        .size:            8
+        .offset:          0
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            sizeA
+        .size:            8
+        .offset:          8
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            sizeB
+        .size:            8
+        .offset:          16
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            D
+        .size:            8
+        .offset:          24
+        .value_kind:      global_buffer
+        .value_type:      f32
+        .address_space:   generic
+      - .name:            C
+        .size:            8
+        .offset:          32
+        .value_kind:      global_buffer
+        .value_type:      f32
+        .address_space:   generic
+      - .name:            A
+        .size:            8
+        .offset:          40
+        .value_kind:      global_buffer
+        .value_type:      f32
+        .address_space:   generic
+      - .name:            B
+        .size:            8
+        .offset:          48
+        .value_kind:      global_buffer
+        .value_type:      f32
+        .address_space:   generic
+      - .name:            alpha
+        .size:            4
+        .offset:          56
+        .value_kind:      by_value
+        .value_type:      f32
+      - .name:            beta
+        .size:            4
+        .offset:          60
+        .value_kind:      by_value
+        .value_type:      f32
+      - .name:            strideD0
+        .size:            4
+        .offset:          64
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideD1
+        .size:            4
+        .offset:          68
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideC0
+        .size:            4
+        .offset:          72
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideC1
+        .size:            4
+        .offset:          76
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideA0
+        .size:            4
+        .offset:          80
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideA1
+        .size:            4
+        .offset:          84
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideB0
+        .size:            4
+        .offset:          88
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideB1
+        .size:            4
+        .offset:          92
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree0
+        .size:            4
+        .offset:          96
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree1
+        .size:            4
+        .offset:          100
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree2
+        .size:            4
+        .offset:          104
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesSum0
+        .size:            4
+        .offset:          108
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            OrigStaggerUIter
+        .size:            4
+        .offset:          112
+        .value_kind:      by_value
+        .value_type:      i32
+      - .name:            NumWorkGroups0
+        .size:            4
+        .offset:          116
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            NumWorkGroups1
+        .size:            4
+        .offset:          120
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            MagicNumberProblemNumGroupTiles0
+        .size:            4
+        .offset:          124
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            GridNumWorkGroups0
+        .size:            4
+        .offset:          128
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            NumFullBlocks
+        .size:            4
+        .offset:          132
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            WgmRemainder1
+        .size:            4
+        .offset:          136
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            MagicNumberWgmRemainder1
+        .size:            4
+        .offset:          140
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            padding
+        .size:            4
+        .offset:          144
+        .value_kind:      by_value
+        .value_type:      u32
+    .group_segment_fixed_size:   28672
+    .kernarg_segment_align:      8
+    .kernarg_segment_size:       152
+    .max_flat_workgroup_size:    512
+    .private_segment_fixed_size: 0
+    .sgpr_count:                 98
+    .sgpr_spill_count:           0
+    .vgpr_count:                 108
+    .vgpr_spill_count:           0
+    .wavefront_size:             64
+...
+.end_amdgpu_metadata
+Cijk_Alik_Bljk_SB_MT32x64x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG16_32_1_WGM8:
+
+/******************************************/
+/* Asm syntax workarounds                 */
+/******************************************/
+.macro _v_add_co_u32 dst, cc, src0, src1, dpp=
+   v_add_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+
+.macro _v_add_u32 dst, src0, src1, dpp=
+   v_add_u32 \dst, \src0, \src1 \dpp
+.endm
+
+.macro _v_sub_co_u32 dst, cc, src0, src1, dpp=
+   v_sub_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+
+.macro _v_sub_u32 dst, src0, src1, dpp=
+   v_sub_u32 \dst, \src0, \src1 \dpp
+.endm
+
+.macro _v_addc_co_u32 dst, ccOut, src0, ccIn, src1, dpp=
+   v_addc_co_u32 \dst, \ccOut, \src0, \ccIn, \src1 \dpp
+.endm
+
+.macro _v_add_lshl_u32 dst, src0, src1, shiftCnt
+    v_add_lshl_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+.macro _v_lshl_add_u32 dst, src0, src1, shiftCnt
+    v_lshl_add_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+/******************************************/
+/* Magic div and mod functions            */
+/******************************************/
+.macro V_MAGIC_DIV dstIdx, dividend, magicNumber, magicShift
+    v_mul_hi_u32 v[\dstIdx+1], \dividend, \magicNumber
+    v_mul_lo_u32 v[\dstIdx+0], \dividend, \magicNumber
+    v_lshrrev_b64 v[\dstIdx:\dstIdx+1], \magicShift, v[\dstIdx:\dstIdx+1]
+.endm
+
+/******************************************/
+/* VGPR Assignments                       */
+/******************************************/
+.set vgprValuC, 0
+/* ValuA/B   Xn=PLR buffer idx,  In=InnerUnroll idx */
+.set vgprValuA_X0_I0, 32
+.set vgprValuA_X1_I0, 34
+.set vgprG2LA, 36
+.set vgprValuB_X0_I0, 40
+.set vgprValuB_X1_I0, 44
+.set vgprG2LB, 48
+.set vgprLocalWriteAddrA, 56
+.set vgprLocalWriteAddrB, 57
+.set vgprGlobalReadOffsetA, 58
+.set vgprGlobalReadOffsetB, 59
+.set vgprLocalReadAddrA, 60
+.set vgprLocalReadAddrB, 61
+.set vgprSerial, 62
+/* Num VGPR=63 */
+
+/******************************************/
+/* SGPR Assignments                       */
+/******************************************/
+.set sgprKernArgAddress, 0
+.set sgprWorkGroup0, 2
+.set sgprWorkGroup1, 3
+.set sgprWorkGroup2, 4
+.set sgprNumWorkGroups0, 5
+.set sgprNumWorkGroups1, 6
+.set sgprSrdA, 8
+.set sgprSrdB, 12
+.set sgprSrdD, 16
+.set sgprSrdC, 20
+.set sgprTensor2dSizeC, 24
+.set sgprTensor2dSizeA, 26
+.set sgprTensor2dSizeB, 28
+.set sgprSaveExecMask, 30
+.set sgprAddressD, 32
+.set sgprAddressC, 34
+.set sgprStridesD, 36
+.set sgprStridesC, 38
+.set sgprAlpha, 40
+.set sgprBeta, 41
+.set sgprSizesFree, 42
+.set sgprSizesSum, 45
+.set sgprLoopCounters, 46
+.set sgprOrigLoopCounter, 47
+.set sgprStridesA, 48
+.set sgprStridesB, 50
+.set sgprAddressA, 52
+.set sgprAddressB, 54
+.set sgprShadowLimitA, 56
+.set sgprShadowLimitB, 58
+.set sgprOrigStaggerUIter, 60
+.set sgprStaggerUIter, 61
+.set sgprWrapUA, 62
+.set sgprWrapUB, 64
+.set sgprNumFullBlocks, 66
+.set sgprWgmRemainder1, 67
+.set sgprMagicNumberWgmRemainder1, 68
+.set sgprGlobalReadIncsA, 69
+.set sgprGlobalReadIncsB, 70
+.set sgprScalarGlobalReadOffsetA, 71
+.set sgprScalarGlobalReadOffsetB, 72
+/* max SGPR=98 */
+
+/* Size Assignments */
+.set sgprSizeD0I, sgprSizesFree+0
+.set sgprSizeD1J, sgprSizesFree+1
+.set sgprSizeDK, sgprSizesFree+2
+.set sgprSizeC0I, sgprSizesFree+0
+.set sgprSizeC1J, sgprSizesFree+1
+.set sgprSizeCK, sgprSizesFree+2
+.set sgprSizeAL, sgprSizesSum+0
+.set sgprSizeA0I, sgprSizesFree+0
+.set sgprSizeAK, sgprSizesFree+2
+.set sgprSizeBL, sgprSizesSum+0
+.set sgprSizeB1J, sgprSizesFree+1
+.set sgprSizeBK, sgprSizesFree+2
+
+/* Stride Assignments */
+.set constStrideD0I, 1
+.set sgprStrideD1J, sgprStridesD+0
+.set sgprStrideDK, sgprStridesD+1
+.set constStrideC0I, 1
+.set sgprStrideC1J, sgprStridesC+0
+.set sgprStrideCK, sgprStridesC+1
+.set constStrideAL, 1
+.set sgprStrideA0I, sgprStridesA+0
+.set sgprStrideAK, sgprStridesA+1
+.set constStrideBL, 1
+.set sgprStrideB1J, sgprStridesB+0
+.set sgprStrideBK, sgprStridesB+1
+
+.set DepthU, 32
+/* Number of elements to shift-left SRD */
+.set SrdShiftLeftA, 4
+.set SrdShiftLeftB, 4
+/* 2GB limit - set offsets to -1 to exceed this and clamp */
+.set BufferLimit, 0x80000000
+/* Bits 127:96 of SRD.  Set DataFormat = 32 bit */
+.set Srd127_96, 0x0020000
+.set BufferOOB, 0x80000000
+
+/* Global Offset A */
+.macro GLOBAL_OFFSET_A vgprAddr vgprOffsetL vgprOffset0I vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStrideA0I], v[\vgprOffset0I] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprOffsetL], v[\vgprTmp+0] // accumulate d1 lower
+_v_add_u32 v[\vgprAddr+0], 0x4, v[\vgprAddr+0]     // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/* Global Offset B */
+.macro GLOBAL_OFFSET_B vgprAddr vgprOffsetL vgprOffset1J vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStrideB1J], v[\vgprOffset1J] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprOffsetL], v[\vgprTmp+0] // accumulate d1 lower
+_v_add_u32 v[\vgprAddr+0], 0x4, v[\vgprAddr+0]     // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/******************************************/
+/* Dynamic Scalar Divide: vQuotient=vDividend/vDivisor; vRemainder=vDividend%vDivisor; */
+/******************************************/
+.macro DYNAMIC_VECTOR_DIVIDE vQuotient vRemainder vDividend vDivisor vTmp0 vTmp1 sTmp
+v_cvt_f32_u32 v[\vQuotient], v[\vDivisor]          //
+v_rcp_f32 v[\vQuotient], v[\vQuotient]             //
+v_mul_f32 v[\vQuotient], 0x4f800000, v[\vQuotient] //
+v_cvt_u32_f32 v[\vQuotient], v[\vQuotient]         //
+v_mul_lo_u32 v[\vRemainder], v[\vDivisor], v[\vQuotient] //
+v_mul_hi_u32 v[\vTmp0], v[\vDivisor], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp1], vcc, 0x0, v[\vRemainder]  //
+v_cmp_ne_i32 s[\sTmp:\sTmp+1], 0x0, v[\vTmp0]      //
+v_cndmask_b32 v[\vRemainder], v[\vTmp1], v[\vRemainder], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vRemainder], v[\vRemainder], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vQuotient], v[\vRemainder] //
+_v_add_co_u32 v[\vQuotient], vcc, v[\vQuotient], v[\vRemainder] //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vTmp0], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vQuotient], v[\vQuotient], v[\vDividend] //
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vDividend], v[\vRemainder] //
+v_cmp_ge_u32 s[\sTmp:\sTmp+1], v[\vDividend], v[\vRemainder] //
+_v_add_co_u32 v[\vRemainder], vcc, 0x1, v[\vQuotient] //
+_v_add_co_u32 v[\vTmp1], vcc, -1, v[\vQuotient]    //
+v_cmp_le_u32 vcc, v[\vDivisor], v[\vTmp0]          //
+s_and_b64 vcc, s[\sTmp:\sTmp+1], vcc               //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vRemainder], vcc //
+v_cndmask_b32 v[\vQuotient], v[\vTmp1], v[\vQuotient], s[\sTmp:\sTmp+1] //
+v_cmp_ne_i32 vcc, 0x0, v[\vDivisor]                //
+v_cndmask_b32 v[\vQuotient], -1, v[\vQuotient], vcc // final result
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vRemainder], vcc, v[\vDividend], v[\vRemainder] // final result
+.endm
+
+/******************************************/
+/* 4x8 thread-tile                        */
+/******************************************/
+.macro MAC_4x8_X0
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[0] iui=0
+s_setprio 1 // Raise priority while processing macs
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[1]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[4]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[5]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[2] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[3]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[6]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[7]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[8] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[9]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[12]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[13]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[10] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[11]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[14]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[15]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[16] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[17]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[20]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[21]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[18] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[19]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[22]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[23]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[24] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[25]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[28]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[29]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[26] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[27]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[30]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[31]
+s_setprio 0 // Reset priority after macs
+.endm
+.macro MAC_4x8_X1
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[0] iui=0
+s_setprio 1 // Raise priority while processing macs
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[1]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[4]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[5]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[2] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[3]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[6]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[7]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[8] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[9]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[12]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[13]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[10] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[11]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[14]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[15]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[16] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[17]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[20]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[21]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[18] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[19]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[22]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[23]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[24] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[25]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[28]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[29]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[26] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[27]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[30]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[31]
+s_setprio 0 // Reset priority after macs
+.endm
+
+
+
+
+/***** program start from here *****/
+
+.long 0xC00A0600, 0x00000008
+.long 0xC00A0D00, 0x00000028
+.long 0xC00A0C00, 0x00000050
+.long 0xC0020B40, 0x0000006C
+.long 0x7EC80300
+.long 0x26CA00BF
+.long 0xB8D0F804
+.long 0xD1130004, 0x0000A0B0
+.long 0x20CC0884
+.long 0x7EA40566
+.long 0xD1130067, 0x0000A08F
+.long 0x7EA20567
+.long 0xBF068151
+.long 0xBF8400EA
+.long 0xBF8CC07F
+.long 0xBE880034
+.long 0xBE890035
+.long 0xBE8A00FF, 0x80000000
+.long 0xBE8B00FF, 0x00020000
+.long 0x96553104
+.long 0x92543104
+.long 0x8ED48254
+.long 0x80085408
+.long 0x82095509
+.long 0x9254A030
+.long 0x92545402
+.long 0x92558830
+.long 0x92555552
+.long 0x81545554
+.long 0x2000CA85
+.long 0xD2850004, 0x00020030
+.long 0x2602CA9F
+.long 0x32A40304
+.long 0x68A4A454
+.long 0x24A4A482
+.long 0x8E478330
+.long 0x80C7FF47, 0x00000120
+.long 0x68A6A447
+.long 0x68A8A647
+.long 0x68AAA847
+.long 0xBECC00FF, 0x00000480
+.long 0x924C4C52
+.long 0xBE8C0036
+.long 0xBE8D0037
+.long 0xBE8E00FF, 0x80000000
+.long 0xBE8F00FF, 0x00020000
+.long 0x96553304
+.long 0x92543304
+.long 0x8ED48254
+.long 0x800C540C
+.long 0x820D550D
+.long 0x9254C032
+.long 0x92545403
+.long 0x92559032
+.long 0x92555552
+.long 0x81545554
+.long 0x2004CA85
+.long 0xD2850004, 0x00020432
+.long 0x2606CA9F
+.long 0x32AC0704
+.long 0x68ACAC54
+.long 0x24ACAC82
+.long 0x8E4A8332
+.long 0x80CAFF4A, 0x00000120
+.long 0x68AEAC4A
+.long 0x68B0AE4A
+.long 0x68B2B04A
+.long 0x68B4B24A
+.long 0x68B6B44A
+.long 0x68B8B64A
+.long 0x68BAB84A
+.long 0xBECE00FF, 0x00000900
+.long 0x924E4E52
+.long 0x814EFF4E, 0x00002400
+.long 0xBF8A0000
+.long 0xBEFC004C
+.long 0x814DFF4C, 0x00001200
+.long 0xE0511000, 0x80023052
+.long 0xE0511120, 0x80023153
+.long 0xE0511240, 0x80023254
+.long 0xE0511360, 0x80023355
+.long 0xBEFC004E
+.long 0x814FFF4E, 0x00002400
+.long 0xE0511000, 0x80034456
+.long 0xE0511120, 0x80034557
+.long 0xE0511240, 0x80034658
+.long 0xE0511360, 0x80034759
+.long 0xE0511480, 0x8003485A
+.long 0xE05115A0, 0x8003495B
+.long 0xE05116C0, 0x80034A5C
+.long 0xE05117E0, 0x80034B5D
+.long 0xBEFC004D
+.long 0x8008FF08, 0x00000080
+.long 0x82098009
+.long 0x800CFF0C, 0x00000080
+.long 0x820D800D
+.long 0xE0511000, 0x80023052
+.long 0xE0511120, 0x80023153
+.long 0xE0511240, 0x80023254
+.long 0xE0511360, 0x80023355
+.long 0xBEFC004F
+.long 0xBF800000
+.long 0xE0511000, 0x80034456
+.long 0xE0511120, 0x80034557
+.long 0xE0511240, 0x80034658
+.long 0xE0511360, 0x80034759
+.long 0xE0511480, 0x8003485A
+.long 0xE05115A0, 0x8003495B
+.long 0xE05116C0, 0x80034A5C
+.long 0xE05117E0, 0x80034B5D
+.long 0x8008FF08, 0x00000080
+.long 0x82098009
+.long 0x800CFF0C, 0x00000080
+.long 0x820D800D
+.long 0xBEFC004C
+.long 0xBF8C4F74
+.long 0xBF8A0000
+.long 0xBF8C0F7C
+.long 0xBF8A0000
+.long 0x8F2E852D
+.long 0x80AE2E80
+.long 0xBF03C22E
+.long 0xBF85004F
+.long 0xBF8A0000
+.long 0xE0511000, 0x80023052
+.long 0xE0511120, 0x80023153
+.long 0xE0511240, 0x80023254
+.long 0xE0511360, 0x80023355
+.long 0xBEFC004E
+.long 0xBF800000
+.long 0xE0511000, 0x80034456
+.long 0xE0511120, 0x80034557
+.long 0xE0511240, 0x80034658
+.long 0xE0511360, 0x80034759
+.long 0xE0511480, 0x8003485A
+.long 0xE05115A0, 0x8003495B
+.long 0xE05116C0, 0x80034A5C
+.long 0xE05117E0, 0x80034B5D
+.long 0xBF8C4F74
+.long 0xBF8A0000
+.long 0x8008FF08, 0x00000080
+.long 0x82098009
+.long 0xBF8C0F7C
+.long 0xBF8A0000
+.long 0x800CFF0C, 0x00000080
+.long 0x820D800D
+.long 0xBEFC004D
+.long 0xBF8A0000
+.long 0xE0511000, 0x80023052
+.long 0xE0511120, 0x80023153
+.long 0xE0511240, 0x80023254
+.long 0xE0511360, 0x80023355
+.long 0xBEFC004F
+.long 0xBF800000
+.long 0xE0511000, 0x80034456
+.long 0xE0511120, 0x80034557
+.long 0xE0511240, 0x80034658
+.long 0xE0511360, 0x80034759
+.long 0xE0511480, 0x8003485A
+.long 0xE05115A0, 0x8003495B
+.long 0xE05116C0, 0x80034A5C
+.long 0xE05117E0, 0x80034B5D
+.long 0xBF8C4F74
+.long 0xBF8A0000
+.long 0x8008FF08, 0x00000080
+.long 0x82098009
+.long 0xBF8C0F7C
+.long 0xBF8A0000
+.long 0x800CFF0C, 0x00000080
+.long 0x820D800D
+.long 0xBEFC004C
+.long 0x802E822E
+.long 0xBF03C22E
+.long 0xBF84FFB1
+.long 0xBF8C0F78
+.long 0xBF8A0000
+.long 0xBF8C0F70
+.long 0xBF8A0000
+.long 0xBF810000
+.long 0xC0060700, 0x00000000
+.long 0xC00A0800, 0x00000018
+.long 0xC00A0A00, 0x00000038
+.long 0xC00A0900, 0x00000040
+.long 0xD3D94000, 0x18000080
+.long 0xD3D94001, 0x18000080
+.long 0xD3D94002, 0x18000080
+.long 0xD3D94003, 0x18000080
+.long 0xD3D94004, 0x18000080
+.long 0xD3D94005, 0x18000080
+.long 0xD3D94006, 0x18000080
+.long 0xD3D94007, 0x18000080
+.long 0xD1130001, 0x00011F65
+.long 0xD285005E, 0x000202A0
+.long 0x20040281
+.long 0xD2850002, 0x000204A0
+.long 0x2002CA84
+.long 0x24020282
+.long 0x68BCBD01
+.long 0x24BCBC82
+.long 0x68BCBD02
+.long 0x68BCBC80
+.long 0x68BEBCFF, 0x00001200
+.long 0xBF8A0000
+.long 0xD1130001, 0x00011F65
+.long 0xD2850060, 0x000202A0
+.long 0x20040281
+.long 0xD2850002, 0x000204A0
+.long 0x2002CA84
+.long 0x24020282
+.long 0x68C0C101
+.long 0x24C0C082
+.long 0x68C0C102
+.long 0x9254FF52, 0x00000900
+.long 0x68C0C054
+.long 0x68C0C0FF, 0x00002400
+.long 0x68C2C0FF, 0x00002400
+.long 0xBF8CC07F
+.long 0xBE900022
+.long 0xBE910023
+.long 0xBE9200FF, 0x80000000
+.long 0xBE9300FF, 0x00020000
+.long 0x925603C0
+.long 0x96552656
+.long 0x92542656
+.long 0x8ED48254
+.long 0x80105410
+.long 0x82115511
+.long 0x96552704
+.long 0x92542704
+.long 0x8ED48254
+.long 0x80105410
+.long 0x82115511
+.long 0xD2850004, 0x0002CC90
+.long 0xD2850003, 0x00004D04
+.long 0x2608CA8F
+.long 0xD2850005, 0x00004D04
+.long 0x200CCA84
+.long 0x240C0C82
+.long 0x68D60B03
+.long 0x925402A0
+.long 0x32D40C54
+.long 0xD1FE0068, 0x020AD76A
+.long 0xBE940020
+.long 0xBE950021
+.long 0xBE9600FF, 0x80000000
+.long 0xBE9700FF, 0x00020000
+.long 0x925603C0
+.long 0x96552456
+.long 0x92542456
+.long 0x8ED48254
+.long 0x80145414
+.long 0x82155515
+.long 0x96552504
+.long 0x92542504
+.long 0x8ED48254
+.long 0x80145414
+.long 0x82155515
+.long 0xD2850004, 0x0002CC90
+.long 0xD2850003, 0x00004904
+.long 0x2608CA8F
+.long 0xD2850005, 0x00004904
+.long 0x200CCA84
+.long 0x240C0C82
+.long 0x68D60B03
+.long 0x925402A0
+.long 0x32D40C54
+.long 0xD1FE0069, 0x020AD76A
+.long 0xBF8A0000
+.long 0xD9FE0000, 0x2000005E
+.long 0xD9FE0900, 0x2800005E
+.long 0xD9FE0040, 0x2400005E
+.long 0xD9FE0940, 0x2C00005E
+.long 0xBF8A0000
+.long 0xD9FE0000, 0x44000060
+.long 0xD9FE0040, 0x48000060
+.long 0x8F2E852D
+.long 0x80AE2E80
+.long 0xBF03C22E
+.long 0xBF850065
+.long 0xBF8A0000
+.long 0xBF8CC17F
+.long 0xD3C50000, 0x04028920
+.long 0xD3C50004, 0x04128928
+.long 0xD3C50000, 0x04028B21
+.long 0xD3C50004, 0x04128B29
+.long 0xD3C50000, 0x04028D22
+.long 0xBF8A0000
+.long 0xD3C50004, 0x04128D2A
+.long 0xD9FE0000, 0x3000005F
+.long 0xD3C50000, 0x04028F23
+.long 0xD9FE0900, 0x3800005F
+.long 0xD3C50004, 0x04128F2B
+.long 0xD9FE0040, 0x3400005F
+.long 0xBF8CC37F
+.long 0xD3C50000, 0x04029124
+.long 0xD9FE0940, 0x3C00005F
+.long 0xD3C50004, 0x0412912C
+.long 0xD3C50000, 0x04029325
+.long 0xD3C50004, 0x0412932D
+.long 0xD3C50000, 0x04029526
+.long 0xD3C50004, 0x0412952E
+.long 0xBF8A0000
+.long 0xD9FE0000, 0x4C000061
+.long 0xD3C50000, 0x04029727
+.long 0xD9FE0040, 0x50000061
+.long 0xD3C50004, 0x0412972F
+.long 0xBF8A0000
+.long 0xBF8CC17F
+.long 0xD3C50000, 0x04029930
+.long 0xD3C50004, 0x04129938
+.long 0xD3C50000, 0x04029B31
+.long 0xD3C50004, 0x04129B39
+.long 0xD3C50000, 0x04029D32
+.long 0xBF8A0000
+.long 0xD3C50004, 0x04129D3A
+.long 0xD9FE0000, 0x2000005E
+.long 0xD3C50000, 0x04029F33
+.long 0xD9FE0900, 0x2800005E
+.long 0xD3C50004, 0x04129F3B
+.long 0xD9FE0040, 0x2400005E
+.long 0xBF8CC37F
+.long 0xD3C50000, 0x0402A134
+.long 0xD9FE0940, 0x2C00005E
+.long 0xD3C50004, 0x0412A13C
+.long 0xD3C50000, 0x0402A335
+.long 0xD3C50004, 0x0412A33D
+.long 0xD3C50000, 0x0402A536
+.long 0xD3C50004, 0x0412A53E
+.long 0xBF8A0000
+.long 0xD9FE0000, 0x44000060
+.long 0xD3C50000, 0x0402A737
+.long 0xD9FE0040, 0x48000060
+.long 0xD3C50004, 0x0412A73F
+.long 0x802E822E
+.long 0xBF03C22E
+.long 0xBF84FF9B
+.long 0xBF8CC17F
+.long 0xD3C50000, 0x04028920
+.long 0xE05C1000, 0x80041068
+.long 0xE05C1040, 0x80041468
+.long 0xD3C50004, 0x04128928
+.long 0xD3C50000, 0x04028B21
+.long 0xBF8A0000
+.long 0xD3C50004, 0x04128B29
+.long 0xD9FE0000, 0x3000005F
+.long 0xD3C50000, 0x04028D22
+.long 0xD9FE0900, 0x3800005F
+.long 0xD3C50004, 0x04128D2A
+.long 0xD9FE0040, 0x3400005F
+.long 0xD3C50000, 0x04028F23
+.long 0xD9FE0940, 0x3C00005F
+.long 0xD3C50004, 0x04128F2B
+.long 0xBF8CC37F
+.long 0xD3C50000, 0x04029124
+.long 0xD3C50004, 0x0412912C
+.long 0xD3C50000, 0x04029325
+.long 0xD3C50004, 0x0412932D
+.long 0xD3C50000, 0x04029526
+.long 0xBF8A0000
+.long 0xD9FE0000, 0x4C000061
+.long 0xD3C50004, 0x0412952E
+.long 0xD9FE0040, 0x50000061
+.long 0xD3C50000, 0x04029727
+.long 0xD3C50004, 0x0412972F
+.long 0xBF8CC17F
+.long 0xD3C50000, 0x04029930
+.long 0xD3C50004, 0x04129938
+.long 0xD3C50000, 0x04029B31
+.long 0xD3C50004, 0x04129B39
+.long 0xD3C50000, 0x04029D32
+.long 0xD3C50004, 0x04129D3A
+.long 0xD3C50000, 0x04029F33
+.long 0xD3C50004, 0x04129F3B
+.long 0xBF8CC07F
+.long 0xD3C50000, 0x0402A134
+.long 0xD3C50000, 0x0402A335
+.long 0xD3C50000, 0x0402A536
+.long 0xD3C50000, 0x0402A737
+.long 0xD3C50004, 0x0412A13C
+.long 0xD3C50004, 0x0412A33D
+.long 0xD3C50004, 0x0412A53E
+.long 0xD3C50004, 0x0412A73F
+.long 0xD3D84000, 0x18000100
+.long 0x0A000028
+.long 0xD3D84001, 0x18000101
+.long 0x0A020228
+.long 0xD3D84002, 0x18000102
+.long 0x0A040428
+.long 0xD3D84003, 0x18000103
+.long 0x0A060628
+.long 0xBF8C0F71
+.long 0xD1CB0000, 0x04005310
+.long 0xD1CB0001, 0x04045311
+.long 0xD1CB0002, 0x04085312
+.long 0xD1CB0003, 0x040C5313
+.long 0xE07C1000, 0x80050069
+.long 0xD3D84004, 0x18000104
+.long 0x0A080828
+.long 0xD3D84005, 0x18000105
+.long 0x0A0A0A28
+.long 0xD3D84006, 0x18000106
+.long 0x0A0C0C28
+.long 0xD3D84007, 0x18000107
+.long 0x0A0E0E28
+.long 0xBF8C0F71
+.long 0xD1CB0004, 0x04105314
+.long 0xD1CB0005, 0x04145315
+.long 0xD1CB0006, 0x04185316
+.long 0xD1CB0007, 0x041C5317
+.long 0xE07C1040, 0x80050469
+.long 0xBF8C0000
+.long 0xBF810000

--- a/Tensile/ReplacementKernels-cov3/Cijk_Alik_Bljk_SB_MT64x128x32_AF0EM8_ASEM8_FL0_GRVW4_ISA908_MDA2_PGR1_PLR1_SU32_TT4_4_VAW1_VW4_WG16_32_1_WGM8.s.txt
+++ b/Tensile/ReplacementKernels-cov3/Cijk_Alik_Bljk_SB_MT64x128x32_AF0EM8_ASEM8_FL0_GRVW4_ISA908_MDA2_PGR1_PLR1_SU32_TT4_4_VAW1_VW4_WG16_32_1_WGM8.s.txt
@@ -1,0 +1,1558 @@
+
+
+/******************************************/
+/* Function Prefix                        */
+/******************************************/
+
+
+
+/******************************************/
+/* Begin Kernel                           */
+/******************************************/
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx908+sram-ecc"
+.text
+.protected Cijk_Alik_Bljk_SB_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT4_4_TLDS0_USFGRO1_VAW1_VS1_VW4_WSGRA0_WSGRB0_WG16_32_1_WGM8
+.globl Cijk_Alik_Bljk_SB_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT4_4_TLDS0_USFGRO1_VAW1_VS1_VW4_WSGRA0_WSGRB0_WG16_32_1_WGM8
+.p2align 8
+.type Cijk_Alik_Bljk_SB_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT4_4_TLDS0_USFGRO1_VAW1_VS1_VW4_WSGRA0_WSGRB0_WG16_32_1_WGM8,@function
+.section .rodata,#alloc
+.p2align 6
+.amdhsa_kernel Cijk_Alik_Bljk_SB_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT4_4_TLDS0_USFGRO1_VAW1_VS1_VW4_WSGRA0_WSGRB0_WG16_32_1_WGM8
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_next_free_vgpr 108 // vgprs
+  .amdhsa_next_free_sgpr 98 // sgprs
+  .amdhsa_group_segment_fixed_size 60000 // lds bytes
+  .amdhsa_private_segment_fixed_size 0
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+.text
+
+/******************************************/
+/* Optimizations and Config:              */
+/******************************************/
+/* ThreadTile= 4 x 4 */
+/* SubGroup= 16 x 32 */
+/* VectorWidth=4 */
+/* GlobalLoadVectorWidthA=4, GlobalLoadVectorWidthB=4 */
+/* DirectToLdsA=False */
+/* DirectToLdsB=False */
+/* UseSgprForGRO=1 */
+.amdgpu_metadata
+---
+amdhsa.version:
+  - 1
+  - 0
+amdhsa.kernels:
+  - .name: Cijk_Alik_Bljk_SB_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT4_4_TLDS0_USFGRO1_VAW1_VS1_VW4_WSGRA0_WSGRB0_WG16_32_1_WGM8
+    .symbol: 'Cijk_Alik_Bljk_SB_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT4_4_TLDS0_USFGRO1_VAW1_VS1_VW4_WSGRA0_WSGRB0_WG16_32_1_WGM8.kd'
+    .language:                   OpenCL C
+    .language_version:
+      - 2
+      - 0
+    .args:
+      - .name:            sizeC
+        .size:            8
+        .offset:          0
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            sizeA
+        .size:            8
+        .offset:          8
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            sizeB
+        .size:            8
+        .offset:          16
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            D
+        .size:            8
+        .offset:          24
+        .value_kind:      global_buffer
+        .value_type:      f32
+        .address_space:   generic
+      - .name:            C
+        .size:            8
+        .offset:          32
+        .value_kind:      global_buffer
+        .value_type:      f32
+        .address_space:   generic
+      - .name:            A
+        .size:            8
+        .offset:          40
+        .value_kind:      global_buffer
+        .value_type:      f32
+        .address_space:   generic
+      - .name:            B
+        .size:            8
+        .offset:          48
+        .value_kind:      global_buffer
+        .value_type:      f32
+        .address_space:   generic
+      - .name:            alpha
+        .size:            4
+        .offset:          56
+        .value_kind:      by_value
+        .value_type:      f32
+      - .name:            beta
+        .size:            4
+        .offset:          60
+        .value_kind:      by_value
+        .value_type:      f32
+      - .name:            strideD0
+        .size:            4
+        .offset:          64
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideD1
+        .size:            4
+        .offset:          68
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideC0
+        .size:            4
+        .offset:          72
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideC1
+        .size:            4
+        .offset:          76
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideA0
+        .size:            4
+        .offset:          80
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideA1
+        .size:            4
+        .offset:          84
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideB0
+        .size:            4
+        .offset:          88
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideB1
+        .size:            4
+        .offset:          92
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree0
+        .size:            4
+        .offset:          96
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree1
+        .size:            4
+        .offset:          100
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree2
+        .size:            4
+        .offset:          104
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesSum0
+        .size:            4
+        .offset:          108
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            OrigStaggerUIter
+        .size:            4
+        .offset:          112
+        .value_kind:      by_value
+        .value_type:      i32
+      - .name:            NumWorkGroups0
+        .size:            4
+        .offset:          116
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            NumWorkGroups1
+        .size:            4
+        .offset:          120
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            MagicNumberProblemNumGroupTiles0
+        .size:            4
+        .offset:          124
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            GridNumWorkGroups0
+        .size:            4
+        .offset:          128
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            NumFullBlocks
+        .size:            4
+        .offset:          132
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            WgmRemainder1
+        .size:            4
+        .offset:          136
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            MagicNumberWgmRemainder1
+        .size:            4
+        .offset:          140
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            padding
+        .size:            4
+        .offset:          144
+        .value_kind:      by_value
+        .value_type:      u32
+    .group_segment_fixed_size:   60000
+    .kernarg_segment_align:      8
+    .kernarg_segment_size:       152
+    .max_flat_workgroup_size:    512
+    .private_segment_fixed_size: 0
+    .sgpr_count:                 98
+    .sgpr_spill_count:           0
+    .vgpr_count:                 108
+    .vgpr_spill_count:           0
+    .wavefront_size:             64
+...
+.end_amdgpu_metadata
+Cijk_Alik_Bljk_SB_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT4_4_TLDS0_USFGRO1_VAW1_VS1_VW4_WSGRA0_WSGRB0_WG16_32_1_WGM8:
+
+/******************************************/
+/* Asm syntax workarounds                 */
+/******************************************/
+.macro _v_add_co_u32 dst, cc, src0, src1, dpp=
+   v_add_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+
+.macro _v_add_u32 dst, src0, src1, dpp=
+   v_add_u32 \dst, \src0, \src1 \dpp
+.endm
+
+.macro _v_sub_co_u32 dst, cc, src0, src1, dpp=
+   v_sub_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+
+.macro _v_sub_u32 dst, src0, src1, dpp=
+   v_sub_u32 \dst, \src0, \src1 \dpp
+.endm
+
+.macro _v_addc_co_u32 dst, ccOut, src0, ccIn, src1, dpp=
+   v_addc_co_u32 \dst, \ccOut, \src0, \ccIn, \src1 \dpp
+.endm
+
+.macro _v_add_lshl_u32 dst, src0, src1, shiftCnt
+    v_add_lshl_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+.macro _v_lshl_add_u32 dst, src0, src1, shiftCnt
+    v_lshl_add_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+/******************************************/
+/* Magic div and mod functions            */
+/******************************************/
+.macro V_MAGIC_DIV dstIdx, dividend, magicNumber, magicShift
+    v_mul_hi_u32 v[\dstIdx+1], \dividend, \magicNumber
+    v_mul_lo_u32 v[\dstIdx+0], \dividend, \magicNumber
+    v_lshrrev_b64 v[\dstIdx:\dstIdx+1], \magicShift, v[\dstIdx:\dstIdx+1]
+.endm
+
+/******************************************/
+/* VGPR Assignments                       */
+/******************************************/
+.set vgprValuC, 0
+/* ValuA/B   Xn=PLR buffer idx,  In=InnerUnroll idx */
+.set vgprValuA_X0_I0, 32
+.set vgprValuA_X1_I0, 36
+.set vgprG2LA, 40
+.set vgprValuB_X0_I0, 48
+.set vgprValuB_X1_I0, 56
+.set vgprG2LB, 64
+.set vgprLocalWriteAddrA, 80
+.set vgprLocalWriteAddrB, 81
+.set vgprGlobalReadOffsetA, 82
+.set vgprGlobalReadOffsetB, 83
+.set vgprLocalReadAddrA, 84
+.set vgprLocalReadAddrB, 85
+.set vgprSerial, 86
+/* Num VGPR=87 */
+
+/******************************************/
+/* SGPR Assignments                       */
+/******************************************/
+.set sgprKernArgAddress, 0
+.set sgprWorkGroup0, 2
+.set sgprWorkGroup1, 3
+.set sgprWorkGroup2, 4
+.set sgprNumWorkGroups0, 5
+.set sgprNumWorkGroups1, 6
+.set sgprSrdA, 8
+.set sgprSrdB, 12
+.set sgprSrdD, 16
+.set sgprSrdC, 20
+.set sgprTensor2dSizeC, 24
+.set sgprTensor2dSizeA, 26
+.set sgprTensor2dSizeB, 28
+.set sgprSaveExecMask, 30
+.set sgprAddressD, 32
+.set sgprAddressC, 34
+.set sgprStridesD, 36
+.set sgprStridesC, 38
+.set sgprAlpha, 40
+.set sgprBeta, 41
+.set sgprSizesFree, 42
+.set sgprSizesSum, 45
+.set sgprLoopCounters, 46
+.set sgprOrigLoopCounter, 47
+.set sgprStridesA, 48
+.set sgprStridesB, 50
+.set sgprAddressA, 52
+.set sgprAddressB, 54
+.set sgprShadowLimitA, 56
+.set sgprShadowLimitB, 58
+.set sgprOrigStaggerUIter, 60
+.set sgprStaggerUIter, 61
+.set sgprWrapUA, 62
+.set sgprWrapUB, 64
+.set sgprNumFullBlocks, 66
+.set sgprWgmRemainder1, 67
+.set sgprMagicNumberWgmRemainder1, 68
+.set sgprGlobalReadIncsA, 69
+.set sgprGlobalReadIncsB, 70
+.set sgprScalarGlobalReadOffsetA, 71
+.set sgprScalarGlobalReadOffsetB, 72
+/* max SGPR=98 */
+
+/* Size Assignments */
+.set sgprSizeD0I, sgprSizesFree+0
+.set sgprSizeD1J, sgprSizesFree+1
+.set sgprSizeDK, sgprSizesFree+2
+.set sgprSizeC0I, sgprSizesFree+0
+.set sgprSizeC1J, sgprSizesFree+1
+.set sgprSizeCK, sgprSizesFree+2
+.set sgprSizeAL, sgprSizesSum+0
+.set sgprSizeA0I, sgprSizesFree+0
+.set sgprSizeAK, sgprSizesFree+2
+.set sgprSizeBL, sgprSizesSum+0
+.set sgprSizeB1J, sgprSizesFree+1
+.set sgprSizeBK, sgprSizesFree+2
+
+/* Stride Assignments */
+.set constStrideD0I, 1
+.set sgprStrideD1J, sgprStridesD+0
+.set sgprStrideDK, sgprStridesD+1
+.set constStrideC0I, 1
+.set sgprStrideC1J, sgprStridesC+0
+.set sgprStrideCK, sgprStridesC+1
+.set constStrideAL, 1
+.set sgprStrideA0I, sgprStridesA+0
+.set sgprStrideAK, sgprStridesA+1
+.set constStrideBL, 1
+.set sgprStrideB1J, sgprStridesB+0
+.set sgprStrideBK, sgprStridesB+1
+
+.set DepthU, 32
+/* Number of elements to shift-left SRD */
+.set SrdShiftLeftA, 4
+.set SrdShiftLeftB, 4
+/* 2GB limit - set offsets to -1 to exceed this and clamp */
+.set BufferLimit, 0x80000000
+/* Bits 127:96 of SRD.  Set DataFormat = 32 bit */
+.set Srd127_96, 0x0020000
+.set BufferOOB, 0x80000000
+
+
+
+
+
+.long 0xC00A0D00, 0x00000028
+.long 0xC00A0C00, 0x00000050
+.long 0xC00A0600, 0x00000008
+.long 0xC0020B40, 0x0000006C
+.long 0xBEFC00FF, 0x00006000
+.long 0x7EC80300
+.long 0x26CA00BF
+.long 0x2004C886
+.long 0xB8D0F804
+.long 0xD1130004, 0x0000A0B0
+.long 0x20CC0884
+.long 0x7EA40566
+.long 0xD1130067, 0x0000A08F
+.long 0x7EA20567
+.long 0xBF068151
+.long 0xBF840212
+.long 0xBF8CC07F
+.long 0xBE880034
+.long 0xBE890035
+.long 0xBE8B00FF, 0x00020000
+.long 0x80B85418
+.long 0x80B95518
+.long 0x8EB88238
+.long 0x80388438
+.long 0x82398039
+.long 0xBF068039
+.long 0x850AFF38, 0x80000000
+.long 0xBE8A00FF, 0x80000000
+.long 0x9254C030
+.long 0x92545402
+.long 0x8E558452
+.long 0x92533055
+.long 0x92553104
+.long 0x81545354
+.long 0x80545554
+.long 0x2000CA85
+.long 0xD2850004, 0x00020030
+.long 0x2602CA9F
+.long 0x32A40304
+.long 0x68A4A454
+.long 0x24A4A482
+.long 0x8E478330
+.long 0x80C7FF47, 0x00000108
+.long 0x68A6A447
+.long 0x68A8A647
+.long 0x68AAA847
+.long 0x68ACAA47
+.long 0x68AEAC47
+.long 0x68B0AE47
+.long 0x68B2B047
+.long 0xBECC00FF, 0x00000840
+.long 0x924C4C52
+.long 0xBE8C0036
+.long 0xBE8D0037
+.long 0xBE8F00FF, 0x00020000
+.long 0x80BA541A
+.long 0x80BB551A
+.long 0x8EBA823A
+.long 0x803A843A
+.long 0x823B803B
+.long 0xBF06803B
+.long 0x850EFF3A, 0x80000000
+.long 0xBE8E00FF, 0x80000000
+.long 0x9254FF32, 0x00000080
+.long 0x92545403
+.long 0x925532A0
+.long 0x92555552
+.long 0x81545554
+.long 0x92553304
+.long 0x80545554
+.long 0x2004CA85
+.long 0x2606CA9F
+.long 0xD2850004, 0x00020432
+.long 0x32400704
+.long 0x68404054
+.long 0x24404082
+.long 0x8E4A8332
+.long 0x80CAFF4A, 0x00000108
+.long 0x6842404A
+.long 0x6844424A
+.long 0x6846444A
+.long 0x6848464A
+.long 0x684A484A
+.long 0x684C4A4A
+.long 0x684E4C4A
+.long 0x68504E4A
+.long 0x6852504A
+.long 0x6854524A
+.long 0x6856544A
+.long 0x6858564A
+.long 0x685A584A
+.long 0x685C5A4A
+.long 0x685E5C4A
+.long 0xBECE00FF, 0x00001080
+.long 0x924E4E52
+.long 0x814EFF4E, 0x00004200
+.long 0xBF8A0000
+.long 0xBEFC004C
+.long 0x814DFF4C, 0x00002100
+.long 0xE0511000, 0x80023052
+.long 0xE0511108, 0x80023153
+.long 0xE0511210, 0x80023254
+.long 0xE0511318, 0x80023355
+.long 0xE0511420, 0x80023456
+.long 0xE0511528, 0x80023557
+.long 0xE0511630, 0x80023658
+.long 0xE0511738, 0x80023759
+.long 0xBEFC004E
+.long 0x814FFF4E, 0x00004200
+.long 0xE0511000, 0x80033020
+.long 0xE0511108, 0x80033121
+.long 0xE0511210, 0x80033222
+.long 0xE0511318, 0x80033323
+.long 0xE0511420, 0x80033424
+.long 0xE0511528, 0x80033525
+.long 0xE0511630, 0x80033626
+.long 0xE0511738, 0x80033727
+.long 0xE0511840, 0x80033828
+.long 0xE0511948, 0x80033929
+.long 0xE0511A50, 0x80033A2A
+.long 0xE0511B58, 0x80033B2B
+.long 0xE0511C60, 0x80033C2C
+.long 0xE0511D68, 0x80033D2D
+.long 0xE0511E70, 0x80033E2E
+.long 0xE0511F78, 0x80033F2F
+.long 0xBEFC004D
+.long 0x68A4A4FF, 0x00000080
+.long 0x68A6A6FF, 0x00000080
+.long 0x68A8A8FF, 0x00000080
+.long 0x68AAAAFF, 0x00000080
+.long 0x68ACACFF, 0x00000080
+.long 0x68AEAEFF, 0x00000080
+.long 0x68B0B0FF, 0x00000080
+.long 0x68B2B2FF, 0x00000080
+.long 0x684040FF, 0x00000080
+.long 0x684242FF, 0x00000080
+.long 0x684444FF, 0x00000080
+.long 0x684646FF, 0x00000080
+.long 0x684848FF, 0x00000080
+.long 0x684A4AFF, 0x00000080
+.long 0x684C4CFF, 0x00000080
+.long 0x684E4EFF, 0x00000080
+.long 0x685050FF, 0x00000080
+.long 0x685252FF, 0x00000080
+.long 0x685454FF, 0x00000080
+.long 0x685656FF, 0x00000080
+.long 0x685858FF, 0x00000080
+.long 0x685A5AFF, 0x00000080
+.long 0x685C5CFF, 0x00000080
+.long 0x685E5EFF, 0x00000080
+.long 0xE0511000, 0x80023052
+.long 0xE0511108, 0x80023153
+.long 0xE0511210, 0x80023254
+.long 0xE0511318, 0x80023355
+.long 0xE0511420, 0x80023456
+.long 0xE0511528, 0x80023557
+.long 0xE0511630, 0x80023658
+.long 0xE0511738, 0x80023759
+.long 0xBEFC004F
+.long 0xBF800000
+.long 0xE0511000, 0x80033020
+.long 0xE0511108, 0x80033121
+.long 0xE0511210, 0x80033222
+.long 0xE0511318, 0x80033323
+.long 0xE0511420, 0x80033424
+.long 0xE0511528, 0x80033525
+.long 0xE0511630, 0x80033626
+.long 0xE0511738, 0x80033727
+.long 0xE0511840, 0x80033828
+.long 0xE0511948, 0x80033929
+.long 0xE0511A50, 0x80033A2A
+.long 0xE0511B58, 0x80033B2B
+.long 0xE0511C60, 0x80033C2C
+.long 0xE0511D68, 0x80033D2D
+.long 0xE0511E70, 0x80033E2E
+.long 0xE0511F78, 0x80033F2F
+.long 0x68A4A4FF, 0x00000080
+.long 0x68A6A6FF, 0x00000080
+.long 0x68A8A8FF, 0x00000080
+.long 0x68AAAAFF, 0x00000080
+.long 0x68ACACFF, 0x00000080
+.long 0x68AEAEFF, 0x00000080
+.long 0x68B0B0FF, 0x00000080
+.long 0x68B2B2FF, 0x00000080
+.long 0x684040FF, 0x00000080
+.long 0x684242FF, 0x00000080
+.long 0x684444FF, 0x00000080
+.long 0x684646FF, 0x00000080
+.long 0x684848FF, 0x00000080
+.long 0x684A4AFF, 0x00000080
+.long 0x684C4CFF, 0x00000080
+.long 0x684E4EFF, 0x00000080
+.long 0x685050FF, 0x00000080
+.long 0x685252FF, 0x00000080
+.long 0x685454FF, 0x00000080
+.long 0x685656FF, 0x00000080
+.long 0x685858FF, 0x00000080
+.long 0x685A5AFF, 0x00000080
+.long 0x685C5CFF, 0x00000080
+.long 0x685E5EFF, 0x00000080
+.long 0xBEFC004C
+.long 0xBF8C8F78
+.long 0xBF8A0000
+.long 0xBF8C4F78
+.long 0xBF8A0000
+.long 0x8F2E852D
+.long 0x80AE2E80
+.long 0xBF06802E
+.long 0xBF8500DC
+.long 0xBF8A0000
+.long 0xE0511000, 0x80023052
+.long 0xE0511108, 0x80023153
+.long 0xE0511210, 0x80023254
+.long 0xE0511318, 0x80023355
+.long 0xE0511420, 0x80023456
+.long 0xE0511528, 0x80023557
+.long 0xE0511630, 0x80023658
+.long 0xE0511738, 0x80023759
+.long 0xBEFC004E
+.long 0xBF800000
+.long 0xE0511000, 0x80033020
+.long 0xE0511108, 0x80033121
+.long 0xE0511210, 0x80033222
+.long 0xE0511318, 0x80033323
+.long 0xE0511420, 0x80033424
+.long 0xE0511528, 0x80033525
+.long 0xE0511630, 0x80033626
+.long 0xE0511738, 0x80033727
+.long 0xE0511840, 0x80033828
+.long 0xE0511948, 0x80033929
+.long 0xE0511A50, 0x80033A2A
+.long 0xE0511B58, 0x80033B2B
+.long 0xE0511C60, 0x80033C2C
+.long 0xE0511D68, 0x80033D2D
+.long 0xE0511E70, 0x80033E2E
+.long 0xE0511F78, 0x80033F2F
+.long 0xBF8C8F78
+.long 0xBF8F0001
+.long 0xBF8A0000
+.long 0x68A4A4FF, 0x00000080
+.long 0x68A6A6FF, 0x00000080
+.long 0x68A8A8FF, 0x00000080
+.long 0x68AAAAFF, 0x00000080
+.long 0x68ACACFF, 0x00000080
+.long 0x68AEAEFF, 0x00000080
+.long 0x68B0B0FF, 0x00000080
+.long 0x68B2B2FF, 0x00000080
+.long 0x684040FF, 0x00000080
+.long 0x684242FF, 0x00000080
+.long 0x684444FF, 0x00000080
+.long 0x684646FF, 0x00000080
+.long 0x684848FF, 0x00000080
+.long 0x684A4AFF, 0x00000080
+.long 0x684C4CFF, 0x00000080
+.long 0x684E4EFF, 0x00000080
+.long 0xBF8F0000
+.long 0xBF8C4F78
+.long 0xBF8F0001
+.long 0xBF8A0000
+.long 0x685050FF, 0x00000080
+.long 0x685252FF, 0x00000080
+.long 0x685454FF, 0x00000080
+.long 0x685656FF, 0x00000080
+.long 0x685858FF, 0x00000080
+.long 0x685A5AFF, 0x00000080
+.long 0x685C5CFF, 0x00000080
+.long 0x685E5EFF, 0x00000080
+.long 0xBF8F0000
+.long 0xBEFC004D
+.long 0x802E812E
+.long 0xBF8A0000
+.long 0xE0511000, 0x80023052
+.long 0xE0511108, 0x80023153
+.long 0xE0511210, 0x80023254
+.long 0xE0511318, 0x80023355
+.long 0xE0511420, 0x80023456
+.long 0xE0511528, 0x80023557
+.long 0xE0511630, 0x80023658
+.long 0xE0511738, 0x80023759
+.long 0xBEFC004F
+.long 0xBF800000
+.long 0xE0511000, 0x80033020
+.long 0xE0511108, 0x80033121
+.long 0xE0511210, 0x80033222
+.long 0xE0511318, 0x80033323
+.long 0xE0511420, 0x80033424
+.long 0xE0511528, 0x80033525
+.long 0xE0511630, 0x80033626
+.long 0xE0511738, 0x80033727
+.long 0xE0511840, 0x80033828
+.long 0xE0511948, 0x80033929
+.long 0xE0511A50, 0x80033A2A
+.long 0xE0511B58, 0x80033B2B
+.long 0xE0511C60, 0x80033C2C
+.long 0xE0511D68, 0x80033D2D
+.long 0xE0511E70, 0x80033E2E
+.long 0xE0511F78, 0x80033F2F
+.long 0xBF8C8F78
+.long 0xBF8A0000
+.long 0xBF8F0001
+.long 0x68A4A4FF, 0x00000080
+.long 0x68A6A6FF, 0x00000080
+.long 0x68A8A8FF, 0x00000080
+.long 0x68AAAAFF, 0x00000080
+.long 0x68ACACFF, 0x00000080
+.long 0x68AEAEFF, 0x00000080
+.long 0x68B0B0FF, 0x00000080
+.long 0x68B2B2FF, 0x00000080
+.long 0x684040FF, 0x00000080
+.long 0x684242FF, 0x00000080
+.long 0x684444FF, 0x00000080
+.long 0x684646FF, 0x00000080
+.long 0x684848FF, 0x00000080
+.long 0x684A4AFF, 0x00000080
+.long 0x684C4CFF, 0x00000080
+.long 0x684E4EFF, 0x00000080
+.long 0xBF8F0000
+.long 0xBF8C4F78
+.long 0xBF8A0000
+.long 0xBF8F0001
+.long 0x685050FF, 0x00000080
+.long 0x685252FF, 0x00000080
+.long 0x685454FF, 0x00000080
+.long 0x685656FF, 0x00000080
+.long 0x685858FF, 0x00000080
+.long 0x685A5AFF, 0x00000080
+.long 0x685C5CFF, 0x00000080
+.long 0x685E5EFF, 0x00000080
+.long 0xBF8F0000
+.long 0xBEFC004C
+.long 0x802E812E
+.long 0xBF00C22E
+.long 0xBF84FF24
+.long 0xBF8C4F70
+.long 0xBF8A0000
+.long 0xBF8C0F70
+.long 0xBF8A0000
+.long 0xBF810000
+.long 0xD3D94000, 0x18000080
+.long 0xD3D94001, 0x18000080
+.long 0xD3D94002, 0x18000080
+.long 0xD3D94003, 0x18000080
+.long 0xD3D94004, 0x18000080
+.long 0xD3D94005, 0x18000080
+.long 0xD3D94006, 0x18000080
+.long 0xD3D94007, 0x18000080
+.long 0xD3D94008, 0x18000080
+.long 0xD3D94009, 0x18000080
+.long 0xD3D9400A, 0x18000080
+.long 0xD3D9400B, 0x18000080
+.long 0xD3D9400C, 0x18000080
+.long 0xD3D9400D, 0x18000080
+.long 0xD3D9400E, 0x18000080
+.long 0xD3D9400F, 0x18000080
+.long 0xD3D94010, 0x18000080
+.long 0xD3D94011, 0x18000080
+.long 0xD3D94012, 0x18000080
+.long 0xD3D94013, 0x18000080
+.long 0xD3D94014, 0x18000080
+.long 0xD3D94015, 0x18000080
+.long 0xD3D94016, 0x18000080
+.long 0xD3D94017, 0x18000080
+.long 0xD3D94018, 0x18000080
+.long 0xD3D94019, 0x18000080
+.long 0xD3D9401A, 0x18000080
+.long 0xD3D9401B, 0x18000080
+.long 0xD3D9401C, 0x18000080
+.long 0xD3D9401D, 0x18000080
+.long 0xD3D9401E, 0x18000080
+.long 0xD3D9401F, 0x18000080
+.long 0xC0060700, 0x00000000
+.long 0xC00A0A00, 0x00000038
+.long 0xC00A0900, 0x00000040
+.long 0xC00A0800, 0x00000018
+.long 0xD1130001, 0x00013F65
+.long 0xD2850060, 0x000202A0
+.long 0x20020281
+.long 0xD2850001, 0x00020282
+.long 0x68C0C101
+.long 0x2002CA85
+.long 0x68C0C101
+.long 0x24C0C082
+.long 0x68C0C080
+.long 0x68C2C0FF, 0x00002100
+.long 0xBF8A0000
+.long 0xD1130001, 0x00013F65
+.long 0xD2850062, 0x000202A0
+.long 0x20020281
+.long 0xD2850001, 0x00020282
+.long 0x68C4C501
+.long 0x2002CA85
+.long 0x68C4C501
+.long 0x24C4C482
+.long 0x9254FF52, 0x00001080
+.long 0x68C4C454
+.long 0x68C4C4FF, 0x00004200
+.long 0x68C6C4FF, 0x00004200
+.long 0xBF8CC07F
+.long 0xBE900022
+.long 0xBE910023
+.long 0xBE9200FF, 0x80000000
+.long 0xBE9300FF, 0x00020000
+.long 0xBE940020
+.long 0xBE950021
+.long 0xBE9600FF, 0x80000000
+.long 0xBE9700FF, 0x00020000
+.long 0x925603FF, 0x00000080
+.long 0x96552656
+.long 0x92542656
+.long 0x8ED48254
+.long 0x80105410
+.long 0x82115511
+.long 0x80145414
+.long 0x82155515
+.long 0x96552704
+.long 0x92542704
+.long 0x8ED48254
+.long 0x80105410
+.long 0x82115511
+.long 0x80145414
+.long 0x82155515
+.long 0x24C8CC86
+.long 0x68C8C965
+.long 0xD2850004, 0x0002CCA0
+.long 0xD2850003, 0x00004D04
+.long 0x2608C89F
+.long 0xD2850005, 0x00004D04
+.long 0x2608C8BF
+.long 0x200C0885
+.long 0x240C0C82
+.long 0x68D60B03
+.long 0x925402C0
+.long 0x32D40C54
+.long 0xD1FE0068, 0x020AD76A
+.long 0xBF8A0000
+.long 0xD86C0000, 0x20000060
+.long 0xD86C1080, 0x21000060
+.long 0xD86C0008, 0x22000060
+.long 0xD86C1088, 0x23000060
+.long 0xD86C0010, 0x24000060
+.long 0xD86C1090, 0x25000060
+.long 0xD86C0018, 0x26000060
+.long 0xD86C1098, 0x27000060
+.long 0xD86C0020, 0x28000060
+.long 0xD86C10A0, 0x29000060
+.long 0xD86C0028, 0x2A000060
+.long 0xD86C10A8, 0x2B000060
+.long 0xD86C0030, 0x2C000060
+.long 0xD86C10B0, 0x2D000060
+.long 0xD86C0038, 0x2E000060
+.long 0xD86C10B8, 0x2F000060
+.long 0xD86C0040, 0x30000060
+.long 0xD86C10C0, 0x31000060
+.long 0xD86C0048, 0x32000060
+.long 0xD86C10C8, 0x33000060
+.long 0xD86C0050, 0x34000060
+.long 0xD86C10D0, 0x35000060
+.long 0xD86C0058, 0x36000060
+.long 0xD86C10D8, 0x37000060
+.long 0xD86C0060, 0x38000060
+.long 0xD86C10E0, 0x39000060
+.long 0xD86C0068, 0x3A000060
+.long 0xD86C10E8, 0x3B000060
+.long 0xD86C0070, 0x3C000060
+.long 0xD86C10F0, 0x3D000060
+.long 0xD86C0078, 0x3E000060
+.long 0xD86C10F8, 0x3F000060
+.long 0xBF8A0000
+.long 0xD86C0000, 0x00000062
+.long 0xD86C0008, 0x01000062
+.long 0xD86C0010, 0x02000062
+.long 0xD86C0018, 0x03000062
+.long 0xD86C0020, 0x04000062
+.long 0xD86C0028, 0x05000062
+.long 0x8F2E852D
+.long 0x80AE2E80
+.long 0xBF06802E
+.long 0xBF85053B
+.long 0xBF8CC47F
+.long 0xD3C40000, 0x04020120
+.long 0xD86C0030, 0x06000062
+.long 0xD86C0038, 0x07000062
+.long 0xD3C40010, 0x04420121
+.long 0xD86C0040, 0x08000062
+.long 0xD86C0048, 0x09000062
+.long 0xD3C40000, 0x04020322
+.long 0xD86C0050, 0x0A000062
+.long 0xD86C0058, 0x0B000062
+.long 0xD86C0060, 0x0C000062
+.long 0xD3C40010, 0x04420323
+.long 0xD86C0068, 0x0D000062
+.long 0xD86C0070, 0x0E000062
+.long 0xD86C0078, 0x0F000062
+.long 0xBF8A0000
+.long 0xBF8CCD7F
+.long 0xD3C40000, 0x04020524
+.long 0xD3C40010, 0x04420525
+.long 0xBF8CCC7F
+.long 0xD3C40000, 0x04020726
+.long 0xD3C40010, 0x04420727
+.long 0xBF8CCB7F
+.long 0xD3C40000, 0x04020928
+.long 0xD3C40010, 0x04420929
+.long 0xBF8CCA7F
+.long 0xD3C40000, 0x04020B2A
+.long 0xD3C40010, 0x04420B2B
+.long 0xBF8CC97F
+.long 0xD3C40000, 0x04020D2C
+.long 0xD3C40010, 0x04420D2D
+.long 0xBF8CC87F
+.long 0xD3C40000, 0x04020F2E
+.long 0xD3C40010, 0x04420F2F
+.long 0xBF8CC07F
+.long 0xD3C40000, 0x04021130
+.long 0xD3C40010, 0x04421131
+.long 0xD3C40000, 0x04021332
+.long 0xD3C40010, 0x04421333
+.long 0xBF8F0000
+.long 0xD3C40000, 0x04021534
+.long 0xD3C40010, 0x04421535
+.long 0xBF8A0000
+.long 0xD3C40000, 0x04021736
+.long 0xD86C0000, 0x40000061
+.long 0xD86C1080, 0x41000061
+.long 0xD86C0008, 0x42000061
+.long 0xD86C1088, 0x43000061
+.long 0xD3C40010, 0x04421737
+.long 0xD86C0010, 0x44000061
+.long 0xD86C1090, 0x45000061
+.long 0xD86C0018, 0x46000061
+.long 0xD86C1098, 0x47000061
+.long 0xD3C40000, 0x04021938
+.long 0xD86C0020, 0x48000061
+.long 0xD86C10A0, 0x49000061
+.long 0xD86C0028, 0x4A000061
+.long 0xD86C10A8, 0x4B000061
+.long 0xD3C40010, 0x04421939
+.long 0xD86C0030, 0x4C000061
+.long 0xD86C10B0, 0x4D000061
+.long 0xD86C0038, 0x4E000061
+.long 0xD86C10B8, 0x4F000061
+.long 0xD3C40000, 0x04021B3A
+.long 0xD86C0040, 0x50000061
+.long 0xD86C10C0, 0x51000061
+.long 0xD86C0048, 0x52000061
+.long 0xD86C10C8, 0x53000061
+.long 0xD3C40010, 0x04421B3B
+.long 0xD86C0050, 0x54000061
+.long 0xD86C10D0, 0x55000061
+.long 0xD86C0058, 0x56000061
+.long 0xD86C10D8, 0x57000061
+.long 0xD3C40000, 0x04021D3C
+.long 0xD86C0060, 0x58000061
+.long 0xD86C10E0, 0x59000061
+.long 0xD86C0068, 0x5A000061
+.long 0xD86C10E8, 0x5B000061
+.long 0xD3C40010, 0x04421D3D
+.long 0xD86C0070, 0x5C000061
+.long 0xD86C10F0, 0x5D000061
+.long 0xD86C0078, 0x5E000061
+.long 0xD86C10F8, 0x5F000061
+.long 0xBF8A0000
+.long 0xD86C0000, 0x10000063
+.long 0xD86C0008, 0x11000063
+.long 0xD3C40000, 0x04021F3E
+.long 0xD86C0010, 0x12000063
+.long 0xD86C0018, 0x13000063
+.long 0xD86C0020, 0x14000063
+.long 0xD86C0028, 0x15000063
+.long 0xD86C0030, 0x16000063
+.long 0xD3C40010, 0x04421F3F
+.long 0xD86C0038, 0x17000063
+.long 0xD86C0040, 0x18000063
+.long 0xD86C0048, 0x19000063
+.long 0xD86C0050, 0x1A000063
+.long 0xD86C0058, 0x1B000063
+.long 0xBF8F0001
+.long 0x802E812E
+.long 0xBF8CCA7F
+.long 0xD3C40000, 0x04022140
+.long 0xD86C0060, 0x1C000063
+.long 0xD86C0068, 0x1D000063
+.long 0xD3C40010, 0x04422141
+.long 0xD86C0070, 0x1E000063
+.long 0xD86C0078, 0x1F000063
+.long 0xD3C40000, 0x04022342
+.long 0xD3C40010, 0x04422343
+.long 0xBF8A0000
+.long 0xBF8CCD7F
+.long 0xD3C40000, 0x04022544
+.long 0xD3C40010, 0x04422545
+.long 0xBF8CCC7F
+.long 0xD3C40000, 0x04022746
+.long 0xD3C40010, 0x04422747
+.long 0xBF8CCB7F
+.long 0xD3C40000, 0x04022948
+.long 0xD3C40010, 0x04422949
+.long 0xBF8CCA7F
+.long 0xD3C40000, 0x04022B4A
+.long 0xD3C40010, 0x04422B4B
+.long 0xBF8CC97F
+.long 0xD3C40000, 0x04022D4C
+.long 0xD3C40010, 0x04422D4D
+.long 0xBF8CC87F
+.long 0xD3C40000, 0x04022F4E
+.long 0xD3C40010, 0x04422F4F
+.long 0xBF8CC07F
+.long 0xD3C40000, 0x04023150
+.long 0xD3C40010, 0x04423151
+.long 0xD3C40000, 0x04023352
+.long 0xD3C40010, 0x04423353
+.long 0xBF8F0000
+.long 0xD3C40000, 0x04023554
+.long 0xD3C40010, 0x04423555
+.long 0xBF8A0000
+.long 0xD86C0000, 0x20000060
+.long 0xD86C1080, 0x21000060
+.long 0xD86C0008, 0x22000060
+.long 0xD86C1088, 0x23000060
+.long 0xD3C40000, 0x04023756
+.long 0xD86C0010, 0x24000060
+.long 0xD86C1090, 0x25000060
+.long 0xD86C0018, 0x26000060
+.long 0xD86C1098, 0x27000060
+.long 0xD3C40010, 0x04423757
+.long 0xD86C0020, 0x28000060
+.long 0xD86C10A0, 0x29000060
+.long 0xD86C0028, 0x2A000060
+.long 0xD86C10A8, 0x2B000060
+.long 0xD3C40000, 0x04023958
+.long 0xD86C0030, 0x2C000060
+.long 0xD86C10B0, 0x2D000060
+.long 0xD86C0038, 0x2E000060
+.long 0xD86C10B8, 0x2F000060
+.long 0xD3C40010, 0x04423959
+.long 0xD86C0040, 0x30000060
+.long 0xD86C10C0, 0x31000060
+.long 0xD86C0048, 0x32000060
+.long 0xD86C10C8, 0x33000060
+.long 0xD3C40000, 0x04023B5A
+.long 0xD86C0050, 0x34000060
+.long 0xD86C10D0, 0x35000060
+.long 0xD86C0058, 0x36000060
+.long 0xD86C10D8, 0x37000060
+.long 0xD3C40010, 0x04423B5B
+.long 0xD86C0060, 0x38000060
+.long 0xD86C10E0, 0x39000060
+.long 0xD86C0068, 0x3A000060
+.long 0xD86C10E8, 0x3B000060
+.long 0xD3C40000, 0x04023D5C
+.long 0xD86C0070, 0x3C000060
+.long 0xD86C10F0, 0x3D000060
+.long 0xD86C0078, 0x3E000060
+.long 0xD86C10F8, 0x3F000060
+.long 0xD3C40010, 0x04423D5D
+.long 0xBF8A0000
+.long 0xD86C0000, 0x00000062
+.long 0xD86C0008, 0x01000062
+.long 0xD86C0010, 0x02000062
+.long 0xD86C0018, 0x03000062
+.long 0xD3C40000, 0x04023F5E
+.long 0xD86C0020, 0x04000062
+.long 0xD86C0028, 0x05000062
+.long 0xD86C0030, 0x06000062
+.long 0xD86C0038, 0x07000062
+.long 0xD3C40010, 0x04423F5F
+.long 0xD86C0040, 0x08000062
+.long 0xD86C0048, 0x09000062
+.long 0xD86C0050, 0x0A000062
+.long 0xD86C0058, 0x0B000062
+.long 0xBF8F0001
+.long 0x802E812E
+.long 0xBF8CCA7F
+.long 0xD3C40000, 0x04020120
+.long 0xD86C0060, 0x0C000062
+.long 0xD86C0068, 0x0D000062
+.long 0xD3C40010, 0x04420121
+.long 0xD86C0070, 0x0E000062
+.long 0xD86C0078, 0x0F000062
+.long 0xD3C40000, 0x04020322
+.long 0xD3C40010, 0x04420323
+.long 0xBF8A0000
+.long 0xBF8CC87F
+.long 0xD3C40000, 0x04020524
+.long 0xD3C40010, 0x04420525
+.long 0xD3C40000, 0x04020726
+.long 0xD3C40010, 0x04420727
+.long 0xD3C40000, 0x04020928
+.long 0xD3C40010, 0x04420929
+.long 0xD3C40000, 0x04020B2A
+.long 0xD3C40010, 0x04420B2B
+.long 0xD3C40000, 0x04020D2C
+.long 0xD3C40010, 0x04420D2D
+.long 0xD3C40000, 0x04020F2E
+.long 0xD3C40010, 0x04420F2F
+.long 0xBF8CC07F
+.long 0xD3C40000, 0x04021130
+.long 0xD3C40010, 0x04421131
+.long 0xD3C40000, 0x04021332
+.long 0xD3C40010, 0x04421333
+.long 0xBF8F0000
+.long 0xD3C40000, 0x04021534
+.long 0xD3C40010, 0x04421535
+.long 0xBF8A0000
+.long 0xD86C0000, 0x40000061
+.long 0xD86C1080, 0x41000061
+.long 0xD86C0008, 0x42000061
+.long 0xD86C1088, 0x43000061
+.long 0xD3C40000, 0x04021736
+.long 0xD86C0010, 0x44000061
+.long 0xD86C1090, 0x45000061
+.long 0xD86C0018, 0x46000061
+.long 0xD86C1098, 0x47000061
+.long 0xD3C40010, 0x04421737
+.long 0xD86C0020, 0x48000061
+.long 0xD86C10A0, 0x49000061
+.long 0xD86C0028, 0x4A000061
+.long 0xD86C10A8, 0x4B000061
+.long 0xD3C40000, 0x04021938
+.long 0xD86C0030, 0x4C000061
+.long 0xD86C10B0, 0x4D000061
+.long 0xD86C0038, 0x4E000061
+.long 0xD86C10B8, 0x4F000061
+.long 0xD3C40010, 0x04421939
+.long 0xD86C0040, 0x50000061
+.long 0xD86C10C0, 0x51000061
+.long 0xD86C0048, 0x52000061
+.long 0xD86C10C8, 0x53000061
+.long 0xD3C40000, 0x04021B3A
+.long 0xD86C0050, 0x54000061
+.long 0xD86C10D0, 0x55000061
+.long 0xD86C0058, 0x56000061
+.long 0xD86C10D8, 0x57000061
+.long 0xD3C40010, 0x04421B3B
+.long 0xD86C0060, 0x58000061
+.long 0xD86C10E0, 0x59000061
+.long 0xD86C0068, 0x5A000061
+.long 0xD86C10E8, 0x5B000061
+.long 0xD3C40000, 0x04021D3C
+.long 0xD86C0070, 0x5C000061
+.long 0xD86C10F0, 0x5D000061
+.long 0xD86C0078, 0x5E000061
+.long 0xD86C10F8, 0x5F000061
+.long 0xD3C40010, 0x04421D3D
+.long 0xBF8A0000
+.long 0xD86C0000, 0x10000063
+.long 0xD86C0008, 0x11000063
+.long 0xD3C40000, 0x04021F3E
+.long 0xD86C0010, 0x12000063
+.long 0xD86C0018, 0x13000063
+.long 0xD86C0020, 0x14000063
+.long 0xD86C0028, 0x15000063
+.long 0xD86C0030, 0x16000063
+.long 0xD3C40010, 0x04421F3F
+.long 0xD86C0038, 0x17000063
+.long 0xD86C0040, 0x18000063
+.long 0xD86C0048, 0x19000063
+.long 0xD86C0050, 0x1A000063
+.long 0xD86C0058, 0x1B000063
+.long 0xBF8F0001
+.long 0x802E812E
+.long 0xBF8CCA7F
+.long 0xD3C40000, 0x04022140
+.long 0xD86C0060, 0x1C000063
+.long 0xD86C0068, 0x1D000063
+.long 0xD3C40010, 0x04422141
+.long 0xD86C0070, 0x1E000063
+.long 0xD86C0078, 0x1F000063
+.long 0xD3C40000, 0x04022342
+.long 0xD3C40010, 0x04422343
+.long 0xBF8A0000
+.long 0xBF8CC87F
+.long 0xD3C40000, 0x04022544
+.long 0xD3C40010, 0x04422545
+.long 0xD3C40000, 0x04022746
+.long 0xD3C40010, 0x04422747
+.long 0xD3C40000, 0x04022948
+.long 0xD3C40010, 0x04422949
+.long 0xD3C40000, 0x04022B4A
+.long 0xD3C40010, 0x04422B4B
+.long 0xD3C40000, 0x04022D4C
+.long 0xD3C40010, 0x04422D4D
+.long 0xD3C40000, 0x04022F4E
+.long 0xD3C40010, 0x04422F4F
+.long 0xBF8CC07F
+.long 0xD3C40000, 0x04023150
+.long 0xD3C40010, 0x04423151
+.long 0xD3C40000, 0x04023352
+.long 0xD3C40010, 0x04423353
+.long 0xBF8F0000
+.long 0xD3C40000, 0x04023554
+.long 0xD3C40010, 0x04423555
+.long 0xBF8A0000
+.long 0xD86C0000, 0x20000060
+.long 0xD86C1080, 0x21000060
+.long 0xD86C0008, 0x22000060
+.long 0xD86C1088, 0x23000060
+.long 0xD3C40000, 0x04023756
+.long 0xD86C0010, 0x24000060
+.long 0xD86C1090, 0x25000060
+.long 0xD86C0018, 0x26000060
+.long 0xD86C1098, 0x27000060
+.long 0xD3C40010, 0x04423757
+.long 0xD86C0020, 0x28000060
+.long 0xD86C10A0, 0x29000060
+.long 0xD86C0028, 0x2A000060
+.long 0xD86C10A8, 0x2B000060
+.long 0xD3C40000, 0x04023958
+.long 0xD86C0030, 0x2C000060
+.long 0xD86C10B0, 0x2D000060
+.long 0xD86C0038, 0x2E000060
+.long 0xD86C10B8, 0x2F000060
+.long 0xD3C40010, 0x04423959
+.long 0xD86C0040, 0x30000060
+.long 0xD86C10C0, 0x31000060
+.long 0xD86C0048, 0x32000060
+.long 0xD86C10C8, 0x33000060
+.long 0xD3C40000, 0x04023B5A
+.long 0xD86C0050, 0x34000060
+.long 0xD86C10D0, 0x35000060
+.long 0xD86C0058, 0x36000060
+.long 0xD86C10D8, 0x37000060
+.long 0xD3C40010, 0x04423B5B
+.long 0xD86C0060, 0x38000060
+.long 0xD86C10E0, 0x39000060
+.long 0xD86C0068, 0x3A000060
+.long 0xD86C10E8, 0x3B000060
+.long 0xD3C40000, 0x04023D5C
+.long 0xD86C0070, 0x3C000060
+.long 0xD86C10F0, 0x3D000060
+.long 0xD86C0078, 0x3E000060
+.long 0xD86C10F8, 0x3F000060
+.long 0xD3C40010, 0x04423D5D
+.long 0xBF8A0000
+.long 0xD86C0000, 0x00000062
+.long 0xD86C0008, 0x01000062
+.long 0xD3C40000, 0x04023F5E
+.long 0xD86C0010, 0x02000062
+.long 0xD86C0018, 0x03000062
+.long 0xD86C0020, 0x04000062
+.long 0xD86C0028, 0x05000062
+.long 0xD86C0030, 0x06000062
+.long 0xD3C40010, 0x04423F5F
+.long 0xD86C0038, 0x07000062
+.long 0xD86C0040, 0x08000062
+.long 0xD86C0048, 0x09000062
+.long 0xD86C0050, 0x0A000062
+.long 0xD86C0058, 0x0B000062
+.long 0xBF8F0001
+.long 0x802E812E
+.long 0xBF00C22E
+.long 0xBF84FEAC
+.long 0xBF8CCA7F
+.long 0xD3C40000, 0x04020120
+.long 0xD3C40010, 0x04420121
+.long 0xD86C0060, 0x0C000062
+.long 0xD86C0068, 0x0D000062
+.long 0xD86C0070, 0x0E000062
+.long 0xD86C0078, 0x0F000062
+.long 0xD3C40000, 0x04020322
+.long 0xD3C40010, 0x04420323
+.long 0xBF8CCC7F
+.long 0xD3C40000, 0x04020524
+.long 0xD3C40010, 0x04420525
+.long 0xD3C40000, 0x04020726
+.long 0xD3C40010, 0x04420727
+.long 0xBF8CCA7F
+.long 0xD3C40000, 0x04020928
+.long 0xD3C40010, 0x04420929
+.long 0xD3C40000, 0x04020B2A
+.long 0xD3C40010, 0x04420B2B
+.long 0xBF8CC87F
+.long 0xD3C40000, 0x04020D2C
+.long 0xD3C40010, 0x04420D2D
+.long 0xD3C40000, 0x04020F2E
+.long 0xD3C40010, 0x04420F2F
+.long 0xBF8CC07F
+.long 0xD3C40000, 0x04021130
+.long 0xBF068029
+.long 0xBF850008
+.long 0xE05C1000, 0x80042068
+.long 0xE05C1020, 0x80042468
+.long 0xE05C1040, 0x80042868
+.long 0xE05C1060, 0x80042C68
+.long 0xD3C40010, 0x04421131
+.long 0xD3C40000, 0x04021332
+.long 0xD3C40010, 0x04421333
+.long 0xD3C40000, 0x04021534
+.long 0xD3C40010, 0x04421535
+.long 0xBF8A0000
+.long 0xD86C0000, 0x40000061
+.long 0xD86C1080, 0x41000061
+.long 0xD86C0008, 0x42000061
+.long 0xD86C1088, 0x43000061
+.long 0xD3C40000, 0x04021736
+.long 0xD86C0010, 0x44000061
+.long 0xD86C1090, 0x45000061
+.long 0xD86C0018, 0x46000061
+.long 0xD86C1098, 0x47000061
+.long 0xD3C40010, 0x04421737
+.long 0xD86C0020, 0x48000061
+.long 0xD86C10A0, 0x49000061
+.long 0xD86C0028, 0x4A000061
+.long 0xD86C10A8, 0x4B000061
+.long 0xD3C40000, 0x04021938
+.long 0xD86C0030, 0x4C000061
+.long 0xD86C10B0, 0x4D000061
+.long 0xD86C0038, 0x4E000061
+.long 0xD86C10B8, 0x4F000061
+.long 0xD3C40010, 0x04421939
+.long 0xD86C0040, 0x50000061
+.long 0xD86C10C0, 0x51000061
+.long 0xD86C0048, 0x52000061
+.long 0xD86C10C8, 0x53000061
+.long 0xD3C40000, 0x04021B3A
+.long 0xD86C0050, 0x54000061
+.long 0xD86C10D0, 0x55000061
+.long 0xD86C0058, 0x56000061
+.long 0xD86C10D8, 0x57000061
+.long 0xD3C40010, 0x04421B3B
+.long 0xD86C0060, 0x58000061
+.long 0xD86C10E0, 0x59000061
+.long 0xD86C0068, 0x5A000061
+.long 0xD86C10E8, 0x5B000061
+.long 0xD3C40000, 0x04021D3C
+.long 0xD86C0070, 0x5C000061
+.long 0xD86C10F0, 0x5D000061
+.long 0xD86C0078, 0x5E000061
+.long 0xD86C10F8, 0x5F000061
+.long 0xD3C40010, 0x04421D3D
+.long 0xBF8A0000
+.long 0xD86C0000, 0x10000063
+.long 0xD86C0008, 0x11000063
+.long 0xD3C40000, 0x04021F3E
+.long 0xD86C0010, 0x12000063
+.long 0xD86C0018, 0x13000063
+.long 0xD86C0020, 0x14000063
+.long 0xD86C0028, 0x15000063
+.long 0xD86C0030, 0x16000063
+.long 0xD3C40010, 0x04421F3F
+.long 0xD86C0038, 0x17000063
+.long 0xD86C0040, 0x18000063
+.long 0xD86C0048, 0x19000063
+.long 0xD86C0050, 0x1A000063
+.long 0xD86C0058, 0x1B000063
+.long 0xBF8CCA7F
+.long 0xD3C40000, 0x04022140
+.long 0xBF068029
+.long 0xBF850008
+.long 0xE05C1080, 0x80043068
+.long 0xE05C10A0, 0x80043468
+.long 0xE05C10C0, 0x80043868
+.long 0xE05C10E0, 0x80043C68
+.long 0xD3C40010, 0x04422141
+.long 0xD86C0060, 0x1C000063
+.long 0xD86C0068, 0x1D000063
+.long 0xD86C0070, 0x1E000063
+.long 0xD86C0078, 0x1F000063
+.long 0xD3C40000, 0x04022342
+.long 0xD3C40010, 0x04422343
+.long 0xBF8CCC7F
+.long 0xD3C40000, 0x04022544
+.long 0xD3C40010, 0x04422545
+.long 0xD3C40000, 0x04022746
+.long 0xD3C40010, 0x04422747
+.long 0xBF8CCA7F
+.long 0xD3C40000, 0x04022948
+.long 0xD3C40010, 0x04422949
+.long 0xD3C40000, 0x04022B4A
+.long 0xD3C40010, 0x04422B4B
+.long 0xBF8CC87F
+.long 0xD3C40000, 0x04022D4C
+.long 0xD3C40010, 0x04422D4D
+.long 0xD3C40000, 0x04022F4E
+.long 0xD3C40010, 0x04422F4F
+.long 0xBF8CC07F
+.long 0xD3C40000, 0x04023150
+.long 0xD3C40000, 0x04023352
+.long 0xD3C40000, 0x04023554
+.long 0xD3C40000, 0x04023756
+.long 0xD3C40000, 0x04023958
+.long 0xD3C40000, 0x04023B5A
+.long 0xD3C40000, 0x04023D5C
+.long 0xD3C40000, 0x04023F5E
+.long 0xBF068029
+.long 0xBF8400A3
+.long 0xD3C40010, 0x04423151
+.long 0xD3D84000, 0x18000100
+.long 0xD3D84001, 0x18000101
+.long 0xD3D84002, 0x18000102
+.long 0xD3D84003, 0x18000103
+.long 0xD3C40010, 0x04423353
+.long 0xD3D84004, 0x18000104
+.long 0xD3D84005, 0x18000105
+.long 0xD3D84006, 0x18000106
+.long 0xD3D84007, 0x18000107
+.long 0xD1050000, 0x00005100
+.long 0xD1050001, 0x00005101
+.long 0xD1050002, 0x00005102
+.long 0xD1050003, 0x00005103
+.long 0xE07C1000, 0x80050068
+.long 0xD3C40010, 0x04423555
+.long 0xD3D84008, 0x18000108
+.long 0xD3D84009, 0x18000109
+.long 0xD3D8400A, 0x1800010A
+.long 0xD3D8400B, 0x1800010B
+.long 0xD1050004, 0x00005104
+.long 0xD1050005, 0x00005105
+.long 0xD1050006, 0x00005106
+.long 0xD1050007, 0x00005107
+.long 0xE07C1020, 0x80050468
+.long 0xD3C40010, 0x04423757
+.long 0xD3D8400C, 0x1800010C
+.long 0xD3D8400D, 0x1800010D
+.long 0xD3D8400E, 0x1800010E
+.long 0xD3D8400F, 0x1800010F
+.long 0xD1050008, 0x00005108
+.long 0xD1050009, 0x00005109
+.long 0xD105000A, 0x0000510A
+.long 0xD105000B, 0x0000510B
+.long 0xE07C1040, 0x80050868
+.long 0xD3C40010, 0x04423959
+.long 0xD105000C, 0x0000510C
+.long 0xD105000D, 0x0000510D
+.long 0xD105000E, 0x0000510E
+.long 0xD105000F, 0x0000510F
+.long 0xE07C1060, 0x80050C68
+.long 0xD3C40010, 0x04423B5B
+.long 0xD3C40010, 0x04423D5D
+.long 0xD3C40010, 0x04423F5F
+.long 0xBF800003
+.long 0xD3D84000, 0x18000110
+.long 0xD3D84001, 0x18000111
+.long 0xD3D84002, 0x18000112
+.long 0xD3D84003, 0x18000113
+.long 0xD3D84004, 0x18000114
+.long 0xD3D84005, 0x18000115
+.long 0xD3D84006, 0x18000116
+.long 0xD3D84007, 0x18000117
+.long 0xD1050000, 0x00005100
+.long 0xD1050001, 0x00005101
+.long 0xD1050002, 0x00005102
+.long 0xD1050003, 0x00005103
+.long 0xE07C1080, 0x80050068
+.long 0xD3D84008, 0x18000118
+.long 0xD3D84009, 0x18000119
+.long 0xD3D8400A, 0x1800011A
+.long 0xD3D8400B, 0x1800011B
+.long 0xD1050004, 0x00005104
+.long 0xD1050005, 0x00005105
+.long 0xD1050006, 0x00005106
+.long 0xD1050007, 0x00005107
+.long 0xE07C10A0, 0x80050468
+.long 0xD3D8400C, 0x1800011C
+.long 0xD3D8400D, 0x1800011D
+.long 0xD3D8400E, 0x1800011E
+.long 0xD3D8400F, 0x1800011F
+.long 0xD1050008, 0x00005108
+.long 0xD1050009, 0x00005109
+.long 0xD105000A, 0x0000510A
+.long 0xD105000B, 0x0000510B
+.long 0xE07C10C0, 0x80050868
+.long 0xD105000C, 0x0000510C
+.long 0xD105000D, 0x0000510D
+.long 0xD105000E, 0x0000510E
+.long 0xD105000F, 0x0000510F
+.long 0xE07C10E0, 0x80050C68
+.long 0xBF8C0000
+.long 0xBF810000
+.long 0xD3C40010, 0x04423151
+.long 0xD3C40010, 0x04423353
+.long 0xD3C40010, 0x04423555
+.long 0xD3C40010, 0x04423757
+.long 0xD3C40010, 0x04423959
+.long 0xD3C40010, 0x04423B5B
+.long 0xD3C40010, 0x04423D5D
+.long 0xD3C40010, 0x04423F5F
+.long 0xD3D84000, 0x18000100
+.long 0xD3D84001, 0x18000101
+.long 0xD3D84002, 0x18000102
+.long 0xD3D84003, 0x18000103
+.long 0xD3D84004, 0x18000104
+.long 0xD3D84005, 0x18000105
+.long 0xD3D84006, 0x18000106
+.long 0xD3D84007, 0x18000107
+.long 0xD3D84008, 0x18000108
+.long 0xD3D84009, 0x18000109
+.long 0xD3D8400A, 0x1800010A
+.long 0xD3D8400B, 0x1800010B
+.long 0xD3D8400C, 0x1800010C
+.long 0xD3D8400D, 0x1800010D
+.long 0xD3D8400E, 0x1800010E
+.long 0xD3D8400F, 0x1800010F
+.long 0xBF8C0F74
+.long 0xD1050000, 0x00005100
+.long 0xD1050001, 0x00005101
+.long 0xD1050002, 0x00005102
+.long 0xD1050003, 0x00005103
+.long 0xD1160000, 0x00005320
+.long 0xD1160001, 0x00005321
+.long 0xD1160002, 0x00005322
+.long 0xD1160003, 0x00005323
+.long 0xE07C1000, 0x80050068
+.long 0xD1050004, 0x00005104
+.long 0xD1050005, 0x00005105
+.long 0xD1050006, 0x00005106
+.long 0xD1050007, 0x00005107
+.long 0xD1160004, 0x00005324
+.long 0xD1160005, 0x00005325
+.long 0xD1160006, 0x00005326
+.long 0xD1160007, 0x00005327
+.long 0xE07C1020, 0x80050468
+.long 0xD1050008, 0x00005108
+.long 0xD1050009, 0x00005109
+.long 0xD105000A, 0x0000510A
+.long 0xD105000B, 0x0000510B
+.long 0xD1160008, 0x00005328
+.long 0xD1160009, 0x00005329
+.long 0xD116000A, 0x0000532A
+.long 0xD116000B, 0x0000532B
+.long 0xE07C1040, 0x80050868
+.long 0xD105000C, 0x0000510C
+.long 0xD105000D, 0x0000510D
+.long 0xD105000E, 0x0000510E
+.long 0xD105000F, 0x0000510F
+.long 0xD116000C, 0x0000532C
+.long 0xD116000D, 0x0000532D
+.long 0xD116000E, 0x0000532E
+.long 0xD116000F, 0x0000532F
+.long 0xE07C1060, 0x80050C68
+.long 0xD3D84000, 0x18000110
+.long 0xD3D84001, 0x18000111
+.long 0xD3D84002, 0x18000112
+.long 0xD3D84003, 0x18000113
+.long 0xD3D84004, 0x18000114
+.long 0xD3D84005, 0x18000115
+.long 0xD3D84006, 0x18000116
+.long 0xD3D84007, 0x18000117
+.long 0xD3D84008, 0x18000118
+.long 0xD3D84009, 0x18000119
+.long 0xD3D8400A, 0x1800011A
+.long 0xD3D8400B, 0x1800011B
+.long 0xD3D8400C, 0x1800011C
+.long 0xD3D8400D, 0x1800011D
+.long 0xD3D8400E, 0x1800011E
+.long 0xD3D8400F, 0x1800011F
+.long 0xBF8C0F70
+.long 0xD1050000, 0x00005100
+.long 0xD1050001, 0x00005101
+.long 0xD1050002, 0x00005102
+.long 0xD1050003, 0x00005103
+.long 0xD1160000, 0x00005330
+.long 0xD1160001, 0x00005331
+.long 0xD1160002, 0x00005332
+.long 0xD1160003, 0x00005333
+.long 0xE07C1080, 0x80050068
+.long 0xD1050004, 0x00005104
+.long 0xD1050005, 0x00005105
+.long 0xD1050006, 0x00005106
+.long 0xD1050007, 0x00005107
+.long 0xD1160004, 0x00005334
+.long 0xD1160005, 0x00005335
+.long 0xD1160006, 0x00005336
+.long 0xD1160007, 0x00005337
+.long 0xE07C10A0, 0x80050468
+.long 0xD1050008, 0x00005108
+.long 0xD1050009, 0x00005109
+.long 0xD105000A, 0x0000510A
+.long 0xD105000B, 0x0000510B
+.long 0xD1160008, 0x00005338
+.long 0xD1160009, 0x00005339
+.long 0xD116000A, 0x0000533A
+.long 0xD116000B, 0x0000533B
+.long 0xE07C10C0, 0x80050868
+.long 0xD105000C, 0x0000510C
+.long 0xD105000D, 0x0000510D
+.long 0xD105000E, 0x0000510E
+.long 0xD105000F, 0x0000510F
+.long 0xD116000C, 0x0000533C
+.long 0xD116000D, 0x0000533D
+.long 0xD116000E, 0x0000533E
+.long 0xD116000F, 0x0000533F
+.long 0xE07C10E0, 0x80050C68
+.long 0xBF8C0000
+.long 0xBF810000
+

--- a/Tensile/ReplacementKernels-cov3/Cijk_Alik_Bljk_SB_MT64x32x32_AF0EM8_ASEM8_FL0_GRVW2_ISA908_MDA2_PGR1_PLR1_SU32_TT2_2_VAW1_VW2_WG32_16_1_WGM8.s.txt
+++ b/Tensile/ReplacementKernels-cov3/Cijk_Alik_Bljk_SB_MT64x32x32_AF0EM8_ASEM8_FL0_GRVW2_ISA908_MDA2_PGR1_PLR1_SU32_TT2_2_VAW1_VW2_WG32_16_1_WGM8.s.txt
@@ -1,0 +1,912 @@
+
+
+/******************************************/
+/* Function Prefix                        */
+/******************************************/
+
+
+
+/******************************************/
+/* Begin Kernel                           */
+/******************************************/
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx908+sram-ecc"
+.text
+.protected Cijk_Alik_Bljk_SB_MT64x32x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG32_16_1_WGM8
+.globl Cijk_Alik_Bljk_SB_MT64x32x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG32_16_1_WGM8
+.p2align 8
+.type Cijk_Alik_Bljk_SB_MT64x32x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG32_16_1_WGM8,@function
+.section .rodata,#alloc
+.p2align 6
+.amdhsa_kernel Cijk_Alik_Bljk_SB_MT64x32x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG32_16_1_WGM8
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_next_free_vgpr 108 // vgprs
+  .amdhsa_next_free_sgpr 98 // sgprs
+  .amdhsa_group_segment_fixed_size 28672 // lds bytes
+  .amdhsa_private_segment_fixed_size 0
+  .amdhsa_system_sgpr_workgroup_id_x 1
+  .amdhsa_system_sgpr_workgroup_id_y 1
+  .amdhsa_system_sgpr_workgroup_id_z 1
+  .amdhsa_system_vgpr_workitem_id 0
+.end_amdhsa_kernel
+.text
+
+/******************************************/
+/* Optimizations and Config:              */
+/******************************************/
+/* ThreadTile= 4 x 4 */
+/* SubGroup= 16 x 32 */
+/* VectorWidth=4 */
+/* GlobalLoadVectorWidthA=4, GlobalLoadVectorWidthB=4 */
+/* DirectToLdsA=False */
+/* DirectToLdsB=False */
+/* UseSgprForGRO=1 */
+.amdgpu_metadata
+---
+amdhsa.version:
+  - 1
+  - 0
+amdhsa.kernels:
+  - .name: Cijk_Alik_Bljk_SB_MT64x32x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG32_16_1_WGM8
+    .symbol: 'Cijk_Alik_Bljk_SB_MT64x32x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG32_16_1_WGM8.kd'
+    .language:                   OpenCL C
+    .language_version:
+      - 2
+      - 0
+    .args:
+      - .name:            sizeC
+        .size:            8
+        .offset:          0
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            sizeA
+        .size:            8
+        .offset:          8
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            sizeB
+        .size:            8
+        .offset:          16
+        .value_kind:      by_value
+        .value_type:      u64
+      - .name:            D
+        .size:            8
+        .offset:          24
+        .value_kind:      global_buffer
+        .value_type:      f32
+        .address_space:   generic
+      - .name:            C
+        .size:            8
+        .offset:          32
+        .value_kind:      global_buffer
+        .value_type:      f32
+        .address_space:   generic
+      - .name:            A
+        .size:            8
+        .offset:          40
+        .value_kind:      global_buffer
+        .value_type:      f32
+        .address_space:   generic
+      - .name:            B
+        .size:            8
+        .offset:          48
+        .value_kind:      global_buffer
+        .value_type:      f32
+        .address_space:   generic
+      - .name:            alpha
+        .size:            4
+        .offset:          56
+        .value_kind:      by_value
+        .value_type:      f32
+      - .name:            beta
+        .size:            4
+        .offset:          60
+        .value_kind:      by_value
+        .value_type:      f32
+      - .name:            strideD0
+        .size:            4
+        .offset:          64
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideD1
+        .size:            4
+        .offset:          68
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideC0
+        .size:            4
+        .offset:          72
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideC1
+        .size:            4
+        .offset:          76
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideA0
+        .size:            4
+        .offset:          80
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideA1
+        .size:            4
+        .offset:          84
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideB0
+        .size:            4
+        .offset:          88
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            strideB1
+        .size:            4
+        .offset:          92
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree0
+        .size:            4
+        .offset:          96
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree1
+        .size:            4
+        .offset:          100
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesFree2
+        .size:            4
+        .offset:          104
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            SizesSum0
+        .size:            4
+        .offset:          108
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            OrigStaggerUIter
+        .size:            4
+        .offset:          112
+        .value_kind:      by_value
+        .value_type:      i32
+      - .name:            NumWorkGroups0
+        .size:            4
+        .offset:          116
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            NumWorkGroups1
+        .size:            4
+        .offset:          120
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            MagicNumberProblemNumGroupTiles0
+        .size:            4
+        .offset:          124
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            GridNumWorkGroups0
+        .size:            4
+        .offset:          128
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            NumFullBlocks
+        .size:            4
+        .offset:          132
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            WgmRemainder1
+        .size:            4
+        .offset:          136
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            MagicNumberWgmRemainder1
+        .size:            4
+        .offset:          140
+        .value_kind:      by_value
+        .value_type:      u32
+      - .name:            padding
+        .size:            4
+        .offset:          144
+        .value_kind:      by_value
+        .value_type:      u32
+    .group_segment_fixed_size:   28672
+    .kernarg_segment_align:      8
+    .kernarg_segment_size:       152
+    .max_flat_workgroup_size:    512
+    .private_segment_fixed_size: 0
+    .sgpr_count:                 98
+    .sgpr_spill_count:           0
+    .vgpr_count:                 108
+    .vgpr_spill_count:           0
+    .wavefront_size:             64
+...
+.end_amdgpu_metadata
+Cijk_Alik_Bljk_SB_MT64x32x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG32_16_1_WGM8:
+
+/******************************************/
+/* Asm syntax workarounds                 */
+/******************************************/
+.macro _v_add_co_u32 dst, cc, src0, src1, dpp=
+   v_add_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+
+.macro _v_add_u32 dst, src0, src1, dpp=
+   v_add_u32 \dst, \src0, \src1 \dpp
+.endm
+
+.macro _v_sub_co_u32 dst, cc, src0, src1, dpp=
+   v_sub_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+
+.macro _v_sub_u32 dst, src0, src1, dpp=
+   v_sub_u32 \dst, \src0, \src1 \dpp
+.endm
+
+.macro _v_addc_co_u32 dst, ccOut, src0, ccIn, src1, dpp=
+   v_addc_co_u32 \dst, \ccOut, \src0, \ccIn, \src1 \dpp
+.endm
+
+.macro _v_add_lshl_u32 dst, src0, src1, shiftCnt
+    v_add_lshl_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+.macro _v_lshl_add_u32 dst, src0, src1, shiftCnt
+    v_lshl_add_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+/******************************************/
+/* Magic div and mod functions            */
+/******************************************/
+.macro V_MAGIC_DIV dstIdx, dividend, magicNumber, magicShift
+    v_mul_hi_u32 v[\dstIdx+1], \dividend, \magicNumber
+    v_mul_lo_u32 v[\dstIdx+0], \dividend, \magicNumber
+    v_lshrrev_b64 v[\dstIdx:\dstIdx+1], \magicShift, v[\dstIdx:\dstIdx+1]
+.endm
+
+/******************************************/
+/* VGPR Assignments                       */
+/******************************************/
+.set vgprValuC, 0
+/* ValuA/B   Xn=PLR buffer idx,  In=InnerUnroll idx */
+.set vgprValuA_X0_I0, 32
+.set vgprValuA_X1_I0, 34
+.set vgprG2LA, 36
+.set vgprValuB_X0_I0, 40
+.set vgprValuB_X1_I0, 44
+.set vgprG2LB, 48
+.set vgprLocalWriteAddrA, 56
+.set vgprLocalWriteAddrB, 57
+.set vgprGlobalReadOffsetA, 58
+.set vgprGlobalReadOffsetB, 59
+.set vgprLocalReadAddrA, 60
+.set vgprLocalReadAddrB, 61
+.set vgprSerial, 62
+/* Num VGPR=63 */
+
+/******************************************/
+/* SGPR Assignments                       */
+/******************************************/
+.set sgprKernArgAddress, 0
+.set sgprWorkGroup0, 2
+.set sgprWorkGroup1, 3
+.set sgprWorkGroup2, 4
+.set sgprNumWorkGroups0, 5
+.set sgprNumWorkGroups1, 6
+.set sgprSrdA, 8
+.set sgprSrdB, 12
+.set sgprSrdD, 16
+.set sgprSrdC, 20
+.set sgprTensor2dSizeC, 24
+.set sgprTensor2dSizeA, 26
+.set sgprTensor2dSizeB, 28
+.set sgprSaveExecMask, 30
+.set sgprAddressD, 32
+.set sgprAddressC, 34
+.set sgprStridesD, 36
+.set sgprStridesC, 38
+.set sgprAlpha, 40
+.set sgprBeta, 41
+.set sgprSizesFree, 42
+.set sgprSizesSum, 45
+.set sgprLoopCounters, 46
+.set sgprOrigLoopCounter, 47
+.set sgprStridesA, 48
+.set sgprStridesB, 50
+.set sgprAddressA, 52
+.set sgprAddressB, 54
+.set sgprShadowLimitA, 56
+.set sgprShadowLimitB, 58
+.set sgprOrigStaggerUIter, 60
+.set sgprStaggerUIter, 61
+.set sgprWrapUA, 62
+.set sgprWrapUB, 64
+.set sgprNumFullBlocks, 66
+.set sgprWgmRemainder1, 67
+.set sgprMagicNumberWgmRemainder1, 68
+.set sgprGlobalReadIncsA, 69
+.set sgprGlobalReadIncsB, 70
+.set sgprScalarGlobalReadOffsetA, 71
+.set sgprScalarGlobalReadOffsetB, 72
+/* max SGPR=98 */
+
+/* Size Assignments */
+.set sgprSizeD0I, sgprSizesFree+0
+.set sgprSizeD1J, sgprSizesFree+1
+.set sgprSizeDK, sgprSizesFree+2
+.set sgprSizeC0I, sgprSizesFree+0
+.set sgprSizeC1J, sgprSizesFree+1
+.set sgprSizeCK, sgprSizesFree+2
+.set sgprSizeAL, sgprSizesSum+0
+.set sgprSizeA0I, sgprSizesFree+0
+.set sgprSizeAK, sgprSizesFree+2
+.set sgprSizeBL, sgprSizesSum+0
+.set sgprSizeB1J, sgprSizesFree+1
+.set sgprSizeBK, sgprSizesFree+2
+
+/* Stride Assignments */
+.set constStrideD0I, 1
+.set sgprStrideD1J, sgprStridesD+0
+.set sgprStrideDK, sgprStridesD+1
+.set constStrideC0I, 1
+.set sgprStrideC1J, sgprStridesC+0
+.set sgprStrideCK, sgprStridesC+1
+.set constStrideAL, 1
+.set sgprStrideA0I, sgprStridesA+0
+.set sgprStrideAK, sgprStridesA+1
+.set constStrideBL, 1
+.set sgprStrideB1J, sgprStridesB+0
+.set sgprStrideBK, sgprStridesB+1
+
+.set DepthU, 32
+/* Number of elements to shift-left SRD */
+.set SrdShiftLeftA, 4
+.set SrdShiftLeftB, 4
+/* 2GB limit - set offsets to -1 to exceed this and clamp */
+.set BufferLimit, 0x80000000
+/* Bits 127:96 of SRD.  Set DataFormat = 32 bit */
+.set Srd127_96, 0x0020000
+.set BufferOOB, 0x80000000
+
+/* Global Offset A */
+.macro GLOBAL_OFFSET_A vgprAddr vgprOffsetL vgprOffset0I vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStrideA0I], v[\vgprOffset0I] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprOffsetL], v[\vgprTmp+0] // accumulate d1 lower
+_v_add_u32 v[\vgprAddr+0], 0x4, v[\vgprAddr+0]     // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/* Global Offset B */
+.macro GLOBAL_OFFSET_B vgprAddr vgprOffsetL vgprOffset1J vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStrideB1J], v[\vgprOffset1J] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprOffsetL], v[\vgprTmp+0] // accumulate d1 lower
+_v_add_u32 v[\vgprAddr+0], 0x4, v[\vgprAddr+0]     // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/******************************************/
+/* Dynamic Scalar Divide: vQuotient=vDividend/vDivisor; vRemainder=vDividend%vDivisor; */
+/******************************************/
+.macro DYNAMIC_VECTOR_DIVIDE vQuotient vRemainder vDividend vDivisor vTmp0 vTmp1 sTmp
+v_cvt_f32_u32 v[\vQuotient], v[\vDivisor]          //
+v_rcp_f32 v[\vQuotient], v[\vQuotient]             //
+v_mul_f32 v[\vQuotient], 0x4f800000, v[\vQuotient] //
+v_cvt_u32_f32 v[\vQuotient], v[\vQuotient]         //
+v_mul_lo_u32 v[\vRemainder], v[\vDivisor], v[\vQuotient] //
+v_mul_hi_u32 v[\vTmp0], v[\vDivisor], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp1], vcc, 0x0, v[\vRemainder]  //
+v_cmp_ne_i32 s[\sTmp:\sTmp+1], 0x0, v[\vTmp0]      //
+v_cndmask_b32 v[\vRemainder], v[\vTmp1], v[\vRemainder], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vRemainder], v[\vRemainder], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vQuotient], v[\vRemainder] //
+_v_add_co_u32 v[\vQuotient], vcc, v[\vQuotient], v[\vRemainder] //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vTmp0], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vQuotient], v[\vQuotient], v[\vDividend] //
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vDividend], v[\vRemainder] //
+v_cmp_ge_u32 s[\sTmp:\sTmp+1], v[\vDividend], v[\vRemainder] //
+_v_add_co_u32 v[\vRemainder], vcc, 0x1, v[\vQuotient] //
+_v_add_co_u32 v[\vTmp1], vcc, -1, v[\vQuotient]    //
+v_cmp_le_u32 vcc, v[\vDivisor], v[\vTmp0]          //
+s_and_b64 vcc, s[\sTmp:\sTmp+1], vcc               //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vRemainder], vcc //
+v_cndmask_b32 v[\vQuotient], v[\vTmp1], v[\vQuotient], s[\sTmp:\sTmp+1] //
+v_cmp_ne_i32 vcc, 0x0, v[\vDivisor]                //
+v_cndmask_b32 v[\vQuotient], -1, v[\vQuotient], vcc // final result
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vRemainder], vcc, v[\vDividend], v[\vRemainder] // final result
+.endm
+
+/******************************************/
+/* 4x8 thread-tile                        */
+/******************************************/
+.macro MAC_4x8_X0
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[0] iui=0
+s_setprio 1 // Raise priority while processing macs
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[1]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[4]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[5]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[2] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[3]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[6]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[7]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[8] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[9]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[12]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[13]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[10] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[11]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[14]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[15]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[16] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[17]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[20]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[21]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[18] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[19]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[22]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[23]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[24] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[25]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[28]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[29]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[26] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[27]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[30]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[31]
+s_setprio 0 // Reset priority after macs
+.endm
+.macro MAC_4x8_X1
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[0] iui=0
+s_setprio 1 // Raise priority while processing macs
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[1]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[4]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[5]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[2] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[3]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[6]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[7]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[8] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[9]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[12]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[13]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[10] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[11]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[14]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[15]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[16] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[17]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[20]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[21]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[18] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[19]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[22]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[23]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[24] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[25]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[28]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[29]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[26] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[27]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[30]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[31]
+s_setprio 0 // Reset priority after macs
+.endm
+
+
+
+
+/***** program start from here *****/
+
+.long 0xC00A0600, 0x00000008
+.long 0xC00A0D00, 0x00000028
+.long 0xC00A0C00, 0x00000050
+.long 0xC0020B40, 0x0000006C
+.long 0x7ECC0300
+.long 0x26CE00BF
+.long 0xB8D0F804
+.long 0xD1130004, 0x0000A0B0
+.long 0x20D00884
+.long 0x7EA40568
+.long 0xD1130069, 0x0000A08F
+.long 0x7EA20569
+.long 0xBF068151
+.long 0xBF8400EA
+.long 0xBF8CC07F
+.long 0xBE880034
+.long 0xBE890035
+.long 0xBE8A00FF, 0x80000000
+.long 0xBE8B00FF, 0x00020000
+.long 0x96553104
+.long 0x92543104
+.long 0x8ED48254
+.long 0x80085408
+.long 0x82095509
+.long 0x9254C030
+.long 0x92545402
+.long 0x92559030
+.long 0x92555552
+.long 0x81545554
+.long 0x2000CE85
+.long 0xD2850004, 0x00020030
+.long 0x2602CE9F
+.long 0x32180304
+.long 0x68181854
+.long 0x24181882
+.long 0x8E478330
+.long 0x80C7FF47, 0x00000120
+.long 0x681A1847
+.long 0x681C1A47
+.long 0x681E1C47
+.long 0x68201E47
+.long 0x68222047
+.long 0x68242247
+.long 0x68262447
+.long 0xBECC00FF, 0x00000900
+.long 0x924C4C52
+.long 0xBE8C0036
+.long 0xBE8D0037
+.long 0xBE8E00FF, 0x80000000
+.long 0xBE8F00FF, 0x00020000
+.long 0x96553304
+.long 0x92543304
+.long 0x8ED48254
+.long 0x800C540C
+.long 0x820D550D
+.long 0x9254A032
+.long 0x92545403
+.long 0x92558832
+.long 0x92555552
+.long 0x81545554
+.long 0x2004CE85
+.long 0xD2850004, 0x00020432
+.long 0x2606CE9F
+.long 0x32280704
+.long 0x68282854
+.long 0x24282882
+.long 0x8E4A8332
+.long 0x80CAFF4A, 0x00000120
+.long 0x682A284A
+.long 0x682C2A4A
+.long 0x682E2C4A
+.long 0xBECE00FF, 0x00000480
+.long 0x924E4E52
+.long 0x814EFF4E, 0x00004800
+.long 0xBF8A0000
+.long 0xBEFC004E
+.long 0x814FFF4E, 0x00001200
+.long 0xE0511000, 0x80030814
+.long 0xE0511120, 0x80030915
+.long 0xE0511240, 0x80030A16
+.long 0xE0511360, 0x80030B17
+.long 0xBEFC004C
+.long 0x814DFF4C, 0x00002400
+.long 0xE0511000, 0x8002000C
+.long 0xE0511120, 0x8002010D
+.long 0xE0511240, 0x8002020E
+.long 0xE0511360, 0x8002030F
+.long 0xE0511480, 0x80020410
+.long 0xE05115A0, 0x80020511
+.long 0xE05116C0, 0x80020612
+.long 0xE05117E0, 0x80020713
+.long 0xBEFC004F
+.long 0x800CFF0C, 0x00000080
+.long 0x820D800D
+.long 0x8008FF08, 0x00000080
+.long 0x82098009
+.long 0xE0511000, 0x80030814
+.long 0xE0511120, 0x80030915
+.long 0xE0511240, 0x80030A16
+.long 0xE0511360, 0x80030B17
+.long 0xBEFC004D
+.long 0xBF800000
+.long 0xE0511000, 0x8002000C
+.long 0xE0511120, 0x8002010D
+.long 0xE0511240, 0x8002020E
+.long 0xE0511360, 0x8002030F
+.long 0xE0511480, 0x80020410
+.long 0xE05115A0, 0x80020511
+.long 0xE05116C0, 0x80020612
+.long 0xE05117E0, 0x80020713
+.long 0x800CFF0C, 0x00000080
+.long 0x820D800D
+.long 0x8008FF08, 0x00000080
+.long 0x82098009
+.long 0xBEFC004E
+.long 0xBF8C4F74
+.long 0xBF8A0000
+.long 0xBF8C0F7C
+.long 0xBF8A0000
+.long 0x8F2E852D
+.long 0x80AE2E80
+.long 0xBF03C22E
+.long 0xBF85004F
+.long 0xBF8A0000
+.long 0xE0511000, 0x80030814
+.long 0xE0511120, 0x80030915
+.long 0xE0511240, 0x80030A16
+.long 0xE0511360, 0x80030B17
+.long 0xBEFC004C
+.long 0xBF800000
+.long 0xE0511000, 0x8002000C
+.long 0xE0511120, 0x8002010D
+.long 0xE0511240, 0x8002020E
+.long 0xE0511360, 0x8002030F
+.long 0xE0511480, 0x80020410
+.long 0xE05115A0, 0x80020511
+.long 0xE05116C0, 0x80020612
+.long 0xE05117E0, 0x80020713
+.long 0xBF8C4F74
+.long 0xBF8A0000
+.long 0x800CFF0C, 0x00000080
+.long 0x820D800D
+.long 0xBF8C0F7C
+.long 0xBF8A0000
+.long 0x8008FF08, 0x00000080
+.long 0x82098009
+.long 0xBEFC004F
+.long 0xBF8A0000
+.long 0xE0511000, 0x80030814
+.long 0xE0511120, 0x80030915
+.long 0xE0511240, 0x80030A16
+.long 0xE0511360, 0x80030B17
+.long 0xBEFC004D
+.long 0xBF800000
+.long 0xE0511000, 0x8002000C
+.long 0xE0511120, 0x8002010D
+.long 0xE0511240, 0x8002020E
+.long 0xE0511360, 0x8002030F
+.long 0xE0511480, 0x80020410
+.long 0xE05115A0, 0x80020511
+.long 0xE05116C0, 0x80020612
+.long 0xE05117E0, 0x80020713
+.long 0xBF8C4F74
+.long 0xBF8A0000
+.long 0x800CFF0C, 0x00000080
+.long 0x820D800D
+.long 0xBF8C0F7C
+.long 0xBF8A0000
+.long 0x8008FF08, 0x00000080
+.long 0x82098009
+.long 0xBEFC004E
+.long 0x802E822E
+.long 0xBF03C22E
+.long 0xBF84FFB1
+.long 0xBF8C0F78
+.long 0xBF8A0000
+.long 0xBF8C0F70
+.long 0xBF8A0000
+.long 0xBF810000
+.long 0xC0060700, 0x00000000
+.long 0xC00A0800, 0x00000018
+.long 0xC00A0A00, 0x00000038
+.long 0xC00A0900, 0x00000040
+.long 0xD3D94000, 0x18000080
+.long 0xD3D94001, 0x18000080
+.long 0xD3D94002, 0x18000080
+.long 0xD3D94003, 0x18000080
+.long 0xD3D94004, 0x18000080
+.long 0xD3D94005, 0x18000080
+.long 0xD3D94006, 0x18000080
+.long 0xD3D94007, 0x18000080
+.long 0xD1130001, 0x00011F67
+.long 0xD2850040, 0x000202A0
+.long 0x20040281
+.long 0xD2850002, 0x000204A0
+.long 0x2002CE84
+.long 0x24020282
+.long 0x68808101
+.long 0x24808082
+.long 0x68808102
+.long 0x9254FF52, 0x00000900
+.long 0x68808054
+.long 0x68808080
+.long 0x688280FF, 0x00002400
+.long 0xBF8A0000
+.long 0xD1130001, 0x00011F67
+.long 0xD2850042, 0x000202A0
+.long 0x20040281
+.long 0xD2850002, 0x000204A0
+.long 0x2002CE84
+.long 0x24020282
+.long 0x68848501
+.long 0x24848482
+.long 0x68848502
+.long 0x688484FF, 0x00004800
+.long 0x688684FF, 0x00001200
+.long 0xBF8CC07F
+.long 0xBE900022
+.long 0xBE910023
+.long 0xBE9200FF, 0x80000000
+.long 0xBE9300FF, 0x00020000
+.long 0x925603A0
+.long 0x96552656
+.long 0x92542656
+.long 0x8ED48254
+.long 0x80105410
+.long 0x82115511
+.long 0x96552704
+.long 0x92542704
+.long 0x8ED48254
+.long 0x80105410
+.long 0x82115511
+.long 0xD2850003, 0x0002D090
+.long 0x2608CE8F
+.long 0xD2850005, 0x00004D04
+.long 0x200CCE84
+.long 0x240C0C82
+.long 0x68D60B03
+.long 0x925402C0
+.long 0x32D40C54
+.long 0xD1FE0044, 0x020AD76A
+.long 0x925426C0
+.long 0x688A8854
+.long 0xBE940020
+.long 0xBE950021
+.long 0xBE9600FF, 0x80000000
+.long 0xBE9700FF, 0x00020000
+.long 0x925603A0
+.long 0x96552456
+.long 0x92542456
+.long 0x8ED48254
+.long 0x80145414
+.long 0x82155515
+.long 0x96552504
+.long 0x92542504
+.long 0x8ED48254
+.long 0x80145414
+.long 0x82155515
+.long 0xD2850003, 0x0002D090
+.long 0x2608CE8F
+.long 0xD2850005, 0x00004904
+.long 0x200CCE84
+.long 0x240C0C82
+.long 0x68D60B03
+.long 0x925402C0
+.long 0x32D40C54
+.long 0xD1FE0046, 0x020AD76A
+.long 0x925426C0
+.long 0x688E8C54
+.long 0xBF8A0000
+.long 0xD9FE0000, 0x20000042
+.long 0xD9FE0900, 0x28000042
+.long 0xD9FE0040, 0x24000042
+.long 0xD9FE0940, 0x2C000042
+.long 0xBF8A0000
+.long 0xD9FE0000, 0x10000040
+.long 0xD9FE0040, 0x14000040
+.long 0x8F2E852D
+.long 0x80AE2E80
+.long 0xBF03C22E
+.long 0xBF850065
+.long 0xBF8A0000
+.long 0xBF8CC17F
+.long 0xD3C50000, 0x04024110
+.long 0xD3C50004, 0x04125110
+.long 0xD3C50000, 0x04024311
+.long 0xD3C50004, 0x04125311
+.long 0xD3C50000, 0x04024512
+.long 0xBF8A0000
+.long 0xD3C50004, 0x04125512
+.long 0xD9FE0000, 0x30000043
+.long 0xD3C50000, 0x04024713
+.long 0xD9FE0900, 0x38000043
+.long 0xD3C50004, 0x04125713
+.long 0xD9FE0040, 0x34000043
+.long 0xBF8CC37F
+.long 0xD3C50000, 0x04024914
+.long 0xD9FE0940, 0x3C000043
+.long 0xD3C50004, 0x04125914
+.long 0xD3C50000, 0x04024B15
+.long 0xD3C50004, 0x04125B15
+.long 0xD3C50000, 0x04024D16
+.long 0xD3C50004, 0x04125D16
+.long 0xBF8A0000
+.long 0xD9FE0000, 0x18000041
+.long 0xD3C50000, 0x04024F17
+.long 0xD9FE0040, 0x1C000041
+.long 0xD3C50004, 0x04125F17
+.long 0xBF8A0000
+.long 0xBF8CC17F
+.long 0xD3C50000, 0x04026118
+.long 0xD3C50004, 0x04127118
+.long 0xD3C50000, 0x04026319
+.long 0xD3C50004, 0x04127319
+.long 0xD3C50000, 0x0402651A
+.long 0xBF8A0000
+.long 0xD3C50004, 0x0412751A
+.long 0xD9FE0000, 0x20000042
+.long 0xD3C50000, 0x0402671B
+.long 0xD9FE0900, 0x28000042
+.long 0xD3C50004, 0x0412771B
+.long 0xD9FE0040, 0x24000042
+.long 0xBF8CC37F
+.long 0xD3C50000, 0x0402691C
+.long 0xD9FE0940, 0x2C000042
+.long 0xD3C50004, 0x0412791C
+.long 0xD3C50000, 0x04026B1D
+.long 0xD3C50004, 0x04127B1D
+.long 0xD3C50000, 0x04026D1E
+.long 0xD3C50004, 0x04127D1E
+.long 0xBF8A0000
+.long 0xD9FE0000, 0x10000040
+.long 0xD3C50000, 0x04026F1F
+.long 0xD9FE0040, 0x14000040
+.long 0xD3C50004, 0x04127F1F
+.long 0x802E822E
+.long 0xBF03C22E
+.long 0xBF84FF9B
+.long 0xBF8CC17F
+.long 0xD3C50000, 0x04024110
+.long 0xE05C1000, 0x80040844
+.long 0xE05C1000, 0x80040C45
+.long 0xD3C50004, 0x04125110
+.long 0xD3C50000, 0x04024311
+.long 0xBF8A0000
+.long 0xD3C50004, 0x04125311
+.long 0xD9FE0000, 0x30000043
+.long 0xD3C50000, 0x04024512
+.long 0xD9FE0900, 0x38000043
+.long 0xD3C50004, 0x04125512
+.long 0xD9FE0040, 0x34000043
+.long 0xD3C50000, 0x04024713
+.long 0xD9FE0940, 0x3C000043
+.long 0xD3C50004, 0x04125713
+.long 0xBF8CC37F
+.long 0xD3C50000, 0x04024914
+.long 0xD3C50004, 0x04125914
+.long 0xD3C50000, 0x04024B15
+.long 0xD3C50004, 0x04125B15
+.long 0xD3C50000, 0x04024D16
+.long 0xBF8A0000
+.long 0xD9FE0000, 0x18000041
+.long 0xD3C50004, 0x04125D16
+.long 0xD9FE0040, 0x1C000041
+.long 0xD3C50000, 0x04024F17
+.long 0xD3C50004, 0x04125F17
+.long 0xBF8CC17F
+.long 0xD3C50000, 0x04026118
+.long 0xD3C50004, 0x04127118
+.long 0xD3C50000, 0x04026319
+.long 0xD3C50004, 0x04127319
+.long 0xD3C50000, 0x0402651A
+.long 0xD3C50004, 0x0412751A
+.long 0xD3C50000, 0x0402671B
+.long 0xD3C50004, 0x0412771B
+.long 0xBF8CC07F
+.long 0xD3C50000, 0x0402691C
+.long 0xD3C50000, 0x04026B1D
+.long 0xD3C50000, 0x04026D1E
+.long 0xD3C50000, 0x04026F1F
+.long 0xD3C50004, 0x0412791C
+.long 0xD3C50004, 0x04127B1D
+.long 0xD3C50004, 0x04127D1E
+.long 0xD3C50004, 0x04127F1F
+.long 0xD3D84000, 0x18000100
+.long 0x0A000028
+.long 0xD3D84001, 0x18000101
+.long 0x0A020228
+.long 0xD3D84002, 0x18000102
+.long 0x0A040428
+.long 0xD3D84003, 0x18000103
+.long 0x0A060628
+.long 0xBF8C0F71
+.long 0xD1CB0000, 0x04005308
+.long 0xD1CB0001, 0x04045309
+.long 0xD1CB0002, 0x0408530A
+.long 0xD1CB0003, 0x040C530B
+.long 0xE07C1000, 0x80050046
+.long 0xD3D84004, 0x18000104
+.long 0x0A080828
+.long 0xD3D84005, 0x18000105
+.long 0x0A0A0A28
+.long 0xD3D84006, 0x18000106
+.long 0x0A0C0C28
+.long 0xD3D84007, 0x18000107
+.long 0x0A0E0E28
+.long 0xBF8C0F71
+.long 0xD1CB0004, 0x0410530C
+.long 0xD1CB0005, 0x0414530D
+.long 0xD1CB0006, 0x0418530E
+.long 0xD1CB0007, 0x041C530F
+.long 0xE07C1000, 0x80050447
+.long 0xBF8C0000
+.long 0xBF810000

--- a/Tensile/ReplacementKernels/Cijk_Ailk_Bjlk_DB_MT48x64x4_AF0EM1_ASEM1_FL1_GRVW2_ISA906_MDA2_PGR1_PLR0_SU0_TT6_4_VAW1_VW2_WG8_16_1_WGM4.s.txt
+++ b/Tensile/ReplacementKernels/Cijk_Ailk_Bjlk_DB_MT48x64x4_AF0EM1_ASEM1_FL1_GRVW2_ISA906_MDA2_PGR1_PLR0_SU0_TT6_4_VAW1_VW2_WG8_16_1_WGM4.s.txt
@@ -1,0 +1,3885 @@
+
+
+/******************************************/
+/* Function Prefix                        */
+/******************************************/
+
+
+
+/******************************************/
+/* Begin Kernel                           */
+/******************************************/
+
+.hsa_code_object_version 2,0
+.hsa_code_object_isa 9, 0, 6, "AMD", "AMDGPU"
+.text
+.protected Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA906_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM4
+.globl Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA906_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM4
+.p2align 8
+.type Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA906_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM4,@function
+.amdgpu_hsa_kernel Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA906_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM4
+Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA906_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM4:
+.amd_kernel_code_t
+  is_ptr64 = 1
+  enable_sgpr_kernarg_segment_ptr = 1
+  kernarg_segment_byte_size = 92 // bytes of kern args
+  workitem_vgpr_count = 84 // vgprs
+  wavefront_sgpr_count = 98 // sgprs
+  compute_pgm_rsrc1_vgprs = 20 // floor((83-1)/4)
+  compute_pgm_rsrc1_sgprs = 13 // floor((98-1)/8)
+  compute_pgm_rsrc2_tidig_comp_cnt = 0 // 1D wg
+  compute_pgm_rsrc2_tgid_x_en = 1 // wg.x
+  compute_pgm_rsrc2_tgid_y_en = 1 // wg.y
+  compute_pgm_rsrc2_tgid_z_en = 1 // wg.z
+  workgroup_group_segment_byte_size = 7680 // lds bytes
+  compute_pgm_rsrc2_user_sgpr = 2 // vcc
+  kernarg_segment_alignment = 4
+  group_segment_alignment = 4
+  private_segment_alignment = 4
+.end_amd_kernel_code_t
+
+.amd_amdgpu_hsa_metadata
+Version: [ 1, 0 ]
+Kernels:
+  - Name: Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA906_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM4
+    SymbolName: 'Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA906_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM4@kd'
+    Language: OpenCL C
+    LanguageVersion: [ 2, 0 ]
+    Args:
+      - Name:            sizeC
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            sizeA
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            sizeB
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            D
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       F64
+        AddrSpaceQual:   Generic
+      - Name:            C
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       F64
+        AddrSpaceQual:   Generic
+      - Name:            A
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       F64
+        AddrSpaceQual:   Generic
+      - Name:            B
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       F64
+        AddrSpaceQual:   Generic
+      - Name:            alpha
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       F64
+      - Name:            beta
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       F64
+      - Name:            strideD0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideD1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideC0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideC1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideA0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideA1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideB0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideB1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree2
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesSum0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            OrigStaggerUIter
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       I32
+      - Name:            NumWorkGroups0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            NumWorkGroups1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            MagicNumberProblemNumGroupTiles0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            GridNumWorkGroups0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            NumFullBlocks
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            WgmRemainder1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            MagicNumberWgmRemainder1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            padding
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+    CodeProps:
+      KernargSegmentSize: 156
+      GroupSegmentFixedSize: 7680
+      PrivateSegmentFixedSize: 0
+      KernargSegmentAlign:  8
+      WavefrontSize:        64
+      NumSGPRs:             98
+      NumVGPRs:             84
+      MaxFlatWorkGroupSize: 128
+.end_amd_amdgpu_hsa_metadata
+
+/******************************************/
+/* Optimizations and Config:              */
+/******************************************/
+/* ThreadTile= 6 x 4 */
+/* SubGroup= 8 x 16 */
+/* VectorWidth=2 */
+/* GlobalLoadVectorWidthA=2, GlobalLoadVectorWidthB=2 */
+/* DirectToLdsA=False */
+/* DirectToLdsB=False */
+/* UseSgprForGRO=False */
+
+/******************************************/
+/* Asm syntax workarounds                 */
+/******************************************/
+.macro _v_add_co_u32 dst, cc, src0, src1, dpp=
+   v_add_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+.macro _v_sub_co_u32 dst, cc, src0, src1, dpp=
+   v_sub_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+.macro _v_addc_co_u32 dst, ccOut, src0, ccIn, src1, dpp=
+   v_addc_co_u32 \dst, \ccOut, \src0, \ccIn, \src1 \dpp
+.endm
+.macro _v_add_lshl_u32 dst, src0, src1, shiftCnt
+    v_add_lshl_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+.macro _v_lshl_add_u32 dst, src0, src1, shiftCnt
+    v_lshl_add_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+/******************************************/
+/* Magic div and mod functions            */
+/******************************************/
+.macro V_MAGIC_DIV dstIdx, dividend, magicNumber, magicShift
+    v_mul_lo_u32 v[\dstIdx+0], \dividend, \magicNumber
+    v_mul_hi_u32 v[\dstIdx+1], \dividend, \magicNumber
+    v_lshrrev_b64 v[\dstIdx:\dstIdx+1], \magicShift, v[\dstIdx:\dstIdx+1]
+.endm
+
+/******************************************/
+/* VGPR Assignments                       */
+/******************************************/
+.set vgprValuC, 0
+/* ValuA/B   Xn=PLR buffer idx,  In=InnerUnroll idx */
+.set vgprValuA_X0_I0, 48
+.set vgprG2LA, 60
+.set vgprValuB_X0_I0, 64
+.set vgprG2LB, 72
+.set vgprLocalWriteAddrA, 76
+.set vgprLocalWriteAddrB, 77
+.set vgprGlobalReadOffsetA, 78
+.set vgprGlobalReadOffsetB, 79
+.set vgprLocalReadAddrA, 80
+.set vgprLocalReadAddrB, 81
+.set vgprSerial, 82
+/* Num VGPR=83 */
+
+/******************************************/
+/* SGPR Assignments                       */
+/******************************************/
+.set sgprKernArgAddress, 0
+.set sgprWorkGroup0, 2
+.set sgprWorkGroup1, 3
+.set sgprWorkGroup2, 4
+.set sgprNumWorkGroups0, 5
+.set sgprNumWorkGroups1, 6
+.set sgprSrdA, 8
+.set sgprSrdB, 12
+.set sgprSrdD, 16
+.set sgprSrdC, 20
+.set sgprTensor2dSizeC, 24
+.set sgprTensor2dSizeA, 26
+.set sgprTensor2dSizeB, 28
+.set sgprSaveExecMask, 30
+.set sgprAddressD, 32
+.set sgprAddressC, 34
+.set sgprStridesC, 36
+.set sgprAlpha, 38
+.set sgprBeta, 40
+.set sgprSizesFree, 42
+.set sgprSizesSum, 45
+.set sgprLoopCounters, 46
+.set sgprOrigLoopCounter, 47
+.set sgprStridesA, 48
+.set sgprStridesB, 50
+.set sgprAddressA, 52
+.set sgprAddressB, 54
+.set sgprShadowLimitA, 56
+.set sgprShadowLimitB, 58
+.set sgprNumFullBlocks, 60
+.set sgprWgmRemainder1, 61
+.set sgprMagicNumberWgmRemainder1, 62
+.set sgprGlobalReadIncsA, 63
+.set sgprGlobalReadIncsB, 64
+.set sgprStridesD, 74
+.set sgprTMP0, 90
+.set sgprTMP1, 91
+.set sgprEdgeSelMask0, 93
+.set sgprEdgeSelMask1, 94
+/* max SGPR=98 */
+
+/******************************************/
+/* 2GB limit - set offsets to -1 to exceed this and clamp */
+/******************************************/
+.set BufferLimit, 0x80000000
+
+/******************************************/
+/* Bits 127:96 of SRD.  Set DataFormat = 32 bit */
+/******************************************/
+.set Srd127_96, 0x0020000
+.set BufferOOB, 0x80000000
+
+/* Global Offset A */
+.macro GLOBAL_OFFSET_A vgprAddr vgprOffset0I vgprOffsetL vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStridesA+0], v[\vgprOffsetL] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprTmp+0], v[\vgprOffset0I] // accumulate d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, 0x2, v[\vgprAddr+0] // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x3, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/* Global Offset B */
+.macro GLOBAL_OFFSET_B vgprAddr vgprOffset1J vgprOffsetL vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStridesB+0], v[\vgprOffsetL] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprTmp+0], v[\vgprOffset1J] // accumulate d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, 0x2, v[\vgprAddr+0] // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x3, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/******************************************/
+/* Dynamic Scalar Divide: vQuotient=vDividend/vDivisor; vRemainder=vDividend%vDivisor; */
+/******************************************/
+.macro DYNAMIC_VECTOR_DIVIDE vQuotient vRemainder vDividend vDivisor vTmp0 vTmp1 sTmp
+v_cvt_f32_u32 v[\vQuotient], v[\vDivisor]          //
+v_rcp_f32 v[\vQuotient], v[\vQuotient]             //
+v_mul_f32 v[\vQuotient], 0x4f800000, v[\vQuotient] //
+v_cvt_u32_f32 v[\vQuotient], v[\vQuotient]         //
+v_mul_lo_u32 v[\vRemainder], v[\vDivisor], v[\vQuotient] //
+v_mul_hi_u32 v[\vTmp0], v[\vDivisor], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp1], vcc, 0x0, v[\vRemainder]  //
+v_cmp_ne_i32 s[\sTmp:\sTmp+1], 0x0, v[\vTmp0]      //
+v_cndmask_b32 v[\vRemainder], v[\vTmp1], v[\vRemainder], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vRemainder], v[\vRemainder], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vQuotient], v[\vRemainder] //
+_v_add_co_u32 v[\vQuotient], vcc, v[\vQuotient], v[\vRemainder] //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vTmp0], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vQuotient], v[\vQuotient], v[\vDividend] //
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vDividend], v[\vRemainder] //
+v_cmp_ge_u32 s[\sTmp:\sTmp+1], v[\vDividend], v[\vRemainder] //
+_v_add_co_u32 v[\vRemainder], vcc, 0x1, v[\vQuotient] //
+_v_add_co_u32 v[\vTmp1], vcc, -1, v[\vQuotient]    //
+v_cmp_le_u32 vcc, v[\vDivisor], v[\vTmp0]          //
+s_and_b64 vcc, s[\sTmp:\sTmp+1], vcc               //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vRemainder], vcc //
+v_cndmask_b32 v[\vQuotient], v[\vTmp1], v[\vQuotient], s[\sTmp:\sTmp+1] //
+v_cmp_ne_i32 vcc, 0x0, v[\vDivisor]                //
+v_cndmask_b32 v[\vQuotient], -1, v[\vQuotient], vcc // final result
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vRemainder], vcc, v[\vDividend], v[\vRemainder] // final result
+.endm
+
+/******************************************/
+/* 6x4 thread-tile                        */
+/******************************************/
+.macro MAC_6x4_X0
+v_fma_f64 v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1]
+s_setprio 1 // Raise priority while processing macs
+v_fma_f64 v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1]
+s_setprio 0 // Reset priority after macs
+.endm
+
+.macro MAC_6x4_X0_part_1
+v_fma_f64 v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1]
+s_setprio 1 // Raise priority while processing macs
+v_fma_f64 v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1]
+.endm
+
+.macro MAC_6x4_X0_part_2
+.endm
+
+.macro MAC_6x4_X0_part_3
+v_fma_f64 v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1]
+s_setprio 0 // Reset Priority
+.endm
+
+.macro MAC_6x4_X0_unprio_0
+v_fma_f64 v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1]
+s_setprio 1 // Raise priority while processing macs
+v_fma_f64 v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1]
+.endm
+
+
+.macro MAC_6x4_X0_part1
+v_fma_f64 v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1]
+s_setprio 1
+v_fma_f64 v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1]
+s_setprio 0
+.endm
+
+
+.macro MAC_6x4_X0_part2
+v_fma_f64 v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1]
+s_setprio 1
+v_fma_f64 v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1]
+s_setprio 0
+.endm
+.macro MAC_6x4_X0_part3
+v_fma_f64 v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1]
+s_setprio 1
+v_fma_f64 v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1]
+s_setprio 0
+.endm
+.macro MAC_6x4_X0_part4
+v_fma_f64 v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1]
+s_setprio 1
+v_fma_f64 v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1]
+//vnop_4
+s_setprio 0
+.endm
+.macro MAC_6x4_X0_part5
+v_fma_f64 v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1]
+s_setprio 1
+v_fma_f64 v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1]
+//vnop_4
+s_setprio 0
+.endm
+.macro MAC_6x4_X0_part6
+v_fma_f64 v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1]
+s_setprio 1
+v_fma_f64 v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1]
+s_setprio 0
+.endm
+
+/******************************************/
+/* Allocate Resources                     */
+/******************************************/
+
+s_mov_b32 m0, 0x1e00                               // LDS clamp at 7680 bytes
+v_mov_b32 v[vgprSerial], v0                        // thread serial id
+
+/* Load Kernel Args */
+s_load_dword s[sgprTensor2dSizeC+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x0 //
+s_load_dword s[sgprTensor2dSizeC+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x4 //
+s_load_dword s[sgprTensor2dSizeA+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x8 //
+s_load_dword s[sgprTensor2dSizeA+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0xc //
+s_load_dword s[sgprTensor2dSizeB+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x10 //
+s_load_dword s[sgprTensor2dSizeB+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x14 //
+s_load_dword s[sgprAddressD], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x18 //
+s_load_dword s[sgprAddressD+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x1c //
+s_load_dword s[sgprAddressC], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x20 //
+s_load_dword s[sgprAddressC+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x24 //
+s_load_dword s[sgprAddressA], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x28 //
+s_load_dword s[sgprAddressA+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x2c //
+s_load_dword s[sgprAddressB], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x30 //
+s_load_dword s[sgprAddressB+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x34 //
+s_load_dword s[sgprAlpha+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x38 //
+s_load_dword s[sgprAlpha+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x3c //
+s_load_dword s[sgprBeta+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x40 //
+s_load_dword s[sgprBeta+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x44 //
+s_load_dword s[sgprStridesD+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x48 //
+s_load_dword s[sgprStridesD+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x4c //
+s_load_dword s[sgprStridesC+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x50 //
+s_load_dword s[sgprStridesC+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x54 //
+s_load_dword s[sgprStridesA+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x58 //
+s_load_dword s[sgprStridesA+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x5c //
+s_load_dword s[sgprStridesB+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x60 //
+s_load_dword s[sgprStridesB+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x64 //
+s_load_dword s[sgprSizesFree+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x68 //
+s_load_dword s[sgprSizesFree+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x6c //
+s_load_dword s[sgprSizesFree+2], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x70 //
+s_load_dword s[sgprSizesSum+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x74 //
+s_load_dword s[sgprNumWorkGroups0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x7c //
+s_load_dword s[sgprNumWorkGroups1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x80 //
+s_load_dword s[sgprNumFullBlocks], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x8c //
+s_load_dword s[sgprWgmRemainder1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x90 //
+s_load_dword s[sgprMagicNumberWgmRemainder1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x94 //
+s_waitcnt lgkmcnt(0)                               // wait for 144 bytes of kern args
+
+
+/******************************************/
+/* Local Read Addresses                   */
+/******************************************/
+
+
+/* local read addresses: tile assignments a */
+
+/*lr0I = serial % SG0I*/
+v_lshrrev_b32 v0, 3, v[vgprSerial]                 // vectorStaticDiv: v0 = v[vgprSerial] / 8
+v_and_b32 v1, 7, v[vgprSerial]                     // vectorStaticDiv: v1 = v[vgprSerial] % 8
+
+
+/* local read addresses: tile assignments b */
+
+/*lr1J = (serial / SG1J) % SG1J*/
+v_lshrrev_b32 v2, 4, v0                            // vectorStaticDiv: v2 = v0 / 16
+v_and_b32 v3, 15, v0                               // vectorStaticDiv: v3 = v0 % 16
+
+
+/* local read addresses: final offsets a */
+
+v_lshrrev_b32 v0, 7, v[vgprSerial]                 // vectorStaticDiv: v0 = v[vgprSerial] / 128
+v_and_b32 v2, 127, v[vgprSerial]                   // vectorStaticDiv: v2 = v[vgprSerial] % 128
+s_mov_b32 s65, 0x30                                // MT0+PAD
+v_mul_lo_u32 v0, s65, v0                           // sgid=sgid*(MT0+PAD)
+v_lshlrev_b32 v1, 1, v1                            // staticMultiply: v1 = v1 * 2
+_v_add_lshl_u32 v[vgprLocalReadAddrA], v0, v1, 0x3 // o = (lroA*VW+sgid*MT0)*bpe
+
+
+/* local read addresses: final offsets b */
+
+v_lshrrev_b32 v0, 7, v[vgprSerial]                 // vectorStaticDiv: v0 = v[vgprSerial] / 128
+v_and_b32 v1, 127, v[vgprSerial]                   // vectorStaticDiv: v1 = v[vgprSerial] % 128
+s_mov_b32 s65, 0x40                                // MT1+PAD
+v_mul_lo_u32 v0, s65, v0                           // sgid=sgid*(MT1+PAD)
+v_lshlrev_b32 v3, 1, v3                            // staticMultiply: v3 = v3 * 2
+_v_add_lshl_u32 v[vgprLocalReadAddrB], v0, v3, 0x3 // o = (lroB*VW+sgid*MT1)*bpe
+
+
+/* local read addresses: declare addresses a */
+
+/* N/A */
+
+
+/* local read addresses: declare addresses b */
+
+_v_add_co_u32 v[vgprLocalReadAddrB+0], vcc, 0x600, v[vgprLocalReadAddrB+0] //  += LdsOffsetB (lower)
+
+
+s_load_dword s[sgprNumWorkGroups1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x80 //
+s_load_dword s[sgprNumFullBlocks], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x8c //
+s_load_dword s[sgprWgmRemainder1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x90 //
+s_load_dword s[sgprMagicNumberWgmRemainder1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x94 //
+/******************************************/
+/* Global Read Addresses                  */
+/******************************************/
+
+
+/* global read addresses: work-group */
+
+/* graWorkGroup mapping */
+s_mov_b32 s69, 0x20000001L                         // magic number for WGM==4
+s_mul_hi_u32 s67, s[sgprWorkGroup1], s69           // s_magic mul
+s_mul_i32 s66, s[sgprWorkGroup1], s69              // s_magic mul
+s_lshr_b64 s[66:67], s[66:67], 31                  // sMagicDiv
+s_mul_i32 s67, s66, 4                              // quotient * non-magic divisor
+s_sub_u32 s67, s[sgprWorkGroup1], s67              // WorkGroup1=remainder
+s_mul_i32 s67, s67, s[sgprNumWorkGroups0]          // (wg1 % WGM)*nwg0
+s_add_u32 s67, s67, s[sgprWorkGroup0]              // wgSerial = wg0 + (wg1 % WGM)*nwg0
+s_cmp_ge_u32 s66, s[sgprNumFullBlocks]             // blockId >= numFullBlocks ?
+s_cmov_b32 s69, s[sgprMagicNumberWgmRemainder1]    //
+s_cselect_b32 s68, s[sgprWgmRemainder1], 4         //
+s_mul_hi_u32 s3, s67, s69                          // s_magic mul
+s_mul_i32 s2, s67, s69                             // s_magic mul
+s_lshr_b64 s[2:3], s[2:3], 31                      // sMagicDiv
+s_mul_i32 s[sgprWorkGroup1], s[sgprWorkGroup0], s68 // quotient * non-magic divisor
+s_sub_u32 s[sgprWorkGroup1], s67, s[sgprWorkGroup1] // WorkGroup1=remainder
+s_mul_i32 s66, s66, 4                              // blockId * WGM
+s_add_u32 s[sgprWorkGroup1], s[sgprWorkGroup1], s66 // wg1 += blockId * WGM
+
+
+/* global read addresses: tile offset assignment a */
+
+/* LVCA = 24 */
+/* v0 = (local)groA-tile = serial%LVCA (note (wgA*MTA) will be added to SRD) */
+/* v1 = groA-unroll = serial/LVCA */
+s_mov_b32 s65, 0x15555556                          //
+v_mul_hi_u32 v3, v[vgprSerial], s65                //
+v_mul_lo_u32 v2, v[vgprSerial], s65                //
+v_lshrrev_b64 v[2:3], 0x21, v[2:3]                 //
+v_mov_b32 v1, v2                                   // vectorStaticDiv: quotient
+s_mov_b32 s65, 0x18                                // divisor
+v_mul_lo_u32 v2, v1, s65                           // vectorStaticDiv: product = quotient * divisor
+_v_sub_co_u32 v0, vcc, v[vgprSerial], v2           // vectorStaticDiv: remainder = dividend - product
+/* gro-tile *= glvw */
+v_lshlrev_b32 v0, 1, v0                            // staticMultiply: v0 = v0 * 2
+
+
+/* global read addresses: tile offset assignment b */
+
+/* LVCB = 32 */
+/* v2 = (local)groB-tile = serial%LVCB (note (wgB*MTB) will be added to SRD) */
+/* v3 = groB-unroll = serial/LVCB */
+v_lshrrev_b32 v3, 5, v[vgprSerial]                 // vectorStaticDiv: v3 = v[vgprSerial] / 32
+v_and_b32 v2, 31, v[vgprSerial]                    // vectorStaticDiv: v2 = v[vgprSerial] % 32
+/* gro-tile *= glvw */
+v_lshlrev_b32 v2, 1, v2                            // staticMultiply: v2 = v2 * 2
+
+
+/* global read addresses: unroll assignment a */
+
+/* v1 */
+
+
+/* global read addresses: unroll assignment b */
+
+/* v3 */
+
+
+/* global read addresses: other free assignments */
+
+/* s[sgprWorkGroup2] */
+
+
+/* global read addresses: tile offsets a */
+
+v_mov_b32 v4, v0                                   // groA0I_0
+
+
+/* global read addresses: tile offsets b */
+
+v_mov_b32 v5, v2                                   // groB1J_0
+
+
+/* global read addresses: unroll offsets a */
+
+v_mov_b32 v6, v1                                   // groAL_0
+
+
+/* global read addresses: unroll offsets b */
+
+v_mov_b32 v7, v3                                   // groBL_0
+
+
+/* global read addresses: shift a */
+
+s_mul_i32 s65, s[sgprWorkGroup0], 48               // WorkGroup[01] * MT
+s_sub_u32 s65, s[sgprSizesFree+0], s65             // edge = Size0I - WG*MT
+s_sub_u32 s65, s65, 2                              // edge -= margin
+v_mov_b32 v8, s65                                  // edge vgpr = Size0I-2
+_v_add_co_u32 v9, vcc, v8, 2                       // add srdShiftLift
+_v_add_co_u32 v10, vcc, v4, 2                      //
+v_cmp_lt_u32 s[66:67], v10, v9                     // offset < edge
+v_cndmask_b32 v4, v8, v4, s[66:67]                 // offset = (offset < edge) ? offset : edge
+
+
+/* global read addresses: shift b */
+
+s_mul_i32 s65, s[sgprWorkGroup1], 64               // WorkGroup[01] * MT
+s_sub_u32 s65, s[sgprSizesFree+1], s65             // edge = Size1J - WG*MT
+s_sub_u32 s65, s65, 2                              // edge -= margin
+v_mov_b32 v8, s65                                  // edge vgpr = Size1J-2
+_v_add_co_u32 v9, vcc, v8, 2                       // add srdShiftLift
+_v_add_co_u32 v10, vcc, v5, 2                      //
+v_cmp_lt_u32 s[66:67], v10, v9                     // offset < edge
+v_cndmask_b32 v5, v8, v5, s[66:67]                 // offset = (offset < edge) ? offset : edge
+
+
+/* global read addresses: final offsets a */
+
+GLOBAL_OFFSET_A vgprGlobalReadOffsetA+0,  4,  6, 8 // gROA_0_0_0_0
+// Offset only valid for 96/128 threads inside the PerLoadTile
+s_mov_b32 s66, 96                                  //
+v_cmp_lt_u32 vcc, v[vgprSerial], s66               // tid < valid-tid
+s_mov_b32 s66, BufferOOB                           //
+v_mov_b32 v11, s66                                 //
+v_cndmask_b32 v[vgprGlobalReadOffsetA+0], v11, v[vgprGlobalReadOffsetA+0], vcc // Mask load so OOB will return 0
+
+
+/* global read addresses: final offsets b */
+
+GLOBAL_OFFSET_B vgprGlobalReadOffsetB+0,  5,  7, 8 // gROB_0_0_0_0
+
+
+/* global read addresses: addresses a */
+
+/* max read offset = size[n] * stride[n-1] */
+s_mul_hi_u32 s69, s[sgprWorkGroup0], 48            // WorkGroup[01] * MT
+s_mul_i32 s68, s[sgprWorkGroup0], 48               // WorkGroup[01] * MT
+s_sub_u32 s[sgprShadowLimitA+0], s[sgprTensor2dSizeA], s68 // sub tileStart
+s_subb_u32 s[sgprShadowLimitA+1], s[sgprTensor2dSizeA+1], s69 // sub tileStart
+s_lshl_b64 s[sgprShadowLimitA:sgprShadowLimitA+1], s[sgprShadowLimitA:sgprShadowLimitA+1], 0x3 // Set limit to use bytes
+s_add_u32 s[sgprShadowLimitA+0], s[sgprShadowLimitA+0], 16 // extend limit for pre-pad
+s_addc_u32 s[sgprShadowLimitA+1], s[sgprShadowLimitA+1], 0 // extend limit for pre-pad
+s_cmp_eq_u32 s[sgprShadowLimitA+1], 0              // are we within 2^32?
+s_cselect_b32 s[sgprSrdA+2], s[sgprShadowLimitA+0], BufferLimit // Move shadow to real if we are within 2^32
+s_mul_hi_u32 s67, s[sgprStridesA+1], s[sgprWorkGroup2] // Stride*WG
+s_mul_i32 s66, s[sgprStridesA+1], s[sgprWorkGroup2] // Stride*WG
+s_add_u32 s68, s68, s66                            // accum wg term to tilestart
+s_addc_u32 s69, s69, s67                           // accum wg term to tilestart
+s_lshl_b64 s[68:69], s[68:69], 3                   // tileStart *= BPE
+s_add_u32 s[sgprSrdA+0], s[sgprAddressA+0], s68    // SRD base = Address+ tileStart0
+s_addc_u32 s[sgprSrdA+1], s[sgprAddressA+1], s69   // SRD base = Address+ tileStart1
+s_sub_u32 s[sgprSrdA+0], s[sgprSrdA+0], 16         // pre-pad to make room for possible pointer shift
+s_subb_u32 s[sgprSrdA+1], s[sgprSrdA+1], 0         // pre-pad to make room for possible pointer shift
+s_mov_b32 s[sgprSrdA+3], Srd127_96                 // Set bits 127_96 in SRD
+
+
+/* global read addresses: addresses b */
+
+/* max read offset = size[n] * stride[n-1] */
+s_mul_hi_u32 s69, s[sgprWorkGroup1], 64            // WorkGroup[01] * MT
+s_mul_i32 s68, s[sgprWorkGroup1], 64               // WorkGroup[01] * MT
+s_sub_u32 s[sgprShadowLimitB+0], s[sgprTensor2dSizeB], s68 // sub tileStart
+s_subb_u32 s[sgprShadowLimitB+1], s[sgprTensor2dSizeB+1], s69 // sub tileStart
+s_lshl_b64 s[sgprShadowLimitB:sgprShadowLimitB+1], s[sgprShadowLimitB:sgprShadowLimitB+1], 0x3 // Set limit to use bytes
+s_add_u32 s[sgprShadowLimitB+0], s[sgprShadowLimitB+0], 16 // extend limit for pre-pad
+s_addc_u32 s[sgprShadowLimitB+1], s[sgprShadowLimitB+1], 0 // extend limit for pre-pad
+s_cmp_eq_u32 s[sgprShadowLimitB+1], 0              // are we within 2^32?
+s_cselect_b32 s[sgprSrdB+2], s[sgprShadowLimitB+0], BufferLimit // Move shadow to real if we are within 2^32
+s_mul_hi_u32 s67, s[sgprStridesB+1], s[sgprWorkGroup2] // Stride*WG
+s_mul_i32 s66, s[sgprStridesB+1], s[sgprWorkGroup2] // Stride*WG
+s_add_u32 s68, s68, s66                            // accum wg term to tilestart
+s_addc_u32 s69, s69, s67                           // accum wg term to tilestart
+s_lshl_b64 s[68:69], s[68:69], 3                   // tileStart *= BPE
+s_add_u32 s[sgprSrdB+0], s[sgprAddressB+0], s68    // SRD base = Address+ tileStart0
+s_addc_u32 s[sgprSrdB+1], s[sgprAddressB+1], s69   // SRD base = Address+ tileStart1
+s_sub_u32 s[sgprSrdB+0], s[sgprSrdB+0], 16         // pre-pad to make room for possible pointer shift
+s_subb_u32 s[sgprSrdB+1], s[sgprSrdB+1], 0         // pre-pad to make room for possible pointer shift
+s_mov_b32 s[sgprSrdB+3], Srd127_96                 // Set bits 127_96 in SRD
+
+
+/* global read addresses: increments a */
+
+s_mul_i32 s[sgprGlobalReadIncsA+0], 0x20, s[sgprStridesA] // incr = stride*4*bytes
+
+
+/* global read addresses: increments b */
+
+s_mul_i32 s[sgprGlobalReadIncsB+0], 0x20, s[sgprStridesB] // incr = stride*4*bytes
+
+
+/******************************************/
+/* Local Write Addresses                  */
+/******************************************/
+
+
+/* local write addresses: tile assignment a */
+
+/* lwaTileA = v0 */
+
+
+/* local write addresses: tile assignment b */
+
+/* lwaTileB = v2 */
+
+
+/* local write addresses: unroll assignment a */
+
+/* lwaUnrollA = v1 */
+
+
+/* local write addresses: unroll assignment b */
+
+/* lwaUnrollB = v3 */
+
+
+/* local write addresses: first offset a */
+
+v_mul_u32_u24 v[vgprLocalWriteAddrA], 0x30, v1     // lwAL**(MTA + PAD)
+_v_add_lshl_u32 v[vgprLocalWriteAddrA], v0, v[vgprLocalWriteAddrA], 0x3 // lwFOA = (lwAA + lwAL*(MT0I+PAD))*bpe
+s_mov_b32 s65, 96                                  // lsc*lsp=48*4
+v_cmp_lt_u32 vcc, v[vgprSerial], s65               // fractional: ensure tid < global read tile elements
+v_mov_b32 v0, 0xf00000                             //
+v_cndmask_b32 v[vgprLocalWriteAddrA], v0, v[vgprLocalWriteAddrA], vcc // Mask load so out-of-gr-tile bounds returns 0
+
+
+/* local write addresses: first offset b */
+
+v_mul_u32_u24 v[vgprLocalWriteAddrB], 0x40, v3     // lwBL**(MTB + PAD)
+_v_add_lshl_u32 v[vgprLocalWriteAddrB], v2, v[vgprLocalWriteAddrB], 0x3 // lwFOB = (lwBB + lwBL*(MT1J+PAD))*bpe
+_v_add_co_u32 v[vgprLocalWriteAddrB], vcc, 0x600, v[vgprLocalWriteAddrB] // lwFOB = lwB1J + lwBL*MT1J + LDS_OFFSET_B=192*8
+
+
+/* local write addresses: final offsets a */
+
+
+/* N/A */
+
+
+/* local write addresses: final offsets b */
+
+
+/* N/A */
+
+
+/* local write addresses: declare addresses a */
+
+/* N/A */
+
+
+/* local write addresses: declare addresses b */
+
+/* N/A */
+
+
+/* local write addresses: init pointers a */
+
+/* N/A */
+
+
+/* local write addresses: init pointers b */
+
+/* N/A */
+
+
+/* declare loop num iterations */
+
+
+s_lshr_b32 s[sgprLoopCounters+0], s[sgprSizesSum+0], 2 // s[sgprLoopCounters+0] = s[sgprSizesSum+0] / 4
+s_mov_b32 s[sgprOrigLoopCounter], s[sgprLoopCounters+0] // copy loop counter
+s_sub_u32 s[sgprLoopCounters+0], 0x0, s[sgprLoopCounters+0] // counterL = -sizeL
+
+
+/* local read addresses: init pointers a */
+
+
+
+/* local read addresses: init pointers b */
+
+
+
+/* TODO-packed- compare against product of all packed C0 sizes not just SizesFree+0 */
+s_mov_b32 s91, 0x0                                 // STATIC_DIV: divisior=48
+s_mul_i32 s90, 0xaaa, s[sgprSizesFree+0]           // tmp1 = dividend * magic hi
+s_lshl_b64 s[90:91], s[90:91], 0x10                // left shift 16 bits
+s_mul_i32 s82, s[sgprSizesFree+0], 0xaaab          // tmp0 = dividend * magic lo
+s_add_u32 s90, s82, s90                            // add lo
+s_addc_u32 s91, s91, 0x0                           // add hi
+s_lshr_b64 s[90:91], s[90:91], 0x21                // tmp1 = (dividend * magic) << shift
+s_mov_b32 s82, s90                                 // quotient
+s_mul_i32 s90, s82, 0x30                           // quotient*divisor
+s_sub_u32 s[sgprEdgeSelMask0], s[sgprSizesFree+0], s90             // rReg = dividend - quotient*divisor
+s_lshr_b32 s82, s[sgprSizesFree+1], 6              // s58 = s[sgprSizesFree+1] / 64
+s_and_b32 s[sgprEdgeSelMask1], 63, s[sgprSizesFree+1]
+
+
+/* prefetch: global -> local */
+
+s_cmp_eq_u32 s[sgprLoopCounters+0], 0x0            // numIter0I == 0
+s_cbranch_scc1 label_0008                          // skip to ShadowInitStart iter b/c numIter==0
+
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+
+
+/* global read inc A */
+s_add_u32  s[sgprSrdA+0], s[sgprSrdA+0], s[sgprGlobalReadIncsA] // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdA+1], s[sgprSrdA+1], 0        // gra SRD += inc(upper)
+s_sub_u32 s[sgprShadowLimitA+0], s[sgprShadowLimitA+0], s[sgprGlobalReadIncsA] // limit -= inc)
+s_subb_u32 s[sgprShadowLimitA+1], s[sgprShadowLimitA+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitA+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdA+2], s[sgprShadowLimitA+0]    // Move shadow to real if we are within 2^32
+
+
+/* global read inc B */
+s_add_u32  s[sgprSrdB+0], s[sgprSrdB+0], s[sgprGlobalReadIncsB] // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdB+1], s[sgprSrdB+1], 0        // gra SRD += inc(upper)
+s_sub_u32 s[sgprShadowLimitB+0], s[sgprShadowLimitB+0], s[sgprGlobalReadIncsB] // limit -= inc)
+s_subb_u32 s[sgprShadowLimitB+1], s[sgprShadowLimitB+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitB+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdB+2], s[sgprShadowLimitB+0]    // Move shadow to real if we are within 2^32
+
+label_0008: // ShadowInitStart
+
+s_mov_b32 s[sgprSrdD+0], s[sgprAddressD+0]         // init SRD base address (lower)
+s_mov_b32 s[sgprSrdD+1], s[sgprAddressD+1]         // init SRD base address (upper) + other fields
+s_mov_b32 s[sgprSrdD+2], 0x80000000                //
+s_mov_b32 s[sgprSrdD+3], Srd127_96                 // Set bits 127_96 in SRD
+s_mov_b32 s[sgprSrdC+0], s[sgprAddressC+0]         // init SRD base address (lower)
+s_mov_b32 s[sgprSrdC+1], s[sgprAddressC+1]         // init SRD base address (upper) + other fields
+s_mov_b32 s[sgprSrdC+2], 0x80000000                //
+s_mov_b32 s[sgprSrdC+3], Srd127_96                 // Set bits 127_96 in SRD
+
+s_mul_i32 s[sgprTMP1], 0x40, s[sgprWorkGroup1]             // <- wg1*MT1
+s_mul_i32 s[sgprTMP0], 0x30, s[sgprWorkGroup1]             // <- wg1*MT1
+s_mul_hi_u32 s67, s[sgprTMP1], s[sgprStridesC+0]           // Scale s68 by Stride
+s_mul_i32 s66, s[sgprTMP1], s[sgprStridesC+0]              // Scale s68 by Stride
+s_lshl_b64 s[66:67], s[66:67], 3                   // scale by bpe
+s_add_u32 s[sgprSrdD+0], s[sgprSrdD+0], s66        // add lo to SRD
+s_addc_u32 s[sgprSrdD+1], s[sgprSrdD+1], s67       // add hi to SRD
+s_add_u32 s[sgprSrdC+0], s[sgprSrdC+0], s66        // add lo to SRD
+s_addc_u32 s[sgprSrdC+1], s[sgprSrdC+1], s67       // add hi to SRD
+
+s_mul_hi_u32 s67, s[sgprWorkGroup2], s[sgprStridesC+1] // Scale s[sgprWorkGroup2] by Stride
+s_mul_i32 s66, s[sgprWorkGroup2], s[sgprStridesC+1] // Scale s[sgprWorkGroup2] by Stride
+s_lshl_b64 s[66:67], s[66:67], 3                   // scale by bpe
+s_add_u32 s[sgprSrdD+0], s[sgprSrdD+0], s66        // add lo to SRD
+s_addc_u32 s[sgprSrdD+1], s[sgprSrdD+1], s67       // add hi to SRD
+s_add_u32 s[sgprSrdC+0], s[sgprSrdC+0], s66        // add lo to SRD
+s_addc_u32 s[sgprSrdC+1], s[sgprSrdC+1], s67       // add hi to SRD
+
+
+v_mov_b32 v[vgprValuC+0], 0x0                      // initC
+v_mov_b32 v[vgprValuC+1], 0x0                      // initC
+v_mov_b32 v[vgprValuC+2], 0x0                      // initC
+v_mov_b32 v[vgprValuC+3], 0x0                      // initC
+v_mov_b32 v[vgprValuC+4], 0x0                      // initC
+v_mov_b32 v[vgprValuC+5], 0x0                      // initC
+v_mov_b32 v[vgprValuC+6], 0x0                      // initC
+v_mov_b32 v[vgprValuC+7], 0x0                      // initC
+v_mov_b32 v[vgprValuC+8], 0x0                      // initC
+v_mov_b32 v[vgprValuC+9], 0x0                      // initC
+v_mov_b32 v[vgprValuC+10], 0x0                     // initC
+v_mov_b32 v[vgprValuC+11], 0x0                     // initC
+v_mov_b32 v[vgprValuC+12], 0x0                     // initC
+v_mov_b32 v[vgprValuC+13], 0x0                     // initC
+v_mov_b32 v[vgprValuC+14], 0x0                     // initC
+v_mov_b32 v[vgprValuC+15], 0x0                     // initC
+v_mov_b32 v[vgprValuC+16], 0x0                     // initC
+v_mov_b32 v[vgprValuC+17], 0x0                     // initC
+v_mov_b32 v[vgprValuC+18], 0x0                     // initC
+v_mov_b32 v[vgprValuC+19], 0x0                     // initC
+v_mov_b32 v[vgprValuC+20], 0x0                     // initC
+v_mov_b32 v[vgprValuC+21], 0x0                     // initC
+v_mov_b32 v[vgprValuC+22], 0x0                     // initC
+v_mov_b32 v[vgprValuC+23], 0x0                     // initC
+v_mov_b32 v[vgprValuC+24], 0x0                     // initC
+v_mov_b32 v[vgprValuC+25], 0x0                     // initC
+v_mov_b32 v[vgprValuC+26], 0x0                     // initC
+v_mov_b32 v[vgprValuC+27], 0x0                     // initC
+v_mov_b32 v[vgprValuC+28], 0x0                     // initC
+v_mov_b32 v[vgprValuC+29], 0x0                     // initC
+v_mov_b32 v[vgprValuC+30], 0x0                     // initC
+v_mov_b32 v[vgprValuC+31], 0x0                     // initC
+v_mov_b32 v[vgprValuC+32], 0x0                     // initC
+v_mov_b32 v[vgprValuC+33], 0x0                     // initC
+v_mov_b32 v[vgprValuC+34], 0x0                     // initC
+v_mov_b32 v[vgprValuC+35], 0x0                     // initC
+v_mov_b32 v[vgprValuC+36], 0x0                     // initC
+v_mov_b32 v[vgprValuC+37], 0x0                     // initC
+v_mov_b32 v[vgprValuC+38], 0x0                     // initC
+v_mov_b32 v[vgprValuC+39], 0x0                     // initC
+v_mov_b32 v[vgprValuC+40], 0x0                     // initC
+v_mov_b32 v[vgprValuC+41], 0x0                     // initC
+v_mov_b32 v[vgprValuC+42], 0x0                     // initC
+v_mov_b32 v[vgprValuC+43], 0x0                     // initC
+v_mov_b32 v[vgprValuC+44], 0x0                     // initC
+v_mov_b32 v[vgprValuC+45], 0x0                     // initC
+v_mov_b32 v[vgprValuC+46], 0x0                     // initC
+v_mov_b32 v[vgprValuC+47], 0x0                     // initC
+s_cmp_eq_u32 s[sgprLoopCounters+0], 0x0            // numIter0I == 0
+s_cbranch_scc1 label_0004                          // after InitC, skip to end of prefetch last iter b/c numIter==0
+
+s_waitcnt vmcnt(0)                                 // 8wait for global read
+
+
+/* local write a */
+
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:0 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 0
+
+
+/* local write b */
+
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:0 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 0
+
+
+/* local write swap a */
+
+
+
+/* local write swap b */
+
+
+
+/* local write init pointers a */
+
+/* N/A */
+
+
+/* local write init pointers b */
+
+/* N/A */
+
+/******************************************/
+/* Unrolled Loop(s) - Begin               */
+/******************************************/
+
+s_cmp_ge_i32 s[sgprLoopCounters+0], 0x0            // LoopCounterL < EndCounter
+s_cbranch_scc1 label_0004                          // don't enter LoopL
+label_0001:
+
+
+/******************************************/
+/* Unroll Loop 1/2 - Begin                */
+/******************************************/
+
+s_barrier //4sync for global read
+
+s_cmp_eq_i32 s[sgprLoopCounters+0], -1             // is this the last iteration
+s_cmov_b32 s[sgprSrdA+2], 0                        // Set limit to 0 for last iteration
+s_cmov_b32 s[sgprSrdB+2], 0                        // Set limit to 0 for last iteration
+
+s_waitcnt lgkmcnt(0)                               // 1wait for local write
+
+
+
+
+/* iter 0 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(2)                               // wait for prior local read old=0 new=0
+//MAC_6x4_X0
+MAC_6x4_X0_part_1
+
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:384 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:512 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* global read inc A */
+s_add_u32  s[sgprSrdA+0], s[sgprSrdA+0], s[sgprGlobalReadIncsA] // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdA+1], s[sgprSrdA+1], 0        // gra SRD += inc(upper)
+s_sub_u32 s[sgprShadowLimitA+0], s[sgprShadowLimitA+0], s[sgprGlobalReadIncsA] // limit -= inc)
+s_subb_u32 s[sgprShadowLimitA+1], s[sgprShadowLimitA+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitA+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdA+2], s[sgprShadowLimitA+0]    // Move shadow to real if we are within 2^32
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:640 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(2)                               // wait for prior local read old=0 new=0
+//MAC_6x4_X0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:768 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* global read inc B */
+s_add_u32  s[sgprSrdB+0], s[sgprSrdB+0], s[sgprGlobalReadIncsB] // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdB+1], s[sgprSrdB+1], 0        // gra SRD += inc(upper)
+s_sub_u32 s[sgprShadowLimitB+0], s[sgprShadowLimitB+0], s[sgprGlobalReadIncsB] // limit -= inc)
+s_subb_u32 s[sgprShadowLimitB+1], s[sgprShadowLimitB+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitB+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdB+2], s[sgprShadowLimitB+0]    // Move shadow to real if we are within 2^32
+
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:896 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1024 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 2 writesPerItem=1 */
+s_waitcnt vmcnt(1)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:4096 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 4096
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(3)                               // wait for prior local read old=0 new=0
+//MAC_6x4_X0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(1)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+/* iter 3 (last) */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:1152 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1280 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1408 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 3 writesPerItem=1 */
+s_waitcnt vmcnt(0)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:4096 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 4096
+
+/* local write swap offsets a */
+
+/* local write swap offsets b */
+
+/* local write init pointers a */
+/* N/A */
+
+/* local write init pointers b */
+/* N/A */
+
+/* local read swap offsets a */
+
+/* local read swap internal offset -> 4096 */
+
+/* local read swap offsets b */
+
+/* local read swap internal offset -> 4096 */
+
+/* local read init pointers a */
+
+/* local read init pointers b */
+s_waitcnt lgkmcnt(3)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(1)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0_part_3
+
+/******************************************/
+/* Unrolled Loop - End 1/2                */
+/******************************************/
+
+s_add_u32 s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+s_cmp_eq_i32 s[sgprLoopCounters+0],  -2            // counterL==0
+s_cbranch_scc1 label_0003                          // exit LoopL
+
+
+/******************************************/
+/* Unroll Loop 2/2 - Begin                */
+/******************************************/
+
+s_barrier //4sync for global read
+
+s_cmp_eq_i32 s[sgprLoopCounters+0], -1             // is this the last iteration
+s_cmov_b32 s[sgprSrdA+2], 0                        // Set limit to 0 for last iteration
+s_cmov_b32 s[sgprSrdB+2], 0                        // Set limit to 0 for last iteration
+
+s_waitcnt lgkmcnt(0)                               // 1wait for local write
+
+
+
+
+/* iter 0 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4096 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4224 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4352 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(2)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4480 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4608 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* global read inc A */
+s_add_u32  s[sgprSrdA+0], s[sgprSrdA+0], s[sgprGlobalReadIncsA] // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdA+1], s[sgprSrdA+1], 0        // gra SRD += inc(upper)
+s_sub_u32 s[sgprShadowLimitA+0], s[sgprShadowLimitA+0], s[sgprGlobalReadIncsA] // limit -= inc)
+s_subb_u32 s[sgprShadowLimitA+1], s[sgprShadowLimitA+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitA+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdA+2], s[sgprShadowLimitA+0]    // Move shadow to real if we are within 2^32
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4736 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(2)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4864 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* global read inc B */
+s_add_u32  s[sgprSrdB+0], s[sgprSrdB+0], s[sgprGlobalReadIncsB] // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdB+1], s[sgprSrdB+1], 0        // gra SRD += inc(upper)
+s_sub_u32 s[sgprShadowLimitB+0], s[sgprShadowLimitB+0], s[sgprGlobalReadIncsB] // limit -= inc)
+s_subb_u32 s[sgprShadowLimitB+1], s[sgprShadowLimitB+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitB+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdB+2], s[sgprShadowLimitB+0]    // Move shadow to real if we are within 2^32
+
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4992 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5120 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 2 writesPerItem=1 */
+s_waitcnt vmcnt(1)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:0 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 0
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(3)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(1)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:5248 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=192 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=192 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5376 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5504 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 3 writesPerItem=1 */
+s_waitcnt vmcnt(0)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:0 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 0
+
+/* local write swap offsets a */
+
+/* local write swap offsets b */
+
+/* local write init pointers a */
+/* N/A */
+
+/* local write init pointers b */
+/* N/A */
+
+/* local read swap offsets a */
+
+/* local read swap internal offset -> 0 */
+
+/* local read swap offsets b */
+
+/* local read swap internal offset -> 0 */
+
+/* local read init pointers a */
+
+/* local read init pointers b */
+s_waitcnt lgkmcnt(3)                               // 6wait for local read old=3 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(1)                               // 6wait for local read old=1 new=0
+MAC_6x4_X0_part_3
+
+/******************************************/
+/* Unrolled Loop - End 2/2 (final)        */
+/******************************************/
+
+s_add_u32 s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+s_cmp_eq_i32 s[sgprLoopCounters+0], -2              // counterL==0
+s_cbranch_scc0 label_0001                          // restart LoopL
+s_cbranch_scc1 label_0002                          // restart LoopL
+
+label_0003: // unroll loop odditer exit
+
+//check edge Batch calculation needed
+//for Batch edge jump to different beta loop optimization code
+s_add_u32      s83,-0x1, s[sgprNumWorkGroups0]       //
+s_cmp_lt_u32   s[sgprWorkGroup0], s83                // wg0 < nwg0-1
+s_cmov_b32     s[sgprEdgeSelMask0], 0x0
+s_cmpk_gt_u32  s[sgprEdgeSelMask0], 0x0
+s_cbranch_scc1 label_1003                            // wg1 < nwg1-1 so skip rMT1 = Size1 % MT1
+s_add_u32      s83, -0x1, s[sgprNumWorkGroups1]      //
+s_cmp_lt_u32   s[sgprWorkGroup1], s83                // wg1 < nwg1-1
+s_cmov_b32     s[sgprEdgeSelMask1], 0x0
+s_cmpk_gt_u32  s[sgprEdgeSelMask1], 0x0
+s_cbranch_scc1 label_1003                            // wg1 < nwg1-1 so skip rMT1 = Size1 % MT1
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4224 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4480 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4608 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4736 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4864 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4992 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5120 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:0 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 4096
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(1)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:5248 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5376 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5504 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_mul_i32 s56, 0x30, s[sgprWorkGroup0]             // s56 = wg0*MT0
+s_mul_i32 s58, 0x40, s[sgprWorkGroup1]             // s56 = wg0*MT0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 3 writesPerItem=1 */
+s_waitcnt vmcnt(0)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:0 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 4096
+
+s_waitcnt lgkmcnt(1)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0_unprio_0
+v_lshrrev_b32 v[vgprLocalWriteAddrB], 3, v[vgprSerial]                // vectorStaticDiv: v49 = v[vgprSerial] / 8
+v_and_b32 v[vgprLocalWriteAddrA], 7, v[vgprSerial]                    // vectorStaticDiv: v48 = v[vgprSerial] % 8
+v_lshlrev_b32 v[vgprLocalWriteAddrA], 1, v[vgprLocalWriteAddrA]       // staticMultiply: v48 = v48 * 2
+v_lshlrev_b32 v[vgprLocalWriteAddrB], 1, v[vgprLocalWriteAddrB]       // staticMultiply: v49 = v49 * 2
+v_mul_lo_u32 v[vgprGlobalReadOffsetB], v[vgprLocalWriteAddrB], s[sgprStridesC+0]           // rowStart vgpr
+_v_add_co_u32 v[vgprLocalWriteAddrA], vcc, s56, v[vgprLocalWriteAddrA]                   // coord0 = tid0*VW + wg0*MT0
+_v_add_lshl_u32 v[vgprGlobalReadOffsetA], v[vgprGlobalReadOffsetB], v[vgprLocalWriteAddrA], 0x3                 // init cb addr <-  rowStart + coord0, scaled by BPE
+s_setprio 0
+
+s_add_u32       s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+s_cmp_eq_i32    s[sgprLoopCounters+0], -1             // is this the last iteration
+s_cmov_b32 	s[sgprSrdA+2], 0                        // Set limit to 0 for last iteration
+s_cmov_b32 	s[sgprSrdB+2], 0                        // Set limit to 0 for last iteration
+s_mov_b32 	s85, s[sgprSrdC+0]
+s_mov_b32 	s86, s[sgprSrdC+1]
+s_mov_b32       s87, s[sgprSrdD+0]
+s_mov_b32       s88, s[sgprSrdD+1]
+
+
+s_waitcnt lgkmcnt(0)                               // 1wait for local write
+s_barrier //4sync for global read
+
+/* iter 0,1 */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:384 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part1
+
+/* iter 1 */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:768  // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1152 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part1
+
+
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:512 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+0:vgprValuC+0+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+0:vgprValuC+0+1] // *= alpha
+v_mul_f64 v[vgprValuC+2:vgprValuC+2+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+2:vgprValuC+2+1] // *= alpha
+v_fma_f64 v[vgprValuC+0:vgprValuC+0+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+0:vgprValuC+0+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+2:vgprValuC+2+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+2:vgprValuC+2+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[0:3], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+12:vgprValuC+12+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+12:vgprValuC+12+1] // *= alpha
+v_mul_f64 v[vgprValuC+14:vgprValuC+14+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+14:vgprValuC+14+1] // *= alpha
+v_fma_f64 v[vgprValuC+12:vgprValuC+12+1], v[vgprG2LB+0:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+12:vgprValuC+12+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+14:vgprValuC+14+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+14:vgprValuC+14+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[12:15], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part2
+
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:896 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1280 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part2
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:640 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+4:vgprValuC+4+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+4:vgprValuC+4+1] // *= alpha
+v_mul_f64 v[vgprValuC+6:vgprValuC+6+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+6:vgprValuC+6+1] // *= alpha
+v_fma_f64 v[vgprValuC+4:vgprValuC+4+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+4:vgprValuC+4+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+6:vgprValuC+6+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+6:vgprValuC+6+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[4:7], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+16:vgprValuC+16+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+16:vgprValuC+16+1] // *= alpha
+v_mul_f64 v[vgprValuC+18:vgprValuC+18+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+18:vgprValuC+18+1] // *= alpha
+v_fma_f64 v[vgprValuC+16:vgprValuC+16+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+16:vgprValuC+16+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+18:vgprValuC+18+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+18:vgprValuC+18+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[16:19], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part3
+
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1024 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:1408 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part3
+
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:384 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+8:vgprValuC+8+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+8:vgprValuC+8+1] // *= alpha
+v_mul_f64 v[vgprValuC+10:vgprValuC+10+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+10:vgprValuC+10+1] // *= alpha
+v_fma_f64 v[vgprValuC+8:vgprValuC+8+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+8:vgprValuC+8+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+10:vgprValuC+10+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+10:vgprValuC+10+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[8:11], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+20:vgprValuC+20+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+20:vgprValuC+20+1] // *= alpha
+v_mul_f64 v[vgprValuC+22:vgprValuC+22+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+22:vgprValuC+22+1] // *= alpha
+v_fma_f64 v[vgprValuC+20:vgprValuC+20+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+20:vgprValuC+20+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+22:vgprValuC+22+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+22:vgprValuC+22+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[20:23], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_mul_i32  s56, s[sgprStridesC+0], 248              // Scale by BPE
+s_add_u32   s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+s_mov_b32   s85, s[sgprSrdC+0]
+s_mov_b32   s86, s[sgprSrdC+1]                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part4
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:768 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+s_lshl_b32   s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32   s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1152 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part4
+
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+s_mul_i32   s56, s[sgprStridesD+0], 248              // Scale by BPE
+s_add_u32   s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:512 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+24:vgprValuC+24+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+24:vgprValuC+24+1] // *= alpha
+v_mul_f64 v[vgprValuC+26:vgprValuC+26+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+26:vgprValuC+26+1] // *= alpha
+v_fma_f64 v[vgprValuC+24:vgprValuC+24+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+24:vgprValuC+24+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+26:vgprValuC+26+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+26:vgprValuC+26+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[24:27], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_mov_b32       s87, s[sgprSrdD+0]
+s_mov_b32       s88, s[sgprSrdD+1]                 /* local read init pointers b */
+s_lshl_b32      s56, s[sgprStridesD+0], 3         // Scale     s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_add_u32       s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32      s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+36:vgprValuC+36+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+36:vgprValuC+36+1] // *= alpha
+v_mul_f64 v[vgprValuC+38:vgprValuC+38+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+38:vgprValuC+38+1] // *= alpha
+v_fma_f64 v[vgprValuC+36:vgprValuC+36+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+36:vgprValuC+36+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+38:vgprValuC+38+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+38:vgprValuC+38+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[36:39], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0_part5
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:896 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1280 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part5
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:640 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+28:vgprValuC+28+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+28:vgprValuC+28+1] // *= alpha
+v_mul_f64 v[vgprValuC+30:vgprValuC+30+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+30:vgprValuC+30+1] // *= alpha
+v_fma_f64 v[vgprValuC+28:vgprValuC+28+1], v[vgprG2LA+0:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+28:vgprValuC+28+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+30:vgprValuC+30+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+30:vgprValuC+30+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[28:31], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+40:vgprValuC+40+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+40:vgprValuC+40+1] // *= alpha
+v_mul_f64 v[vgprValuC+42:vgprValuC+42+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+42:vgprValuC+42+1] // *= alpha
+v_fma_f64 v[vgprValuC+40:vgprValuC+40+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+40:vgprValuC+40+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+42:vgprValuC+42+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+42:vgprValuC+42+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[40:43], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part6
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1024 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1408 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part6
+
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+32:vgprValuC+32+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+32:vgprValuC+32+1] // *= alpha
+v_mul_f64 v[vgprValuC+34:vgprValuC+34+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+34:vgprValuC+34+1] // *= alpha
+v_fma_f64 v[vgprValuC+32:vgprValuC+32+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+32:vgprValuC+32+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+34:vgprValuC+34+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+34:vgprValuC+34+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[32:35], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_lshl_b32  s56, 	   s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32   s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+
+v_mul_f64 v[vgprValuC+44:vgprValuC+44+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+44:vgprValuC+44+1] // *= alpha
+v_mul_f64 v[vgprValuC+46:vgprValuC+46+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+46:vgprValuC+46+1] // *= alpha
+v_fma_f64 v[vgprValuC+44:vgprValuC+44+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+44:vgprValuC+44+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+46:vgprValuC+46+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+46:vgprValuC+46+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[44:47], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_add_u32            s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+
+
+s_endpgm
+
+label_0002:
+
+/* TODO-packed- compare against product of all packed C0 sizes not just SizesFree+0 */
+//s_mov_b32 s91, 0x0                                 // STATIC_DIV: divisior=48
+//s_mul_i32 s90, 0xaaa, s[sgprSizesFree+0]           // tmp1 = dividend * magic hi
+//s_lshl_b64 s[90:91], s[90:91], 0x10                // left shift 16 bits
+//s_mul_i32 s82, s[sgprSizesFree+0], 0xaaab          // tmp0 = dividend * magic lo
+//s_add_u32 s90, s82, s90                            // add lo
+//s_addc_u32 s91, s91, 0x0                           // add hi
+//s_lshr_b64 s[90:91], s[90:91], 0x21                // tmp1 = (dividend * magic) << shift
+//s_mov_b32 s82, s90                                 // quotient
+//s_mul_i32 s90, s82, 0x30                           // quotient*divisor
+//s_sub_u32 s[sgprEdgeSelMask0], s[sgprSizesFree+0], s90             // rReg = dividend - quotient*divisor
+//s_lshr_b32 s82, s[sgprSizesFree+1], 6              // s58 = s[sgprSizesFree+1] / 64
+//s_and_b32 s[sgprEdgeSelMask1], 63, s[sgprSizesFree+1]
+
+//check edge Batch calculation needed
+//for Batch edge jump to different beta loop optimization code
+s_add_u32      s83,-0x1, s[sgprNumWorkGroups0]       //
+s_cmp_lt_u32   s[sgprWorkGroup0], s83                // wg0 < nwg0-1
+s_cmov_b32     s[sgprEdgeSelMask0], 0x0
+s_cmpk_gt_u32  s[sgprEdgeSelMask0], 0x0
+s_cbranch_scc1 label_1002                            // wg1 < nwg1-1 so skip rMT1 = Size1 % MT1
+s_add_u32      s83, -0x1, s[sgprNumWorkGroups1]      //
+s_cmp_lt_u32   s[sgprWorkGroup1], s83                // wg1 < nwg1-1
+s_cmov_b32     s[sgprEdgeSelMask1], 0x0
+s_cmpk_gt_u32  s[sgprEdgeSelMask1], 0x0
+s_cbranch_scc1 label_1002                            // wg1 < nwg1-1 so skip rMT1 = Size1 % MT1
+
+/******************************************/
+
+s_waitcnt lgkmcnt(0)                                 // 1wait for local write
+s_barrier //4sync for global read
+
+/* iter 0 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(2)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:384 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:512 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:640 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(2)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:768 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:896 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1024 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:4096 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 4096
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(3)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(1)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:1152 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1280 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+s_mul_i32 s56, 0x30, s[sgprWorkGroup0]             // s56 = wg0*MT0
+s_mul_i32 s58, 0x40, s[sgprWorkGroup1]             // s56 = wg0*MT0
+/* sched write - iter 3 writesPerItem=1 */
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1408 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(0)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:4096 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 4096
+
+s_waitcnt lgkmcnt(1)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0_unprio_0
+v_lshrrev_b32 v[vgprLocalWriteAddrB], 3, v[vgprSerial]                // vectorStaticDiv: v49 = v[vgprSerial] / 8
+v_and_b32 v[vgprLocalWriteAddrA], 7, v[vgprSerial]                    // vectorStaticDiv: v48 = v[vgprSerial] % 8
+v_lshlrev_b32 v[vgprLocalWriteAddrA], 1, v[vgprLocalWriteAddrA]       // staticMultiply: v48 = v48 * 2
+v_lshlrev_b32 v[vgprLocalWriteAddrB], 1, v[vgprLocalWriteAddrB]       // staticMultiply: v49 = v49 * 2
+v_mul_lo_u32 v[vgprGlobalReadOffsetB], v[vgprLocalWriteAddrB], s[sgprStridesC+0]           // rowStart vgpr
+_v_add_co_u32 v[vgprLocalWriteAddrA], vcc, s56, v[vgprLocalWriteAddrA]                   // coord0 = tid0*VW + wg0*MT0
+_v_add_lshl_u32 v[vgprGlobalReadOffsetA], v[vgprGlobalReadOffsetB], v[vgprLocalWriteAddrA], 0x3                 // init cb addr <-  rowStart + coord0, scaled by BPE
+s_setprio 0
+
+s_add_u32       s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+s_cmp_eq_i32    s[sgprLoopCounters+0], -1             // is this the last iteration
+s_cmov_b32 	s[sgprSrdA+2], 0                        // Set limit to 0 for last iteration
+s_cmov_b32 	s[sgprSrdB+2], 0                        // Set limit to 0 for last iteration
+s_mov_b32 	s85, s[sgprSrdC+0]
+s_mov_b32 	s86, s[sgprSrdC+1]
+s_mov_b32       s87, s[sgprSrdD+0]
+s_mov_b32       s88, s[sgprSrdD+1]
+
+
+s_waitcnt lgkmcnt(0)                               // 1wait for local write
+s_barrier //4sync for global read
+
+/* iter 0,1 */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4480 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part1
+
+/* iter 1 */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4864 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5248 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part1
+
+
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4224 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4608 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+0:vgprValuC+0+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+0:vgprValuC+0+1] // *= alpha
+v_mul_f64 v[vgprValuC+2:vgprValuC+2+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+2:vgprValuC+2+1] // *= alpha
+v_fma_f64 v[vgprValuC+0:vgprValuC+0+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+0:vgprValuC+0+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+2:vgprValuC+2+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+2:vgprValuC+2+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[0:3], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+12:vgprValuC+12+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+12:vgprValuC+12+1] // *= alpha
+v_mul_f64 v[vgprValuC+14:vgprValuC+14+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+14:vgprValuC+14+1] // *= alpha
+v_fma_f64 v[vgprValuC+12:vgprValuC+12+1], v[vgprG2LB+0:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+12:vgprValuC+12+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+14:vgprValuC+14+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+14:vgprValuC+14+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[12:15], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part2
+
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4992 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5376 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part2
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4736 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+4:vgprValuC+4+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+4:vgprValuC+4+1] // *= alpha
+v_mul_f64 v[vgprValuC+6:vgprValuC+6+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+6:vgprValuC+6+1] // *= alpha
+v_fma_f64 v[vgprValuC+4:vgprValuC+4+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+4:vgprValuC+4+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+6:vgprValuC+6+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+6:vgprValuC+6+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[4:7], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+16:vgprValuC+16+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+16:vgprValuC+16+1] // *= alpha
+v_mul_f64 v[vgprValuC+18:vgprValuC+18+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+18:vgprValuC+18+1] // *= alpha
+v_fma_f64 v[vgprValuC+16:vgprValuC+16+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+16:vgprValuC+16+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+18:vgprValuC+18+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+18:vgprValuC+18+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[16:19], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part3
+
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5120 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:5504 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part3
+
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4480 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+8:vgprValuC+8+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+8:vgprValuC+8+1] // *= alpha
+v_mul_f64 v[vgprValuC+10:vgprValuC+10+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+10:vgprValuC+10+1] // *= alpha
+v_fma_f64 v[vgprValuC+8:vgprValuC+8+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+8:vgprValuC+8+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+10:vgprValuC+10+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+10:vgprValuC+10+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[8:11], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+20:vgprValuC+20+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+20:vgprValuC+20+1] // *= alpha
+v_mul_f64 v[vgprValuC+22:vgprValuC+22+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+22:vgprValuC+22+1] // *= alpha
+v_fma_f64 v[vgprValuC+20:vgprValuC+20+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+20:vgprValuC+20+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+22:vgprValuC+22+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+22:vgprValuC+22+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[20:23], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_mul_i32  s56, s[sgprStridesC+0], 248              // Scale by BPE
+s_add_u32   s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+s_mov_b32   s85, s[sgprSrdC+0]
+s_mov_b32   s86, s[sgprSrdC+1]                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part4
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4864 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+s_lshl_b32   s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32   s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5248 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part4
+
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4224 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+s_mul_i32   s56, s[sgprStridesD+0], 248              // Scale by BPE
+s_add_u32   s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4608 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+24:vgprValuC+24+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+24:vgprValuC+24+1] // *= alpha
+v_mul_f64 v[vgprValuC+26:vgprValuC+26+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+26:vgprValuC+26+1] // *= alpha
+v_fma_f64 v[vgprValuC+24:vgprValuC+24+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+24:vgprValuC+24+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+26:vgprValuC+26+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+26:vgprValuC+26+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[24:27], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_mov_b32       s87, s[sgprSrdD+0]
+s_mov_b32       s88, s[sgprSrdD+1]                 /* local read init pointers b */
+s_lshl_b32      s56, s[sgprStridesD+0], 3         // Scale     s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_add_u32       s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32      s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+36:vgprValuC+36+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+36:vgprValuC+36+1] // *= alpha
+v_mul_f64 v[vgprValuC+38:vgprValuC+38+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+38:vgprValuC+38+1] // *= alpha
+v_fma_f64 v[vgprValuC+36:vgprValuC+36+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+36:vgprValuC+36+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+38:vgprValuC+38+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+38:vgprValuC+38+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[36:39], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0_part5
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4992 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5376 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part5
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4736 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+28:vgprValuC+28+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+28:vgprValuC+28+1] // *= alpha
+v_mul_f64 v[vgprValuC+30:vgprValuC+30+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+30:vgprValuC+30+1] // *= alpha
+v_fma_f64 v[vgprValuC+28:vgprValuC+28+1], v[vgprG2LA+0:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+28:vgprValuC+28+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+30:vgprValuC+30+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+30:vgprValuC+30+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[28:31], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+40:vgprValuC+40+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+40:vgprValuC+40+1] // *= alpha
+v_mul_f64 v[vgprValuC+42:vgprValuC+42+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+42:vgprValuC+42+1] // *= alpha
+v_fma_f64 v[vgprValuC+40:vgprValuC+40+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+40:vgprValuC+40+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+42:vgprValuC+42+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+42:vgprValuC+42+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[40:43], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part6
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5120 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5504 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part6
+
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+32:vgprValuC+32+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+32:vgprValuC+32+1] // *= alpha
+v_mul_f64 v[vgprValuC+34:vgprValuC+34+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+34:vgprValuC+34+1] // *= alpha
+v_fma_f64 v[vgprValuC+32:vgprValuC+32+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+32:vgprValuC+32+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+34:vgprValuC+34+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+34:vgprValuC+34+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[32:35], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_lshl_b32  s56, 	   s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32   s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+
+v_mul_f64 v[vgprValuC+44:vgprValuC+44+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+44:vgprValuC+44+1] // *= alpha
+v_mul_f64 v[vgprValuC+46:vgprValuC+46+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+46:vgprValuC+46+1] // *= alpha
+v_fma_f64 v[vgprValuC+44:vgprValuC+44+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+44:vgprValuC+44+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+46:vgprValuC+46+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+46:vgprValuC+46+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[44:47], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_add_u32            s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+
+
+s_endpgm
+
+label_1002:
+
+/******************************************/
+//branch logic gets executed for edge MT to use legacy alph_beta code
+
+s_waitcnt lgkmcnt(0)                                 // 1wait for local write
+s_barrier //4sync for global read
+
+/* iter 0 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:384 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:512 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:640 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:768 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:896 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt vmcnt(1)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:4096 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 4096
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1024 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:1152 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1280 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 3 writesPerItem=1 */
+s_waitcnt vmcnt(0)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:4096 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 4096
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1408 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0
+
+
+s_waitcnt lgkmcnt(0)                               // 1wait for local write
+s_barrier //4sync for global read
+
+
+/* iter 0 */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4096 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4224 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4352 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4480 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4608 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4736 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4864 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4992 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5120 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:5248 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5376 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5504 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=192 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=192 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0
+s_add_u32 s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+
+s_branch label_0004
+
+label_1003:
+
+s_waitcnt lgkmcnt(0)                               // 1wait for local write
+s_barrier //4sync for global read
+
+
+/* iter 0 */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4096 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4224 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4352 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4480 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4608 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4736 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4864 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4992 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* sched write - iter 2 writesPerItem=1 */
+s_waitcnt vmcnt(1)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:0 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5120 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:5248 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5376 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 3 writesPerItem=1 */
+s_waitcnt vmcnt(0)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:0 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5504 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=192 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=192 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+
+/* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0
+
+s_add_u32 s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+s_cmp_eq_i32 s[sgprLoopCounters+0], -1             // is this the last iteration
+s_cmov_b32 s[sgprSrdA+2], 0                        // Set limit to 0 for last iteration
+s_cmov_b32 s[sgprSrdB+2], 0                        // Set limit to 0 for last iteration
+
+s_waitcnt lgkmcnt(0)                               // 1wait for local write
+
+s_barrier //4sync for global read
+
+/* iter 0 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:384 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:512 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:640 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:768 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:896 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1024 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:1152 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1280 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1408 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0
+s_add_u32 s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+
+label_0004:
+
+
+/******************************************/
+/* Tail Loop                              */
+/******************************************/
+
+
+/* local write reset offsets a */
+
+
+
+/* local write reset offsets b */
+
+
+
+s_cmp_eq_u32 s[sgprOrigLoopCounter], 0             // completely skipped unroll loop?
+s_cselect_b32 s66, 0, s[sgprGlobalReadIncsA]       // force to 0?
+s_cselect_b32 s67, 0, s[sgprGlobalReadIncsB]       // force to 0?
+s_sub_u32  s[sgprSrdA+0], s[sgprSrdA+0], s66       // gra SRD -= inc(lower)
+s_subb_u32  s[sgprSrdA+1], s[sgprSrdA+1], 0        // gra SRD -= inc(upper)
+s_add_u32 s[sgprShadowLimitA+0], s[sgprShadowLimitA+0], s66 // limit -= inc)
+s_addc_u32 s[sgprShadowLimitA+1], s[sgprShadowLimitA+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitA+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdA+2], s[sgprShadowLimitA+0]    // Move shadow to real if we are within 2^32
+
+s_sub_u32  s[sgprSrdB+0], s[sgprSrdB+0], s67       // gra SRD -= inc(lower)
+s_subb_u32  s[sgprSrdB+1], s[sgprSrdB+1], 0        // gra SRD -= inc(upper)
+s_add_u32 s[sgprShadowLimitB+0], s[sgprShadowLimitB+0], s67 // limit -= inc)
+s_addc_u32 s[sgprShadowLimitB+1], s[sgprShadowLimitB+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitB+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdB+2], s[sgprShadowLimitB+0]    // Move shadow to real if we are within 2^32
+
+//numIterL = (((sizeL % LOCAL_DEPTHU) + LOCAL_SPLITU - 1) / LOCAL_SPLITU)
+s_lshr_b32 s66, s[sgprSizesSum+0], 2               // s66 = s[sgprSizesSum+0] / 4
+s_and_b32 s[sgprLoopCounters+0], 3, s[sgprSizesSum+0] // s[sgprLoopCounters+0] = s[sgprSizesSum+0] % 4
+s_cmp_eq_u32 s[sgprLoopCounters+0], 0x0            // numIterL == 0
+s_cbranch_scc1 label_0006                          // skip to end of tail loop b/c numIter==0
+s_sub_u32 s[sgprLoopCounters+0], 0x0, s[sgprLoopCounters+0] // counterL = -sizeL
+
+
+/* global read a */
+
+/* g2l=0, load component 0 */
+buffer_load_dwordx2 v[vgprG2LA+0+0:vgprG2LA+0+0+1], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // load one buffer value
+/* g2l=0, load component 1 */
+buffer_load_dwordx2 v[vgprG2LA+0+2:vgprG2LA+0+2+1], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:8 // load one buffer value
+_v_add_co_u32 v[vgprGlobalReadOffsetA+0], vcc, v[vgprGlobalReadOffsetA+0], 8 // graOffset += 1 * bpe
+
+
+/* global read b */
+
+/* g2l=0, load component 0 */
+buffer_load_dwordx2 v[vgprG2LB+0+0:vgprG2LB+0+0+1], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // load one buffer value
+/* g2l=0, load component 1 */
+buffer_load_dwordx2 v[vgprG2LB+0+2:vgprG2LB+0+2+1], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:8 // load one buffer value
+_v_add_co_u32 v[vgprGlobalReadOffsetB+0], vcc, v[vgprGlobalReadOffsetB+0], 8 // graOffset += 1 * bpe
+
+s_waitcnt vmcnt(0)                                 // 2wait for global read
+
+s_barrier //
+
+/* local write init pointers a */
+
+/* N/A */
+
+
+/* local write init pointers b */
+
+/* N/A */
+
+
+/* local write a */
+
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:0 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 0
+
+
+/* local write b */
+
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:0 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 0
+
+s_waitcnt lgkmcnt(0)                               // 5wait for local write
+
+s_barrier //
+
+
+/* local read reset offsets a */
+
+/* handled internally */
+v_and_b32 v[vgprLocalReadAddrA], 0xfff, v[vgprLocalReadAddrA] // reset Red,Blk -> Red
+
+
+/* local read reset offsets b */
+
+/* handled internally */
+v_and_b32 v[vgprLocalReadAddrB], 0xfff, v[vgprLocalReadAddrB] // reset Red,Blk -> Red
+
+
+/* local read init pointers a */
+
+
+
+/* local read init pointers b */
+
+
+
+/* tail loop: macs */
+
+s_cmp_ge_i32 s[sgprLoopCounters+0], 0x0            // LoopCounterL < EndCounter
+s_cbranch_scc1 label_0006                          // don't enter LoopL
+s_mov_b32 s[sgprOrigLoopCounter], 0                // repurpose to count each localRead increment
+label_0005:
+
+
+/* local read a */
+
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+
+/* local read b */
+
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+
+/* local read inc a */
+
+s_mov_b32 s65, 0x180                               // inc
+_v_add_co_u32 v[vgprLocalReadAddrA], vcc, s65, v[vgprLocalReadAddrA] // lrA += 384 (LSU*(MT+PAD)*bpe)
+
+
+/* local read inc b */
+
+s_mov_b32 s65, 0x200                               // inc
+_v_add_co_u32 v[vgprLocalReadAddrB], vcc, s65, v[vgprLocalReadAddrB] // lrB += 512 (LSU*(MT+PAD)*bpe)
+
+s_waitcnt lgkmcnt(0)                               // 4wait for local read
+
+MAC_6x4_X0
+s_add_u32 s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+s_add_u32 s[sgprOrigLoopCounter], s[sgprOrigLoopCounter], 0x1 // inc counterL
+s_cmp_eq_i32 s[sgprLoopCounters+0], 0x0            // counterL==0
+s_cbranch_scc0 label_0005                          // restart LoopL
+label_0006:
+
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // wait for all summation activity
+
+
+/* shift vector components d0 */
+
+v_mov_b32 v50, s[sgprWorkGroup0]                   //
+v_mul_i32_i24 v50, -0x30, v50                      // wg*MT
+_v_add_co_u32 v50, vcc, s[sgprSizesFree+0], v50    // wgMT = Size - wg*MT
+v_mov_b32 v48, 0x30                                // MT
+v_cmp_lt_u32 s[56:57], v50, v48                    // wgMT < MT
+v_cndmask_b32 v50, v48, v50, s[56:57]              // wgMT = (wgMT < MT) ? wgMT : MT
+v_lshrrev_b32 v52, 1, v50                          // vectorStaticDiv: v52 = v50 / 2
+v_and_b32 v53, 1, v50                              // vectorStaticDiv: v53 = v50 % 2
+v_lshrrev_b32 v54, 3, v52                          // vectorStaticDiv: v54 = v52 / 8
+v_and_b32 v55, 7, v52                              // vectorStaticDiv: v55 = v52 % 8
+v_and_b32 v56, 7, v[vgprSerial]                    // vectorStaticDiv: v56 = v[vgprSerial] % 8
+v_lshrrev_b32 v57, 4, v50                          // vectorStaticDiv: v57 = v50 / 16
+v_and_b32 v58, 1, v50                              // vectorStaticDiv: v58 = v50 % 2
+v_mov_b32 v59, v58                                 // duplicate
+v_lshrrev_b32 v58, 1, v59                          // vectorStaticDiv: v58 = v59 / 2
+_v_add_co_u32 v58, vcc, v57, v58                   // vId = 2 components
+v_cmp_eq_u32 s[56:57], v56, v55                    // mask
+v_mov_b32 v48, s56                                 //
+v_mov_b32 v49, s57                                 //
+v_cmp_eq_u32 vcc, v53, 0x1                         // wgMT%VW == 1
+s_cbranch_vccnz label_0010                         // shift d0 r=1
+s_branch label_0014                                // no shifting
+
+/******************************************/
+/* shift d0 r=1                           */
+/******************************************/
+label_0010:
+v_cmp_eq_u32 vcc, v58, 0x0                         // wgMT/(SG*VW) == 0
+s_cbranch_vccnz label_0011                         // shift d0, r=1, v=0
+v_cmp_eq_u32 vcc, v58, 0x1                         // wgMT/(SG*VW) == 1
+s_cbranch_vccnz label_0012                         // shift d0, r=1, v=1
+v_cmp_eq_u32 vcc, v58, 0x2                         // wgMT/(SG*VW) == 2
+s_cbranch_vccnz label_0013                         // shift d0, r=1, v=2
+
+/* shift d0 r=1 v=0 */
+label_0011:
+v_cmpx_eq_u32 s[56:57], v56, v55                   // serial % SG == (wgMT/VECTOR_WIDTH)%SG
+// src=1, dst=0
+v_mov_b32 v0, v2                                   // rC[0+0*VW+0*TT0I] = rC[1+0*VW+0*TT0I]
+v_mov_b32 v1, v3                                   // rC[0+0*VW+0*TT0I] = rC[1+0*VW+0*TT0I]
+// src=7, dst=6
+v_mov_b32 v12, v14                                 // rC[0+0*VW+1*TT0I] = rC[1+0*VW+1*TT0I]
+v_mov_b32 v13, v15                                 // rC[0+0*VW+1*TT0I] = rC[1+0*VW+1*TT0I]
+// src=13, dst=12
+v_mov_b32 v24, v26                                 // rC[0+0*VW+2*TT0I] = rC[1+0*VW+2*TT0I]
+v_mov_b32 v25, v27                                 // rC[0+0*VW+2*TT0I] = rC[1+0*VW+2*TT0I]
+// src=19, dst=18
+v_mov_b32 v36, v38                                 // rC[0+0*VW+3*TT0I] = rC[1+0*VW+3*TT0I]
+v_mov_b32 v37, v39                                 // rC[0+0*VW+3*TT0I] = rC[1+0*VW+3*TT0I]
+s_mov_b64 s[56:57], 0xFFFFFFFFFFFFFFFF             // to restore all threads active
+s_or_saveexec_b64 vcc, s[56:57]                    // all threads active
+s_branch label_0014                                // done shifting
+
+/* shift d0 r=1 v=1 */
+label_0012:
+v_cmpx_eq_u32 s[56:57], v56, v55                   // serial % SG == (wgMT/VECTOR_WIDTH)%SG
+// src=3, dst=2
+v_mov_b32 v4, v6                                   // rC[0+1*VW+0*TT0I] = rC[1+1*VW+0*TT0I]
+v_mov_b32 v5, v7                                   // rC[0+1*VW+0*TT0I] = rC[1+1*VW+0*TT0I]
+// src=9, dst=8
+v_mov_b32 v16, v18                                 // rC[0+1*VW+1*TT0I] = rC[1+1*VW+1*TT0I]
+v_mov_b32 v17, v19                                 // rC[0+1*VW+1*TT0I] = rC[1+1*VW+1*TT0I]
+// src=15, dst=14
+v_mov_b32 v28, v30                                 // rC[0+1*VW+2*TT0I] = rC[1+1*VW+2*TT0I]
+v_mov_b32 v29, v31                                 // rC[0+1*VW+2*TT0I] = rC[1+1*VW+2*TT0I]
+// src=21, dst=20
+v_mov_b32 v40, v42                                 // rC[0+1*VW+3*TT0I] = rC[1+1*VW+3*TT0I]
+v_mov_b32 v41, v43                                 // rC[0+1*VW+3*TT0I] = rC[1+1*VW+3*TT0I]
+s_mov_b64 s[56:57], 0xFFFFFFFFFFFFFFFF             // to restore all threads active
+s_or_saveexec_b64 vcc, s[56:57]                    // all threads active
+s_branch label_0014                                // done shifting
+
+/* shift d0 r=1 v=2 */
+label_0013:
+v_cmpx_eq_u32 s[56:57], v56, v55                   // serial % SG == (wgMT/VECTOR_WIDTH)%SG
+// src=5, dst=4
+v_mov_b32 v8, v10                                  // rC[0+2*VW+0*TT0I] = rC[1+2*VW+0*TT0I]
+v_mov_b32 v9, v11                                  // rC[0+2*VW+0*TT0I] = rC[1+2*VW+0*TT0I]
+// src=11, dst=10
+v_mov_b32 v20, v22                                 // rC[0+2*VW+1*TT0I] = rC[1+2*VW+1*TT0I]
+v_mov_b32 v21, v23                                 // rC[0+2*VW+1*TT0I] = rC[1+2*VW+1*TT0I]
+// src=17, dst=16
+v_mov_b32 v32, v34                                 // rC[0+2*VW+2*TT0I] = rC[1+2*VW+2*TT0I]
+v_mov_b32 v33, v35                                 // rC[0+2*VW+2*TT0I] = rC[1+2*VW+2*TT0I]
+// src=23, dst=22
+v_mov_b32 v44, v46                                 // rC[0+2*VW+3*TT0I] = rC[1+2*VW+3*TT0I]
+v_mov_b32 v45, v47                                 // rC[0+2*VW+3*TT0I] = rC[1+2*VW+3*TT0I]
+s_mov_b64 s[56:57], 0xFFFFFFFFFFFFFFFF             // to restore all threads active
+s_or_saveexec_b64 vcc, s[56:57]                    // all threads active
+s_branch label_0014                                // done shifting
+label_0014: // end shift0
+
+
+/* shift vector components d1 */
+
+v_mov_b32 v50, s[sgprWorkGroup1]                   //
+v_mul_i32_i24 v50, -0x40, v50                      // wg*MT
+_v_add_co_u32 v50, vcc, s[sgprSizesFree+1], v50    // wgMT = Size - wg*MT
+v_mov_b32 v48, 0x40                                // MT
+v_cmp_lt_u32 s[56:57], v50, v48                    // wgMT < MT
+v_cndmask_b32 v50, v48, v50, s[56:57]              // wgMT = (wgMT < MT) ? wgMT : MT
+v_lshrrev_b32 v52, 1, v50                          // vectorStaticDiv: v52 = v50 / 2
+v_and_b32 v53, 1, v50                              // vectorStaticDiv: v53 = v50 % 2
+v_lshrrev_b32 v54, 4, v52                          // vectorStaticDiv: v54 = v52 / 16
+v_and_b32 v55, 15, v52                             // vectorStaticDiv: v55 = v52 % 16
+v_lshrrev_b32 v56, 3, v[vgprSerial]                // vectorStaticDiv: v56 = v[vgprSerial] / 8
+v_and_b32 v57, 15, v56                             // vectorStaticDiv: v57 = v56 % 16
+v_lshrrev_b32 v56, 5, v50                          // vectorStaticDiv: v56 = v50 / 32
+v_and_b32 v58, 1, v50                              // vectorStaticDiv: v58 = v50 % 2
+v_mov_b32 v59, v58                                 // duplicate
+v_lshrrev_b32 v58, 1, v59                          // vectorStaticDiv: v58 = v59 / 2
+_v_add_co_u32 v58, vcc, v56, v58                   // vId = 2 components
+v_cmp_eq_u32 s[56:57], v57, v55                    // mask
+v_mov_b32 v48, s56                                 //
+v_mov_b32 v49, s57                                 //
+v_cmp_eq_u32 vcc, v53, 0x1                         // wgMT%VW == 1
+s_cbranch_vccnz label_0018                         // shift d1 r=1
+s_branch label_0021                                // no shifting
+
+/******************************************/
+/* shift d1 r=1                           */
+/******************************************/
+label_0018:
+v_cmp_eq_u32 vcc, v58, 0x0                         // wgMT/(SG*VW) == 0
+s_cbranch_vccnz label_0019                         // shift d1, r=1, v=0
+v_cmp_eq_u32 vcc, v58, 0x1                         // wgMT/(SG*VW) == 1
+s_cbranch_vccnz label_0020                         // shift d1, r=1, v=1
+
+/* shift d1 r=1 v=0 */
+label_0019:
+v_cmpx_eq_u32 s[56:57], v57, v55                   // serial % SG == (wgMT/VECTOR_WIDTH)%SG
+// src=6, dst=0
+v_mov_b32 v0, v12                                  // rC[0+0*TT0I*VW+0*TT0I] = rC[0+0*TT0I*VW+1*TT0I]
+v_mov_b32 v1, v13                                  // rC[0+0*TT0I*VW+0*TT0I] = rC[0+0*TT0I*VW+1*TT0I]
+// src=7, dst=1
+v_mov_b32 v2, v14                                  // rC[1+0*TT0I*VW+0*TT0I] = rC[1+0*TT0I*VW+1*TT0I]
+v_mov_b32 v3, v15                                  // rC[1+0*TT0I*VW+0*TT0I] = rC[1+0*TT0I*VW+1*TT0I]
+// src=8, dst=2
+v_mov_b32 v4, v16                                  // rC[2+0*TT0I*VW+0*TT0I] = rC[2+0*TT0I*VW+1*TT0I]
+v_mov_b32 v5, v17                                  // rC[2+0*TT0I*VW+0*TT0I] = rC[2+0*TT0I*VW+1*TT0I]
+// src=9, dst=3
+v_mov_b32 v6, v18                                  // rC[3+0*TT0I*VW+0*TT0I] = rC[3+0*TT0I*VW+1*TT0I]
+v_mov_b32 v7, v19                                  // rC[3+0*TT0I*VW+0*TT0I] = rC[3+0*TT0I*VW+1*TT0I]
+// src=10, dst=4
+v_mov_b32 v8, v20                                  // rC[4+0*TT0I*VW+0*TT0I] = rC[4+0*TT0I*VW+1*TT0I]
+v_mov_b32 v9, v21                                  // rC[4+0*TT0I*VW+0*TT0I] = rC[4+0*TT0I*VW+1*TT0I]
+// src=11, dst=5
+v_mov_b32 v10, v22                                 // rC[5+0*TT0I*VW+0*TT0I] = rC[5+0*TT0I*VW+1*TT0I]
+v_mov_b32 v11, v23                                 // rC[5+0*TT0I*VW+0*TT0I] = rC[5+0*TT0I*VW+1*TT0I]
+s_mov_b64 s[56:57], 0xFFFFFFFFFFFFFFFF             // to restore all threads active
+s_or_saveexec_b64 vcc, s[56:57]                    // all threads active
+s_branch label_0021                                // done shifting
+
+/* shift d1 r=1 v=1 */
+label_0020:
+v_cmpx_eq_u32 s[56:57], v57, v55                   // serial % SG == (wgMT/VECTOR_WIDTH)%SG
+// src=18, dst=12
+v_mov_b32 v24, v36                                 // rC[0+1*TT0I*VW+0*TT0I] = rC[0+1*TT0I*VW+1*TT0I]
+v_mov_b32 v25, v37                                 // rC[0+1*TT0I*VW+0*TT0I] = rC[0+1*TT0I*VW+1*TT0I]
+// src=19, dst=13
+v_mov_b32 v26, v38                                 // rC[1+1*TT0I*VW+0*TT0I] = rC[1+1*TT0I*VW+1*TT0I]
+v_mov_b32 v27, v39                                 // rC[1+1*TT0I*VW+0*TT0I] = rC[1+1*TT0I*VW+1*TT0I]
+// src=20, dst=14
+v_mov_b32 v28, v40                                 // rC[2+1*TT0I*VW+0*TT0I] = rC[2+1*TT0I*VW+1*TT0I]
+v_mov_b32 v29, v41                                 // rC[2+1*TT0I*VW+0*TT0I] = rC[2+1*TT0I*VW+1*TT0I]
+// src=21, dst=15
+v_mov_b32 v30, v42                                 // rC[3+1*TT0I*VW+0*TT0I] = rC[3+1*TT0I*VW+1*TT0I]
+v_mov_b32 v31, v43                                 // rC[3+1*TT0I*VW+0*TT0I] = rC[3+1*TT0I*VW+1*TT0I]
+// src=22, dst=16
+v_mov_b32 v32, v44                                 // rC[4+1*TT0I*VW+0*TT0I] = rC[4+1*TT0I*VW+1*TT0I]
+v_mov_b32 v33, v45                                 // rC[4+1*TT0I*VW+0*TT0I] = rC[4+1*TT0I*VW+1*TT0I]
+// src=23, dst=17
+v_mov_b32 v34, v46                                 // rC[5+1*TT0I*VW+0*TT0I] = rC[5+1*TT0I*VW+1*TT0I]
+v_mov_b32 v35, v47                                 // rC[5+1*TT0I*VW+0*TT0I] = rC[5+1*TT0I*VW+1*TT0I]
+s_mov_b64 s[56:57], 0xFFFFFFFFFFFFFFFF             // to restore all threads active
+s_or_saveexec_b64 vcc, s[56:57]                    // all threads active
+label_0021: // end shift0
+
+
+
+/* not-LocalSplitU: global write indices */
+
+s_mov_b32 s[sgprSrdD+0], s[sgprAddressD+0]         // init SRD base address (lower)
+s_mov_b32 s[sgprSrdD+1], s[sgprAddressD+1]         // init SRD base address (upper) + other fields
+s_mov_b32 s[sgprSrdD+2], 0x80000000                //
+s_mov_b32 s[sgprSrdD+3], Srd127_96                 // Set bits 127_96 in SRD
+s_mov_b32 s[sgprSrdC+0], s[sgprAddressC+0]         // init SRD base address (lower)
+s_mov_b32 s[sgprSrdC+1], s[sgprAddressC+1]         // init SRD base address (upper) + other fields
+s_mov_b32 s[sgprSrdC+2], 0x80000000                //
+s_mov_b32 s[sgprSrdC+3], Srd127_96                 // Set bits 127_96 in SRD
+
+s_mul_i32 s58, 0x40, s[sgprWorkGroup1]             // <- wg1*MT1
+s_mul_hi_u32 s57, s58, s[sgprStridesC+0]           // Scale s58 by Stride
+s_mul_i32 s56, s58, s[sgprStridesC+0]              // Scale s58 by Stride
+s_lshl_b64 s[56:57], s[56:57], 3                   // scale by bpe
+s_add_u32 s[sgprSrdD+0], s[sgprSrdD+0], s56        // add lo to SRD
+s_addc_u32 s[sgprSrdD+1], s[sgprSrdD+1], s57       // add hi to SRD
+s_add_u32 s[sgprSrdC+0], s[sgprSrdC+0], s56        // add lo to SRD
+s_addc_u32 s[sgprSrdC+1], s[sgprSrdC+1], s57       // add hi to SRD
+
+s_mul_hi_u32 s57, s[sgprWorkGroup2], s[sgprStridesC+1] // Scale s[sgprWorkGroup2] by Stride
+s_mul_i32 s56, s[sgprWorkGroup2], s[sgprStridesC+1] // Scale s[sgprWorkGroup2] by Stride
+s_lshl_b64 s[56:57], s[56:57], 3                   // scale by bpe
+s_add_u32 s[sgprSrdD+0], s[sgprSrdD+0], s56        // add lo to SRD
+s_addc_u32 s[sgprSrdD+1], s[sgprSrdD+1], s57       // add hi to SRD
+s_add_u32 s[sgprSrdC+0], s[sgprSrdC+0], s56        // add lo to SRD
+s_addc_u32 s[sgprSrdC+1], s[sgprSrdC+1], s57       // add hi to SRD
+
+v_lshrrev_b32 v49, 3, v[vgprSerial]                // vectorStaticDiv: v49 = v[vgprSerial] / 8
+v_and_b32 v48, 7, v[vgprSerial]                    // vectorStaticDiv: v48 = v[vgprSerial] % 8
+v_lshlrev_b32 v48, 1, v48                          // staticMultiply: v48 = v48 * 2
+v_lshlrev_b32 v49, 1, v49                          // staticMultiply: v49 = v49 * 2
+v_mul_lo_u32 v50, v49, s[sgprStridesC+0]           // rowStart vgpr
+
+s_mul_i32 s56, 0x30, s[sgprWorkGroup0]             // s56 = wg0*MT0
+_v_add_co_u32 v48, vcc, s56, v48                   // coord0 = tid0*VW + wg0*MT0
+s_mul_i32 s58, 0x40, s[sgprWorkGroup1]             // <- wg1*MT1
+_v_add_co_u32 v49, vcc, s58, v49                   // coord1 = tid1*VW + wg1*MT1
+
+//v_mov_b32 v48,v[vgprLocalWriteAddrA]
+//v_mov_b32 v49,v[vgprLocalWriteAddrB]
+//v_mov_b32 v50,v[vgprGlobalReadOffsetB]           // rowStart vgpr
+//_v_add_lshl_u32 v[vgprGlobalReadOffsetA], v[vgprGlobalReadOffsetB], v[vgprLocalWriteAddrA], 0x3                 // init cb addr <-  rowStart + coord0, scaled by BPE
+
+/* not-LocalSplitU: global write */
+
+s_mov_b32 s56, s[sgprBeta+0]                       // tmp = Beta[0]
+s_or_b32 s56, s[sgprBeta+1], s56                   // tmp |= Beta[1]
+s_cmpk_eq_u32 s56, 0x0                             // Beta == 0
+s_cbranch_scc0 label_0030                          // Beta is not zero; so jump to B nonzero
+
+s_mov_b32 s56, 0x0                                 // rMT0=0
+s_add_u32 s58, -0x1, s[sgprNumWorkGroups0]         //
+s_cmp_lt_u32 s[sgprWorkGroup0], s58                // wg0 < nwg0-1
+s_cbranch_scc1 label_0027                          // wg0 < nwg0-1 so skip rMT0 = Size0 % MT0
+/* TODO-packed- compare against product of all packed C0 sizes not just SizesFree+0 */
+s_mov_b32 s61, 0x0                                 // STATIC_DIV: divisior=48
+s_mul_i32 s60, 0xaaa, s[sgprSizesFree+0]           // tmp1 = dividend * magic hi
+s_lshl_b64 s[60:61], s[60:61], 0x10                // left shift 16 bits
+s_mul_i32 s58, s[sgprSizesFree+0], 0xaaab          // tmp0 = dividend * magic lo
+s_add_u32 s60, s58, s60                            // add lo
+s_addc_u32 s61, s61, 0x0                           // add hi
+s_lshr_b64 s[60:61], s[60:61], 0x21                // tmp1 = (dividend * magic) << shift
+s_mov_b32 s58, s60                                 // quotient
+s_mul_i32 s60, s58, 0x30                           // quotient*divisor
+s_sub_u32 s56, s[sgprSizesFree+0], s60             // rReg = dividend - quotient*divisor
+label_0027:
+s_cmpk_gt_u32 s56, 0x0                             // rMT0 > 0
+s_cbranch_scc1 label_0029                          // edges required so jump to E1
+s_mov_b32 s56, 0x0                                 // rMT1=0
+s_add_u32 s58, -0x1, s[sgprNumWorkGroups1]         //
+s_cmp_lt_u32 s[sgprWorkGroup1], s58                // wg1 < nwg1-1
+s_cbranch_scc1 label_0028                          // wg1 < nwg1-1 so skip rMT1 = Size1 % MT1
+s_lshr_b32 s58, s[sgprSizesFree+1], 6              // s58 = s[sgprSizesFree+1] / 64
+s_and_b32 s56, 63, s[sgprSizesFree+1]              // s56 = s[sgprSizesFree+1] % 64
+label_0028:
+s_cmpk_gt_u32 s56, 0x0                             // rMT1 > 0
+s_cbranch_scc1 label_0029                          // edges required so jump to E1
+label_0026:
+
+/******************************************/
+/* Global Write Batch #0 (d1,d0,vc1,vc0) =
+   (0,0,0,0:vw2); (0,1,0,0:vw2); (0,2,0,0:vw2); (0,0,1,0:vw2); (0,1,1,0:vw2); (0,2,1,0:vw2); (1,0,0,0:vw2); (1,1,0,0:vw2); (1,2,0,0:vw2); (1,0,1,0:vw2); (1,1,1,0:vw2); (1,2,1,0:vw2) */
+/******************************************/
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(0,0,0,0) coordOffset1=0 element-rows coordOffset0=0 rows */
+_v_add_lshl_u32 v54, v50, v48, 0x3                 // init cb addr <-  rowStart + coord0, scaled by BPE
+/* (d1,vc1,d0,vc0)=(0,0,1,0) coordOffset1=0 element-rows coordOffset0=16 rows */
+/* (d1,vc1,d0,vc0)=(0,0,2,0) coordOffset1=0 element-rows coordOffset0=32 rows */
+/* (d1,vc1,d0,vc0)=(0,1,0,0) coordOffset1=1 element-rows coordOffset0=0 rows */
+/* (d1,vc1,d0,vc0)=(0,1,1,0) coordOffset1=1 element-rows coordOffset0=16 rows */
+/* (d1,vc1,d0,vc0)=(0,1,2,0) coordOffset1=1 element-rows coordOffset0=32 rows */
+/* (d1,vc1,d0,vc0)=(1,0,0,0) coordOffset1=32 element-rows coordOffset0=0 rows */
+/* (d1,vc1,d0,vc0)=(1,0,1,0) coordOffset1=32 element-rows coordOffset0=16 rows */
+/* (d1,vc1,d0,vc0)=(1,0,2,0) coordOffset1=32 element-rows coordOffset0=32 rows */
+/* (d1,vc1,d0,vc0)=(1,1,0,0) coordOffset1=33 element-rows coordOffset0=0 rows */
+/* (d1,vc1,d0,vc0)=(1,1,1,0) coordOffset1=33 element-rows coordOffset0=16 rows */
+/* (d1,vc1,d0,vc0)=(1,1,2,0) coordOffset1=33 element-rows coordOffset0=32 rows */
+
+/* rC *= alpha batchEements=[(0, 0, 0, 0), (0, 1, 0, 0), (0, 2, 0, 0), (0, 0, 1, 0), (0, 1, 1, 0), (0, 2, 1, 0), (1, 0, 0, 0), (1, 1, 0, 0), (1, 2, 0, 0), (1, 0, 1, 0), (1, 1, 1, 0), (1, 2, 1, 0)] */
+//v_mul_f64 v[vgprValuC+0:vgprValuC+0+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+0:vgprValuC+0+1] // *= alpha
+//v_mul_f64 v[vgprValuC+2:vgprValuC+2+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+2:vgprValuC+2+1] // *= alpha
+//v_mul_f64 v[vgprValuC+4:vgprValuC+4+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+4:vgprValuC+4+1] // *= alpha
+//v_mul_f64 v[vgprValuC+6:vgprValuC+6+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+6:vgprValuC+6+1] // *= alpha
+//v_mul_f64 v[vgprValuC+8:vgprValuC+8+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+8:vgprValuC+8+1] // *= alpha
+//v_mul_f64 v[vgprValuC+10:vgprValuC+10+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+10:vgprValuC+10+1] // *= alpha
+//v_mul_f64 v[vgprValuC+12:vgprValuC+12+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+12:vgprValuC+12+1] // *= alpha
+//v_mul_f64 v[vgprValuC+14:vgprValuC+14+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+14:vgprValuC+14+1] // *= alpha
+//v_mul_f64 v[vgprValuC+16:vgprValuC+16+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+16:vgprValuC+16+1] // *= alpha
+//v_mul_f64 v[vgprValuC+18:vgprValuC+18+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+18:vgprValuC+18+1] // *= alpha
+//v_mul_f64 v[vgprValuC+20:vgprValuC+20+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+20:vgprValuC+20+1] // *= alpha
+//v_mul_f64 v[vgprValuC+22:vgprValuC+22+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+22:vgprValuC+22+1] // *= alpha
+//v_mul_f64 v[vgprValuC+24:vgprValuC+24+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+24:vgprValuC+24+1] // *= alpha
+//v_mul_f64 v[vgprValuC+26:vgprValuC+26+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+26:vgprValuC+26+1] // *= alpha
+//v_mul_f64 v[vgprValuC+28:vgprValuC+28+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+28:vgprValuC+28+1] // *= alpha
+//v_mul_f64 v[vgprValuC+30:vgprValuC+30+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+30:vgprValuC+30+1] // *= alpha
+//v_mul_f64 v[vgprValuC+32:vgprValuC+32+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+32:vgprValuC+32+1] // *= alpha
+//v_mul_f64 v[vgprValuC+34:vgprValuC+34+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+34:vgprValuC+34+1] // *= alpha
+//v_mul_f64 v[vgprValuC+36:vgprValuC+36+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+36:vgprValuC+36+1] // *= alpha
+//v_mul_f64 v[vgprValuC+38:vgprValuC+38+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+38:vgprValuC+38+1] // *= alpha
+//v_mul_f64 v[vgprValuC+40:vgprValuC+40+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+40:vgprValuC+40+1] // *= alpha
+//v_mul_f64 v[vgprValuC+42:vgprValuC+42+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+42:vgprValuC+42+1] // *= alpha
+//v_mul_f64 v[vgprValuC+44:vgprValuC+44+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+44:vgprValuC+44+1] // *= alpha
+//v_mul_f64 v[vgprValuC+46:vgprValuC+46+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+46:vgprValuC+46+1] // *= alpha
+
+/* apply mask, calc new C and issue write */
+buffer_store_dwordx4 v[0:3], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx4 v[4:7], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+buffer_store_dwordx4 v[8:11], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+buffer_store_dwordx4 v[12:15], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx4 v[16:19], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+buffer_store_dwordx4 v[20:23], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_mul_i32 s56, s[sgprStridesC+0], 248              // scale StrideC *= 31 * bpe
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+buffer_store_dwordx4 v[24:27], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx4 v[28:31], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+buffer_store_dwordx4 v[32:35], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+buffer_store_dwordx4 v[36:39], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx4 v[40:43], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+buffer_store_dwordx4 v[44:47], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_branch label_0037                                // jump to end
+label_0029:
+
+/******************************************/
+/* Global Write Edge Batch #0 (d1,d0,vc1,vc0) =
+   (0,0,0,0:vw1); (0,0,0,1:vw1); (0,1,0,0:vw1); (0,1,0,1:vw1); (0,2,0,0:vw1); (0,2,0,1:vw1); (0,0,1,0:vw1); (0,0,1,1:vw1); (0,1,1,0:vw1); (0,1,1,1:vw1); (0,2,1,0:vw1); (0,2,1,1:vw1); (1,0,0,0:vw1); (1,0,0,1:vw1); (1,1,0,0:vw1); (1,1,0,1:vw1); (1,2,0,0:vw1); (1,2,0,1:vw1) */
+/******************************************/
+
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(0,0,0,0) coordOffset1=0 element-rows coordOffset0=0 rows */
+v_mov_b32 v51, v50                                 // rowPtr <- rowStart (first row)
+_v_add_lshl_u32 v54, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[62:63], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v54, -1, v54, s[62:63]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,0,0,1) coordOffset1=0 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v55, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[64:65], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v55, -1, v55, s[64:65]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,0,1,0) coordOffset1=0 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v56, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[66:67], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v56, -1, v56, s[66:67]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,0,1,1) coordOffset1=0 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v57, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[68:69], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v57, -1, v57, s[68:69]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,0,2,0) coordOffset1=0 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v58, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[70:71], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v58, -1, v58, s[70:71]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,0,2,1) coordOffset1=0 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v59, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[72:73], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v59, -1, v59, s[72:73]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,1,0,0) coordOffset1=1 element-rows coordOffset0=0 rows */
+_v_add_co_u32 v53, vcc, v49, 1                     // coord1 += d1*sg1*VW + vc1
+_v_add_co_u32 v51, vcc, v51, s[sgprStridesC+0]     // rowPtr <- move to start of new row
+_v_add_lshl_u32 v60, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[74:75], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v60, -1, v60, s[74:75]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,1,0,1) coordOffset1=1 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v61, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[76:77], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v61, -1, v61, s[76:77]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,1,1,0) coordOffset1=1 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v62, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[78:79], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v62, -1, v62, s[78:79]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,1,1,1) coordOffset1=1 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v63, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[80:81], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v63, -1, v63, s[80:81]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,1,2,0) coordOffset1=1 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v64, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[82:83], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v64, -1, v64, s[82:83]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,1,2,1) coordOffset1=1 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v65, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[84:85], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v65, -1, v65, s[84:85]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,0,0,0) coordOffset1=32 element-rows coordOffset0=0 rows */
+_v_add_co_u32 v53, vcc, v49, 32                    // coord1 += d1*sg1*VW + vc1
+s_mul_i32 s56, s[sgprStridesC+0], 32               // scale StrideC *= coordOffset1(32)
+_v_add_co_u32 v51, vcc, v50, s56                   // rowPtr <- inc for non-0 (tt1+vc1))
+_v_add_lshl_u32 v66, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[86:87], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v66, -1, v66, s[86:87]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,0,0,1) coordOffset1=32 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v67, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[88:89], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v67, -1, v67, s[88:89]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,0,1,0) coordOffset1=32 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v68, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[90:91], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v68, -1, v68, s[90:91]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,0,1,1) coordOffset1=32 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v69, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[92:93], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v69, -1, v69, s[92:93]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,0,2,0) coordOffset1=32 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v70, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[94:95], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v70, -1, v70, s[94:95]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,0,2,1) coordOffset1=32 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v71, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[96:97], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v71, -1, v71, s[96:97]               // clip if OOB. offset
+
+/* rC *= alpha batchEements=[(0, 0, 0, 0), (0, 0, 0, 1), (0, 1, 0, 0), (0, 1, 0, 1), (0, 2, 0, 0), (0, 2, 0, 1), (0, 0, 1, 0), (0, 0, 1, 1), (0, 1, 1, 0), (0, 1, 1, 1), (0, 2, 1, 0), (0, 2, 1, 1), (1, 0, 0, 0), (1, 0, 0, 1), (1, 1, 0, 0), (1, 1, 0, 1), (1, 2, 0, 0), (1, 2, 0, 1)] */
+//v_mul_f64 v[vgprValuC+0:vgprValuC+0+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+0:vgprValuC+0+1] // *= alpha
+//v_mul_f64 v[vgprValuC+2:vgprValuC+2+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+2:vgprValuC+2+1] // *= alpha
+//v_mul_f64 v[vgprValuC+4:vgprValuC+4+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+4:vgprValuC+4+1] // *= alpha
+//v_mul_f64 v[vgprValuC+6:vgprValuC+6+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+6:vgprValuC+6+1] // *= alpha
+//v_mul_f64 v[vgprValuC+8:vgprValuC+8+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+8:vgprValuC+8+1] // *= alpha
+//v_mul_f64 v[vgprValuC+10:vgprValuC+10+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+10:vgprValuC+10+1] // *= alpha
+//v_mul_f64 v[vgprValuC+12:vgprValuC+12+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+12:vgprValuC+12+1] // *= alpha
+//v_mul_f64 v[vgprValuC+14:vgprValuC+14+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+14:vgprValuC+14+1] // *= alpha
+//v_mul_f64 v[vgprValuC+16:vgprValuC+16+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+16:vgprValuC+16+1] // *= alpha
+//v_mul_f64 v[vgprValuC+18:vgprValuC+18+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+18:vgprValuC+18+1] // *= alpha
+//v_mul_f64 v[vgprValuC+20:vgprValuC+20+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+20:vgprValuC+20+1] // *= alpha
+//v_mul_f64 v[vgprValuC+22:vgprValuC+22+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+22:vgprValuC+22+1] // *= alpha
+//v_mul_f64 v[vgprValuC+24:vgprValuC+24+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+24:vgprValuC+24+1] // *= alpha
+//v_mul_f64 v[vgprValuC+26:vgprValuC+26+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+26:vgprValuC+26+1] // *= alpha
+//v_mul_f64 v[vgprValuC+28:vgprValuC+28+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+28:vgprValuC+28+1] // *= alpha
+//v_mul_f64 v[vgprValuC+30:vgprValuC+30+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+30:vgprValuC+30+1] // *= alpha
+//v_mul_f64 v[vgprValuC+32:vgprValuC+32+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+32:vgprValuC+32+1] // *= alpha
+//v_mul_f64 v[vgprValuC+34:vgprValuC+34+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+34:vgprValuC+34+1] // *= alpha
+
+/* apply mask, calc new C and issue write */
+buffer_store_dwordx2 v[0:1], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[2:3], v55, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[4:5], v56, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[6:7], v57, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[8:9], v58, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[10:11], v59, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[12:13], v60, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[14:15], v61, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[16:17], v62, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[18:19], v63, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[20:21], v64, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[22:23], v65, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[24:25], v66, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[26:27], v67, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[28:29], v68, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[30:31], v69, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[32:33], v70, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[34:35], v71, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+/******************************************/
+/* Global Write Edge Batch #1 (d1,d0,vc1,vc0) =
+   (1,0,1,0:vw1); (1,0,1,1:vw1); (1,1,1,0:vw1); (1,1,1,1:vw1); (1,2,1,0:vw1); (1,2,1,1:vw1) */
+/******************************************/
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(1,1,0,0) coordOffset1=33 element-rows coordOffset0=0 rows */
+_v_add_co_u32 v53, vcc, v49, 33                    // coord1 += d1*sg1*VW + vc1
+_v_add_co_u32 v51, vcc, v51, s[sgprStridesC+0]     // rowPtr <- move to start of new row
+_v_add_lshl_u32 v54, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[62:63], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v54, -1, v54, s[62:63]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,1,0,1) coordOffset1=33 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v55, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[64:65], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v55, -1, v55, s[64:65]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,1,1,0) coordOffset1=33 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v56, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[66:67], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v56, -1, v56, s[66:67]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,1,1,1) coordOffset1=33 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v57, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[68:69], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v57, -1, v57, s[68:69]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,1,2,0) coordOffset1=33 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v58, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[70:71], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v58, -1, v58, s[70:71]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,1,2,1) coordOffset1=33 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v59, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[72:73], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v59, -1, v59, s[72:73]               // clip if OOB. offset
+
+/* rC *= alpha batchEements=[(1, 0, 1, 0), (1, 0, 1, 1), (1, 1, 1, 0), (1, 1, 1, 1), (1, 2, 1, 0), (1, 2, 1, 1)] */
+//v_mul_f64 v[vgprValuC+36:vgprValuC+36+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+36:vgprValuC+36+1] // *= alpha
+//v_mul_f64 v[vgprValuC+38:vgprValuC+38+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+38:vgprValuC+38+1] // *= alpha
+//v_mul_f64 v[vgprValuC+40:vgprValuC+40+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+40:vgprValuC+40+1] // *= alpha
+//v_mul_f64 v[vgprValuC+42:vgprValuC+42+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+42:vgprValuC+42+1] // *= alpha
+//v_mul_f64 v[vgprValuC+44:vgprValuC+44+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+44:vgprValuC+44+1] // *= alpha
+//v_mul_f64 v[vgprValuC+46:vgprValuC+46+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+46:vgprValuC+46+1] // *= alpha
+
+/* apply mask, calc new C and issue write */
+buffer_store_dwordx2 v[36:37], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[38:39], v55, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[40:41], v56, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[42:43], v57, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[44:45], v58, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[46:47], v59, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_branch label_0037                                // jump to end
+label_0030:
+s_mov_b32 s56, 0x0                                 // rMT0=0
+s_add_u32 s58, -0x1, s[sgprNumWorkGroups0]         //
+s_cmp_lt_u32 s[sgprWorkGroup0], s58                // wg0 < nwg0-1
+s_cbranch_scc1 label_0034                          // wg0 < nwg0-1 so skip rMT0 = Size0 % MT0
+/* TODO-packed- compare against product of all packed C0 sizes not just SizesFree+0 */
+s_mov_b32 s61, 0x0                                 // STATIC_DIV: divisior=48
+s_mul_i32 s60, 0xaaa, s[sgprSizesFree+0]           // tmp1 = dividend * magic hi
+s_lshl_b64 s[60:61], s[60:61], 0x10                // left shift 16 bits
+s_mul_i32 s58, s[sgprSizesFree+0], 0xaaab          // tmp0 = dividend * magic lo
+s_add_u32 s60, s58, s60                            // add lo
+s_addc_u32 s61, s61, 0x0                           // add hi
+s_lshr_b64 s[60:61], s[60:61], 0x21                // tmp1 = (dividend * magic) << shift
+s_mov_b32 s58, s60                                 // quotient
+s_mul_i32 s60, s58, 0x30                           // quotient*divisor
+s_sub_u32 s56, s[sgprSizesFree+0], s60             // rReg = dividend - quotient*divisor
+label_0034:
+s_cmpk_gt_u32 s56, 0x0                             // rMT0 > 0
+s_cbranch_scc1 label_0036                          // edges required so jump to E1
+s_mov_b32 s56, 0x0                                 // rMT1=0
+s_add_u32 s58, -0x1, s[sgprNumWorkGroups1]         //
+s_cmp_lt_u32 s[sgprWorkGroup1], s58                // wg1 < nwg1-1
+s_cbranch_scc1 label_0035                          // wg1 < nwg1-1 so skip rMT1 = Size1 % MT1
+s_lshr_b32 s58, s[sgprSizesFree+1], 6              // s58 = s[sgprSizesFree+1] / 64
+s_and_b32 s56, 63, s[sgprSizesFree+1]              // s56 = s[sgprSizesFree+1] % 64
+label_0035:
+s_cmpk_gt_u32 s56, 0x0                             // rMT1 > 0
+s_cbranch_scc1 label_0036                          // edges required so jump to E1
+label_0033:
+
+/******************************************/
+/* Global Write Beta Batch #0 (d1,d0,vc1,vc0) =
+   (0,0,0,0:vw2); (0,1,0,0:vw2); (0,2,0,0:vw2); (0,0,1,0:vw2); (0,1,1,0:vw2); (0,2,1,0:vw2) */
+/******************************************/
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(0,0,0,0) coordOffset1=0 element-rows coordOffset0=0 rows */
+_v_add_lshl_u32 v54, v[vgprGlobalReadOffsetB], v48, 0x3                 // init cb addr <-  rowStart + coord0, scaled by BPE
+buffer_load_dwordx4 v[55:58], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,1,0) coordOffset1=0 element-rows coordOffset0=16 rows */
+buffer_load_dwordx4 v[59:62], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,2,0) coordOffset1=0 element-rows coordOffset0=32 rows */
+buffer_load_dwordx4 v[63:66], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,0,0) coordOffset1=1 element-rows coordOffset0=0 rows */
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+buffer_load_dwordx4 v[67:70], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,1,0) coordOffset1=1 element-rows coordOffset0=16 rows */
+buffer_load_dwordx4 v[71:74], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,2,0) coordOffset1=1 element-rows coordOffset0=32 rows */
+buffer_load_dwordx4 v[75:78], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+
+/* rC *= alpha batchEements=[(0, 0, 0, 0), (0, 1, 0, 0), (0, 2, 0, 0), (0, 0, 1, 0), (0, 1, 1, 0), (0, 2, 1, 0)] */
+v_mul_f64 v[vgprValuC+0:vgprValuC+0+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+0:vgprValuC+0+1] // *= alpha
+v_mul_f64 v[vgprValuC+2:vgprValuC+2+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+2:vgprValuC+2+1] // *= alpha
+v_mul_f64 v[vgprValuC+4:vgprValuC+4+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+4:vgprValuC+4+1] // *= alpha
+v_mul_f64 v[vgprValuC+6:vgprValuC+6+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+6:vgprValuC+6+1] // *= alpha
+v_mul_f64 v[vgprValuC+8:vgprValuC+8+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+8:vgprValuC+8+1] // *= alpha
+v_mul_f64 v[vgprValuC+10:vgprValuC+10+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+10:vgprValuC+10+1] // *= alpha
+v_mul_f64 v[vgprValuC+12:vgprValuC+12+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+12:vgprValuC+12+1] // *= alpha
+v_mul_f64 v[vgprValuC+14:vgprValuC+14+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+14:vgprValuC+14+1] // *= alpha
+v_mul_f64 v[vgprValuC+16:vgprValuC+16+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+16:vgprValuC+16+1] // *= alpha
+v_mul_f64 v[vgprValuC+18:vgprValuC+18+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+18:vgprValuC+18+1] // *= alpha
+v_mul_f64 v[vgprValuC+20:vgprValuC+20+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+20:vgprValuC+20+1] // *= alpha
+v_mul_f64 v[vgprValuC+22:vgprValuC+22+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+22:vgprValuC+22+1] // *= alpha
+
+/* apply mask, calc new C and issue write */
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+0:vgprValuC+0+1], v[55:56], s[sgprBeta:sgprBeta+1], v[vgprValuC+0:vgprValuC+0+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+2:vgprValuC+2+1], v[57:58], s[sgprBeta:sgprBeta+1], v[vgprValuC+2:vgprValuC+2+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[0:3], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+4:vgprValuC+4+1], v[59:60], s[sgprBeta:sgprBeta+1], v[vgprValuC+4:vgprValuC+4+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+6:vgprValuC+6+1], v[61:62], s[sgprBeta:sgprBeta+1], v[vgprValuC+6:vgprValuC+6+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[4:7], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+8:vgprValuC+8+1], v[63:64], s[sgprBeta:sgprBeta+1], v[vgprValuC+8:vgprValuC+8+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+10:vgprValuC+10+1], v[65:66], s[sgprBeta:sgprBeta+1], v[vgprValuC+10:vgprValuC+10+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[8:11], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+12:vgprValuC+12+1], v[67:68], s[sgprBeta:sgprBeta+1], v[vgprValuC+12:vgprValuC+12+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+14:vgprValuC+14+1], v[69:70], s[sgprBeta:sgprBeta+1], v[vgprValuC+14:vgprValuC+14+1] // finalSum = sum*alpha + C*beta
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+buffer_store_dwordx4 v[12:15], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+16:vgprValuC+16+1], v[71:72], s[sgprBeta:sgprBeta+1], v[vgprValuC+16:vgprValuC+16+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+18:vgprValuC+18+1], v[73:74], s[sgprBeta:sgprBeta+1], v[vgprValuC+18:vgprValuC+18+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[16:19], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+20:vgprValuC+20+1], v[75:76], s[sgprBeta:sgprBeta+1], v[vgprValuC+20:vgprValuC+20+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+22:vgprValuC+22+1], v[77:78], s[sgprBeta:sgprBeta+1], v[vgprValuC+22:vgprValuC+22+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[20:23], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+
+/******************************************/
+/* Global Write Beta Batch #1 (d1,d0,vc1,vc0) =
+   (1,0,0,0:vw2); (1,1,0,0:vw2); (1,2,0,0:vw2); (1,0,1,0:vw2); (1,1,1,0:vw2); (1,2,1,0:vw2) */
+/******************************************/
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(1,0,0,0) coordOffset1=32 element-rows coordOffset0=0 rows */
+s_mul_i32 s56, s[sgprStridesD+0], 248              // scale StrideC *= 31 * bpe
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+buffer_load_dwordx4 v[55:58], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,1,0) coordOffset1=32 element-rows coordOffset0=16 rows */
+buffer_load_dwordx4 v[59:62], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,2,0) coordOffset1=32 element-rows coordOffset0=32 rows */
+buffer_load_dwordx4 v[63:66], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,0,0) coordOffset1=33 element-rows coordOffset0=0 rows */
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+buffer_load_dwordx4 v[67:70], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,1,0) coordOffset1=33 element-rows coordOffset0=16 rows */
+buffer_load_dwordx4 v[71:74], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,2,0) coordOffset1=33 element-rows coordOffset0=32 rows */
+buffer_load_dwordx4 v[75:78], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+
+/* rC *= alpha batchEements=[(1, 0, 0, 0), (1, 1, 0, 0), (1, 2, 0, 0), (1, 0, 1, 0), (1, 1, 1, 0), (1, 2, 1, 0)] */
+v_mul_f64 v[vgprValuC+24:vgprValuC+24+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+24:vgprValuC+24+1] // *= alpha
+v_mul_f64 v[vgprValuC+26:vgprValuC+26+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+26:vgprValuC+26+1] // *= alpha
+v_mul_f64 v[vgprValuC+28:vgprValuC+28+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+28:vgprValuC+28+1] // *= alpha
+v_mul_f64 v[vgprValuC+30:vgprValuC+30+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+30:vgprValuC+30+1] // *= alpha
+v_mul_f64 v[vgprValuC+32:vgprValuC+32+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+32:vgprValuC+32+1] // *= alpha
+v_mul_f64 v[vgprValuC+34:vgprValuC+34+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+34:vgprValuC+34+1] // *= alpha
+v_mul_f64 v[vgprValuC+36:vgprValuC+36+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+36:vgprValuC+36+1] // *= alpha
+v_mul_f64 v[vgprValuC+38:vgprValuC+38+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+38:vgprValuC+38+1] // *= alpha
+v_mul_f64 v[vgprValuC+40:vgprValuC+40+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+40:vgprValuC+40+1] // *= alpha
+v_mul_f64 v[vgprValuC+42:vgprValuC+42+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+42:vgprValuC+42+1] // *= alpha
+v_mul_f64 v[vgprValuC+44:vgprValuC+44+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+44:vgprValuC+44+1] // *= alpha
+v_mul_f64 v[vgprValuC+46:vgprValuC+46+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+46:vgprValuC+46+1] // *= alpha
+
+/* apply mask, calc new C and issue write */
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+24:vgprValuC+24+1], v[55:56], s[sgprBeta:sgprBeta+1], v[vgprValuC+24:vgprValuC+24+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+26:vgprValuC+26+1], v[57:58], s[sgprBeta:sgprBeta+1], v[vgprValuC+26:vgprValuC+26+1] // finalSum = sum*alpha + C*beta
+s_mul_i32 s56, s[sgprStridesD+0], 248              // scale StrideC *= 31 * bpe
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+buffer_store_dwordx4 v[24:27], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+28:vgprValuC+28+1], v[59:60], s[sgprBeta:sgprBeta+1], v[vgprValuC+28:vgprValuC+28+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+30:vgprValuC+30+1], v[61:62], s[sgprBeta:sgprBeta+1], v[vgprValuC+30:vgprValuC+30+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[28:31], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+32:vgprValuC+32+1], v[63:64], s[sgprBeta:sgprBeta+1], v[vgprValuC+32:vgprValuC+32+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+34:vgprValuC+34+1], v[65:66], s[sgprBeta:sgprBeta+1], v[vgprValuC+34:vgprValuC+34+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[32:35], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+36:vgprValuC+36+1], v[67:68], s[sgprBeta:sgprBeta+1], v[vgprValuC+36:vgprValuC+36+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+38:vgprValuC+38+1], v[69:70], s[sgprBeta:sgprBeta+1], v[vgprValuC+38:vgprValuC+38+1] // finalSum = sum*alpha + C*beta
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+buffer_store_dwordx4 v[36:39], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+40:vgprValuC+40+1], v[71:72], s[sgprBeta:sgprBeta+1], v[vgprValuC+40:vgprValuC+40+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+42:vgprValuC+42+1], v[73:74], s[sgprBeta:sgprBeta+1], v[vgprValuC+42:vgprValuC+42+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[40:43], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+44:vgprValuC+44+1], v[75:76], s[sgprBeta:sgprBeta+1], v[vgprValuC+44:vgprValuC+44+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+46:vgprValuC+46+1], v[77:78], s[sgprBeta:sgprBeta+1], v[vgprValuC+46:vgprValuC+46+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[44:47], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_branch label_0037                                // jump to end
+label_0036:
+
+/******************************************/
+/* Global Write Beta Edge Batch #0 (d1,d0,vc1,vc0) =
+   (0,0,0,0:vw1); (0,0,0,1:vw1); (0,1,0,0:vw1); (0,1,0,1:vw1); (0,2,0,0:vw1); (0,2,0,1:vw1); (0,0,1,0:vw1); (0,0,1,1:vw1) */
+/******************************************/
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(0,0,0,0) coordOffset1=0 element-rows coordOffset0=0 rows */
+v_mov_b32 v51, v50                                 // rowPtr <- rowStart (first row)
+_v_add_lshl_u32 v54, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[62:63], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v54, -1, v54, s[62:63]               // clip if OOB. offset
+buffer_load_dwordx2 v[55:56], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,0,1) coordOffset1=0 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v57, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[64:65], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v57, -1, v57, s[64:65]               // clip if OOB. offset
+buffer_load_dwordx2 v[58:59], v57, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,1,0) coordOffset1=0 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v60, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[66:67], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v60, -1, v60, s[66:67]               // clip if OOB. offset
+buffer_load_dwordx2 v[61:62], v60, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,1,1) coordOffset1=0 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v63, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[68:69], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v63, -1, v63, s[68:69]               // clip if OOB. offset
+buffer_load_dwordx2 v[64:65], v63, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,2,0) coordOffset1=0 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v66, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[70:71], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v66, -1, v66, s[70:71]               // clip if OOB. offset
+buffer_load_dwordx2 v[67:68], v66, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,2,1) coordOffset1=0 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v69, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[72:73], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v69, -1, v69, s[72:73]               // clip if OOB. offset
+buffer_load_dwordx2 v[70:71], v69, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,0,0) coordOffset1=1 element-rows coordOffset0=0 rows */
+_v_add_co_u32 v53, vcc, v49, 1                     // coord1 += d1*sg1*VW + vc1
+_v_add_co_u32 v51, vcc, v51, s[sgprStridesC+0]     // rowPtr <- move to start of new row
+_v_add_lshl_u32 v72, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[74:75], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v72, -1, v72, s[74:75]               // clip if OOB. offset
+buffer_load_dwordx2 v[73:74], v72, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,0,1) coordOffset1=1 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v75, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[76:77], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v75, -1, v75, s[76:77]               // clip if OOB. offset
+buffer_load_dwordx2 v[76:77], v75, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+
+/* rC *= alpha batchEements=[(0, 0, 0, 0), (0, 0, 0, 1), (0, 1, 0, 0), (0, 1, 0, 1), (0, 2, 0, 0), (0, 2, 0, 1), (0, 0, 1, 0), (0, 0, 1, 1)] */
+v_mul_f64 v[vgprValuC+0:vgprValuC+0+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+0:vgprValuC+0+1] // *= alpha
+v_mul_f64 v[vgprValuC+2:vgprValuC+2+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+2:vgprValuC+2+1] // *= alpha
+v_mul_f64 v[vgprValuC+4:vgprValuC+4+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+4:vgprValuC+4+1] // *= alpha
+v_mul_f64 v[vgprValuC+6:vgprValuC+6+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+6:vgprValuC+6+1] // *= alpha
+v_mul_f64 v[vgprValuC+8:vgprValuC+8+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+8:vgprValuC+8+1] // *= alpha
+v_mul_f64 v[vgprValuC+10:vgprValuC+10+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+10:vgprValuC+10+1] // *= alpha
+v_mul_f64 v[vgprValuC+12:vgprValuC+12+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+12:vgprValuC+12+1] // *= alpha
+v_mul_f64 v[vgprValuC+14:vgprValuC+14+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+14:vgprValuC+14+1] // *= alpha
+s_waitcnt vmcnt(0)                                 // wait C
+
+/* apply mask, calc new C and issue write */
+v_fma_f64 v[vgprValuC+0:vgprValuC+0+1], v[55:56], s[sgprBeta:sgprBeta+1], v[vgprValuC+0:vgprValuC+0+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[0:1], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+2:vgprValuC+2+1], v[58:59], s[sgprBeta:sgprBeta+1], v[vgprValuC+2:vgprValuC+2+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[2:3], v57, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+4:vgprValuC+4+1], v[61:62], s[sgprBeta:sgprBeta+1], v[vgprValuC+4:vgprValuC+4+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[4:5], v60, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+6:vgprValuC+6+1], v[64:65], s[sgprBeta:sgprBeta+1], v[vgprValuC+6:vgprValuC+6+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[6:7], v63, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+8:vgprValuC+8+1], v[67:68], s[sgprBeta:sgprBeta+1], v[vgprValuC+8:vgprValuC+8+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[8:9], v66, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+10:vgprValuC+10+1], v[70:71], s[sgprBeta:sgprBeta+1], v[vgprValuC+10:vgprValuC+10+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[10:11], v69, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+12:vgprValuC+12+1], v[73:74], s[sgprBeta:sgprBeta+1], v[vgprValuC+12:vgprValuC+12+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[12:13], v72, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+14:vgprValuC+14+1], v[76:77], s[sgprBeta:sgprBeta+1], v[vgprValuC+14:vgprValuC+14+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[14:15], v75, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+/******************************************/
+/* Global Write Beta Edge Batch #1 (d1,d0,vc1,vc0) =
+   (0,1,1,0:vw1); (0,1,1,1:vw1); (0,2,1,0:vw1); (0,2,1,1:vw1); (1,0,0,0:vw1); (1,0,0,1:vw1); (1,1,0,0:vw1); (1,1,0,1:vw1) */
+/******************************************/
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(0,1,1,0) coordOffset1=1 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v54, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[62:63], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v54, -1, v54, s[62:63]               // clip if OOB. offset
+buffer_load_dwordx2 v[55:56], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,1,1) coordOffset1=1 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v57, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[64:65], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v57, -1, v57, s[64:65]               // clip if OOB. offset
+buffer_load_dwordx2 v[58:59], v57, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,2,0) coordOffset1=1 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v60, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[66:67], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v60, -1, v60, s[66:67]               // clip if OOB. offset
+buffer_load_dwordx2 v[61:62], v60, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,2,1) coordOffset1=1 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v63, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[68:69], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v63, -1, v63, s[68:69]               // clip if OOB. offset
+buffer_load_dwordx2 v[64:65], v63, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,0,0) coordOffset1=32 element-rows coordOffset0=0 rows */
+_v_add_co_u32 v53, vcc, v49, 32                    // coord1 += d1*sg1*VW + vc1
+s_mul_i32 s56, s[sgprStridesC+0], 32               // scale StrideC *= coordOffset1(32)
+_v_add_co_u32 v51, vcc, v50, s56                   // rowPtr <- inc for non-0 (tt1+vc1))
+_v_add_lshl_u32 v66, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[70:71], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v66, -1, v66, s[70:71]               // clip if OOB. offset
+buffer_load_dwordx2 v[67:68], v66, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,0,1) coordOffset1=32 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v69, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[72:73], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v69, -1, v69, s[72:73]               // clip if OOB. offset
+buffer_load_dwordx2 v[70:71], v69, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,1,0) coordOffset1=32 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v72, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[74:75], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v72, -1, v72, s[74:75]               // clip if OOB. offset
+buffer_load_dwordx2 v[73:74], v72, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,1,1) coordOffset1=32 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v75, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[76:77], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v75, -1, v75, s[76:77]               // clip if OOB. offset
+buffer_load_dwordx2 v[76:77], v75, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+
+/* rC *= alpha batchEements=[(0, 1, 1, 0), (0, 1, 1, 1), (0, 2, 1, 0), (0, 2, 1, 1), (1, 0, 0, 0), (1, 0, 0, 1), (1, 1, 0, 0), (1, 1, 0, 1)] */
+v_mul_f64 v[vgprValuC+16:vgprValuC+16+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+16:vgprValuC+16+1] // *= alpha
+v_mul_f64 v[vgprValuC+18:vgprValuC+18+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+18:vgprValuC+18+1] // *= alpha
+v_mul_f64 v[vgprValuC+20:vgprValuC+20+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+20:vgprValuC+20+1] // *= alpha
+v_mul_f64 v[vgprValuC+22:vgprValuC+22+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+22:vgprValuC+22+1] // *= alpha
+v_mul_f64 v[vgprValuC+24:vgprValuC+24+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+24:vgprValuC+24+1] // *= alpha
+v_mul_f64 v[vgprValuC+26:vgprValuC+26+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+26:vgprValuC+26+1] // *= alpha
+v_mul_f64 v[vgprValuC+28:vgprValuC+28+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+28:vgprValuC+28+1] // *= alpha
+v_mul_f64 v[vgprValuC+30:vgprValuC+30+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+30:vgprValuC+30+1] // *= alpha
+s_waitcnt vmcnt(0)                                 // wait C
+
+/* apply mask, calc new C and issue write */
+v_fma_f64 v[vgprValuC+16:vgprValuC+16+1], v[55:56], s[sgprBeta:sgprBeta+1], v[vgprValuC+16:vgprValuC+16+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[16:17], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+18:vgprValuC+18+1], v[58:59], s[sgprBeta:sgprBeta+1], v[vgprValuC+18:vgprValuC+18+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[18:19], v57, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+20:vgprValuC+20+1], v[61:62], s[sgprBeta:sgprBeta+1], v[vgprValuC+20:vgprValuC+20+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[20:21], v60, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+22:vgprValuC+22+1], v[64:65], s[sgprBeta:sgprBeta+1], v[vgprValuC+22:vgprValuC+22+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[22:23], v63, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+24:vgprValuC+24+1], v[67:68], s[sgprBeta:sgprBeta+1], v[vgprValuC+24:vgprValuC+24+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[24:25], v66, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+26:vgprValuC+26+1], v[70:71], s[sgprBeta:sgprBeta+1], v[vgprValuC+26:vgprValuC+26+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[26:27], v69, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+28:vgprValuC+28+1], v[73:74], s[sgprBeta:sgprBeta+1], v[vgprValuC+28:vgprValuC+28+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[28:29], v72, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+30:vgprValuC+30+1], v[76:77], s[sgprBeta:sgprBeta+1], v[vgprValuC+30:vgprValuC+30+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[30:31], v75, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+/******************************************/
+/* Global Write Beta Edge Batch #2 (d1,d0,vc1,vc0) =
+   (1,2,0,0:vw1); (1,2,0,1:vw1); (1,0,1,0:vw1); (1,0,1,1:vw1); (1,1,1,0:vw1); (1,1,1,1:vw1); (1,2,1,0:vw1); (1,2,1,1:vw1) */
+/******************************************/
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(1,0,2,0) coordOffset1=32 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v54, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[62:63], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v54, -1, v54, s[62:63]               // clip if OOB. offset
+buffer_load_dwordx2 v[55:56], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,2,1) coordOffset1=32 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v57, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[64:65], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v57, -1, v57, s[64:65]               // clip if OOB. offset
+buffer_load_dwordx2 v[58:59], v57, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,0,0) coordOffset1=33 element-rows coordOffset0=0 rows */
+_v_add_co_u32 v53, vcc, v49, 33                    // coord1 += d1*sg1*VW + vc1
+_v_add_co_u32 v51, vcc, v51, s[sgprStridesC+0]     // rowPtr <- move to start of new row
+_v_add_lshl_u32 v60, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[66:67], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v60, -1, v60, s[66:67]               // clip if OOB. offset
+buffer_load_dwordx2 v[61:62], v60, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,0,1) coordOffset1=33 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v63, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[68:69], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v63, -1, v63, s[68:69]               // clip if OOB. offset
+buffer_load_dwordx2 v[64:65], v63, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,1,0) coordOffset1=33 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v66, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[70:71], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v66, -1, v66, s[70:71]               // clip if OOB. offset
+buffer_load_dwordx2 v[67:68], v66, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,1,1) coordOffset1=33 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v69, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[72:73], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v69, -1, v69, s[72:73]               // clip if OOB. offset
+buffer_load_dwordx2 v[70:71], v69, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,2,0) coordOffset1=33 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v72, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[74:75], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v72, -1, v72, s[74:75]               // clip if OOB. offset
+buffer_load_dwordx2 v[73:74], v72, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,2,1) coordOffset1=33 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v75, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[76:77], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v75, -1, v75, s[76:77]               // clip if OOB. offset
+buffer_load_dwordx2 v[76:77], v75, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+
+/* rC *= alpha batchEements=[(1, 2, 0, 0), (1, 2, 0, 1), (1, 0, 1, 0), (1, 0, 1, 1), (1, 1, 1, 0), (1, 1, 1, 1), (1, 2, 1, 0), (1, 2, 1, 1)] */
+v_mul_f64 v[vgprValuC+32:vgprValuC+32+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+32:vgprValuC+32+1] // *= alpha
+v_mul_f64 v[vgprValuC+34:vgprValuC+34+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+34:vgprValuC+34+1] // *= alpha
+v_mul_f64 v[vgprValuC+36:vgprValuC+36+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+36:vgprValuC+36+1] // *= alpha
+v_mul_f64 v[vgprValuC+38:vgprValuC+38+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+38:vgprValuC+38+1] // *= alpha
+v_mul_f64 v[vgprValuC+40:vgprValuC+40+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+40:vgprValuC+40+1] // *= alpha
+v_mul_f64 v[vgprValuC+42:vgprValuC+42+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+42:vgprValuC+42+1] // *= alpha
+v_mul_f64 v[vgprValuC+44:vgprValuC+44+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+44:vgprValuC+44+1] // *= alpha
+v_mul_f64 v[vgprValuC+46:vgprValuC+46+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+46:vgprValuC+46+1] // *= alpha
+s_waitcnt vmcnt(0)                                 // wait C
+
+/* apply mask, calc new C and issue write */
+v_fma_f64 v[vgprValuC+32:vgprValuC+32+1], v[55:56], s[sgprBeta:sgprBeta+1], v[vgprValuC+32:vgprValuC+32+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[32:33], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+34:vgprValuC+34+1], v[58:59], s[sgprBeta:sgprBeta+1], v[vgprValuC+34:vgprValuC+34+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[34:35], v57, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+36:vgprValuC+36+1], v[61:62], s[sgprBeta:sgprBeta+1], v[vgprValuC+36:vgprValuC+36+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[36:37], v60, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+38:vgprValuC+38+1], v[64:65], s[sgprBeta:sgprBeta+1], v[vgprValuC+38:vgprValuC+38+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[38:39], v63, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+40:vgprValuC+40+1], v[67:68], s[sgprBeta:sgprBeta+1], v[vgprValuC+40:vgprValuC+40+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[40:41], v66, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+42:vgprValuC+42+1], v[70:71], s[sgprBeta:sgprBeta+1], v[vgprValuC+42:vgprValuC+42+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[42:43], v69, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+44:vgprValuC+44+1], v[73:74], s[sgprBeta:sgprBeta+1], v[vgprValuC+44:vgprValuC+44+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[44:45], v72, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+46:vgprValuC+46+1], v[76:77], s[sgprBeta:sgprBeta+1], v[vgprValuC+46:vgprValuC+46+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[46:47], v75, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_branch label_0037                                // jump to end
+label_0037:
+
+label_0038:  /// KernelEnd
+s_endpgm                                           // Kernel End
+
+

--- a/Tensile/ReplacementKernels/Cijk_Ailk_Bjlk_DB_MT48x64x4_AF0EM1_ASEM1_FL1_GRVW2_ISA906_MDA2_PGR1_PLR0_SU0_TT6_4_VAW1_VW2_WG8_16_1_WGM8.s.txt
+++ b/Tensile/ReplacementKernels/Cijk_Ailk_Bjlk_DB_MT48x64x4_AF0EM1_ASEM1_FL1_GRVW2_ISA906_MDA2_PGR1_PLR0_SU0_TT6_4_VAW1_VW2_WG8_16_1_WGM8.s.txt
@@ -1,0 +1,3885 @@
+
+
+/******************************************/
+/* Function Prefix                        */
+/******************************************/
+
+
+
+/******************************************/
+/* Begin Kernel                           */
+/******************************************/
+
+.hsa_code_object_version 2,0
+.hsa_code_object_isa 9, 0, 6, "AMD", "AMDGPU"
+.text
+.protected Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA906_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM8
+.globl Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA906_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM8
+.p2align 8
+.type Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA906_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM8,@function
+.amdgpu_hsa_kernel Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA906_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM8
+Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA906_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM8:
+.amd_kernel_code_t
+  is_ptr64 = 1
+  enable_sgpr_kernarg_segment_ptr = 1
+  kernarg_segment_byte_size = 92 // bytes of kern args
+  workitem_vgpr_count = 84 // vgprs
+  wavefront_sgpr_count = 98 // sgprs
+  compute_pgm_rsrc1_vgprs = 20 // floor((83-1)/4)
+  compute_pgm_rsrc1_sgprs = 13 // floor((98-1)/8)
+  compute_pgm_rsrc2_tidig_comp_cnt = 0 // 1D wg
+  compute_pgm_rsrc2_tgid_x_en = 1 // wg.x
+  compute_pgm_rsrc2_tgid_y_en = 1 // wg.y
+  compute_pgm_rsrc2_tgid_z_en = 1 // wg.z
+  workgroup_group_segment_byte_size = 7680 // lds bytes
+  compute_pgm_rsrc2_user_sgpr = 2 // vcc
+  kernarg_segment_alignment = 4
+  group_segment_alignment = 4
+  private_segment_alignment = 4
+.end_amd_kernel_code_t
+
+.amd_amdgpu_hsa_metadata
+Version: [ 1, 0 ]
+Kernels:
+  - Name: Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA906_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM8
+    SymbolName: 'Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA906_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM8@kd'
+    Language: OpenCL C
+    LanguageVersion: [ 2, 0 ]
+    Args:
+      - Name:            sizeC
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            sizeA
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            sizeB
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            D
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       F64
+        AddrSpaceQual:   Generic
+      - Name:            C
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       F64
+        AddrSpaceQual:   Generic
+      - Name:            A
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       F64
+        AddrSpaceQual:   Generic
+      - Name:            B
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       F64
+        AddrSpaceQual:   Generic
+      - Name:            alpha
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       F64
+      - Name:            beta
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       F64
+      - Name:            strideD0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideD1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideC0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideC1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideA0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideA1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideB0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideB1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree2
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesSum0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            OrigStaggerUIter
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       I32
+      - Name:            NumWorkGroups0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            NumWorkGroups1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            MagicNumberProblemNumGroupTiles0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            GridNumWorkGroups0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            NumFullBlocks
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            WgmRemainder1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            MagicNumberWgmRemainder1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            padding
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+    CodeProps:
+      KernargSegmentSize: 156
+      GroupSegmentFixedSize: 7680
+      PrivateSegmentFixedSize: 0
+      KernargSegmentAlign:  8
+      WavefrontSize:        64
+      NumSGPRs:             98
+      NumVGPRs:             84
+      MaxFlatWorkGroupSize: 128
+.end_amd_amdgpu_hsa_metadata
+
+/******************************************/
+/* Optimizations and Config:              */
+/******************************************/
+/* ThreadTile= 6 x 4 */
+/* SubGroup= 8 x 16 */
+/* VectorWidth=2 */
+/* GlobalLoadVectorWidthA=2, GlobalLoadVectorWidthB=2 */
+/* DirectToLdsA=False */
+/* DirectToLdsB=False */
+/* UseSgprForGRO=False */
+
+/******************************************/
+/* Asm syntax workarounds                 */
+/******************************************/
+.macro _v_add_co_u32 dst, cc, src0, src1, dpp=
+   v_add_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+.macro _v_sub_co_u32 dst, cc, src0, src1, dpp=
+   v_sub_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+.macro _v_addc_co_u32 dst, ccOut, src0, ccIn, src1, dpp=
+   v_addc_co_u32 \dst, \ccOut, \src0, \ccIn, \src1 \dpp
+.endm
+.macro _v_add_lshl_u32 dst, src0, src1, shiftCnt
+    v_add_lshl_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+.macro _v_lshl_add_u32 dst, src0, src1, shiftCnt
+    v_lshl_add_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+/******************************************/
+/* Magic div and mod functions            */
+/******************************************/
+.macro V_MAGIC_DIV dstIdx, dividend, magicNumber, magicShift
+    v_mul_lo_u32 v[\dstIdx+0], \dividend, \magicNumber
+    v_mul_hi_u32 v[\dstIdx+1], \dividend, \magicNumber
+    v_lshrrev_b64 v[\dstIdx:\dstIdx+1], \magicShift, v[\dstIdx:\dstIdx+1]
+.endm
+
+/******************************************/
+/* VGPR Assignments                       */
+/******************************************/
+.set vgprValuC, 0
+/* ValuA/B   Xn=PLR buffer idx,  In=InnerUnroll idx */
+.set vgprValuA_X0_I0, 48
+.set vgprG2LA, 60
+.set vgprValuB_X0_I0, 64
+.set vgprG2LB, 72
+.set vgprLocalWriteAddrA, 76
+.set vgprLocalWriteAddrB, 77
+.set vgprGlobalReadOffsetA, 78
+.set vgprGlobalReadOffsetB, 79
+.set vgprLocalReadAddrA, 80
+.set vgprLocalReadAddrB, 81
+.set vgprSerial, 82
+/* Num VGPR=83 */
+
+/******************************************/
+/* SGPR Assignments                       */
+/******************************************/
+.set sgprKernArgAddress, 0
+.set sgprWorkGroup0, 2
+.set sgprWorkGroup1, 3
+.set sgprWorkGroup2, 4
+.set sgprNumWorkGroups0, 5
+.set sgprNumWorkGroups1, 6
+.set sgprSrdA, 8
+.set sgprSrdB, 12
+.set sgprSrdD, 16
+.set sgprSrdC, 20
+.set sgprTensor2dSizeC, 24
+.set sgprTensor2dSizeA, 26
+.set sgprTensor2dSizeB, 28
+.set sgprSaveExecMask, 30
+.set sgprAddressD, 32
+.set sgprAddressC, 34
+.set sgprStridesC, 36
+.set sgprAlpha, 38
+.set sgprBeta, 40
+.set sgprSizesFree, 42
+.set sgprSizesSum, 45
+.set sgprLoopCounters, 46
+.set sgprOrigLoopCounter, 47
+.set sgprStridesA, 48
+.set sgprStridesB, 50
+.set sgprAddressA, 52
+.set sgprAddressB, 54
+.set sgprShadowLimitA, 56
+.set sgprShadowLimitB, 58
+.set sgprNumFullBlocks, 60
+.set sgprWgmRemainder1, 61
+.set sgprMagicNumberWgmRemainder1, 62
+.set sgprGlobalReadIncsA, 63
+.set sgprGlobalReadIncsB, 64
+.set sgprStridesD, 74
+.set sgprTMP0, 90
+.set sgprTMP1, 91
+.set sgprEdgeSelMask0, 93
+.set sgprEdgeSelMask1, 94
+/* max SGPR=98 */
+
+/******************************************/
+/* 2GB limit - set offsets to -1 to exceed this and clamp */
+/******************************************/
+.set BufferLimit, 0x80000000
+
+/******************************************/
+/* Bits 127:96 of SRD.  Set DataFormat = 32 bit */
+/******************************************/
+.set Srd127_96, 0x0020000
+.set BufferOOB, 0x80000000
+
+/* Global Offset A */
+.macro GLOBAL_OFFSET_A vgprAddr vgprOffset0I vgprOffsetL vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStridesA+0], v[\vgprOffsetL] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprTmp+0], v[\vgprOffset0I] // accumulate d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, 0x2, v[\vgprAddr+0] // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x3, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/* Global Offset B */
+.macro GLOBAL_OFFSET_B vgprAddr vgprOffset1J vgprOffsetL vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStridesB+0], v[\vgprOffsetL] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprTmp+0], v[\vgprOffset1J] // accumulate d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, 0x2, v[\vgprAddr+0] // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x3, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/******************************************/
+/* Dynamic Scalar Divide: vQuotient=vDividend/vDivisor; vRemainder=vDividend%vDivisor; */
+/******************************************/
+.macro DYNAMIC_VECTOR_DIVIDE vQuotient vRemainder vDividend vDivisor vTmp0 vTmp1 sTmp
+v_cvt_f32_u32 v[\vQuotient], v[\vDivisor]          //
+v_rcp_f32 v[\vQuotient], v[\vQuotient]             //
+v_mul_f32 v[\vQuotient], 0x4f800000, v[\vQuotient] //
+v_cvt_u32_f32 v[\vQuotient], v[\vQuotient]         //
+v_mul_lo_u32 v[\vRemainder], v[\vDivisor], v[\vQuotient] //
+v_mul_hi_u32 v[\vTmp0], v[\vDivisor], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp1], vcc, 0x0, v[\vRemainder]  //
+v_cmp_ne_i32 s[\sTmp:\sTmp+1], 0x0, v[\vTmp0]      //
+v_cndmask_b32 v[\vRemainder], v[\vTmp1], v[\vRemainder], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vRemainder], v[\vRemainder], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vQuotient], v[\vRemainder] //
+_v_add_co_u32 v[\vQuotient], vcc, v[\vQuotient], v[\vRemainder] //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vTmp0], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vQuotient], v[\vQuotient], v[\vDividend] //
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vDividend], v[\vRemainder] //
+v_cmp_ge_u32 s[\sTmp:\sTmp+1], v[\vDividend], v[\vRemainder] //
+_v_add_co_u32 v[\vRemainder], vcc, 0x1, v[\vQuotient] //
+_v_add_co_u32 v[\vTmp1], vcc, -1, v[\vQuotient]    //
+v_cmp_le_u32 vcc, v[\vDivisor], v[\vTmp0]          //
+s_and_b64 vcc, s[\sTmp:\sTmp+1], vcc               //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vRemainder], vcc //
+v_cndmask_b32 v[\vQuotient], v[\vTmp1], v[\vQuotient], s[\sTmp:\sTmp+1] //
+v_cmp_ne_i32 vcc, 0x0, v[\vDivisor]                //
+v_cndmask_b32 v[\vQuotient], -1, v[\vQuotient], vcc // final result
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vRemainder], vcc, v[\vDividend], v[\vRemainder] // final result
+.endm
+
+/******************************************/
+/* 6x4 thread-tile                        */
+/******************************************/
+.macro MAC_6x4_X0
+v_fma_f64 v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1]
+s_setprio 1 // Raise priority while processing macs
+v_fma_f64 v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1]
+s_setprio 0 // Reset priority after macs
+.endm
+
+.macro MAC_6x4_X0_part_1
+v_fma_f64 v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1]
+s_setprio 1 // Raise priority while processing macs
+v_fma_f64 v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1]
+.endm
+
+.macro MAC_6x4_X0_part_2
+.endm
+
+.macro MAC_6x4_X0_part_3
+v_fma_f64 v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1]
+s_setprio 0 // Reset Priority
+.endm
+
+.macro MAC_6x4_X0_unprio_0
+v_fma_f64 v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1]
+s_setprio 1 // Raise priority while processing macs
+v_fma_f64 v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1]
+.endm
+
+
+.macro MAC_6x4_X0_part1
+v_fma_f64 v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1]
+s_setprio 1
+v_fma_f64 v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1]
+s_setprio 0
+.endm
+
+
+.macro MAC_6x4_X0_part2
+v_fma_f64 v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1]
+s_setprio 1
+v_fma_f64 v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1]
+s_setprio 0
+.endm
+.macro MAC_6x4_X0_part3
+v_fma_f64 v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1]
+s_setprio 1
+v_fma_f64 v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1]
+s_setprio 0
+.endm
+.macro MAC_6x4_X0_part4
+v_fma_f64 v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1]
+s_setprio 1
+v_fma_f64 v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1]
+//vnop_4
+s_setprio 0
+.endm
+.macro MAC_6x4_X0_part5
+v_fma_f64 v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1]
+s_setprio 1
+v_fma_f64 v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1]
+//vnop_4
+s_setprio 0
+.endm
+.macro MAC_6x4_X0_part6
+v_fma_f64 v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1]
+s_setprio 1
+v_fma_f64 v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1]
+s_setprio 0
+.endm
+
+/******************************************/
+/* Allocate Resources                     */
+/******************************************/
+
+s_mov_b32 m0, 0x1e00                               // LDS clamp at 7680 bytes
+v_mov_b32 v[vgprSerial], v0                        // thread serial id
+
+/* Load Kernel Args */
+s_load_dword s[sgprTensor2dSizeC+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x0 //
+s_load_dword s[sgprTensor2dSizeC+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x4 //
+s_load_dword s[sgprTensor2dSizeA+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x8 //
+s_load_dword s[sgprTensor2dSizeA+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0xc //
+s_load_dword s[sgprTensor2dSizeB+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x10 //
+s_load_dword s[sgprTensor2dSizeB+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x14 //
+s_load_dword s[sgprAddressD], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x18 //
+s_load_dword s[sgprAddressD+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x1c //
+s_load_dword s[sgprAddressC], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x20 //
+s_load_dword s[sgprAddressC+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x24 //
+s_load_dword s[sgprAddressA], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x28 //
+s_load_dword s[sgprAddressA+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x2c //
+s_load_dword s[sgprAddressB], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x30 //
+s_load_dword s[sgprAddressB+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x34 //
+s_load_dword s[sgprAlpha+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x38 //
+s_load_dword s[sgprAlpha+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x3c //
+s_load_dword s[sgprBeta+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x40 //
+s_load_dword s[sgprBeta+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x44 //
+s_load_dword s[sgprStridesD+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x48 //
+s_load_dword s[sgprStridesD+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x4c //
+s_load_dword s[sgprStridesC+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x50 //
+s_load_dword s[sgprStridesC+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x54 //
+s_load_dword s[sgprStridesA+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x58 //
+s_load_dword s[sgprStridesA+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x5c //
+s_load_dword s[sgprStridesB+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x60 //
+s_load_dword s[sgprStridesB+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x64 //
+s_load_dword s[sgprSizesFree+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x68 //
+s_load_dword s[sgprSizesFree+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x6c //
+s_load_dword s[sgprSizesFree+2], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x70 //
+s_load_dword s[sgprSizesSum+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x74 //
+s_load_dword s[sgprNumWorkGroups0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x7c //
+s_load_dword s[sgprNumWorkGroups1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x80 //
+s_load_dword s[sgprNumFullBlocks], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x8c //
+s_load_dword s[sgprWgmRemainder1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x90 //
+s_load_dword s[sgprMagicNumberWgmRemainder1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x94 //
+s_waitcnt lgkmcnt(0)                               // wait for 144 bytes of kern args
+
+
+/******************************************/
+/* Local Read Addresses                   */
+/******************************************/
+
+
+/* local read addresses: tile assignments a */
+
+/*lr0I = serial % SG0I*/
+v_lshrrev_b32 v0, 3, v[vgprSerial]                 // vectorStaticDiv: v0 = v[vgprSerial] / 8
+v_and_b32 v1, 7, v[vgprSerial]                     // vectorStaticDiv: v1 = v[vgprSerial] % 8
+
+
+/* local read addresses: tile assignments b */
+
+/*lr1J = (serial / SG1J) % SG1J*/
+v_lshrrev_b32 v2, 4, v0                            // vectorStaticDiv: v2 = v0 / 16
+v_and_b32 v3, 15, v0                               // vectorStaticDiv: v3 = v0 % 16
+
+
+/* local read addresses: final offsets a */
+
+v_lshrrev_b32 v0, 7, v[vgprSerial]                 // vectorStaticDiv: v0 = v[vgprSerial] / 128
+v_and_b32 v2, 127, v[vgprSerial]                   // vectorStaticDiv: v2 = v[vgprSerial] % 128
+s_mov_b32 s65, 0x30                                // MT0+PAD
+v_mul_lo_u32 v0, s65, v0                           // sgid=sgid*(MT0+PAD)
+v_lshlrev_b32 v1, 1, v1                            // staticMultiply: v1 = v1 * 2
+_v_add_lshl_u32 v[vgprLocalReadAddrA], v0, v1, 0x3 // o = (lroA*VW+sgid*MT0)*bpe
+
+
+/* local read addresses: final offsets b */
+
+v_lshrrev_b32 v0, 7, v[vgprSerial]                 // vectorStaticDiv: v0 = v[vgprSerial] / 128
+v_and_b32 v1, 127, v[vgprSerial]                   // vectorStaticDiv: v1 = v[vgprSerial] % 128
+s_mov_b32 s65, 0x40                                // MT1+PAD
+v_mul_lo_u32 v0, s65, v0                           // sgid=sgid*(MT1+PAD)
+v_lshlrev_b32 v3, 1, v3                            // staticMultiply: v3 = v3 * 2
+_v_add_lshl_u32 v[vgprLocalReadAddrB], v0, v3, 0x3 // o = (lroB*VW+sgid*MT1)*bpe
+
+
+/* local read addresses: declare addresses a */
+
+/* N/A */
+
+
+/* local read addresses: declare addresses b */
+
+_v_add_co_u32 v[vgprLocalReadAddrB+0], vcc, 0x600, v[vgprLocalReadAddrB+0] //  += LdsOffsetB (lower)
+
+
+s_load_dword s[sgprNumWorkGroups1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x80 //
+s_load_dword s[sgprNumFullBlocks], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x8c //
+s_load_dword s[sgprWgmRemainder1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x90 //
+s_load_dword s[sgprMagicNumberWgmRemainder1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x94 //
+/******************************************/
+/* Global Read Addresses                  */
+/******************************************/
+
+
+/* global read addresses: work-group */
+
+/* graWorkGroup mapping */
+s_mov_b32 s69, 0x10000001L                         // magic number for WGM==4
+s_mul_hi_u32 s67, s[sgprWorkGroup1], s69           // s_magic mul
+s_mul_i32 s66, s[sgprWorkGroup1], s69              // s_magic mul
+s_lshr_b64 s[66:67], s[66:67], 31                  // sMagicDiv
+s_mul_i32 s67, s66, 8                              // quotient * non-magic divisor
+s_sub_u32 s67, s[sgprWorkGroup1], s67              // WorkGroup1=remainder
+s_mul_i32 s67, s67, s[sgprNumWorkGroups0]          // (wg1 % WGM)*nwg0
+s_add_u32 s67, s67, s[sgprWorkGroup0]              // wgSerial = wg0 + (wg1 % WGM)*nwg0
+s_cmp_ge_u32 s66, s[sgprNumFullBlocks]             // blockId >= numFullBlocks ?
+s_cmov_b32 s69, s[sgprMagicNumberWgmRemainder1]    //
+s_cselect_b32 s68, s[sgprWgmRemainder1], 8         //
+s_mul_hi_u32 s3, s67, s69                          // s_magic mul
+s_mul_i32 s2, s67, s69                             // s_magic mul
+s_lshr_b64 s[2:3], s[2:3], 31                      // sMagicDiv
+s_mul_i32 s[sgprWorkGroup1], s[sgprWorkGroup0], s68 // quotient * non-magic divisor
+s_sub_u32 s[sgprWorkGroup1], s67, s[sgprWorkGroup1] // WorkGroup1=remainder
+s_mul_i32 s66, s66, 8                              // blockId * WGM
+s_add_u32 s[sgprWorkGroup1], s[sgprWorkGroup1], s66 // wg1 += blockId * WGM
+
+
+/* global read addresses: tile offset assignment a */
+
+/* LVCA = 24 */
+/* v0 = (local)groA-tile = serial%LVCA (note (wgA*MTA) will be added to SRD) */
+/* v1 = groA-unroll = serial/LVCA */
+s_mov_b32 s65, 0x15555556                          //
+v_mul_hi_u32 v3, v[vgprSerial], s65                //
+v_mul_lo_u32 v2, v[vgprSerial], s65                //
+v_lshrrev_b64 v[2:3], 0x21, v[2:3]                 //
+v_mov_b32 v1, v2                                   // vectorStaticDiv: quotient
+s_mov_b32 s65, 0x18                                // divisor
+v_mul_lo_u32 v2, v1, s65                           // vectorStaticDiv: product = quotient * divisor
+_v_sub_co_u32 v0, vcc, v[vgprSerial], v2           // vectorStaticDiv: remainder = dividend - product
+/* gro-tile *= glvw */
+v_lshlrev_b32 v0, 1, v0                            // staticMultiply: v0 = v0 * 2
+
+
+/* global read addresses: tile offset assignment b */
+
+/* LVCB = 32 */
+/* v2 = (local)groB-tile = serial%LVCB (note (wgB*MTB) will be added to SRD) */
+/* v3 = groB-unroll = serial/LVCB */
+v_lshrrev_b32 v3, 5, v[vgprSerial]                 // vectorStaticDiv: v3 = v[vgprSerial] / 32
+v_and_b32 v2, 31, v[vgprSerial]                    // vectorStaticDiv: v2 = v[vgprSerial] % 32
+/* gro-tile *= glvw */
+v_lshlrev_b32 v2, 1, v2                            // staticMultiply: v2 = v2 * 2
+
+
+/* global read addresses: unroll assignment a */
+
+/* v1 */
+
+
+/* global read addresses: unroll assignment b */
+
+/* v3 */
+
+
+/* global read addresses: other free assignments */
+
+/* s[sgprWorkGroup2] */
+
+
+/* global read addresses: tile offsets a */
+
+v_mov_b32 v4, v0                                   // groA0I_0
+
+
+/* global read addresses: tile offsets b */
+
+v_mov_b32 v5, v2                                   // groB1J_0
+
+
+/* global read addresses: unroll offsets a */
+
+v_mov_b32 v6, v1                                   // groAL_0
+
+
+/* global read addresses: unroll offsets b */
+
+v_mov_b32 v7, v3                                   // groBL_0
+
+
+/* global read addresses: shift a */
+
+s_mul_i32 s65, s[sgprWorkGroup0], 48               // WorkGroup[01] * MT
+s_sub_u32 s65, s[sgprSizesFree+0], s65             // edge = Size0I - WG*MT
+s_sub_u32 s65, s65, 2                              // edge -= margin
+v_mov_b32 v8, s65                                  // edge vgpr = Size0I-2
+_v_add_co_u32 v9, vcc, v8, 2                       // add srdShiftLift
+_v_add_co_u32 v10, vcc, v4, 2                      //
+v_cmp_lt_u32 s[66:67], v10, v9                     // offset < edge
+v_cndmask_b32 v4, v8, v4, s[66:67]                 // offset = (offset < edge) ? offset : edge
+
+
+/* global read addresses: shift b */
+
+s_mul_i32 s65, s[sgprWorkGroup1], 64               // WorkGroup[01] * MT
+s_sub_u32 s65, s[sgprSizesFree+1], s65             // edge = Size1J - WG*MT
+s_sub_u32 s65, s65, 2                              // edge -= margin
+v_mov_b32 v8, s65                                  // edge vgpr = Size1J-2
+_v_add_co_u32 v9, vcc, v8, 2                       // add srdShiftLift
+_v_add_co_u32 v10, vcc, v5, 2                      //
+v_cmp_lt_u32 s[66:67], v10, v9                     // offset < edge
+v_cndmask_b32 v5, v8, v5, s[66:67]                 // offset = (offset < edge) ? offset : edge
+
+
+/* global read addresses: final offsets a */
+
+GLOBAL_OFFSET_A vgprGlobalReadOffsetA+0,  4,  6, 8 // gROA_0_0_0_0
+// Offset only valid for 96/128 threads inside the PerLoadTile
+s_mov_b32 s66, 96                                  //
+v_cmp_lt_u32 vcc, v[vgprSerial], s66               // tid < valid-tid
+s_mov_b32 s66, BufferOOB                           //
+v_mov_b32 v11, s66                                 //
+v_cndmask_b32 v[vgprGlobalReadOffsetA+0], v11, v[vgprGlobalReadOffsetA+0], vcc // Mask load so OOB will return 0
+
+
+/* global read addresses: final offsets b */
+
+GLOBAL_OFFSET_B vgprGlobalReadOffsetB+0,  5,  7, 8 // gROB_0_0_0_0
+
+
+/* global read addresses: addresses a */
+
+/* max read offset = size[n] * stride[n-1] */
+s_mul_hi_u32 s69, s[sgprWorkGroup0], 48            // WorkGroup[01] * MT
+s_mul_i32 s68, s[sgprWorkGroup0], 48               // WorkGroup[01] * MT
+s_sub_u32 s[sgprShadowLimitA+0], s[sgprTensor2dSizeA], s68 // sub tileStart
+s_subb_u32 s[sgprShadowLimitA+1], s[sgprTensor2dSizeA+1], s69 // sub tileStart
+s_lshl_b64 s[sgprShadowLimitA:sgprShadowLimitA+1], s[sgprShadowLimitA:sgprShadowLimitA+1], 0x3 // Set limit to use bytes
+s_add_u32 s[sgprShadowLimitA+0], s[sgprShadowLimitA+0], 16 // extend limit for pre-pad
+s_addc_u32 s[sgprShadowLimitA+1], s[sgprShadowLimitA+1], 0 // extend limit for pre-pad
+s_cmp_eq_u32 s[sgprShadowLimitA+1], 0              // are we within 2^32?
+s_cselect_b32 s[sgprSrdA+2], s[sgprShadowLimitA+0], BufferLimit // Move shadow to real if we are within 2^32
+s_mul_hi_u32 s67, s[sgprStridesA+1], s[sgprWorkGroup2] // Stride*WG
+s_mul_i32 s66, s[sgprStridesA+1], s[sgprWorkGroup2] // Stride*WG
+s_add_u32 s68, s68, s66                            // accum wg term to tilestart
+s_addc_u32 s69, s69, s67                           // accum wg term to tilestart
+s_lshl_b64 s[68:69], s[68:69], 3                   // tileStart *= BPE
+s_add_u32 s[sgprSrdA+0], s[sgprAddressA+0], s68    // SRD base = Address+ tileStart0
+s_addc_u32 s[sgprSrdA+1], s[sgprAddressA+1], s69   // SRD base = Address+ tileStart1
+s_sub_u32 s[sgprSrdA+0], s[sgprSrdA+0], 16         // pre-pad to make room for possible pointer shift
+s_subb_u32 s[sgprSrdA+1], s[sgprSrdA+1], 0         // pre-pad to make room for possible pointer shift
+s_mov_b32 s[sgprSrdA+3], Srd127_96                 // Set bits 127_96 in SRD
+
+
+/* global read addresses: addresses b */
+
+/* max read offset = size[n] * stride[n-1] */
+s_mul_hi_u32 s69, s[sgprWorkGroup1], 64            // WorkGroup[01] * MT
+s_mul_i32 s68, s[sgprWorkGroup1], 64               // WorkGroup[01] * MT
+s_sub_u32 s[sgprShadowLimitB+0], s[sgprTensor2dSizeB], s68 // sub tileStart
+s_subb_u32 s[sgprShadowLimitB+1], s[sgprTensor2dSizeB+1], s69 // sub tileStart
+s_lshl_b64 s[sgprShadowLimitB:sgprShadowLimitB+1], s[sgprShadowLimitB:sgprShadowLimitB+1], 0x3 // Set limit to use bytes
+s_add_u32 s[sgprShadowLimitB+0], s[sgprShadowLimitB+0], 16 // extend limit for pre-pad
+s_addc_u32 s[sgprShadowLimitB+1], s[sgprShadowLimitB+1], 0 // extend limit for pre-pad
+s_cmp_eq_u32 s[sgprShadowLimitB+1], 0              // are we within 2^32?
+s_cselect_b32 s[sgprSrdB+2], s[sgprShadowLimitB+0], BufferLimit // Move shadow to real if we are within 2^32
+s_mul_hi_u32 s67, s[sgprStridesB+1], s[sgprWorkGroup2] // Stride*WG
+s_mul_i32 s66, s[sgprStridesB+1], s[sgprWorkGroup2] // Stride*WG
+s_add_u32 s68, s68, s66                            // accum wg term to tilestart
+s_addc_u32 s69, s69, s67                           // accum wg term to tilestart
+s_lshl_b64 s[68:69], s[68:69], 3                   // tileStart *= BPE
+s_add_u32 s[sgprSrdB+0], s[sgprAddressB+0], s68    // SRD base = Address+ tileStart0
+s_addc_u32 s[sgprSrdB+1], s[sgprAddressB+1], s69   // SRD base = Address+ tileStart1
+s_sub_u32 s[sgprSrdB+0], s[sgprSrdB+0], 16         // pre-pad to make room for possible pointer shift
+s_subb_u32 s[sgprSrdB+1], s[sgprSrdB+1], 0         // pre-pad to make room for possible pointer shift
+s_mov_b32 s[sgprSrdB+3], Srd127_96                 // Set bits 127_96 in SRD
+
+
+/* global read addresses: increments a */
+
+s_mul_i32 s[sgprGlobalReadIncsA+0], 0x20, s[sgprStridesA] // incr = stride*4*bytes
+
+
+/* global read addresses: increments b */
+
+s_mul_i32 s[sgprGlobalReadIncsB+0], 0x20, s[sgprStridesB] // incr = stride*4*bytes
+
+
+/******************************************/
+/* Local Write Addresses                  */
+/******************************************/
+
+
+/* local write addresses: tile assignment a */
+
+/* lwaTileA = v0 */
+
+
+/* local write addresses: tile assignment b */
+
+/* lwaTileB = v2 */
+
+
+/* local write addresses: unroll assignment a */
+
+/* lwaUnrollA = v1 */
+
+
+/* local write addresses: unroll assignment b */
+
+/* lwaUnrollB = v3 */
+
+
+/* local write addresses: first offset a */
+
+v_mul_u32_u24 v[vgprLocalWriteAddrA], 0x30, v1     // lwAL**(MTA + PAD)
+_v_add_lshl_u32 v[vgprLocalWriteAddrA], v0, v[vgprLocalWriteAddrA], 0x3 // lwFOA = (lwAA + lwAL*(MT0I+PAD))*bpe
+s_mov_b32 s65, 96                                  // lsc*lsp=48*4
+v_cmp_lt_u32 vcc, v[vgprSerial], s65               // fractional: ensure tid < global read tile elements
+v_mov_b32 v0, 0xf00000                             //
+v_cndmask_b32 v[vgprLocalWriteAddrA], v0, v[vgprLocalWriteAddrA], vcc // Mask load so out-of-gr-tile bounds returns 0
+
+
+/* local write addresses: first offset b */
+
+v_mul_u32_u24 v[vgprLocalWriteAddrB], 0x40, v3     // lwBL**(MTB + PAD)
+_v_add_lshl_u32 v[vgprLocalWriteAddrB], v2, v[vgprLocalWriteAddrB], 0x3 // lwFOB = (lwBB + lwBL*(MT1J+PAD))*bpe
+_v_add_co_u32 v[vgprLocalWriteAddrB], vcc, 0x600, v[vgprLocalWriteAddrB] // lwFOB = lwB1J + lwBL*MT1J + LDS_OFFSET_B=192*8
+
+
+/* local write addresses: final offsets a */
+
+
+/* N/A */
+
+
+/* local write addresses: final offsets b */
+
+
+/* N/A */
+
+
+/* local write addresses: declare addresses a */
+
+/* N/A */
+
+
+/* local write addresses: declare addresses b */
+
+/* N/A */
+
+
+/* local write addresses: init pointers a */
+
+/* N/A */
+
+
+/* local write addresses: init pointers b */
+
+/* N/A */
+
+
+/* declare loop num iterations */
+
+
+s_lshr_b32 s[sgprLoopCounters+0], s[sgprSizesSum+0], 2 // s[sgprLoopCounters+0] = s[sgprSizesSum+0] / 4
+s_mov_b32 s[sgprOrigLoopCounter], s[sgprLoopCounters+0] // copy loop counter
+s_sub_u32 s[sgprLoopCounters+0], 0x0, s[sgprLoopCounters+0] // counterL = -sizeL
+
+
+/* local read addresses: init pointers a */
+
+
+
+/* local read addresses: init pointers b */
+
+
+
+/* TODO-packed- compare against product of all packed C0 sizes not just SizesFree+0 */
+s_mov_b32 s91, 0x0                                 // STATIC_DIV: divisior=48
+s_mul_i32 s90, 0xaaa, s[sgprSizesFree+0]           // tmp1 = dividend * magic hi
+s_lshl_b64 s[90:91], s[90:91], 0x10                // left shift 16 bits
+s_mul_i32 s82, s[sgprSizesFree+0], 0xaaab          // tmp0 = dividend * magic lo
+s_add_u32 s90, s82, s90                            // add lo
+s_addc_u32 s91, s91, 0x0                           // add hi
+s_lshr_b64 s[90:91], s[90:91], 0x21                // tmp1 = (dividend * magic) << shift
+s_mov_b32 s82, s90                                 // quotient
+s_mul_i32 s90, s82, 0x30                           // quotient*divisor
+s_sub_u32 s[sgprEdgeSelMask0], s[sgprSizesFree+0], s90             // rReg = dividend - quotient*divisor
+s_lshr_b32 s82, s[sgprSizesFree+1], 6              // s58 = s[sgprSizesFree+1] / 64
+s_and_b32 s[sgprEdgeSelMask1], 63, s[sgprSizesFree+1]
+
+
+/* prefetch: global -> local */
+
+s_cmp_eq_u32 s[sgprLoopCounters+0], 0x0            // numIter0I == 0
+s_cbranch_scc1 label_0008                          // skip to ShadowInitStart iter b/c numIter==0
+
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+
+
+/* global read inc A */
+s_add_u32  s[sgprSrdA+0], s[sgprSrdA+0], s[sgprGlobalReadIncsA] // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdA+1], s[sgprSrdA+1], 0        // gra SRD += inc(upper)
+s_sub_u32 s[sgprShadowLimitA+0], s[sgprShadowLimitA+0], s[sgprGlobalReadIncsA] // limit -= inc)
+s_subb_u32 s[sgprShadowLimitA+1], s[sgprShadowLimitA+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitA+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdA+2], s[sgprShadowLimitA+0]    // Move shadow to real if we are within 2^32
+
+
+/* global read inc B */
+s_add_u32  s[sgprSrdB+0], s[sgprSrdB+0], s[sgprGlobalReadIncsB] // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdB+1], s[sgprSrdB+1], 0        // gra SRD += inc(upper)
+s_sub_u32 s[sgprShadowLimitB+0], s[sgprShadowLimitB+0], s[sgprGlobalReadIncsB] // limit -= inc)
+s_subb_u32 s[sgprShadowLimitB+1], s[sgprShadowLimitB+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitB+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdB+2], s[sgprShadowLimitB+0]    // Move shadow to real if we are within 2^32
+
+label_0008: // ShadowInitStart
+
+s_mov_b32 s[sgprSrdD+0], s[sgprAddressD+0]         // init SRD base address (lower)
+s_mov_b32 s[sgprSrdD+1], s[sgprAddressD+1]         // init SRD base address (upper) + other fields
+s_mov_b32 s[sgprSrdD+2], 0x80000000                //
+s_mov_b32 s[sgprSrdD+3], Srd127_96                 // Set bits 127_96 in SRD
+s_mov_b32 s[sgprSrdC+0], s[sgprAddressC+0]         // init SRD base address (lower)
+s_mov_b32 s[sgprSrdC+1], s[sgprAddressC+1]         // init SRD base address (upper) + other fields
+s_mov_b32 s[sgprSrdC+2], 0x80000000                //
+s_mov_b32 s[sgprSrdC+3], Srd127_96                 // Set bits 127_96 in SRD
+
+s_mul_i32 s[sgprTMP1], 0x40, s[sgprWorkGroup1]             // <- wg1*MT1
+s_mul_i32 s[sgprTMP0], 0x30, s[sgprWorkGroup1]             // <- wg1*MT1
+s_mul_hi_u32 s67, s[sgprTMP1], s[sgprStridesC+0]           // Scale s68 by Stride
+s_mul_i32 s66, s[sgprTMP1], s[sgprStridesC+0]              // Scale s68 by Stride
+s_lshl_b64 s[66:67], s[66:67], 3                   // scale by bpe
+s_add_u32 s[sgprSrdD+0], s[sgprSrdD+0], s66        // add lo to SRD
+s_addc_u32 s[sgprSrdD+1], s[sgprSrdD+1], s67       // add hi to SRD
+s_add_u32 s[sgprSrdC+0], s[sgprSrdC+0], s66        // add lo to SRD
+s_addc_u32 s[sgprSrdC+1], s[sgprSrdC+1], s67       // add hi to SRD
+
+s_mul_hi_u32 s67, s[sgprWorkGroup2], s[sgprStridesC+1] // Scale s[sgprWorkGroup2] by Stride
+s_mul_i32 s66, s[sgprWorkGroup2], s[sgprStridesC+1] // Scale s[sgprWorkGroup2] by Stride
+s_lshl_b64 s[66:67], s[66:67], 3                   // scale by bpe
+s_add_u32 s[sgprSrdD+0], s[sgprSrdD+0], s66        // add lo to SRD
+s_addc_u32 s[sgprSrdD+1], s[sgprSrdD+1], s67       // add hi to SRD
+s_add_u32 s[sgprSrdC+0], s[sgprSrdC+0], s66        // add lo to SRD
+s_addc_u32 s[sgprSrdC+1], s[sgprSrdC+1], s67       // add hi to SRD
+
+
+v_mov_b32 v[vgprValuC+0], 0x0                      // initC
+v_mov_b32 v[vgprValuC+1], 0x0                      // initC
+v_mov_b32 v[vgprValuC+2], 0x0                      // initC
+v_mov_b32 v[vgprValuC+3], 0x0                      // initC
+v_mov_b32 v[vgprValuC+4], 0x0                      // initC
+v_mov_b32 v[vgprValuC+5], 0x0                      // initC
+v_mov_b32 v[vgprValuC+6], 0x0                      // initC
+v_mov_b32 v[vgprValuC+7], 0x0                      // initC
+v_mov_b32 v[vgprValuC+8], 0x0                      // initC
+v_mov_b32 v[vgprValuC+9], 0x0                      // initC
+v_mov_b32 v[vgprValuC+10], 0x0                     // initC
+v_mov_b32 v[vgprValuC+11], 0x0                     // initC
+v_mov_b32 v[vgprValuC+12], 0x0                     // initC
+v_mov_b32 v[vgprValuC+13], 0x0                     // initC
+v_mov_b32 v[vgprValuC+14], 0x0                     // initC
+v_mov_b32 v[vgprValuC+15], 0x0                     // initC
+v_mov_b32 v[vgprValuC+16], 0x0                     // initC
+v_mov_b32 v[vgprValuC+17], 0x0                     // initC
+v_mov_b32 v[vgprValuC+18], 0x0                     // initC
+v_mov_b32 v[vgprValuC+19], 0x0                     // initC
+v_mov_b32 v[vgprValuC+20], 0x0                     // initC
+v_mov_b32 v[vgprValuC+21], 0x0                     // initC
+v_mov_b32 v[vgprValuC+22], 0x0                     // initC
+v_mov_b32 v[vgprValuC+23], 0x0                     // initC
+v_mov_b32 v[vgprValuC+24], 0x0                     // initC
+v_mov_b32 v[vgprValuC+25], 0x0                     // initC
+v_mov_b32 v[vgprValuC+26], 0x0                     // initC
+v_mov_b32 v[vgprValuC+27], 0x0                     // initC
+v_mov_b32 v[vgprValuC+28], 0x0                     // initC
+v_mov_b32 v[vgprValuC+29], 0x0                     // initC
+v_mov_b32 v[vgprValuC+30], 0x0                     // initC
+v_mov_b32 v[vgprValuC+31], 0x0                     // initC
+v_mov_b32 v[vgprValuC+32], 0x0                     // initC
+v_mov_b32 v[vgprValuC+33], 0x0                     // initC
+v_mov_b32 v[vgprValuC+34], 0x0                     // initC
+v_mov_b32 v[vgprValuC+35], 0x0                     // initC
+v_mov_b32 v[vgprValuC+36], 0x0                     // initC
+v_mov_b32 v[vgprValuC+37], 0x0                     // initC
+v_mov_b32 v[vgprValuC+38], 0x0                     // initC
+v_mov_b32 v[vgprValuC+39], 0x0                     // initC
+v_mov_b32 v[vgprValuC+40], 0x0                     // initC
+v_mov_b32 v[vgprValuC+41], 0x0                     // initC
+v_mov_b32 v[vgprValuC+42], 0x0                     // initC
+v_mov_b32 v[vgprValuC+43], 0x0                     // initC
+v_mov_b32 v[vgprValuC+44], 0x0                     // initC
+v_mov_b32 v[vgprValuC+45], 0x0                     // initC
+v_mov_b32 v[vgprValuC+46], 0x0                     // initC
+v_mov_b32 v[vgprValuC+47], 0x0                     // initC
+s_cmp_eq_u32 s[sgprLoopCounters+0], 0x0            // numIter0I == 0
+s_cbranch_scc1 label_0004                          // after InitC, skip to end of prefetch last iter b/c numIter==0
+
+s_waitcnt vmcnt(0)                                 // 8wait for global read
+
+
+/* local write a */
+
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:0 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 0
+
+
+/* local write b */
+
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:0 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 0
+
+
+/* local write swap a */
+
+
+
+/* local write swap b */
+
+
+
+/* local write init pointers a */
+
+/* N/A */
+
+
+/* local write init pointers b */
+
+/* N/A */
+
+/******************************************/
+/* Unrolled Loop(s) - Begin               */
+/******************************************/
+
+s_cmp_ge_i32 s[sgprLoopCounters+0], 0x0            // LoopCounterL < EndCounter
+s_cbranch_scc1 label_0004                          // don't enter LoopL
+label_0001:
+
+
+/******************************************/
+/* Unroll Loop 1/2 - Begin                */
+/******************************************/
+
+s_barrier //4sync for global read
+
+s_cmp_eq_i32 s[sgprLoopCounters+0], -1             // is this the last iteration
+s_cmov_b32 s[sgprSrdA+2], 0                        // Set limit to 0 for last iteration
+s_cmov_b32 s[sgprSrdB+2], 0                        // Set limit to 0 for last iteration
+
+s_waitcnt lgkmcnt(0)                               // 1wait for local write
+
+
+
+
+/* iter 0 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(2)                               // wait for prior local read old=0 new=0
+//MAC_6x4_X0
+MAC_6x4_X0_part_1
+
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:384 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:512 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* global read inc A */
+s_add_u32  s[sgprSrdA+0], s[sgprSrdA+0], s[sgprGlobalReadIncsA] // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdA+1], s[sgprSrdA+1], 0        // gra SRD += inc(upper)
+s_sub_u32 s[sgprShadowLimitA+0], s[sgprShadowLimitA+0], s[sgprGlobalReadIncsA] // limit -= inc)
+s_subb_u32 s[sgprShadowLimitA+1], s[sgprShadowLimitA+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitA+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdA+2], s[sgprShadowLimitA+0]    // Move shadow to real if we are within 2^32
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:640 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(2)                               // wait for prior local read old=0 new=0
+//MAC_6x4_X0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:768 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* global read inc B */
+s_add_u32  s[sgprSrdB+0], s[sgprSrdB+0], s[sgprGlobalReadIncsB] // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdB+1], s[sgprSrdB+1], 0        // gra SRD += inc(upper)
+s_sub_u32 s[sgprShadowLimitB+0], s[sgprShadowLimitB+0], s[sgprGlobalReadIncsB] // limit -= inc)
+s_subb_u32 s[sgprShadowLimitB+1], s[sgprShadowLimitB+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitB+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdB+2], s[sgprShadowLimitB+0]    // Move shadow to real if we are within 2^32
+
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:896 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1024 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 2 writesPerItem=1 */
+s_waitcnt vmcnt(1)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:4096 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 4096
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(3)                               // wait for prior local read old=0 new=0
+//MAC_6x4_X0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(1)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+/* iter 3 (last) */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:1152 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1280 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1408 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 3 writesPerItem=1 */
+s_waitcnt vmcnt(0)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:4096 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 4096
+
+/* local write swap offsets a */
+
+/* local write swap offsets b */
+
+/* local write init pointers a */
+/* N/A */
+
+/* local write init pointers b */
+/* N/A */
+
+/* local read swap offsets a */
+
+/* local read swap internal offset -> 4096 */
+
+/* local read swap offsets b */
+
+/* local read swap internal offset -> 4096 */
+
+/* local read init pointers a */
+
+/* local read init pointers b */
+s_waitcnt lgkmcnt(3)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(1)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0_part_3
+
+/******************************************/
+/* Unrolled Loop - End 1/2                */
+/******************************************/
+
+s_add_u32 s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+s_cmp_eq_i32 s[sgprLoopCounters+0],  -2            // counterL==0
+s_cbranch_scc1 label_0003                          // exit LoopL
+
+
+/******************************************/
+/* Unroll Loop 2/2 - Begin                */
+/******************************************/
+
+s_barrier //4sync for global read
+
+s_cmp_eq_i32 s[sgprLoopCounters+0], -1             // is this the last iteration
+s_cmov_b32 s[sgprSrdA+2], 0                        // Set limit to 0 for last iteration
+s_cmov_b32 s[sgprSrdB+2], 0                        // Set limit to 0 for last iteration
+
+s_waitcnt lgkmcnt(0)                               // 1wait for local write
+
+
+
+
+/* iter 0 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4096 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4224 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4352 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(2)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4480 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4608 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* global read inc A */
+s_add_u32  s[sgprSrdA+0], s[sgprSrdA+0], s[sgprGlobalReadIncsA] // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdA+1], s[sgprSrdA+1], 0        // gra SRD += inc(upper)
+s_sub_u32 s[sgprShadowLimitA+0], s[sgprShadowLimitA+0], s[sgprGlobalReadIncsA] // limit -= inc)
+s_subb_u32 s[sgprShadowLimitA+1], s[sgprShadowLimitA+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitA+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdA+2], s[sgprShadowLimitA+0]    // Move shadow to real if we are within 2^32
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4736 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(2)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4864 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* global read inc B */
+s_add_u32  s[sgprSrdB+0], s[sgprSrdB+0], s[sgprGlobalReadIncsB] // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdB+1], s[sgprSrdB+1], 0        // gra SRD += inc(upper)
+s_sub_u32 s[sgprShadowLimitB+0], s[sgprShadowLimitB+0], s[sgprGlobalReadIncsB] // limit -= inc)
+s_subb_u32 s[sgprShadowLimitB+1], s[sgprShadowLimitB+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitB+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdB+2], s[sgprShadowLimitB+0]    // Move shadow to real if we are within 2^32
+
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4992 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5120 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 2 writesPerItem=1 */
+s_waitcnt vmcnt(1)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:0 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 0
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(3)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(1)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:5248 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=192 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=192 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5376 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5504 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 3 writesPerItem=1 */
+s_waitcnt vmcnt(0)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:0 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 0
+
+/* local write swap offsets a */
+
+/* local write swap offsets b */
+
+/* local write init pointers a */
+/* N/A */
+
+/* local write init pointers b */
+/* N/A */
+
+/* local read swap offsets a */
+
+/* local read swap internal offset -> 0 */
+
+/* local read swap offsets b */
+
+/* local read swap internal offset -> 0 */
+
+/* local read init pointers a */
+
+/* local read init pointers b */
+s_waitcnt lgkmcnt(3)                               // 6wait for local read old=3 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(1)                               // 6wait for local read old=1 new=0
+MAC_6x4_X0_part_3
+
+/******************************************/
+/* Unrolled Loop - End 2/2 (final)        */
+/******************************************/
+
+s_add_u32 s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+s_cmp_eq_i32 s[sgprLoopCounters+0], -2              // counterL==0
+s_cbranch_scc0 label_0001                          // restart LoopL
+s_cbranch_scc1 label_0002                          // restart LoopL
+
+label_0003: // unroll loop odditer exit
+
+//check edge Batch calculation needed
+//for Batch edge jump to different beta loop optimization code
+s_add_u32      s83,-0x1, s[sgprNumWorkGroups0]       //
+s_cmp_lt_u32   s[sgprWorkGroup0], s83                // wg0 < nwg0-1
+s_cmov_b32     s[sgprEdgeSelMask0], 0x0
+s_cmpk_gt_u32  s[sgprEdgeSelMask0], 0x0
+s_cbranch_scc1 label_1003                            // wg1 < nwg1-1 so skip rMT1 = Size1 % MT1
+s_add_u32      s83, -0x1, s[sgprNumWorkGroups1]      //
+s_cmp_lt_u32   s[sgprWorkGroup1], s83                // wg1 < nwg1-1
+s_cmov_b32     s[sgprEdgeSelMask1], 0x0
+s_cmpk_gt_u32  s[sgprEdgeSelMask1], 0x0
+s_cbranch_scc1 label_1003                            // wg1 < nwg1-1 so skip rMT1 = Size1 % MT1
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4224 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4480 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4608 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4736 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4864 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4992 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5120 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:0 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 4096
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(1)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:5248 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5376 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5504 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_mul_i32 s56, 0x30, s[sgprWorkGroup0]             // s56 = wg0*MT0
+s_mul_i32 s58, 0x40, s[sgprWorkGroup1]             // s56 = wg0*MT0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 3 writesPerItem=1 */
+s_waitcnt vmcnt(0)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:0 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 4096
+
+s_waitcnt lgkmcnt(1)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0_unprio_0
+v_lshrrev_b32 v[vgprLocalWriteAddrB], 3, v[vgprSerial]                // vectorStaticDiv: v49 = v[vgprSerial] / 8
+v_and_b32 v[vgprLocalWriteAddrA], 7, v[vgprSerial]                    // vectorStaticDiv: v48 = v[vgprSerial] % 8
+v_lshlrev_b32 v[vgprLocalWriteAddrA], 1, v[vgprLocalWriteAddrA]       // staticMultiply: v48 = v48 * 2
+v_lshlrev_b32 v[vgprLocalWriteAddrB], 1, v[vgprLocalWriteAddrB]       // staticMultiply: v49 = v49 * 2
+v_mul_lo_u32 v[vgprGlobalReadOffsetB], v[vgprLocalWriteAddrB], s[sgprStridesC+0]           // rowStart vgpr
+_v_add_co_u32 v[vgprLocalWriteAddrA], vcc, s56, v[vgprLocalWriteAddrA]                   // coord0 = tid0*VW + wg0*MT0
+_v_add_lshl_u32 v[vgprGlobalReadOffsetA], v[vgprGlobalReadOffsetB], v[vgprLocalWriteAddrA], 0x3                 // init cb addr <-  rowStart + coord0, scaled by BPE
+s_setprio 0
+
+s_add_u32       s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+s_cmp_eq_i32    s[sgprLoopCounters+0], -1             // is this the last iteration
+s_cmov_b32 	s[sgprSrdA+2], 0                        // Set limit to 0 for last iteration
+s_cmov_b32 	s[sgprSrdB+2], 0                        // Set limit to 0 for last iteration
+s_mov_b32 	s85, s[sgprSrdC+0]
+s_mov_b32 	s86, s[sgprSrdC+1]
+s_mov_b32       s87, s[sgprSrdD+0]
+s_mov_b32       s88, s[sgprSrdD+1]
+
+
+s_waitcnt lgkmcnt(0)                               // 1wait for local write
+s_barrier //4sync for global read
+
+/* iter 0,1 */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:384 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part1
+
+/* iter 1 */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:768  // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1152 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part1
+
+
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:512 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+0:vgprValuC+0+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+0:vgprValuC+0+1] // *= alpha
+v_mul_f64 v[vgprValuC+2:vgprValuC+2+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+2:vgprValuC+2+1] // *= alpha
+v_fma_f64 v[vgprValuC+0:vgprValuC+0+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+0:vgprValuC+0+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+2:vgprValuC+2+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+2:vgprValuC+2+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[0:3], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+12:vgprValuC+12+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+12:vgprValuC+12+1] // *= alpha
+v_mul_f64 v[vgprValuC+14:vgprValuC+14+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+14:vgprValuC+14+1] // *= alpha
+v_fma_f64 v[vgprValuC+12:vgprValuC+12+1], v[vgprG2LB+0:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+12:vgprValuC+12+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+14:vgprValuC+14+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+14:vgprValuC+14+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[12:15], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part2
+
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:896 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1280 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part2
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:640 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+4:vgprValuC+4+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+4:vgprValuC+4+1] // *= alpha
+v_mul_f64 v[vgprValuC+6:vgprValuC+6+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+6:vgprValuC+6+1] // *= alpha
+v_fma_f64 v[vgprValuC+4:vgprValuC+4+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+4:vgprValuC+4+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+6:vgprValuC+6+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+6:vgprValuC+6+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[4:7], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+16:vgprValuC+16+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+16:vgprValuC+16+1] // *= alpha
+v_mul_f64 v[vgprValuC+18:vgprValuC+18+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+18:vgprValuC+18+1] // *= alpha
+v_fma_f64 v[vgprValuC+16:vgprValuC+16+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+16:vgprValuC+16+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+18:vgprValuC+18+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+18:vgprValuC+18+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[16:19], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part3
+
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1024 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:1408 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part3
+
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:384 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+8:vgprValuC+8+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+8:vgprValuC+8+1] // *= alpha
+v_mul_f64 v[vgprValuC+10:vgprValuC+10+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+10:vgprValuC+10+1] // *= alpha
+v_fma_f64 v[vgprValuC+8:vgprValuC+8+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+8:vgprValuC+8+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+10:vgprValuC+10+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+10:vgprValuC+10+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[8:11], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+20:vgprValuC+20+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+20:vgprValuC+20+1] // *= alpha
+v_mul_f64 v[vgprValuC+22:vgprValuC+22+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+22:vgprValuC+22+1] // *= alpha
+v_fma_f64 v[vgprValuC+20:vgprValuC+20+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+20:vgprValuC+20+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+22:vgprValuC+22+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+22:vgprValuC+22+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[20:23], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_mul_i32  s56, s[sgprStridesC+0], 248              // Scale by BPE
+s_add_u32   s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+s_mov_b32   s85, s[sgprSrdC+0]
+s_mov_b32   s86, s[sgprSrdC+1]                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part4
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:768 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+s_lshl_b32   s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32   s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1152 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part4
+
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+s_mul_i32   s56, s[sgprStridesD+0], 248              // Scale by BPE
+s_add_u32   s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:512 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+24:vgprValuC+24+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+24:vgprValuC+24+1] // *= alpha
+v_mul_f64 v[vgprValuC+26:vgprValuC+26+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+26:vgprValuC+26+1] // *= alpha
+v_fma_f64 v[vgprValuC+24:vgprValuC+24+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+24:vgprValuC+24+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+26:vgprValuC+26+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+26:vgprValuC+26+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[24:27], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_mov_b32       s87, s[sgprSrdD+0]
+s_mov_b32       s88, s[sgprSrdD+1]                 /* local read init pointers b */
+s_lshl_b32      s56, s[sgprStridesD+0], 3         // Scale     s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_add_u32       s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32      s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+36:vgprValuC+36+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+36:vgprValuC+36+1] // *= alpha
+v_mul_f64 v[vgprValuC+38:vgprValuC+38+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+38:vgprValuC+38+1] // *= alpha
+v_fma_f64 v[vgprValuC+36:vgprValuC+36+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+36:vgprValuC+36+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+38:vgprValuC+38+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+38:vgprValuC+38+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[36:39], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0_part5
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:896 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1280 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part5
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:640 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+28:vgprValuC+28+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+28:vgprValuC+28+1] // *= alpha
+v_mul_f64 v[vgprValuC+30:vgprValuC+30+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+30:vgprValuC+30+1] // *= alpha
+v_fma_f64 v[vgprValuC+28:vgprValuC+28+1], v[vgprG2LA+0:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+28:vgprValuC+28+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+30:vgprValuC+30+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+30:vgprValuC+30+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[28:31], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+40:vgprValuC+40+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+40:vgprValuC+40+1] // *= alpha
+v_mul_f64 v[vgprValuC+42:vgprValuC+42+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+42:vgprValuC+42+1] // *= alpha
+v_fma_f64 v[vgprValuC+40:vgprValuC+40+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+40:vgprValuC+40+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+42:vgprValuC+42+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+42:vgprValuC+42+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[40:43], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part6
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1024 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1408 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part6
+
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+32:vgprValuC+32+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+32:vgprValuC+32+1] // *= alpha
+v_mul_f64 v[vgprValuC+34:vgprValuC+34+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+34:vgprValuC+34+1] // *= alpha
+v_fma_f64 v[vgprValuC+32:vgprValuC+32+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+32:vgprValuC+32+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+34:vgprValuC+34+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+34:vgprValuC+34+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[32:35], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_lshl_b32  s56, 	   s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32   s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+
+v_mul_f64 v[vgprValuC+44:vgprValuC+44+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+44:vgprValuC+44+1] // *= alpha
+v_mul_f64 v[vgprValuC+46:vgprValuC+46+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+46:vgprValuC+46+1] // *= alpha
+v_fma_f64 v[vgprValuC+44:vgprValuC+44+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+44:vgprValuC+44+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+46:vgprValuC+46+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+46:vgprValuC+46+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[44:47], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_add_u32            s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+
+
+s_endpgm
+
+label_0002:
+
+/* TODO-packed- compare against product of all packed C0 sizes not just SizesFree+0 */
+//s_mov_b32 s91, 0x0                                 // STATIC_DIV: divisior=48
+//s_mul_i32 s90, 0xaaa, s[sgprSizesFree+0]           // tmp1 = dividend * magic hi
+//s_lshl_b64 s[90:91], s[90:91], 0x10                // left shift 16 bits
+//s_mul_i32 s82, s[sgprSizesFree+0], 0xaaab          // tmp0 = dividend * magic lo
+//s_add_u32 s90, s82, s90                            // add lo
+//s_addc_u32 s91, s91, 0x0                           // add hi
+//s_lshr_b64 s[90:91], s[90:91], 0x21                // tmp1 = (dividend * magic) << shift
+//s_mov_b32 s82, s90                                 // quotient
+//s_mul_i32 s90, s82, 0x30                           // quotient*divisor
+//s_sub_u32 s[sgprEdgeSelMask0], s[sgprSizesFree+0], s90             // rReg = dividend - quotient*divisor
+//s_lshr_b32 s82, s[sgprSizesFree+1], 6              // s58 = s[sgprSizesFree+1] / 64
+//s_and_b32 s[sgprEdgeSelMask1], 63, s[sgprSizesFree+1]
+
+//check edge Batch calculation needed
+//for Batch edge jump to different beta loop optimization code
+s_add_u32      s83,-0x1, s[sgprNumWorkGroups0]       //
+s_cmp_lt_u32   s[sgprWorkGroup0], s83                // wg0 < nwg0-1
+s_cmov_b32     s[sgprEdgeSelMask0], 0x0
+s_cmpk_gt_u32  s[sgprEdgeSelMask0], 0x0
+s_cbranch_scc1 label_1002                            // wg1 < nwg1-1 so skip rMT1 = Size1 % MT1
+s_add_u32      s83, -0x1, s[sgprNumWorkGroups1]      //
+s_cmp_lt_u32   s[sgprWorkGroup1], s83                // wg1 < nwg1-1
+s_cmov_b32     s[sgprEdgeSelMask1], 0x0
+s_cmpk_gt_u32  s[sgprEdgeSelMask1], 0x0
+s_cbranch_scc1 label_1002                            // wg1 < nwg1-1 so skip rMT1 = Size1 % MT1
+
+/******************************************/
+
+s_waitcnt lgkmcnt(0)                                 // 1wait for local write
+s_barrier //4sync for global read
+
+/* iter 0 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(2)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:384 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:512 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:640 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(2)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:768 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:896 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1024 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:4096 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 4096
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(3)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(1)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:1152 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1280 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+s_mul_i32 s56, 0x30, s[sgprWorkGroup0]             // s56 = wg0*MT0
+s_mul_i32 s58, 0x40, s[sgprWorkGroup1]             // s56 = wg0*MT0
+/* sched write - iter 3 writesPerItem=1 */
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1408 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(0)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:4096 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 4096
+
+s_waitcnt lgkmcnt(1)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0_unprio_0
+v_lshrrev_b32 v[vgprLocalWriteAddrB], 3, v[vgprSerial]                // vectorStaticDiv: v49 = v[vgprSerial] / 8
+v_and_b32 v[vgprLocalWriteAddrA], 7, v[vgprSerial]                    // vectorStaticDiv: v48 = v[vgprSerial] % 8
+v_lshlrev_b32 v[vgprLocalWriteAddrA], 1, v[vgprLocalWriteAddrA]       // staticMultiply: v48 = v48 * 2
+v_lshlrev_b32 v[vgprLocalWriteAddrB], 1, v[vgprLocalWriteAddrB]       // staticMultiply: v49 = v49 * 2
+v_mul_lo_u32 v[vgprGlobalReadOffsetB], v[vgprLocalWriteAddrB], s[sgprStridesC+0]           // rowStart vgpr
+_v_add_co_u32 v[vgprLocalWriteAddrA], vcc, s56, v[vgprLocalWriteAddrA]                   // coord0 = tid0*VW + wg0*MT0
+_v_add_lshl_u32 v[vgprGlobalReadOffsetA], v[vgprGlobalReadOffsetB], v[vgprLocalWriteAddrA], 0x3                 // init cb addr <-  rowStart + coord0, scaled by BPE
+s_setprio 0
+
+s_add_u32       s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+s_cmp_eq_i32    s[sgprLoopCounters+0], -1             // is this the last iteration
+s_cmov_b32 	s[sgprSrdA+2], 0                        // Set limit to 0 for last iteration
+s_cmov_b32 	s[sgprSrdB+2], 0                        // Set limit to 0 for last iteration
+s_mov_b32 	s85, s[sgprSrdC+0]
+s_mov_b32 	s86, s[sgprSrdC+1]
+s_mov_b32       s87, s[sgprSrdD+0]
+s_mov_b32       s88, s[sgprSrdD+1]
+
+
+s_waitcnt lgkmcnt(0)                               // 1wait for local write
+s_barrier //4sync for global read
+
+/* iter 0,1 */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4480 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part1
+
+/* iter 1 */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4864 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5248 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part1
+
+
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4224 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4608 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+0:vgprValuC+0+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+0:vgprValuC+0+1] // *= alpha
+v_mul_f64 v[vgprValuC+2:vgprValuC+2+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+2:vgprValuC+2+1] // *= alpha
+v_fma_f64 v[vgprValuC+0:vgprValuC+0+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+0:vgprValuC+0+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+2:vgprValuC+2+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+2:vgprValuC+2+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[0:3], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+12:vgprValuC+12+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+12:vgprValuC+12+1] // *= alpha
+v_mul_f64 v[vgprValuC+14:vgprValuC+14+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+14:vgprValuC+14+1] // *= alpha
+v_fma_f64 v[vgprValuC+12:vgprValuC+12+1], v[vgprG2LB+0:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+12:vgprValuC+12+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+14:vgprValuC+14+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+14:vgprValuC+14+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[12:15], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part2
+
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4992 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5376 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part2
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4736 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+4:vgprValuC+4+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+4:vgprValuC+4+1] // *= alpha
+v_mul_f64 v[vgprValuC+6:vgprValuC+6+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+6:vgprValuC+6+1] // *= alpha
+v_fma_f64 v[vgprValuC+4:vgprValuC+4+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+4:vgprValuC+4+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+6:vgprValuC+6+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+6:vgprValuC+6+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[4:7], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+16:vgprValuC+16+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+16:vgprValuC+16+1] // *= alpha
+v_mul_f64 v[vgprValuC+18:vgprValuC+18+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+18:vgprValuC+18+1] // *= alpha
+v_fma_f64 v[vgprValuC+16:vgprValuC+16+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+16:vgprValuC+16+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+18:vgprValuC+18+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+18:vgprValuC+18+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[16:19], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part3
+
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5120 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:5504 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part3
+
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4480 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+8:vgprValuC+8+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+8:vgprValuC+8+1] // *= alpha
+v_mul_f64 v[vgprValuC+10:vgprValuC+10+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+10:vgprValuC+10+1] // *= alpha
+v_fma_f64 v[vgprValuC+8:vgprValuC+8+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+8:vgprValuC+8+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+10:vgprValuC+10+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+10:vgprValuC+10+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[8:11], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+20:vgprValuC+20+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+20:vgprValuC+20+1] // *= alpha
+v_mul_f64 v[vgprValuC+22:vgprValuC+22+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+22:vgprValuC+22+1] // *= alpha
+v_fma_f64 v[vgprValuC+20:vgprValuC+20+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+20:vgprValuC+20+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+22:vgprValuC+22+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+22:vgprValuC+22+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[20:23], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_mul_i32  s56, s[sgprStridesC+0], 248              // Scale by BPE
+s_add_u32   s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+s_mov_b32   s85, s[sgprSrdC+0]
+s_mov_b32   s86, s[sgprSrdC+1]                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part4
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4864 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+s_lshl_b32   s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32   s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5248 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part4
+
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4224 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+s_mul_i32   s56, s[sgprStridesD+0], 248              // Scale by BPE
+s_add_u32   s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4608 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+24:vgprValuC+24+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+24:vgprValuC+24+1] // *= alpha
+v_mul_f64 v[vgprValuC+26:vgprValuC+26+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+26:vgprValuC+26+1] // *= alpha
+v_fma_f64 v[vgprValuC+24:vgprValuC+24+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+24:vgprValuC+24+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+26:vgprValuC+26+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+26:vgprValuC+26+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[24:27], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_mov_b32       s87, s[sgprSrdD+0]
+s_mov_b32       s88, s[sgprSrdD+1]                 /* local read init pointers b */
+s_lshl_b32      s56, s[sgprStridesD+0], 3         // Scale     s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_add_u32       s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32      s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+36:vgprValuC+36+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+36:vgprValuC+36+1] // *= alpha
+v_mul_f64 v[vgprValuC+38:vgprValuC+38+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+38:vgprValuC+38+1] // *= alpha
+v_fma_f64 v[vgprValuC+36:vgprValuC+36+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+36:vgprValuC+36+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+38:vgprValuC+38+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+38:vgprValuC+38+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[36:39], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0_part5
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4992 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5376 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part5
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4736 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+28:vgprValuC+28+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+28:vgprValuC+28+1] // *= alpha
+v_mul_f64 v[vgprValuC+30:vgprValuC+30+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+30:vgprValuC+30+1] // *= alpha
+v_fma_f64 v[vgprValuC+28:vgprValuC+28+1], v[vgprG2LA+0:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+28:vgprValuC+28+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+30:vgprValuC+30+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+30:vgprValuC+30+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[28:31], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+40:vgprValuC+40+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+40:vgprValuC+40+1] // *= alpha
+v_mul_f64 v[vgprValuC+42:vgprValuC+42+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+42:vgprValuC+42+1] // *= alpha
+v_fma_f64 v[vgprValuC+40:vgprValuC+40+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+40:vgprValuC+40+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+42:vgprValuC+42+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+42:vgprValuC+42+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[40:43], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part6
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5120 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5504 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part6
+
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+32:vgprValuC+32+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+32:vgprValuC+32+1] // *= alpha
+v_mul_f64 v[vgprValuC+34:vgprValuC+34+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+34:vgprValuC+34+1] // *= alpha
+v_fma_f64 v[vgprValuC+32:vgprValuC+32+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+32:vgprValuC+32+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+34:vgprValuC+34+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+34:vgprValuC+34+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[32:35], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_lshl_b32  s56, 	   s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32   s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+
+v_mul_f64 v[vgprValuC+44:vgprValuC+44+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+44:vgprValuC+44+1] // *= alpha
+v_mul_f64 v[vgprValuC+46:vgprValuC+46+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+46:vgprValuC+46+1] // *= alpha
+v_fma_f64 v[vgprValuC+44:vgprValuC+44+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+44:vgprValuC+44+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+46:vgprValuC+46+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+46:vgprValuC+46+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[44:47], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_add_u32            s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+
+
+s_endpgm
+
+label_1002:
+
+/******************************************/
+//branch logic gets executed for edge MT to use legacy alph_beta code
+
+s_waitcnt lgkmcnt(0)                                 // 1wait for local write
+s_barrier //4sync for global read
+
+/* iter 0 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:384 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:512 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:640 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:768 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:896 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt vmcnt(1)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:4096 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 4096
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1024 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:1152 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1280 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 3 writesPerItem=1 */
+s_waitcnt vmcnt(0)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:4096 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 4096
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1408 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0
+
+
+s_waitcnt lgkmcnt(0)                               // 1wait for local write
+s_barrier //4sync for global read
+
+
+/* iter 0 */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4096 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4224 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4352 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4480 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4608 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4736 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4864 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4992 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5120 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:5248 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5376 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5504 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=192 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=192 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0
+s_add_u32 s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+
+s_branch label_0004
+
+label_1003:
+
+s_waitcnt lgkmcnt(0)                               // 1wait for local write
+s_barrier //4sync for global read
+
+
+/* iter 0 */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4096 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4224 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4352 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4480 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4608 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4736 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4864 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4992 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* sched write - iter 2 writesPerItem=1 */
+s_waitcnt vmcnt(1)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:0 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5120 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:5248 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5376 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 3 writesPerItem=1 */
+s_waitcnt vmcnt(0)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:0 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5504 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=192 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=192 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+
+/* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0
+
+s_add_u32 s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+s_cmp_eq_i32 s[sgprLoopCounters+0], -1             // is this the last iteration
+s_cmov_b32 s[sgprSrdA+2], 0                        // Set limit to 0 for last iteration
+s_cmov_b32 s[sgprSrdB+2], 0                        // Set limit to 0 for last iteration
+
+s_waitcnt lgkmcnt(0)                               // 1wait for local write
+
+s_barrier //4sync for global read
+
+/* iter 0 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:384 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:512 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:640 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:768 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:896 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1024 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:1152 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1280 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1408 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0
+s_add_u32 s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+
+label_0004:
+
+
+/******************************************/
+/* Tail Loop                              */
+/******************************************/
+
+
+/* local write reset offsets a */
+
+
+
+/* local write reset offsets b */
+
+
+
+s_cmp_eq_u32 s[sgprOrigLoopCounter], 0             // completely skipped unroll loop?
+s_cselect_b32 s66, 0, s[sgprGlobalReadIncsA]       // force to 0?
+s_cselect_b32 s67, 0, s[sgprGlobalReadIncsB]       // force to 0?
+s_sub_u32  s[sgprSrdA+0], s[sgprSrdA+0], s66       // gra SRD -= inc(lower)
+s_subb_u32  s[sgprSrdA+1], s[sgprSrdA+1], 0        // gra SRD -= inc(upper)
+s_add_u32 s[sgprShadowLimitA+0], s[sgprShadowLimitA+0], s66 // limit -= inc)
+s_addc_u32 s[sgprShadowLimitA+1], s[sgprShadowLimitA+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitA+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdA+2], s[sgprShadowLimitA+0]    // Move shadow to real if we are within 2^32
+
+s_sub_u32  s[sgprSrdB+0], s[sgprSrdB+0], s67       // gra SRD -= inc(lower)
+s_subb_u32  s[sgprSrdB+1], s[sgprSrdB+1], 0        // gra SRD -= inc(upper)
+s_add_u32 s[sgprShadowLimitB+0], s[sgprShadowLimitB+0], s67 // limit -= inc)
+s_addc_u32 s[sgprShadowLimitB+1], s[sgprShadowLimitB+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitB+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdB+2], s[sgprShadowLimitB+0]    // Move shadow to real if we are within 2^32
+
+//numIterL = (((sizeL % LOCAL_DEPTHU) + LOCAL_SPLITU - 1) / LOCAL_SPLITU)
+s_lshr_b32 s66, s[sgprSizesSum+0], 2               // s66 = s[sgprSizesSum+0] / 4
+s_and_b32 s[sgprLoopCounters+0], 3, s[sgprSizesSum+0] // s[sgprLoopCounters+0] = s[sgprSizesSum+0] % 4
+s_cmp_eq_u32 s[sgprLoopCounters+0], 0x0            // numIterL == 0
+s_cbranch_scc1 label_0006                          // skip to end of tail loop b/c numIter==0
+s_sub_u32 s[sgprLoopCounters+0], 0x0, s[sgprLoopCounters+0] // counterL = -sizeL
+
+
+/* global read a */
+
+/* g2l=0, load component 0 */
+buffer_load_dwordx2 v[vgprG2LA+0+0:vgprG2LA+0+0+1], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // load one buffer value
+/* g2l=0, load component 1 */
+buffer_load_dwordx2 v[vgprG2LA+0+2:vgprG2LA+0+2+1], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:8 // load one buffer value
+_v_add_co_u32 v[vgprGlobalReadOffsetA+0], vcc, v[vgprGlobalReadOffsetA+0], 8 // graOffset += 1 * bpe
+
+
+/* global read b */
+
+/* g2l=0, load component 0 */
+buffer_load_dwordx2 v[vgprG2LB+0+0:vgprG2LB+0+0+1], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // load one buffer value
+/* g2l=0, load component 1 */
+buffer_load_dwordx2 v[vgprG2LB+0+2:vgprG2LB+0+2+1], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:8 // load one buffer value
+_v_add_co_u32 v[vgprGlobalReadOffsetB+0], vcc, v[vgprGlobalReadOffsetB+0], 8 // graOffset += 1 * bpe
+
+s_waitcnt vmcnt(0)                                 // 2wait for global read
+
+s_barrier //
+
+/* local write init pointers a */
+
+/* N/A */
+
+
+/* local write init pointers b */
+
+/* N/A */
+
+
+/* local write a */
+
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:0 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 0
+
+
+/* local write b */
+
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:0 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 0
+
+s_waitcnt lgkmcnt(0)                               // 5wait for local write
+
+s_barrier //
+
+
+/* local read reset offsets a */
+
+/* handled internally */
+v_and_b32 v[vgprLocalReadAddrA], 0xfff, v[vgprLocalReadAddrA] // reset Red,Blk -> Red
+
+
+/* local read reset offsets b */
+
+/* handled internally */
+v_and_b32 v[vgprLocalReadAddrB], 0xfff, v[vgprLocalReadAddrB] // reset Red,Blk -> Red
+
+
+/* local read init pointers a */
+
+
+
+/* local read init pointers b */
+
+
+
+/* tail loop: macs */
+
+s_cmp_ge_i32 s[sgprLoopCounters+0], 0x0            // LoopCounterL < EndCounter
+s_cbranch_scc1 label_0006                          // don't enter LoopL
+s_mov_b32 s[sgprOrigLoopCounter], 0                // repurpose to count each localRead increment
+label_0005:
+
+
+/* local read a */
+
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+
+/* local read b */
+
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+
+/* local read inc a */
+
+s_mov_b32 s65, 0x180                               // inc
+_v_add_co_u32 v[vgprLocalReadAddrA], vcc, s65, v[vgprLocalReadAddrA] // lrA += 384 (LSU*(MT+PAD)*bpe)
+
+
+/* local read inc b */
+
+s_mov_b32 s65, 0x200                               // inc
+_v_add_co_u32 v[vgprLocalReadAddrB], vcc, s65, v[vgprLocalReadAddrB] // lrB += 512 (LSU*(MT+PAD)*bpe)
+
+s_waitcnt lgkmcnt(0)                               // 4wait for local read
+
+MAC_6x4_X0
+s_add_u32 s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+s_add_u32 s[sgprOrigLoopCounter], s[sgprOrigLoopCounter], 0x1 // inc counterL
+s_cmp_eq_i32 s[sgprLoopCounters+0], 0x0            // counterL==0
+s_cbranch_scc0 label_0005                          // restart LoopL
+label_0006:
+
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // wait for all summation activity
+
+
+/* shift vector components d0 */
+
+v_mov_b32 v50, s[sgprWorkGroup0]                   //
+v_mul_i32_i24 v50, -0x30, v50                      // wg*MT
+_v_add_co_u32 v50, vcc, s[sgprSizesFree+0], v50    // wgMT = Size - wg*MT
+v_mov_b32 v48, 0x30                                // MT
+v_cmp_lt_u32 s[56:57], v50, v48                    // wgMT < MT
+v_cndmask_b32 v50, v48, v50, s[56:57]              // wgMT = (wgMT < MT) ? wgMT : MT
+v_lshrrev_b32 v52, 1, v50                          // vectorStaticDiv: v52 = v50 / 2
+v_and_b32 v53, 1, v50                              // vectorStaticDiv: v53 = v50 % 2
+v_lshrrev_b32 v54, 3, v52                          // vectorStaticDiv: v54 = v52 / 8
+v_and_b32 v55, 7, v52                              // vectorStaticDiv: v55 = v52 % 8
+v_and_b32 v56, 7, v[vgprSerial]                    // vectorStaticDiv: v56 = v[vgprSerial] % 8
+v_lshrrev_b32 v57, 4, v50                          // vectorStaticDiv: v57 = v50 / 16
+v_and_b32 v58, 1, v50                              // vectorStaticDiv: v58 = v50 % 2
+v_mov_b32 v59, v58                                 // duplicate
+v_lshrrev_b32 v58, 1, v59                          // vectorStaticDiv: v58 = v59 / 2
+_v_add_co_u32 v58, vcc, v57, v58                   // vId = 2 components
+v_cmp_eq_u32 s[56:57], v56, v55                    // mask
+v_mov_b32 v48, s56                                 //
+v_mov_b32 v49, s57                                 //
+v_cmp_eq_u32 vcc, v53, 0x1                         // wgMT%VW == 1
+s_cbranch_vccnz label_0010                         // shift d0 r=1
+s_branch label_0014                                // no shifting
+
+/******************************************/
+/* shift d0 r=1                           */
+/******************************************/
+label_0010:
+v_cmp_eq_u32 vcc, v58, 0x0                         // wgMT/(SG*VW) == 0
+s_cbranch_vccnz label_0011                         // shift d0, r=1, v=0
+v_cmp_eq_u32 vcc, v58, 0x1                         // wgMT/(SG*VW) == 1
+s_cbranch_vccnz label_0012                         // shift d0, r=1, v=1
+v_cmp_eq_u32 vcc, v58, 0x2                         // wgMT/(SG*VW) == 2
+s_cbranch_vccnz label_0013                         // shift d0, r=1, v=2
+
+/* shift d0 r=1 v=0 */
+label_0011:
+v_cmpx_eq_u32 s[56:57], v56, v55                   // serial % SG == (wgMT/VECTOR_WIDTH)%SG
+// src=1, dst=0
+v_mov_b32 v0, v2                                   // rC[0+0*VW+0*TT0I] = rC[1+0*VW+0*TT0I]
+v_mov_b32 v1, v3                                   // rC[0+0*VW+0*TT0I] = rC[1+0*VW+0*TT0I]
+// src=7, dst=6
+v_mov_b32 v12, v14                                 // rC[0+0*VW+1*TT0I] = rC[1+0*VW+1*TT0I]
+v_mov_b32 v13, v15                                 // rC[0+0*VW+1*TT0I] = rC[1+0*VW+1*TT0I]
+// src=13, dst=12
+v_mov_b32 v24, v26                                 // rC[0+0*VW+2*TT0I] = rC[1+0*VW+2*TT0I]
+v_mov_b32 v25, v27                                 // rC[0+0*VW+2*TT0I] = rC[1+0*VW+2*TT0I]
+// src=19, dst=18
+v_mov_b32 v36, v38                                 // rC[0+0*VW+3*TT0I] = rC[1+0*VW+3*TT0I]
+v_mov_b32 v37, v39                                 // rC[0+0*VW+3*TT0I] = rC[1+0*VW+3*TT0I]
+s_mov_b64 s[56:57], 0xFFFFFFFFFFFFFFFF             // to restore all threads active
+s_or_saveexec_b64 vcc, s[56:57]                    // all threads active
+s_branch label_0014                                // done shifting
+
+/* shift d0 r=1 v=1 */
+label_0012:
+v_cmpx_eq_u32 s[56:57], v56, v55                   // serial % SG == (wgMT/VECTOR_WIDTH)%SG
+// src=3, dst=2
+v_mov_b32 v4, v6                                   // rC[0+1*VW+0*TT0I] = rC[1+1*VW+0*TT0I]
+v_mov_b32 v5, v7                                   // rC[0+1*VW+0*TT0I] = rC[1+1*VW+0*TT0I]
+// src=9, dst=8
+v_mov_b32 v16, v18                                 // rC[0+1*VW+1*TT0I] = rC[1+1*VW+1*TT0I]
+v_mov_b32 v17, v19                                 // rC[0+1*VW+1*TT0I] = rC[1+1*VW+1*TT0I]
+// src=15, dst=14
+v_mov_b32 v28, v30                                 // rC[0+1*VW+2*TT0I] = rC[1+1*VW+2*TT0I]
+v_mov_b32 v29, v31                                 // rC[0+1*VW+2*TT0I] = rC[1+1*VW+2*TT0I]
+// src=21, dst=20
+v_mov_b32 v40, v42                                 // rC[0+1*VW+3*TT0I] = rC[1+1*VW+3*TT0I]
+v_mov_b32 v41, v43                                 // rC[0+1*VW+3*TT0I] = rC[1+1*VW+3*TT0I]
+s_mov_b64 s[56:57], 0xFFFFFFFFFFFFFFFF             // to restore all threads active
+s_or_saveexec_b64 vcc, s[56:57]                    // all threads active
+s_branch label_0014                                // done shifting
+
+/* shift d0 r=1 v=2 */
+label_0013:
+v_cmpx_eq_u32 s[56:57], v56, v55                   // serial % SG == (wgMT/VECTOR_WIDTH)%SG
+// src=5, dst=4
+v_mov_b32 v8, v10                                  // rC[0+2*VW+0*TT0I] = rC[1+2*VW+0*TT0I]
+v_mov_b32 v9, v11                                  // rC[0+2*VW+0*TT0I] = rC[1+2*VW+0*TT0I]
+// src=11, dst=10
+v_mov_b32 v20, v22                                 // rC[0+2*VW+1*TT0I] = rC[1+2*VW+1*TT0I]
+v_mov_b32 v21, v23                                 // rC[0+2*VW+1*TT0I] = rC[1+2*VW+1*TT0I]
+// src=17, dst=16
+v_mov_b32 v32, v34                                 // rC[0+2*VW+2*TT0I] = rC[1+2*VW+2*TT0I]
+v_mov_b32 v33, v35                                 // rC[0+2*VW+2*TT0I] = rC[1+2*VW+2*TT0I]
+// src=23, dst=22
+v_mov_b32 v44, v46                                 // rC[0+2*VW+3*TT0I] = rC[1+2*VW+3*TT0I]
+v_mov_b32 v45, v47                                 // rC[0+2*VW+3*TT0I] = rC[1+2*VW+3*TT0I]
+s_mov_b64 s[56:57], 0xFFFFFFFFFFFFFFFF             // to restore all threads active
+s_or_saveexec_b64 vcc, s[56:57]                    // all threads active
+s_branch label_0014                                // done shifting
+label_0014: // end shift0
+
+
+/* shift vector components d1 */
+
+v_mov_b32 v50, s[sgprWorkGroup1]                   //
+v_mul_i32_i24 v50, -0x40, v50                      // wg*MT
+_v_add_co_u32 v50, vcc, s[sgprSizesFree+1], v50    // wgMT = Size - wg*MT
+v_mov_b32 v48, 0x40                                // MT
+v_cmp_lt_u32 s[56:57], v50, v48                    // wgMT < MT
+v_cndmask_b32 v50, v48, v50, s[56:57]              // wgMT = (wgMT < MT) ? wgMT : MT
+v_lshrrev_b32 v52, 1, v50                          // vectorStaticDiv: v52 = v50 / 2
+v_and_b32 v53, 1, v50                              // vectorStaticDiv: v53 = v50 % 2
+v_lshrrev_b32 v54, 4, v52                          // vectorStaticDiv: v54 = v52 / 16
+v_and_b32 v55, 15, v52                             // vectorStaticDiv: v55 = v52 % 16
+v_lshrrev_b32 v56, 3, v[vgprSerial]                // vectorStaticDiv: v56 = v[vgprSerial] / 8
+v_and_b32 v57, 15, v56                             // vectorStaticDiv: v57 = v56 % 16
+v_lshrrev_b32 v56, 5, v50                          // vectorStaticDiv: v56 = v50 / 32
+v_and_b32 v58, 1, v50                              // vectorStaticDiv: v58 = v50 % 2
+v_mov_b32 v59, v58                                 // duplicate
+v_lshrrev_b32 v58, 1, v59                          // vectorStaticDiv: v58 = v59 / 2
+_v_add_co_u32 v58, vcc, v56, v58                   // vId = 2 components
+v_cmp_eq_u32 s[56:57], v57, v55                    // mask
+v_mov_b32 v48, s56                                 //
+v_mov_b32 v49, s57                                 //
+v_cmp_eq_u32 vcc, v53, 0x1                         // wgMT%VW == 1
+s_cbranch_vccnz label_0018                         // shift d1 r=1
+s_branch label_0021                                // no shifting
+
+/******************************************/
+/* shift d1 r=1                           */
+/******************************************/
+label_0018:
+v_cmp_eq_u32 vcc, v58, 0x0                         // wgMT/(SG*VW) == 0
+s_cbranch_vccnz label_0019                         // shift d1, r=1, v=0
+v_cmp_eq_u32 vcc, v58, 0x1                         // wgMT/(SG*VW) == 1
+s_cbranch_vccnz label_0020                         // shift d1, r=1, v=1
+
+/* shift d1 r=1 v=0 */
+label_0019:
+v_cmpx_eq_u32 s[56:57], v57, v55                   // serial % SG == (wgMT/VECTOR_WIDTH)%SG
+// src=6, dst=0
+v_mov_b32 v0, v12                                  // rC[0+0*TT0I*VW+0*TT0I] = rC[0+0*TT0I*VW+1*TT0I]
+v_mov_b32 v1, v13                                  // rC[0+0*TT0I*VW+0*TT0I] = rC[0+0*TT0I*VW+1*TT0I]
+// src=7, dst=1
+v_mov_b32 v2, v14                                  // rC[1+0*TT0I*VW+0*TT0I] = rC[1+0*TT0I*VW+1*TT0I]
+v_mov_b32 v3, v15                                  // rC[1+0*TT0I*VW+0*TT0I] = rC[1+0*TT0I*VW+1*TT0I]
+// src=8, dst=2
+v_mov_b32 v4, v16                                  // rC[2+0*TT0I*VW+0*TT0I] = rC[2+0*TT0I*VW+1*TT0I]
+v_mov_b32 v5, v17                                  // rC[2+0*TT0I*VW+0*TT0I] = rC[2+0*TT0I*VW+1*TT0I]
+// src=9, dst=3
+v_mov_b32 v6, v18                                  // rC[3+0*TT0I*VW+0*TT0I] = rC[3+0*TT0I*VW+1*TT0I]
+v_mov_b32 v7, v19                                  // rC[3+0*TT0I*VW+0*TT0I] = rC[3+0*TT0I*VW+1*TT0I]
+// src=10, dst=4
+v_mov_b32 v8, v20                                  // rC[4+0*TT0I*VW+0*TT0I] = rC[4+0*TT0I*VW+1*TT0I]
+v_mov_b32 v9, v21                                  // rC[4+0*TT0I*VW+0*TT0I] = rC[4+0*TT0I*VW+1*TT0I]
+// src=11, dst=5
+v_mov_b32 v10, v22                                 // rC[5+0*TT0I*VW+0*TT0I] = rC[5+0*TT0I*VW+1*TT0I]
+v_mov_b32 v11, v23                                 // rC[5+0*TT0I*VW+0*TT0I] = rC[5+0*TT0I*VW+1*TT0I]
+s_mov_b64 s[56:57], 0xFFFFFFFFFFFFFFFF             // to restore all threads active
+s_or_saveexec_b64 vcc, s[56:57]                    // all threads active
+s_branch label_0021                                // done shifting
+
+/* shift d1 r=1 v=1 */
+label_0020:
+v_cmpx_eq_u32 s[56:57], v57, v55                   // serial % SG == (wgMT/VECTOR_WIDTH)%SG
+// src=18, dst=12
+v_mov_b32 v24, v36                                 // rC[0+1*TT0I*VW+0*TT0I] = rC[0+1*TT0I*VW+1*TT0I]
+v_mov_b32 v25, v37                                 // rC[0+1*TT0I*VW+0*TT0I] = rC[0+1*TT0I*VW+1*TT0I]
+// src=19, dst=13
+v_mov_b32 v26, v38                                 // rC[1+1*TT0I*VW+0*TT0I] = rC[1+1*TT0I*VW+1*TT0I]
+v_mov_b32 v27, v39                                 // rC[1+1*TT0I*VW+0*TT0I] = rC[1+1*TT0I*VW+1*TT0I]
+// src=20, dst=14
+v_mov_b32 v28, v40                                 // rC[2+1*TT0I*VW+0*TT0I] = rC[2+1*TT0I*VW+1*TT0I]
+v_mov_b32 v29, v41                                 // rC[2+1*TT0I*VW+0*TT0I] = rC[2+1*TT0I*VW+1*TT0I]
+// src=21, dst=15
+v_mov_b32 v30, v42                                 // rC[3+1*TT0I*VW+0*TT0I] = rC[3+1*TT0I*VW+1*TT0I]
+v_mov_b32 v31, v43                                 // rC[3+1*TT0I*VW+0*TT0I] = rC[3+1*TT0I*VW+1*TT0I]
+// src=22, dst=16
+v_mov_b32 v32, v44                                 // rC[4+1*TT0I*VW+0*TT0I] = rC[4+1*TT0I*VW+1*TT0I]
+v_mov_b32 v33, v45                                 // rC[4+1*TT0I*VW+0*TT0I] = rC[4+1*TT0I*VW+1*TT0I]
+// src=23, dst=17
+v_mov_b32 v34, v46                                 // rC[5+1*TT0I*VW+0*TT0I] = rC[5+1*TT0I*VW+1*TT0I]
+v_mov_b32 v35, v47                                 // rC[5+1*TT0I*VW+0*TT0I] = rC[5+1*TT0I*VW+1*TT0I]
+s_mov_b64 s[56:57], 0xFFFFFFFFFFFFFFFF             // to restore all threads active
+s_or_saveexec_b64 vcc, s[56:57]                    // all threads active
+label_0021: // end shift0
+
+
+
+/* not-LocalSplitU: global write indices */
+
+s_mov_b32 s[sgprSrdD+0], s[sgprAddressD+0]         // init SRD base address (lower)
+s_mov_b32 s[sgprSrdD+1], s[sgprAddressD+1]         // init SRD base address (upper) + other fields
+s_mov_b32 s[sgprSrdD+2], 0x80000000                //
+s_mov_b32 s[sgprSrdD+3], Srd127_96                 // Set bits 127_96 in SRD
+s_mov_b32 s[sgprSrdC+0], s[sgprAddressC+0]         // init SRD base address (lower)
+s_mov_b32 s[sgprSrdC+1], s[sgprAddressC+1]         // init SRD base address (upper) + other fields
+s_mov_b32 s[sgprSrdC+2], 0x80000000                //
+s_mov_b32 s[sgprSrdC+3], Srd127_96                 // Set bits 127_96 in SRD
+
+s_mul_i32 s58, 0x40, s[sgprWorkGroup1]             // <- wg1*MT1
+s_mul_hi_u32 s57, s58, s[sgprStridesC+0]           // Scale s58 by Stride
+s_mul_i32 s56, s58, s[sgprStridesC+0]              // Scale s58 by Stride
+s_lshl_b64 s[56:57], s[56:57], 3                   // scale by bpe
+s_add_u32 s[sgprSrdD+0], s[sgprSrdD+0], s56        // add lo to SRD
+s_addc_u32 s[sgprSrdD+1], s[sgprSrdD+1], s57       // add hi to SRD
+s_add_u32 s[sgprSrdC+0], s[sgprSrdC+0], s56        // add lo to SRD
+s_addc_u32 s[sgprSrdC+1], s[sgprSrdC+1], s57       // add hi to SRD
+
+s_mul_hi_u32 s57, s[sgprWorkGroup2], s[sgprStridesC+1] // Scale s[sgprWorkGroup2] by Stride
+s_mul_i32 s56, s[sgprWorkGroup2], s[sgprStridesC+1] // Scale s[sgprWorkGroup2] by Stride
+s_lshl_b64 s[56:57], s[56:57], 3                   // scale by bpe
+s_add_u32 s[sgprSrdD+0], s[sgprSrdD+0], s56        // add lo to SRD
+s_addc_u32 s[sgprSrdD+1], s[sgprSrdD+1], s57       // add hi to SRD
+s_add_u32 s[sgprSrdC+0], s[sgprSrdC+0], s56        // add lo to SRD
+s_addc_u32 s[sgprSrdC+1], s[sgprSrdC+1], s57       // add hi to SRD
+
+v_lshrrev_b32 v49, 3, v[vgprSerial]                // vectorStaticDiv: v49 = v[vgprSerial] / 8
+v_and_b32 v48, 7, v[vgprSerial]                    // vectorStaticDiv: v48 = v[vgprSerial] % 8
+v_lshlrev_b32 v48, 1, v48                          // staticMultiply: v48 = v48 * 2
+v_lshlrev_b32 v49, 1, v49                          // staticMultiply: v49 = v49 * 2
+v_mul_lo_u32 v50, v49, s[sgprStridesC+0]           // rowStart vgpr
+
+s_mul_i32 s56, 0x30, s[sgprWorkGroup0]             // s56 = wg0*MT0
+_v_add_co_u32 v48, vcc, s56, v48                   // coord0 = tid0*VW + wg0*MT0
+s_mul_i32 s58, 0x40, s[sgprWorkGroup1]             // <- wg1*MT1
+_v_add_co_u32 v49, vcc, s58, v49                   // coord1 = tid1*VW + wg1*MT1
+
+//v_mov_b32 v48,v[vgprLocalWriteAddrA]
+//v_mov_b32 v49,v[vgprLocalWriteAddrB]
+//v_mov_b32 v50,v[vgprGlobalReadOffsetB]           // rowStart vgpr
+//_v_add_lshl_u32 v[vgprGlobalReadOffsetA], v[vgprGlobalReadOffsetB], v[vgprLocalWriteAddrA], 0x3                 // init cb addr <-  rowStart + coord0, scaled by BPE
+
+/* not-LocalSplitU: global write */
+
+s_mov_b32 s56, s[sgprBeta+0]                       // tmp = Beta[0]
+s_or_b32 s56, s[sgprBeta+1], s56                   // tmp |= Beta[1]
+s_cmpk_eq_u32 s56, 0x0                             // Beta == 0
+s_cbranch_scc0 label_0030                          // Beta is not zero; so jump to B nonzero
+
+s_mov_b32 s56, 0x0                                 // rMT0=0
+s_add_u32 s58, -0x1, s[sgprNumWorkGroups0]         //
+s_cmp_lt_u32 s[sgprWorkGroup0], s58                // wg0 < nwg0-1
+s_cbranch_scc1 label_0027                          // wg0 < nwg0-1 so skip rMT0 = Size0 % MT0
+/* TODO-packed- compare against product of all packed C0 sizes not just SizesFree+0 */
+s_mov_b32 s61, 0x0                                 // STATIC_DIV: divisior=48
+s_mul_i32 s60, 0xaaa, s[sgprSizesFree+0]           // tmp1 = dividend * magic hi
+s_lshl_b64 s[60:61], s[60:61], 0x10                // left shift 16 bits
+s_mul_i32 s58, s[sgprSizesFree+0], 0xaaab          // tmp0 = dividend * magic lo
+s_add_u32 s60, s58, s60                            // add lo
+s_addc_u32 s61, s61, 0x0                           // add hi
+s_lshr_b64 s[60:61], s[60:61], 0x21                // tmp1 = (dividend * magic) << shift
+s_mov_b32 s58, s60                                 // quotient
+s_mul_i32 s60, s58, 0x30                           // quotient*divisor
+s_sub_u32 s56, s[sgprSizesFree+0], s60             // rReg = dividend - quotient*divisor
+label_0027:
+s_cmpk_gt_u32 s56, 0x0                             // rMT0 > 0
+s_cbranch_scc1 label_0029                          // edges required so jump to E1
+s_mov_b32 s56, 0x0                                 // rMT1=0
+s_add_u32 s58, -0x1, s[sgprNumWorkGroups1]         //
+s_cmp_lt_u32 s[sgprWorkGroup1], s58                // wg1 < nwg1-1
+s_cbranch_scc1 label_0028                          // wg1 < nwg1-1 so skip rMT1 = Size1 % MT1
+s_lshr_b32 s58, s[sgprSizesFree+1], 6              // s58 = s[sgprSizesFree+1] / 64
+s_and_b32 s56, 63, s[sgprSizesFree+1]              // s56 = s[sgprSizesFree+1] % 64
+label_0028:
+s_cmpk_gt_u32 s56, 0x0                             // rMT1 > 0
+s_cbranch_scc1 label_0029                          // edges required so jump to E1
+label_0026:
+
+/******************************************/
+/* Global Write Batch #0 (d1,d0,vc1,vc0) =
+   (0,0,0,0:vw2); (0,1,0,0:vw2); (0,2,0,0:vw2); (0,0,1,0:vw2); (0,1,1,0:vw2); (0,2,1,0:vw2); (1,0,0,0:vw2); (1,1,0,0:vw2); (1,2,0,0:vw2); (1,0,1,0:vw2); (1,1,1,0:vw2); (1,2,1,0:vw2) */
+/******************************************/
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(0,0,0,0) coordOffset1=0 element-rows coordOffset0=0 rows */
+_v_add_lshl_u32 v54, v50, v48, 0x3                 // init cb addr <-  rowStart + coord0, scaled by BPE
+/* (d1,vc1,d0,vc0)=(0,0,1,0) coordOffset1=0 element-rows coordOffset0=16 rows */
+/* (d1,vc1,d0,vc0)=(0,0,2,0) coordOffset1=0 element-rows coordOffset0=32 rows */
+/* (d1,vc1,d0,vc0)=(0,1,0,0) coordOffset1=1 element-rows coordOffset0=0 rows */
+/* (d1,vc1,d0,vc0)=(0,1,1,0) coordOffset1=1 element-rows coordOffset0=16 rows */
+/* (d1,vc1,d0,vc0)=(0,1,2,0) coordOffset1=1 element-rows coordOffset0=32 rows */
+/* (d1,vc1,d0,vc0)=(1,0,0,0) coordOffset1=32 element-rows coordOffset0=0 rows */
+/* (d1,vc1,d0,vc0)=(1,0,1,0) coordOffset1=32 element-rows coordOffset0=16 rows */
+/* (d1,vc1,d0,vc0)=(1,0,2,0) coordOffset1=32 element-rows coordOffset0=32 rows */
+/* (d1,vc1,d0,vc0)=(1,1,0,0) coordOffset1=33 element-rows coordOffset0=0 rows */
+/* (d1,vc1,d0,vc0)=(1,1,1,0) coordOffset1=33 element-rows coordOffset0=16 rows */
+/* (d1,vc1,d0,vc0)=(1,1,2,0) coordOffset1=33 element-rows coordOffset0=32 rows */
+
+/* rC *= alpha batchEements=[(0, 0, 0, 0), (0, 1, 0, 0), (0, 2, 0, 0), (0, 0, 1, 0), (0, 1, 1, 0), (0, 2, 1, 0), (1, 0, 0, 0), (1, 1, 0, 0), (1, 2, 0, 0), (1, 0, 1, 0), (1, 1, 1, 0), (1, 2, 1, 0)] */
+//v_mul_f64 v[vgprValuC+0:vgprValuC+0+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+0:vgprValuC+0+1] // *= alpha
+//v_mul_f64 v[vgprValuC+2:vgprValuC+2+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+2:vgprValuC+2+1] // *= alpha
+//v_mul_f64 v[vgprValuC+4:vgprValuC+4+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+4:vgprValuC+4+1] // *= alpha
+//v_mul_f64 v[vgprValuC+6:vgprValuC+6+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+6:vgprValuC+6+1] // *= alpha
+//v_mul_f64 v[vgprValuC+8:vgprValuC+8+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+8:vgprValuC+8+1] // *= alpha
+//v_mul_f64 v[vgprValuC+10:vgprValuC+10+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+10:vgprValuC+10+1] // *= alpha
+//v_mul_f64 v[vgprValuC+12:vgprValuC+12+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+12:vgprValuC+12+1] // *= alpha
+//v_mul_f64 v[vgprValuC+14:vgprValuC+14+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+14:vgprValuC+14+1] // *= alpha
+//v_mul_f64 v[vgprValuC+16:vgprValuC+16+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+16:vgprValuC+16+1] // *= alpha
+//v_mul_f64 v[vgprValuC+18:vgprValuC+18+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+18:vgprValuC+18+1] // *= alpha
+//v_mul_f64 v[vgprValuC+20:vgprValuC+20+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+20:vgprValuC+20+1] // *= alpha
+//v_mul_f64 v[vgprValuC+22:vgprValuC+22+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+22:vgprValuC+22+1] // *= alpha
+//v_mul_f64 v[vgprValuC+24:vgprValuC+24+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+24:vgprValuC+24+1] // *= alpha
+//v_mul_f64 v[vgprValuC+26:vgprValuC+26+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+26:vgprValuC+26+1] // *= alpha
+//v_mul_f64 v[vgprValuC+28:vgprValuC+28+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+28:vgprValuC+28+1] // *= alpha
+//v_mul_f64 v[vgprValuC+30:vgprValuC+30+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+30:vgprValuC+30+1] // *= alpha
+//v_mul_f64 v[vgprValuC+32:vgprValuC+32+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+32:vgprValuC+32+1] // *= alpha
+//v_mul_f64 v[vgprValuC+34:vgprValuC+34+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+34:vgprValuC+34+1] // *= alpha
+//v_mul_f64 v[vgprValuC+36:vgprValuC+36+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+36:vgprValuC+36+1] // *= alpha
+//v_mul_f64 v[vgprValuC+38:vgprValuC+38+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+38:vgprValuC+38+1] // *= alpha
+//v_mul_f64 v[vgprValuC+40:vgprValuC+40+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+40:vgprValuC+40+1] // *= alpha
+//v_mul_f64 v[vgprValuC+42:vgprValuC+42+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+42:vgprValuC+42+1] // *= alpha
+//v_mul_f64 v[vgprValuC+44:vgprValuC+44+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+44:vgprValuC+44+1] // *= alpha
+//v_mul_f64 v[vgprValuC+46:vgprValuC+46+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+46:vgprValuC+46+1] // *= alpha
+
+/* apply mask, calc new C and issue write */
+buffer_store_dwordx4 v[0:3], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx4 v[4:7], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+buffer_store_dwordx4 v[8:11], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+buffer_store_dwordx4 v[12:15], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx4 v[16:19], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+buffer_store_dwordx4 v[20:23], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_mul_i32 s56, s[sgprStridesC+0], 248              // scale StrideC *= 31 * bpe
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+buffer_store_dwordx4 v[24:27], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx4 v[28:31], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+buffer_store_dwordx4 v[32:35], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+buffer_store_dwordx4 v[36:39], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx4 v[40:43], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+buffer_store_dwordx4 v[44:47], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_branch label_0037                                // jump to end
+label_0029:
+
+/******************************************/
+/* Global Write Edge Batch #0 (d1,d0,vc1,vc0) =
+   (0,0,0,0:vw1); (0,0,0,1:vw1); (0,1,0,0:vw1); (0,1,0,1:vw1); (0,2,0,0:vw1); (0,2,0,1:vw1); (0,0,1,0:vw1); (0,0,1,1:vw1); (0,1,1,0:vw1); (0,1,1,1:vw1); (0,2,1,0:vw1); (0,2,1,1:vw1); (1,0,0,0:vw1); (1,0,0,1:vw1); (1,1,0,0:vw1); (1,1,0,1:vw1); (1,2,0,0:vw1); (1,2,0,1:vw1) */
+/******************************************/
+
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(0,0,0,0) coordOffset1=0 element-rows coordOffset0=0 rows */
+v_mov_b32 v51, v50                                 // rowPtr <- rowStart (first row)
+_v_add_lshl_u32 v54, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[62:63], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v54, -1, v54, s[62:63]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,0,0,1) coordOffset1=0 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v55, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[64:65], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v55, -1, v55, s[64:65]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,0,1,0) coordOffset1=0 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v56, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[66:67], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v56, -1, v56, s[66:67]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,0,1,1) coordOffset1=0 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v57, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[68:69], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v57, -1, v57, s[68:69]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,0,2,0) coordOffset1=0 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v58, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[70:71], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v58, -1, v58, s[70:71]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,0,2,1) coordOffset1=0 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v59, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[72:73], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v59, -1, v59, s[72:73]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,1,0,0) coordOffset1=1 element-rows coordOffset0=0 rows */
+_v_add_co_u32 v53, vcc, v49, 1                     // coord1 += d1*sg1*VW + vc1
+_v_add_co_u32 v51, vcc, v51, s[sgprStridesC+0]     // rowPtr <- move to start of new row
+_v_add_lshl_u32 v60, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[74:75], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v60, -1, v60, s[74:75]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,1,0,1) coordOffset1=1 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v61, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[76:77], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v61, -1, v61, s[76:77]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,1,1,0) coordOffset1=1 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v62, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[78:79], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v62, -1, v62, s[78:79]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,1,1,1) coordOffset1=1 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v63, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[80:81], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v63, -1, v63, s[80:81]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,1,2,0) coordOffset1=1 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v64, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[82:83], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v64, -1, v64, s[82:83]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,1,2,1) coordOffset1=1 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v65, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[84:85], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v65, -1, v65, s[84:85]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,0,0,0) coordOffset1=32 element-rows coordOffset0=0 rows */
+_v_add_co_u32 v53, vcc, v49, 32                    // coord1 += d1*sg1*VW + vc1
+s_mul_i32 s56, s[sgprStridesC+0], 32               // scale StrideC *= coordOffset1(32)
+_v_add_co_u32 v51, vcc, v50, s56                   // rowPtr <- inc for non-0 (tt1+vc1))
+_v_add_lshl_u32 v66, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[86:87], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v66, -1, v66, s[86:87]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,0,0,1) coordOffset1=32 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v67, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[88:89], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v67, -1, v67, s[88:89]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,0,1,0) coordOffset1=32 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v68, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[90:91], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v68, -1, v68, s[90:91]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,0,1,1) coordOffset1=32 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v69, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[92:93], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v69, -1, v69, s[92:93]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,0,2,0) coordOffset1=32 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v70, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[94:95], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v70, -1, v70, s[94:95]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,0,2,1) coordOffset1=32 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v71, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[96:97], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v71, -1, v71, s[96:97]               // clip if OOB. offset
+
+/* rC *= alpha batchEements=[(0, 0, 0, 0), (0, 0, 0, 1), (0, 1, 0, 0), (0, 1, 0, 1), (0, 2, 0, 0), (0, 2, 0, 1), (0, 0, 1, 0), (0, 0, 1, 1), (0, 1, 1, 0), (0, 1, 1, 1), (0, 2, 1, 0), (0, 2, 1, 1), (1, 0, 0, 0), (1, 0, 0, 1), (1, 1, 0, 0), (1, 1, 0, 1), (1, 2, 0, 0), (1, 2, 0, 1)] */
+//v_mul_f64 v[vgprValuC+0:vgprValuC+0+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+0:vgprValuC+0+1] // *= alpha
+//v_mul_f64 v[vgprValuC+2:vgprValuC+2+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+2:vgprValuC+2+1] // *= alpha
+//v_mul_f64 v[vgprValuC+4:vgprValuC+4+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+4:vgprValuC+4+1] // *= alpha
+//v_mul_f64 v[vgprValuC+6:vgprValuC+6+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+6:vgprValuC+6+1] // *= alpha
+//v_mul_f64 v[vgprValuC+8:vgprValuC+8+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+8:vgprValuC+8+1] // *= alpha
+//v_mul_f64 v[vgprValuC+10:vgprValuC+10+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+10:vgprValuC+10+1] // *= alpha
+//v_mul_f64 v[vgprValuC+12:vgprValuC+12+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+12:vgprValuC+12+1] // *= alpha
+//v_mul_f64 v[vgprValuC+14:vgprValuC+14+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+14:vgprValuC+14+1] // *= alpha
+//v_mul_f64 v[vgprValuC+16:vgprValuC+16+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+16:vgprValuC+16+1] // *= alpha
+//v_mul_f64 v[vgprValuC+18:vgprValuC+18+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+18:vgprValuC+18+1] // *= alpha
+//v_mul_f64 v[vgprValuC+20:vgprValuC+20+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+20:vgprValuC+20+1] // *= alpha
+//v_mul_f64 v[vgprValuC+22:vgprValuC+22+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+22:vgprValuC+22+1] // *= alpha
+//v_mul_f64 v[vgprValuC+24:vgprValuC+24+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+24:vgprValuC+24+1] // *= alpha
+//v_mul_f64 v[vgprValuC+26:vgprValuC+26+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+26:vgprValuC+26+1] // *= alpha
+//v_mul_f64 v[vgprValuC+28:vgprValuC+28+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+28:vgprValuC+28+1] // *= alpha
+//v_mul_f64 v[vgprValuC+30:vgprValuC+30+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+30:vgprValuC+30+1] // *= alpha
+//v_mul_f64 v[vgprValuC+32:vgprValuC+32+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+32:vgprValuC+32+1] // *= alpha
+//v_mul_f64 v[vgprValuC+34:vgprValuC+34+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+34:vgprValuC+34+1] // *= alpha
+
+/* apply mask, calc new C and issue write */
+buffer_store_dwordx2 v[0:1], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[2:3], v55, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[4:5], v56, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[6:7], v57, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[8:9], v58, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[10:11], v59, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[12:13], v60, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[14:15], v61, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[16:17], v62, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[18:19], v63, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[20:21], v64, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[22:23], v65, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[24:25], v66, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[26:27], v67, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[28:29], v68, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[30:31], v69, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[32:33], v70, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[34:35], v71, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+/******************************************/
+/* Global Write Edge Batch #1 (d1,d0,vc1,vc0) =
+   (1,0,1,0:vw1); (1,0,1,1:vw1); (1,1,1,0:vw1); (1,1,1,1:vw1); (1,2,1,0:vw1); (1,2,1,1:vw1) */
+/******************************************/
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(1,1,0,0) coordOffset1=33 element-rows coordOffset0=0 rows */
+_v_add_co_u32 v53, vcc, v49, 33                    // coord1 += d1*sg1*VW + vc1
+_v_add_co_u32 v51, vcc, v51, s[sgprStridesC+0]     // rowPtr <- move to start of new row
+_v_add_lshl_u32 v54, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[62:63], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v54, -1, v54, s[62:63]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,1,0,1) coordOffset1=33 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v55, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[64:65], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v55, -1, v55, s[64:65]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,1,1,0) coordOffset1=33 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v56, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[66:67], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v56, -1, v56, s[66:67]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,1,1,1) coordOffset1=33 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v57, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[68:69], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v57, -1, v57, s[68:69]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,1,2,0) coordOffset1=33 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v58, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[70:71], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v58, -1, v58, s[70:71]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,1,2,1) coordOffset1=33 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v59, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[72:73], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v59, -1, v59, s[72:73]               // clip if OOB. offset
+
+/* rC *= alpha batchEements=[(1, 0, 1, 0), (1, 0, 1, 1), (1, 1, 1, 0), (1, 1, 1, 1), (1, 2, 1, 0), (1, 2, 1, 1)] */
+//v_mul_f64 v[vgprValuC+36:vgprValuC+36+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+36:vgprValuC+36+1] // *= alpha
+//v_mul_f64 v[vgprValuC+38:vgprValuC+38+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+38:vgprValuC+38+1] // *= alpha
+//v_mul_f64 v[vgprValuC+40:vgprValuC+40+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+40:vgprValuC+40+1] // *= alpha
+//v_mul_f64 v[vgprValuC+42:vgprValuC+42+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+42:vgprValuC+42+1] // *= alpha
+//v_mul_f64 v[vgprValuC+44:vgprValuC+44+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+44:vgprValuC+44+1] // *= alpha
+//v_mul_f64 v[vgprValuC+46:vgprValuC+46+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+46:vgprValuC+46+1] // *= alpha
+
+/* apply mask, calc new C and issue write */
+buffer_store_dwordx2 v[36:37], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[38:39], v55, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[40:41], v56, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[42:43], v57, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[44:45], v58, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[46:47], v59, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_branch label_0037                                // jump to end
+label_0030:
+s_mov_b32 s56, 0x0                                 // rMT0=0
+s_add_u32 s58, -0x1, s[sgprNumWorkGroups0]         //
+s_cmp_lt_u32 s[sgprWorkGroup0], s58                // wg0 < nwg0-1
+s_cbranch_scc1 label_0034                          // wg0 < nwg0-1 so skip rMT0 = Size0 % MT0
+/* TODO-packed- compare against product of all packed C0 sizes not just SizesFree+0 */
+s_mov_b32 s61, 0x0                                 // STATIC_DIV: divisior=48
+s_mul_i32 s60, 0xaaa, s[sgprSizesFree+0]           // tmp1 = dividend * magic hi
+s_lshl_b64 s[60:61], s[60:61], 0x10                // left shift 16 bits
+s_mul_i32 s58, s[sgprSizesFree+0], 0xaaab          // tmp0 = dividend * magic lo
+s_add_u32 s60, s58, s60                            // add lo
+s_addc_u32 s61, s61, 0x0                           // add hi
+s_lshr_b64 s[60:61], s[60:61], 0x21                // tmp1 = (dividend * magic) << shift
+s_mov_b32 s58, s60                                 // quotient
+s_mul_i32 s60, s58, 0x30                           // quotient*divisor
+s_sub_u32 s56, s[sgprSizesFree+0], s60             // rReg = dividend - quotient*divisor
+label_0034:
+s_cmpk_gt_u32 s56, 0x0                             // rMT0 > 0
+s_cbranch_scc1 label_0036                          // edges required so jump to E1
+s_mov_b32 s56, 0x0                                 // rMT1=0
+s_add_u32 s58, -0x1, s[sgprNumWorkGroups1]         //
+s_cmp_lt_u32 s[sgprWorkGroup1], s58                // wg1 < nwg1-1
+s_cbranch_scc1 label_0035                          // wg1 < nwg1-1 so skip rMT1 = Size1 % MT1
+s_lshr_b32 s58, s[sgprSizesFree+1], 6              // s58 = s[sgprSizesFree+1] / 64
+s_and_b32 s56, 63, s[sgprSizesFree+1]              // s56 = s[sgprSizesFree+1] % 64
+label_0035:
+s_cmpk_gt_u32 s56, 0x0                             // rMT1 > 0
+s_cbranch_scc1 label_0036                          // edges required so jump to E1
+label_0033:
+
+/******************************************/
+/* Global Write Beta Batch #0 (d1,d0,vc1,vc0) =
+   (0,0,0,0:vw2); (0,1,0,0:vw2); (0,2,0,0:vw2); (0,0,1,0:vw2); (0,1,1,0:vw2); (0,2,1,0:vw2) */
+/******************************************/
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(0,0,0,0) coordOffset1=0 element-rows coordOffset0=0 rows */
+_v_add_lshl_u32 v54, v[vgprGlobalReadOffsetB], v48, 0x3                 // init cb addr <-  rowStart + coord0, scaled by BPE
+buffer_load_dwordx4 v[55:58], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,1,0) coordOffset1=0 element-rows coordOffset0=16 rows */
+buffer_load_dwordx4 v[59:62], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,2,0) coordOffset1=0 element-rows coordOffset0=32 rows */
+buffer_load_dwordx4 v[63:66], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,0,0) coordOffset1=1 element-rows coordOffset0=0 rows */
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+buffer_load_dwordx4 v[67:70], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,1,0) coordOffset1=1 element-rows coordOffset0=16 rows */
+buffer_load_dwordx4 v[71:74], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,2,0) coordOffset1=1 element-rows coordOffset0=32 rows */
+buffer_load_dwordx4 v[75:78], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+
+/* rC *= alpha batchEements=[(0, 0, 0, 0), (0, 1, 0, 0), (0, 2, 0, 0), (0, 0, 1, 0), (0, 1, 1, 0), (0, 2, 1, 0)] */
+v_mul_f64 v[vgprValuC+0:vgprValuC+0+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+0:vgprValuC+0+1] // *= alpha
+v_mul_f64 v[vgprValuC+2:vgprValuC+2+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+2:vgprValuC+2+1] // *= alpha
+v_mul_f64 v[vgprValuC+4:vgprValuC+4+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+4:vgprValuC+4+1] // *= alpha
+v_mul_f64 v[vgprValuC+6:vgprValuC+6+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+6:vgprValuC+6+1] // *= alpha
+v_mul_f64 v[vgprValuC+8:vgprValuC+8+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+8:vgprValuC+8+1] // *= alpha
+v_mul_f64 v[vgprValuC+10:vgprValuC+10+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+10:vgprValuC+10+1] // *= alpha
+v_mul_f64 v[vgprValuC+12:vgprValuC+12+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+12:vgprValuC+12+1] // *= alpha
+v_mul_f64 v[vgprValuC+14:vgprValuC+14+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+14:vgprValuC+14+1] // *= alpha
+v_mul_f64 v[vgprValuC+16:vgprValuC+16+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+16:vgprValuC+16+1] // *= alpha
+v_mul_f64 v[vgprValuC+18:vgprValuC+18+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+18:vgprValuC+18+1] // *= alpha
+v_mul_f64 v[vgprValuC+20:vgprValuC+20+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+20:vgprValuC+20+1] // *= alpha
+v_mul_f64 v[vgprValuC+22:vgprValuC+22+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+22:vgprValuC+22+1] // *= alpha
+
+/* apply mask, calc new C and issue write */
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+0:vgprValuC+0+1], v[55:56], s[sgprBeta:sgprBeta+1], v[vgprValuC+0:vgprValuC+0+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+2:vgprValuC+2+1], v[57:58], s[sgprBeta:sgprBeta+1], v[vgprValuC+2:vgprValuC+2+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[0:3], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+4:vgprValuC+4+1], v[59:60], s[sgprBeta:sgprBeta+1], v[vgprValuC+4:vgprValuC+4+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+6:vgprValuC+6+1], v[61:62], s[sgprBeta:sgprBeta+1], v[vgprValuC+6:vgprValuC+6+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[4:7], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+8:vgprValuC+8+1], v[63:64], s[sgprBeta:sgprBeta+1], v[vgprValuC+8:vgprValuC+8+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+10:vgprValuC+10+1], v[65:66], s[sgprBeta:sgprBeta+1], v[vgprValuC+10:vgprValuC+10+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[8:11], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+12:vgprValuC+12+1], v[67:68], s[sgprBeta:sgprBeta+1], v[vgprValuC+12:vgprValuC+12+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+14:vgprValuC+14+1], v[69:70], s[sgprBeta:sgprBeta+1], v[vgprValuC+14:vgprValuC+14+1] // finalSum = sum*alpha + C*beta
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+buffer_store_dwordx4 v[12:15], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+16:vgprValuC+16+1], v[71:72], s[sgprBeta:sgprBeta+1], v[vgprValuC+16:vgprValuC+16+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+18:vgprValuC+18+1], v[73:74], s[sgprBeta:sgprBeta+1], v[vgprValuC+18:vgprValuC+18+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[16:19], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+20:vgprValuC+20+1], v[75:76], s[sgprBeta:sgprBeta+1], v[vgprValuC+20:vgprValuC+20+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+22:vgprValuC+22+1], v[77:78], s[sgprBeta:sgprBeta+1], v[vgprValuC+22:vgprValuC+22+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[20:23], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+
+/******************************************/
+/* Global Write Beta Batch #1 (d1,d0,vc1,vc0) =
+   (1,0,0,0:vw2); (1,1,0,0:vw2); (1,2,0,0:vw2); (1,0,1,0:vw2); (1,1,1,0:vw2); (1,2,1,0:vw2) */
+/******************************************/
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(1,0,0,0) coordOffset1=32 element-rows coordOffset0=0 rows */
+s_mul_i32 s56, s[sgprStridesD+0], 248              // scale StrideC *= 31 * bpe
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+buffer_load_dwordx4 v[55:58], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,1,0) coordOffset1=32 element-rows coordOffset0=16 rows */
+buffer_load_dwordx4 v[59:62], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,2,0) coordOffset1=32 element-rows coordOffset0=32 rows */
+buffer_load_dwordx4 v[63:66], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,0,0) coordOffset1=33 element-rows coordOffset0=0 rows */
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+buffer_load_dwordx4 v[67:70], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,1,0) coordOffset1=33 element-rows coordOffset0=16 rows */
+buffer_load_dwordx4 v[71:74], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,2,0) coordOffset1=33 element-rows coordOffset0=32 rows */
+buffer_load_dwordx4 v[75:78], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+
+/* rC *= alpha batchEements=[(1, 0, 0, 0), (1, 1, 0, 0), (1, 2, 0, 0), (1, 0, 1, 0), (1, 1, 1, 0), (1, 2, 1, 0)] */
+v_mul_f64 v[vgprValuC+24:vgprValuC+24+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+24:vgprValuC+24+1] // *= alpha
+v_mul_f64 v[vgprValuC+26:vgprValuC+26+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+26:vgprValuC+26+1] // *= alpha
+v_mul_f64 v[vgprValuC+28:vgprValuC+28+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+28:vgprValuC+28+1] // *= alpha
+v_mul_f64 v[vgprValuC+30:vgprValuC+30+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+30:vgprValuC+30+1] // *= alpha
+v_mul_f64 v[vgprValuC+32:vgprValuC+32+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+32:vgprValuC+32+1] // *= alpha
+v_mul_f64 v[vgprValuC+34:vgprValuC+34+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+34:vgprValuC+34+1] // *= alpha
+v_mul_f64 v[vgprValuC+36:vgprValuC+36+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+36:vgprValuC+36+1] // *= alpha
+v_mul_f64 v[vgprValuC+38:vgprValuC+38+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+38:vgprValuC+38+1] // *= alpha
+v_mul_f64 v[vgprValuC+40:vgprValuC+40+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+40:vgprValuC+40+1] // *= alpha
+v_mul_f64 v[vgprValuC+42:vgprValuC+42+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+42:vgprValuC+42+1] // *= alpha
+v_mul_f64 v[vgprValuC+44:vgprValuC+44+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+44:vgprValuC+44+1] // *= alpha
+v_mul_f64 v[vgprValuC+46:vgprValuC+46+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+46:vgprValuC+46+1] // *= alpha
+
+/* apply mask, calc new C and issue write */
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+24:vgprValuC+24+1], v[55:56], s[sgprBeta:sgprBeta+1], v[vgprValuC+24:vgprValuC+24+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+26:vgprValuC+26+1], v[57:58], s[sgprBeta:sgprBeta+1], v[vgprValuC+26:vgprValuC+26+1] // finalSum = sum*alpha + C*beta
+s_mul_i32 s56, s[sgprStridesD+0], 248              // scale StrideC *= 31 * bpe
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+buffer_store_dwordx4 v[24:27], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+28:vgprValuC+28+1], v[59:60], s[sgprBeta:sgprBeta+1], v[vgprValuC+28:vgprValuC+28+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+30:vgprValuC+30+1], v[61:62], s[sgprBeta:sgprBeta+1], v[vgprValuC+30:vgprValuC+30+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[28:31], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+32:vgprValuC+32+1], v[63:64], s[sgprBeta:sgprBeta+1], v[vgprValuC+32:vgprValuC+32+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+34:vgprValuC+34+1], v[65:66], s[sgprBeta:sgprBeta+1], v[vgprValuC+34:vgprValuC+34+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[32:35], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+36:vgprValuC+36+1], v[67:68], s[sgprBeta:sgprBeta+1], v[vgprValuC+36:vgprValuC+36+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+38:vgprValuC+38+1], v[69:70], s[sgprBeta:sgprBeta+1], v[vgprValuC+38:vgprValuC+38+1] // finalSum = sum*alpha + C*beta
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+buffer_store_dwordx4 v[36:39], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+40:vgprValuC+40+1], v[71:72], s[sgprBeta:sgprBeta+1], v[vgprValuC+40:vgprValuC+40+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+42:vgprValuC+42+1], v[73:74], s[sgprBeta:sgprBeta+1], v[vgprValuC+42:vgprValuC+42+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[40:43], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+44:vgprValuC+44+1], v[75:76], s[sgprBeta:sgprBeta+1], v[vgprValuC+44:vgprValuC+44+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+46:vgprValuC+46+1], v[77:78], s[sgprBeta:sgprBeta+1], v[vgprValuC+46:vgprValuC+46+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[44:47], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_branch label_0037                                // jump to end
+label_0036:
+
+/******************************************/
+/* Global Write Beta Edge Batch #0 (d1,d0,vc1,vc0) =
+   (0,0,0,0:vw1); (0,0,0,1:vw1); (0,1,0,0:vw1); (0,1,0,1:vw1); (0,2,0,0:vw1); (0,2,0,1:vw1); (0,0,1,0:vw1); (0,0,1,1:vw1) */
+/******************************************/
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(0,0,0,0) coordOffset1=0 element-rows coordOffset0=0 rows */
+v_mov_b32 v51, v50                                 // rowPtr <- rowStart (first row)
+_v_add_lshl_u32 v54, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[62:63], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v54, -1, v54, s[62:63]               // clip if OOB. offset
+buffer_load_dwordx2 v[55:56], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,0,1) coordOffset1=0 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v57, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[64:65], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v57, -1, v57, s[64:65]               // clip if OOB. offset
+buffer_load_dwordx2 v[58:59], v57, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,1,0) coordOffset1=0 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v60, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[66:67], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v60, -1, v60, s[66:67]               // clip if OOB. offset
+buffer_load_dwordx2 v[61:62], v60, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,1,1) coordOffset1=0 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v63, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[68:69], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v63, -1, v63, s[68:69]               // clip if OOB. offset
+buffer_load_dwordx2 v[64:65], v63, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,2,0) coordOffset1=0 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v66, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[70:71], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v66, -1, v66, s[70:71]               // clip if OOB. offset
+buffer_load_dwordx2 v[67:68], v66, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,2,1) coordOffset1=0 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v69, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[72:73], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v69, -1, v69, s[72:73]               // clip if OOB. offset
+buffer_load_dwordx2 v[70:71], v69, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,0,0) coordOffset1=1 element-rows coordOffset0=0 rows */
+_v_add_co_u32 v53, vcc, v49, 1                     // coord1 += d1*sg1*VW + vc1
+_v_add_co_u32 v51, vcc, v51, s[sgprStridesC+0]     // rowPtr <- move to start of new row
+_v_add_lshl_u32 v72, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[74:75], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v72, -1, v72, s[74:75]               // clip if OOB. offset
+buffer_load_dwordx2 v[73:74], v72, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,0,1) coordOffset1=1 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v75, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[76:77], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v75, -1, v75, s[76:77]               // clip if OOB. offset
+buffer_load_dwordx2 v[76:77], v75, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+
+/* rC *= alpha batchEements=[(0, 0, 0, 0), (0, 0, 0, 1), (0, 1, 0, 0), (0, 1, 0, 1), (0, 2, 0, 0), (0, 2, 0, 1), (0, 0, 1, 0), (0, 0, 1, 1)] */
+v_mul_f64 v[vgprValuC+0:vgprValuC+0+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+0:vgprValuC+0+1] // *= alpha
+v_mul_f64 v[vgprValuC+2:vgprValuC+2+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+2:vgprValuC+2+1] // *= alpha
+v_mul_f64 v[vgprValuC+4:vgprValuC+4+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+4:vgprValuC+4+1] // *= alpha
+v_mul_f64 v[vgprValuC+6:vgprValuC+6+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+6:vgprValuC+6+1] // *= alpha
+v_mul_f64 v[vgprValuC+8:vgprValuC+8+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+8:vgprValuC+8+1] // *= alpha
+v_mul_f64 v[vgprValuC+10:vgprValuC+10+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+10:vgprValuC+10+1] // *= alpha
+v_mul_f64 v[vgprValuC+12:vgprValuC+12+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+12:vgprValuC+12+1] // *= alpha
+v_mul_f64 v[vgprValuC+14:vgprValuC+14+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+14:vgprValuC+14+1] // *= alpha
+s_waitcnt vmcnt(0)                                 // wait C
+
+/* apply mask, calc new C and issue write */
+v_fma_f64 v[vgprValuC+0:vgprValuC+0+1], v[55:56], s[sgprBeta:sgprBeta+1], v[vgprValuC+0:vgprValuC+0+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[0:1], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+2:vgprValuC+2+1], v[58:59], s[sgprBeta:sgprBeta+1], v[vgprValuC+2:vgprValuC+2+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[2:3], v57, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+4:vgprValuC+4+1], v[61:62], s[sgprBeta:sgprBeta+1], v[vgprValuC+4:vgprValuC+4+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[4:5], v60, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+6:vgprValuC+6+1], v[64:65], s[sgprBeta:sgprBeta+1], v[vgprValuC+6:vgprValuC+6+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[6:7], v63, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+8:vgprValuC+8+1], v[67:68], s[sgprBeta:sgprBeta+1], v[vgprValuC+8:vgprValuC+8+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[8:9], v66, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+10:vgprValuC+10+1], v[70:71], s[sgprBeta:sgprBeta+1], v[vgprValuC+10:vgprValuC+10+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[10:11], v69, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+12:vgprValuC+12+1], v[73:74], s[sgprBeta:sgprBeta+1], v[vgprValuC+12:vgprValuC+12+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[12:13], v72, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+14:vgprValuC+14+1], v[76:77], s[sgprBeta:sgprBeta+1], v[vgprValuC+14:vgprValuC+14+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[14:15], v75, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+/******************************************/
+/* Global Write Beta Edge Batch #1 (d1,d0,vc1,vc0) =
+   (0,1,1,0:vw1); (0,1,1,1:vw1); (0,2,1,0:vw1); (0,2,1,1:vw1); (1,0,0,0:vw1); (1,0,0,1:vw1); (1,1,0,0:vw1); (1,1,0,1:vw1) */
+/******************************************/
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(0,1,1,0) coordOffset1=1 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v54, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[62:63], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v54, -1, v54, s[62:63]               // clip if OOB. offset
+buffer_load_dwordx2 v[55:56], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,1,1) coordOffset1=1 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v57, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[64:65], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v57, -1, v57, s[64:65]               // clip if OOB. offset
+buffer_load_dwordx2 v[58:59], v57, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,2,0) coordOffset1=1 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v60, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[66:67], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v60, -1, v60, s[66:67]               // clip if OOB. offset
+buffer_load_dwordx2 v[61:62], v60, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,2,1) coordOffset1=1 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v63, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[68:69], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v63, -1, v63, s[68:69]               // clip if OOB. offset
+buffer_load_dwordx2 v[64:65], v63, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,0,0) coordOffset1=32 element-rows coordOffset0=0 rows */
+_v_add_co_u32 v53, vcc, v49, 32                    // coord1 += d1*sg1*VW + vc1
+s_mul_i32 s56, s[sgprStridesC+0], 32               // scale StrideC *= coordOffset1(32)
+_v_add_co_u32 v51, vcc, v50, s56                   // rowPtr <- inc for non-0 (tt1+vc1))
+_v_add_lshl_u32 v66, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[70:71], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v66, -1, v66, s[70:71]               // clip if OOB. offset
+buffer_load_dwordx2 v[67:68], v66, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,0,1) coordOffset1=32 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v69, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[72:73], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v69, -1, v69, s[72:73]               // clip if OOB. offset
+buffer_load_dwordx2 v[70:71], v69, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,1,0) coordOffset1=32 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v72, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[74:75], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v72, -1, v72, s[74:75]               // clip if OOB. offset
+buffer_load_dwordx2 v[73:74], v72, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,1,1) coordOffset1=32 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v75, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[76:77], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v75, -1, v75, s[76:77]               // clip if OOB. offset
+buffer_load_dwordx2 v[76:77], v75, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+
+/* rC *= alpha batchEements=[(0, 1, 1, 0), (0, 1, 1, 1), (0, 2, 1, 0), (0, 2, 1, 1), (1, 0, 0, 0), (1, 0, 0, 1), (1, 1, 0, 0), (1, 1, 0, 1)] */
+v_mul_f64 v[vgprValuC+16:vgprValuC+16+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+16:vgprValuC+16+1] // *= alpha
+v_mul_f64 v[vgprValuC+18:vgprValuC+18+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+18:vgprValuC+18+1] // *= alpha
+v_mul_f64 v[vgprValuC+20:vgprValuC+20+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+20:vgprValuC+20+1] // *= alpha
+v_mul_f64 v[vgprValuC+22:vgprValuC+22+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+22:vgprValuC+22+1] // *= alpha
+v_mul_f64 v[vgprValuC+24:vgprValuC+24+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+24:vgprValuC+24+1] // *= alpha
+v_mul_f64 v[vgprValuC+26:vgprValuC+26+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+26:vgprValuC+26+1] // *= alpha
+v_mul_f64 v[vgprValuC+28:vgprValuC+28+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+28:vgprValuC+28+1] // *= alpha
+v_mul_f64 v[vgprValuC+30:vgprValuC+30+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+30:vgprValuC+30+1] // *= alpha
+s_waitcnt vmcnt(0)                                 // wait C
+
+/* apply mask, calc new C and issue write */
+v_fma_f64 v[vgprValuC+16:vgprValuC+16+1], v[55:56], s[sgprBeta:sgprBeta+1], v[vgprValuC+16:vgprValuC+16+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[16:17], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+18:vgprValuC+18+1], v[58:59], s[sgprBeta:sgprBeta+1], v[vgprValuC+18:vgprValuC+18+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[18:19], v57, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+20:vgprValuC+20+1], v[61:62], s[sgprBeta:sgprBeta+1], v[vgprValuC+20:vgprValuC+20+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[20:21], v60, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+22:vgprValuC+22+1], v[64:65], s[sgprBeta:sgprBeta+1], v[vgprValuC+22:vgprValuC+22+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[22:23], v63, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+24:vgprValuC+24+1], v[67:68], s[sgprBeta:sgprBeta+1], v[vgprValuC+24:vgprValuC+24+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[24:25], v66, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+26:vgprValuC+26+1], v[70:71], s[sgprBeta:sgprBeta+1], v[vgprValuC+26:vgprValuC+26+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[26:27], v69, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+28:vgprValuC+28+1], v[73:74], s[sgprBeta:sgprBeta+1], v[vgprValuC+28:vgprValuC+28+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[28:29], v72, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+30:vgprValuC+30+1], v[76:77], s[sgprBeta:sgprBeta+1], v[vgprValuC+30:vgprValuC+30+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[30:31], v75, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+/******************************************/
+/* Global Write Beta Edge Batch #2 (d1,d0,vc1,vc0) =
+   (1,2,0,0:vw1); (1,2,0,1:vw1); (1,0,1,0:vw1); (1,0,1,1:vw1); (1,1,1,0:vw1); (1,1,1,1:vw1); (1,2,1,0:vw1); (1,2,1,1:vw1) */
+/******************************************/
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(1,0,2,0) coordOffset1=32 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v54, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[62:63], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v54, -1, v54, s[62:63]               // clip if OOB. offset
+buffer_load_dwordx2 v[55:56], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,2,1) coordOffset1=32 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v57, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[64:65], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v57, -1, v57, s[64:65]               // clip if OOB. offset
+buffer_load_dwordx2 v[58:59], v57, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,0,0) coordOffset1=33 element-rows coordOffset0=0 rows */
+_v_add_co_u32 v53, vcc, v49, 33                    // coord1 += d1*sg1*VW + vc1
+_v_add_co_u32 v51, vcc, v51, s[sgprStridesC+0]     // rowPtr <- move to start of new row
+_v_add_lshl_u32 v60, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[66:67], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v60, -1, v60, s[66:67]               // clip if OOB. offset
+buffer_load_dwordx2 v[61:62], v60, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,0,1) coordOffset1=33 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v63, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[68:69], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v63, -1, v63, s[68:69]               // clip if OOB. offset
+buffer_load_dwordx2 v[64:65], v63, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,1,0) coordOffset1=33 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v66, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[70:71], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v66, -1, v66, s[70:71]               // clip if OOB. offset
+buffer_load_dwordx2 v[67:68], v66, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,1,1) coordOffset1=33 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v69, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[72:73], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v69, -1, v69, s[72:73]               // clip if OOB. offset
+buffer_load_dwordx2 v[70:71], v69, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,2,0) coordOffset1=33 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v72, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[74:75], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v72, -1, v72, s[74:75]               // clip if OOB. offset
+buffer_load_dwordx2 v[73:74], v72, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,2,1) coordOffset1=33 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v75, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[76:77], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v75, -1, v75, s[76:77]               // clip if OOB. offset
+buffer_load_dwordx2 v[76:77], v75, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+
+/* rC *= alpha batchEements=[(1, 2, 0, 0), (1, 2, 0, 1), (1, 0, 1, 0), (1, 0, 1, 1), (1, 1, 1, 0), (1, 1, 1, 1), (1, 2, 1, 0), (1, 2, 1, 1)] */
+v_mul_f64 v[vgprValuC+32:vgprValuC+32+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+32:vgprValuC+32+1] // *= alpha
+v_mul_f64 v[vgprValuC+34:vgprValuC+34+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+34:vgprValuC+34+1] // *= alpha
+v_mul_f64 v[vgprValuC+36:vgprValuC+36+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+36:vgprValuC+36+1] // *= alpha
+v_mul_f64 v[vgprValuC+38:vgprValuC+38+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+38:vgprValuC+38+1] // *= alpha
+v_mul_f64 v[vgprValuC+40:vgprValuC+40+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+40:vgprValuC+40+1] // *= alpha
+v_mul_f64 v[vgprValuC+42:vgprValuC+42+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+42:vgprValuC+42+1] // *= alpha
+v_mul_f64 v[vgprValuC+44:vgprValuC+44+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+44:vgprValuC+44+1] // *= alpha
+v_mul_f64 v[vgprValuC+46:vgprValuC+46+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+46:vgprValuC+46+1] // *= alpha
+s_waitcnt vmcnt(0)                                 // wait C
+
+/* apply mask, calc new C and issue write */
+v_fma_f64 v[vgprValuC+32:vgprValuC+32+1], v[55:56], s[sgprBeta:sgprBeta+1], v[vgprValuC+32:vgprValuC+32+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[32:33], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+34:vgprValuC+34+1], v[58:59], s[sgprBeta:sgprBeta+1], v[vgprValuC+34:vgprValuC+34+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[34:35], v57, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+36:vgprValuC+36+1], v[61:62], s[sgprBeta:sgprBeta+1], v[vgprValuC+36:vgprValuC+36+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[36:37], v60, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+38:vgprValuC+38+1], v[64:65], s[sgprBeta:sgprBeta+1], v[vgprValuC+38:vgprValuC+38+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[38:39], v63, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+40:vgprValuC+40+1], v[67:68], s[sgprBeta:sgprBeta+1], v[vgprValuC+40:vgprValuC+40+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[40:41], v66, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+42:vgprValuC+42+1], v[70:71], s[sgprBeta:sgprBeta+1], v[vgprValuC+42:vgprValuC+42+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[42:43], v69, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+44:vgprValuC+44+1], v[73:74], s[sgprBeta:sgprBeta+1], v[vgprValuC+44:vgprValuC+44+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[44:45], v72, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+46:vgprValuC+46+1], v[76:77], s[sgprBeta:sgprBeta+1], v[vgprValuC+46:vgprValuC+46+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[46:47], v75, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_branch label_0037                                // jump to end
+label_0037:
+
+label_0038:  /// KernelEnd
+s_endpgm                                           // Kernel End
+
+

--- a/Tensile/ReplacementKernels/Cijk_Ailk_Bjlk_DB_MT48x64x4_AF0EM1_ASEM1_FL1_GRVW2_ISA908_MDA2_PGR1_PLR0_SU0_TT6_4_VAW1_VW2_WG8_16_1_WGM4.s.txt
+++ b/Tensile/ReplacementKernels/Cijk_Ailk_Bjlk_DB_MT48x64x4_AF0EM1_ASEM1_FL1_GRVW2_ISA908_MDA2_PGR1_PLR0_SU0_TT6_4_VAW1_VW2_WG8_16_1_WGM4.s.txt
@@ -1,0 +1,3896 @@
+
+
+/******************************************/
+/* Function Prefix                        */
+/******************************************/
+
+
+
+/******************************************/
+/* Begin Kernel                           */
+/******************************************/
+
+.hsa_code_object_version 2,0
+.hsa_code_object_isa 9, 0, 8, "AMD", "AMDGPU"
+.text
+.protected Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM4
+.globl Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM4
+.p2align 8
+.type Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM4,@function
+.amdgpu_hsa_kernel Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM4
+Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM4:
+.amd_kernel_code_t
+  is_ptr64 = 1
+  enable_sgpr_kernarg_segment_ptr = 1
+  kernarg_segment_byte_size = 92 // bytes of kern args
+  workitem_vgpr_count = 84 // vgprs
+  wavefront_sgpr_count = 98 // sgprs
+  compute_pgm_rsrc1_vgprs = 20 // floor((83-1)/4)
+  compute_pgm_rsrc1_sgprs = 13 // floor((98-1)/8)
+  compute_pgm_rsrc2_tidig_comp_cnt = 0 // 1D wg
+  compute_pgm_rsrc2_tgid_x_en = 1 // wg.x
+  compute_pgm_rsrc2_tgid_y_en = 1 // wg.y
+  compute_pgm_rsrc2_tgid_z_en = 1 // wg.z
+  workgroup_group_segment_byte_size = 7680 // lds bytes
+  compute_pgm_rsrc2_user_sgpr = 2 // vcc
+  kernarg_segment_alignment = 4
+  group_segment_alignment = 4
+  private_segment_alignment = 4
+.end_amd_kernel_code_t
+
+.amd_amdgpu_hsa_metadata
+Version: [ 1, 0 ]
+Kernels:
+  - Name: Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM4
+    SymbolName: 'Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM4@kd'
+    Language: OpenCL C
+    LanguageVersion: [ 2, 0 ]
+    Args:
+      - Name:            sizeC
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            sizeA
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            sizeB
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            D
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       F64
+        AddrSpaceQual:   Generic
+      - Name:            C
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       F64
+        AddrSpaceQual:   Generic
+      - Name:            A
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       F64
+        AddrSpaceQual:   Generic
+      - Name:            B
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       F64
+        AddrSpaceQual:   Generic
+      - Name:            alpha
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       F64
+      - Name:            beta
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       F64
+      - Name:            strideD0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideD1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideC0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideC1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideA0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideA1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideB0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideB1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree2
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesSum0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            OrigStaggerUIter
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       I32
+      - Name:            NumWorkGroups0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            NumWorkGroups1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            MagicNumberProblemNumGroupTiles0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            GridNumWorkGroups0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            NumFullBlocks
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            WgmRemainder1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            MagicNumberWgmRemainder1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            padding
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+    CodeProps:
+      KernargSegmentSize: 156
+      GroupSegmentFixedSize: 7680
+      PrivateSegmentFixedSize: 0
+      KernargSegmentAlign:  8
+      WavefrontSize:        64
+      NumSGPRs:             98
+      NumVGPRs:             84
+      MaxFlatWorkGroupSize: 128
+.end_amd_amdgpu_hsa_metadata
+
+/******************************************/
+/* Optimizations and Config:              */
+/******************************************/
+/* ThreadTile= 6 x 4 */
+/* SubGroup= 8 x 16 */
+/* VectorWidth=2 */
+/* GlobalLoadVectorWidthA=2, GlobalLoadVectorWidthB=2 */
+/* DirectToLdsA=False */
+/* DirectToLdsB=False */
+/* UseSgprForGRO=False */
+
+/******************************************/
+/* Asm syntax workarounds                 */
+/******************************************/
+.macro _v_add_co_u32 dst, cc, src0, src1, dpp=
+   v_add_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+.macro _v_sub_co_u32 dst, cc, src0, src1, dpp=
+   v_sub_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+.macro _v_addc_co_u32 dst, ccOut, src0, ccIn, src1, dpp=
+   v_addc_co_u32 \dst, \ccOut, \src0, \ccIn, \src1 \dpp
+.endm
+.macro _v_add_lshl_u32 dst, src0, src1, shiftCnt
+    v_add_lshl_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+.macro _v_lshl_add_u32 dst, src0, src1, shiftCnt
+    v_lshl_add_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+/******************************************/
+/* Magic div and mod functions            */
+/******************************************/
+.macro V_MAGIC_DIV dstIdx, dividend, magicNumber, magicShift
+    v_mul_lo_u32 v[\dstIdx+0], \dividend, \magicNumber
+    v_mul_hi_u32 v[\dstIdx+1], \dividend, \magicNumber
+    v_lshrrev_b64 v[\dstIdx:\dstIdx+1], \magicShift, v[\dstIdx:\dstIdx+1]
+.endm
+
+/******************************************/
+/* VGPR Assignments                       */
+/******************************************/
+.set vgprValuC, 0
+/* ValuA/B   Xn=PLR buffer idx,  In=InnerUnroll idx */
+.set vgprValuA_X0_I0, 48
+.set vgprG2LA, 60
+.set vgprValuB_X0_I0, 64
+.set vgprG2LB, 72
+.set vgprLocalWriteAddrA, 76
+.set vgprLocalWriteAddrB, 77
+.set vgprGlobalReadOffsetA, 78
+.set vgprGlobalReadOffsetB, 79
+.set vgprLocalReadAddrA, 80
+.set vgprLocalReadAddrB, 81
+.set vgprSerial, 82
+/* Num VGPR=83 */
+
+/******************************************/
+/* SGPR Assignments                       */
+/******************************************/
+.set sgprKernArgAddress, 0
+.set sgprWorkGroup0, 2
+.set sgprWorkGroup1, 3
+.set sgprWorkGroup2, 4
+.set sgprNumWorkGroups0, 5
+.set sgprNumWorkGroups1, 6
+.set sgprSrdA, 8
+.set sgprSrdB, 12
+.set sgprSrdD, 16
+.set sgprSrdC, 20
+.set sgprTensor2dSizeC, 24
+.set sgprTensor2dSizeA, 26
+.set sgprTensor2dSizeB, 28
+.set sgprSaveExecMask, 30
+.set sgprAddressD, 32
+.set sgprAddressC, 34
+.set sgprStridesC, 36
+.set sgprAlpha, 38
+.set sgprBeta, 40
+.set sgprSizesFree, 42
+.set sgprSizesSum, 45
+.set sgprLoopCounters, 46
+.set sgprOrigLoopCounter, 47
+.set sgprStridesA, 48
+.set sgprStridesB, 50
+.set sgprAddressA, 52
+.set sgprAddressB, 54
+.set sgprShadowLimitA, 56
+.set sgprShadowLimitB, 58
+.set sgprNumFullBlocks, 60
+.set sgprWgmRemainder1, 61
+.set sgprMagicNumberWgmRemainder1, 62
+.set sgprGlobalReadIncsA, 63
+.set sgprGlobalReadIncsB, 64
+.set sgprStridesD, 74
+.set sgprTMP0, 90
+.set sgprTMP1, 91
+.set sgprEdgeSelMask0, 93
+.set sgprEdgeSelMask1, 94
+/* max SGPR=98 */
+
+/******************************************/
+/* 2GB limit - set offsets to -1 to exceed this and clamp */
+/******************************************/
+.set BufferLimit, 0x80000000
+
+/******************************************/
+/* Bits 127:96 of SRD.  Set DataFormat = 32 bit */
+/******************************************/
+.set Srd127_96, 0x0020000
+.set BufferOOB, 0x80000000
+
+/* Global Offset A */
+.macro GLOBAL_OFFSET_A vgprAddr vgprOffset0I vgprOffsetL vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStridesA+0], v[\vgprOffsetL] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprTmp+0], v[\vgprOffset0I] // accumulate d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, 0x2, v[\vgprAddr+0] // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x3, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/* Global Offset B */
+.macro GLOBAL_OFFSET_B vgprAddr vgprOffset1J vgprOffsetL vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStridesB+0], v[\vgprOffsetL] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprTmp+0], v[\vgprOffset1J] // accumulate d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, 0x2, v[\vgprAddr+0] // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x3, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/******************************************/
+/* Dynamic Scalar Divide: vQuotient=vDividend/vDivisor; vRemainder=vDividend%vDivisor; */
+/******************************************/
+.macro DYNAMIC_VECTOR_DIVIDE vQuotient vRemainder vDividend vDivisor vTmp0 vTmp1 sTmp
+v_cvt_f32_u32 v[\vQuotient], v[\vDivisor]          //
+v_rcp_f32 v[\vQuotient], v[\vQuotient]             //
+v_mul_f32 v[\vQuotient], 0x4f800000, v[\vQuotient] //
+v_cvt_u32_f32 v[\vQuotient], v[\vQuotient]         //
+v_mul_lo_u32 v[\vRemainder], v[\vDivisor], v[\vQuotient] //
+v_mul_hi_u32 v[\vTmp0], v[\vDivisor], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp1], vcc, 0x0, v[\vRemainder]  //
+v_cmp_ne_i32 s[\sTmp:\sTmp+1], 0x0, v[\vTmp0]      //
+v_cndmask_b32 v[\vRemainder], v[\vTmp1], v[\vRemainder], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vRemainder], v[\vRemainder], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vQuotient], v[\vRemainder] //
+_v_add_co_u32 v[\vQuotient], vcc, v[\vQuotient], v[\vRemainder] //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vTmp0], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vQuotient], v[\vQuotient], v[\vDividend] //
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vDividend], v[\vRemainder] //
+v_cmp_ge_u32 s[\sTmp:\sTmp+1], v[\vDividend], v[\vRemainder] //
+_v_add_co_u32 v[\vRemainder], vcc, 0x1, v[\vQuotient] //
+_v_add_co_u32 v[\vTmp1], vcc, -1, v[\vQuotient]    //
+v_cmp_le_u32 vcc, v[\vDivisor], v[\vTmp0]          //
+s_and_b64 vcc, s[\sTmp:\sTmp+1], vcc               //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vRemainder], vcc //
+v_cndmask_b32 v[\vQuotient], v[\vTmp1], v[\vQuotient], s[\sTmp:\sTmp+1] //
+v_cmp_ne_i32 vcc, 0x0, v[\vDivisor]                //
+v_cndmask_b32 v[\vQuotient], -1, v[\vQuotient], vcc // final result
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vRemainder], vcc, v[\vDividend], v[\vRemainder] // final result
+.endm
+
+/******************************************/
+/* 6x4 thread-tile                        */
+/******************************************/
+.macro MAC_6x4_X0
+v_fma_f64 v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1]
+s_setprio 1 // Raise priority while processing macs
+v_fma_f64 v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1]
+s_setprio 0 // Reset priority after macs
+.endm
+
+.macro MAC_6x4_X0_part_1
+v_fma_f64 v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1]
+s_setprio 1 // Raise priority while processing macs
+v_fma_f64 v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1]
+.endm
+
+.macro MAC_6x4_X0_part_2
+.endm
+
+.macro MAC_6x4_X0_part_3
+v_fma_f64 v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1]
+s_setprio 0 // Reset Priority
+.endm
+
+.macro MAC_6x4_X0_unprio_0
+v_fma_f64 v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1]
+s_setprio 1 // Raise priority while processing macs
+v_fma_f64 v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1]
+.endm
+
+
+.macro MAC_6x4_X0_part1
+v_fma_f64 v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1]
+s_setprio 1
+v_fma_f64 v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1]
+s_setprio 0
+.endm
+
+
+.macro MAC_6x4_X0_part2
+v_fma_f64 v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1]
+s_setprio 1
+v_fma_f64 v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1]
+s_setprio 0
+.endm
+.macro MAC_6x4_X0_part3
+v_fma_f64 v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1]
+s_setprio 1
+v_fma_f64 v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1]
+s_setprio 0
+.endm
+.macro MAC_6x4_X0_part4
+v_fma_f64 v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1]
+s_setprio 1
+v_fma_f64 v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1]
+//vnop_4
+s_setprio 0
+.endm
+.macro MAC_6x4_X0_part5
+v_fma_f64 v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1]
+s_setprio 1
+v_fma_f64 v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1]
+//vnop_4
+s_setprio 0
+.endm
+.macro MAC_6x4_X0_part6
+v_fma_f64 v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1]
+s_setprio 1
+v_fma_f64 v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1]
+s_setprio 0
+.endm
+
+/******************************************/
+/* Allocate Resources                     */
+/******************************************/
+
+s_mov_b32 m0, 0x1e00                               // LDS clamp at 7680 bytes
+v_mov_b32 v[vgprSerial], v0                        // thread serial id
+
+/* Load Kernel Args */
+s_load_dword s[sgprTensor2dSizeC+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x0 //
+s_load_dword s[sgprTensor2dSizeC+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x4 //
+s_load_dword s[sgprTensor2dSizeA+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x8 //
+s_load_dword s[sgprTensor2dSizeA+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0xc //
+s_load_dword s[sgprTensor2dSizeB+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x10 //
+s_load_dword s[sgprTensor2dSizeB+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x14 //
+s_load_dword s[sgprAddressD], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x18 //
+s_load_dword s[sgprAddressD+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x1c //
+s_load_dword s[sgprAddressC], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x20 //
+s_load_dword s[sgprAddressC+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x24 //
+s_load_dword s[sgprAddressA], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x28 //
+s_load_dword s[sgprAddressA+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x2c //
+s_load_dword s[sgprAddressB], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x30 //
+s_load_dword s[sgprAddressB+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x34 //
+s_load_dword s[sgprAlpha+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x38 //
+s_load_dword s[sgprAlpha+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x3c //
+s_load_dword s[sgprBeta+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x40 //
+s_load_dword s[sgprBeta+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x44 //
+s_load_dword s[sgprStridesD+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x48 //
+s_load_dword s[sgprStridesD+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x4c //
+s_load_dword s[sgprStridesC+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x50 //
+s_load_dword s[sgprStridesC+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x54 //
+s_load_dword s[sgprStridesA+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x58 //
+s_load_dword s[sgprStridesA+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x5c //
+s_load_dword s[sgprStridesB+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x60 //
+s_load_dword s[sgprStridesB+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x64 //
+s_load_dword s[sgprSizesFree+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x68 //
+s_load_dword s[sgprSizesFree+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x6c //
+s_load_dword s[sgprSizesFree+2], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x70 //
+s_load_dword s[sgprSizesSum+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x74 //
+s_load_dword s[sgprNumWorkGroups0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x7c //
+s_load_dword s[sgprNumWorkGroups1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x80 //
+s_load_dword s[sgprNumFullBlocks], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x8c //
+s_load_dword s[sgprWgmRemainder1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x90 //
+s_load_dword s[sgprMagicNumberWgmRemainder1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x94 //
+s_waitcnt lgkmcnt(0)                               // wait for 144 bytes of kern args
+
+
+/******************************************/
+/* Local Read Addresses                   */
+/******************************************/
+
+
+/* local read addresses: tile assignments a */
+
+/*lr0I = serial % SG0I*/
+v_lshrrev_b32 v0, 3, v[vgprSerial]                 // vectorStaticDiv: v0 = v[vgprSerial] / 8
+v_and_b32 v1, 7, v[vgprSerial]                     // vectorStaticDiv: v1 = v[vgprSerial] % 8
+
+
+/* local read addresses: tile assignments b */
+
+/*lr1J = (serial / SG1J) % SG1J*/
+v_lshrrev_b32 v2, 4, v0                            // vectorStaticDiv: v2 = v0 / 16
+v_and_b32 v3, 15, v0                               // vectorStaticDiv: v3 = v0 % 16
+
+
+/* local read addresses: final offsets a */
+
+v_lshrrev_b32 v0, 7, v[vgprSerial]                 // vectorStaticDiv: v0 = v[vgprSerial] / 128
+v_and_b32 v2, 127, v[vgprSerial]                   // vectorStaticDiv: v2 = v[vgprSerial] % 128
+s_mov_b32 s65, 0x30                                // MT0+PAD
+v_mul_lo_u32 v0, s65, v0                           // sgid=sgid*(MT0+PAD)
+v_lshlrev_b32 v1, 1, v1                            // staticMultiply: v1 = v1 * 2
+_v_add_lshl_u32 v[vgprLocalReadAddrA], v0, v1, 0x3 // o = (lroA*VW+sgid*MT0)*bpe
+
+
+/* local read addresses: final offsets b */
+
+v_lshrrev_b32 v0, 7, v[vgprSerial]                 // vectorStaticDiv: v0 = v[vgprSerial] / 128
+v_and_b32 v1, 127, v[vgprSerial]                   // vectorStaticDiv: v1 = v[vgprSerial] % 128
+s_mov_b32 s65, 0x40                                // MT1+PAD
+v_mul_lo_u32 v0, s65, v0                           // sgid=sgid*(MT1+PAD)
+v_lshlrev_b32 v3, 1, v3                            // staticMultiply: v3 = v3 * 2
+_v_add_lshl_u32 v[vgprLocalReadAddrB], v0, v3, 0x3 // o = (lroB*VW+sgid*MT1)*bpe
+
+
+/* local read addresses: declare addresses a */
+
+/* N/A */
+
+
+/* local read addresses: declare addresses b */
+
+_v_add_co_u32 v[vgprLocalReadAddrB+0], vcc, 0x600, v[vgprLocalReadAddrB+0] //  += LdsOffsetB (lower)
+
+
+s_load_dword s[sgprNumWorkGroups1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x80 //
+s_load_dword s[sgprNumFullBlocks], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x8c //
+s_load_dword s[sgprWgmRemainder1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x90 //
+s_load_dword s[sgprMagicNumberWgmRemainder1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x94 //
+/******************************************/
+/* Global Read Addresses                  */
+/******************************************/
+
+
+/* global read addresses: work-group */
+
+/* graWorkGroup mapping */
+s_mov_b32 s69, 0x20000001L                         // magic number for WGM==4
+s_mul_hi_u32 s67, s[sgprWorkGroup1], s69           // s_magic mul
+s_mul_i32 s66, s[sgprWorkGroup1], s69              // s_magic mul
+s_lshr_b64 s[66:67], s[66:67], 31                  // sMagicDiv
+s_mul_i32 s67, s66, 4                              // quotient * non-magic divisor
+s_sub_u32 s67, s[sgprWorkGroup1], s67              // WorkGroup1=remainder
+s_mul_i32 s67, s67, s[sgprNumWorkGroups0]          // (wg1 % WGM)*nwg0
+s_add_u32 s67, s67, s[sgprWorkGroup0]              // wgSerial = wg0 + (wg1 % WGM)*nwg0
+s_cmp_ge_u32 s66, s[sgprNumFullBlocks]             // blockId >= numFullBlocks ?
+s_cmov_b32 s69, s[sgprMagicNumberWgmRemainder1]    //
+s_cselect_b32 s68, s[sgprWgmRemainder1], 4         //
+s_mul_hi_u32 s3, s67, s69                          // s_magic mul
+s_mul_i32 s2, s67, s69                             // s_magic mul
+s_lshr_b64 s[2:3], s[2:3], 31                      // sMagicDiv
+s_mul_i32 s[sgprWorkGroup1], s[sgprWorkGroup0], s68 // quotient * non-magic divisor
+s_sub_u32 s[sgprWorkGroup1], s67, s[sgprWorkGroup1] // WorkGroup1=remainder
+s_mul_i32 s66, s66, 4                              // blockId * WGM
+s_add_u32 s[sgprWorkGroup1], s[sgprWorkGroup1], s66 // wg1 += blockId * WGM
+
+
+/* global read addresses: tile offset assignment a */
+
+/* LVCA = 24 */
+/* v0 = (local)groA-tile = serial%LVCA (note (wgA*MTA) will be added to SRD) */
+/* v1 = groA-unroll = serial/LVCA */
+s_mov_b32 s65, 0x15555556                          //
+v_mul_hi_u32 v3, v[vgprSerial], s65                //
+v_mul_lo_u32 v2, v[vgprSerial], s65                //
+v_lshrrev_b64 v[2:3], 0x21, v[2:3]                 //
+v_mov_b32 v1, v2                                   // vectorStaticDiv: quotient
+s_mov_b32 s65, 0x18                                // divisor
+v_mul_lo_u32 v2, v1, s65                           // vectorStaticDiv: product = quotient * divisor
+_v_sub_co_u32 v0, vcc, v[vgprSerial], v2           // vectorStaticDiv: remainder = dividend - product
+/* gro-tile *= glvw */
+v_lshlrev_b32 v0, 1, v0                            // staticMultiply: v0 = v0 * 2
+
+
+/* global read addresses: tile offset assignment b */
+
+/* LVCB = 32 */
+/* v2 = (local)groB-tile = serial%LVCB (note (wgB*MTB) will be added to SRD) */
+/* v3 = groB-unroll = serial/LVCB */
+v_lshrrev_b32 v3, 5, v[vgprSerial]                 // vectorStaticDiv: v3 = v[vgprSerial] / 32
+v_and_b32 v2, 31, v[vgprSerial]                    // vectorStaticDiv: v2 = v[vgprSerial] % 32
+/* gro-tile *= glvw */
+v_lshlrev_b32 v2, 1, v2                            // staticMultiply: v2 = v2 * 2
+
+
+/* global read addresses: unroll assignment a */
+
+/* v1 */
+
+
+/* global read addresses: unroll assignment b */
+
+/* v3 */
+
+
+/* global read addresses: other free assignments */
+
+/* s[sgprWorkGroup2] */
+
+
+/* global read addresses: tile offsets a */
+
+v_mov_b32 v4, v0                                   // groA0I_0
+
+
+/* global read addresses: tile offsets b */
+
+v_mov_b32 v5, v2                                   // groB1J_0
+
+
+/* global read addresses: unroll offsets a */
+
+v_mov_b32 v6, v1                                   // groAL_0
+
+
+/* global read addresses: unroll offsets b */
+
+v_mov_b32 v7, v3                                   // groBL_0
+
+
+/* global read addresses: shift a */
+
+s_mul_i32 s65, s[sgprWorkGroup0], 48               // WorkGroup[01] * MT
+s_sub_u32 s65, s[sgprSizesFree+0], s65             // edge = Size0I - WG*MT
+s_sub_u32 s65, s65, 2                              // edge -= margin
+v_mov_b32 v8, s65                                  // edge vgpr = Size0I-2
+_v_add_co_u32 v9, vcc, v8, 2                       // add srdShiftLift
+_v_add_co_u32 v10, vcc, v4, 2                      //
+v_cmp_lt_u32 s[66:67], v10, v9                     // offset < edge
+v_cndmask_b32 v4, v8, v4, s[66:67]                 // offset = (offset < edge) ? offset : edge
+
+
+/* global read addresses: shift b */
+
+s_mul_i32 s65, s[sgprWorkGroup1], 64               // WorkGroup[01] * MT
+s_sub_u32 s65, s[sgprSizesFree+1], s65             // edge = Size1J - WG*MT
+s_sub_u32 s65, s65, 2                              // edge -= margin
+v_mov_b32 v8, s65                                  // edge vgpr = Size1J-2
+_v_add_co_u32 v9, vcc, v8, 2                       // add srdShiftLift
+_v_add_co_u32 v10, vcc, v5, 2                      //
+v_cmp_lt_u32 s[66:67], v10, v9                     // offset < edge
+v_cndmask_b32 v5, v8, v5, s[66:67]                 // offset = (offset < edge) ? offset : edge
+
+
+/* global read addresses: final offsets a */
+
+GLOBAL_OFFSET_A vgprGlobalReadOffsetA+0,  4,  6, 8 // gROA_0_0_0_0
+// Offset only valid for 96/128 threads inside the PerLoadTile
+s_mov_b32 s66, 96                                  //
+v_cmp_lt_u32 vcc, v[vgprSerial], s66               // tid < valid-tid
+s_mov_b32 s66, BufferOOB                           //
+v_mov_b32 v11, s66                                 //
+v_cndmask_b32 v[vgprGlobalReadOffsetA+0], v11, v[vgprGlobalReadOffsetA+0], vcc // Mask load so OOB will return 0
+
+
+/* global read addresses: final offsets b */
+
+GLOBAL_OFFSET_B vgprGlobalReadOffsetB+0,  5,  7, 8 // gROB_0_0_0_0
+
+
+/* global read addresses: addresses a */
+
+/* max read offset = size[n] * stride[n-1] */
+s_mul_hi_u32 s69, s[sgprWorkGroup0], 48            // WorkGroup[01] * MT
+s_mul_i32 s68, s[sgprWorkGroup0], 48               // WorkGroup[01] * MT
+s_sub_u32 s[sgprShadowLimitA+0], s[sgprTensor2dSizeA], s68 // sub tileStart
+s_subb_u32 s[sgprShadowLimitA+1], s[sgprTensor2dSizeA+1], s69 // sub tileStart
+s_lshl_b64 s[sgprShadowLimitA:sgprShadowLimitA+1], s[sgprShadowLimitA:sgprShadowLimitA+1], 0x3 // Set limit to use bytes
+s_add_u32 s[sgprShadowLimitA+0], s[sgprShadowLimitA+0], 16 // extend limit for pre-pad
+s_addc_u32 s[sgprShadowLimitA+1], s[sgprShadowLimitA+1], 0 // extend limit for pre-pad
+s_cmp_eq_u32 s[sgprShadowLimitA+1], 0              // are we within 2^32?
+s_cselect_b32 s[sgprSrdA+2], s[sgprShadowLimitA+0], BufferLimit // Move shadow to real if we are within 2^32
+s_mul_hi_u32 s67, s[sgprStridesA+1], s[sgprWorkGroup2] // Stride*WG
+s_mul_i32 s66, s[sgprStridesA+1], s[sgprWorkGroup2] // Stride*WG
+s_add_u32 s68, s68, s66                            // accum wg term to tilestart
+s_addc_u32 s69, s69, s67                           // accum wg term to tilestart
+s_lshl_b64 s[68:69], s[68:69], 3                   // tileStart *= BPE
+s_add_u32 s[sgprSrdA+0], s[sgprAddressA+0], s68    // SRD base = Address+ tileStart0
+s_addc_u32 s[sgprSrdA+1], s[sgprAddressA+1], s69   // SRD base = Address+ tileStart1
+s_sub_u32 s[sgprSrdA+0], s[sgprSrdA+0], 16         // pre-pad to make room for possible pointer shift
+s_subb_u32 s[sgprSrdA+1], s[sgprSrdA+1], 0         // pre-pad to make room for possible pointer shift
+s_mov_b32 s[sgprSrdA+3], Srd127_96                 // Set bits 127_96 in SRD
+
+
+/* global read addresses: addresses b */
+
+/* max read offset = size[n] * stride[n-1] */
+s_mul_hi_u32 s69, s[sgprWorkGroup1], 64            // WorkGroup[01] * MT
+s_mul_i32 s68, s[sgprWorkGroup1], 64               // WorkGroup[01] * MT
+s_sub_u32 s[sgprShadowLimitB+0], s[sgprTensor2dSizeB], s68 // sub tileStart
+s_subb_u32 s[sgprShadowLimitB+1], s[sgprTensor2dSizeB+1], s69 // sub tileStart
+s_lshl_b64 s[sgprShadowLimitB:sgprShadowLimitB+1], s[sgprShadowLimitB:sgprShadowLimitB+1], 0x3 // Set limit to use bytes
+s_add_u32 s[sgprShadowLimitB+0], s[sgprShadowLimitB+0], 16 // extend limit for pre-pad
+s_addc_u32 s[sgprShadowLimitB+1], s[sgprShadowLimitB+1], 0 // extend limit for pre-pad
+s_cmp_eq_u32 s[sgprShadowLimitB+1], 0              // are we within 2^32?
+s_cselect_b32 s[sgprSrdB+2], s[sgprShadowLimitB+0], BufferLimit // Move shadow to real if we are within 2^32
+s_mul_hi_u32 s67, s[sgprStridesB+1], s[sgprWorkGroup2] // Stride*WG
+s_mul_i32 s66, s[sgprStridesB+1], s[sgprWorkGroup2] // Stride*WG
+s_add_u32 s68, s68, s66                            // accum wg term to tilestart
+s_addc_u32 s69, s69, s67                           // accum wg term to tilestart
+s_lshl_b64 s[68:69], s[68:69], 3                   // tileStart *= BPE
+s_add_u32 s[sgprSrdB+0], s[sgprAddressB+0], s68    // SRD base = Address+ tileStart0
+s_addc_u32 s[sgprSrdB+1], s[sgprAddressB+1], s69   // SRD base = Address+ tileStart1
+s_sub_u32 s[sgprSrdB+0], s[sgprSrdB+0], 16         // pre-pad to make room for possible pointer shift
+s_subb_u32 s[sgprSrdB+1], s[sgprSrdB+1], 0         // pre-pad to make room for possible pointer shift
+s_mov_b32 s[sgprSrdB+3], Srd127_96                 // Set bits 127_96 in SRD
+
+
+/* global read addresses: increments a */
+
+s_mul_i32 s[sgprGlobalReadIncsA+0], 0x20, s[sgprStridesA] // incr = stride*4*bytes
+
+
+/* global read addresses: increments b */
+
+s_mul_i32 s[sgprGlobalReadIncsB+0], 0x20, s[sgprStridesB] // incr = stride*4*bytes
+
+
+/******************************************/
+/* Local Write Addresses                  */
+/******************************************/
+
+
+/* local write addresses: tile assignment a */
+
+/* lwaTileA = v0 */
+
+
+/* local write addresses: tile assignment b */
+
+/* lwaTileB = v2 */
+
+
+/* local write addresses: unroll assignment a */
+
+/* lwaUnrollA = v1 */
+
+
+/* local write addresses: unroll assignment b */
+
+/* lwaUnrollB = v3 */
+
+
+/* local write addresses: first offset a */
+
+v_mul_u32_u24 v[vgprLocalWriteAddrA], 0x30, v1     // lwAL**(MTA + PAD)
+_v_add_lshl_u32 v[vgprLocalWriteAddrA], v0, v[vgprLocalWriteAddrA], 0x3 // lwFOA = (lwAA + lwAL*(MT0I+PAD))*bpe
+s_mov_b32 s65, 96                                  // lsc*lsp=48*4
+v_cmp_lt_u32 vcc, v[vgprSerial], s65               // fractional: ensure tid < global read tile elements
+v_mov_b32 v0, 0xf00000                             //
+v_cndmask_b32 v[vgprLocalWriteAddrA], v0, v[vgprLocalWriteAddrA], vcc // Mask load so out-of-gr-tile bounds returns 0
+
+
+/* local write addresses: first offset b */
+
+v_mul_u32_u24 v[vgprLocalWriteAddrB], 0x40, v3     // lwBL**(MTB + PAD)
+_v_add_lshl_u32 v[vgprLocalWriteAddrB], v2, v[vgprLocalWriteAddrB], 0x3 // lwFOB = (lwBB + lwBL*(MT1J+PAD))*bpe
+_v_add_co_u32 v[vgprLocalWriteAddrB], vcc, 0x600, v[vgprLocalWriteAddrB] // lwFOB = lwB1J + lwBL*MT1J + LDS_OFFSET_B=192*8
+
+
+/* local write addresses: final offsets a */
+
+
+/* N/A */
+
+
+/* local write addresses: final offsets b */
+
+
+/* N/A */
+
+
+/* local write addresses: declare addresses a */
+
+/* N/A */
+
+
+/* local write addresses: declare addresses b */
+
+/* N/A */
+
+
+/* local write addresses: init pointers a */
+
+/* N/A */
+
+
+/* local write addresses: init pointers b */
+
+/* N/A */
+
+
+/* declare loop num iterations */
+
+
+s_lshr_b32 s[sgprLoopCounters+0], s[sgprSizesSum+0], 2 // s[sgprLoopCounters+0] = s[sgprSizesSum+0] / 4
+s_mov_b32 s[sgprOrigLoopCounter], s[sgprLoopCounters+0] // copy loop counter
+s_sub_u32 s[sgprLoopCounters+0], 0x0, s[sgprLoopCounters+0] // counterL = -sizeL
+
+
+/* local read addresses: init pointers a */
+
+
+
+/* local read addresses: init pointers b */
+
+
+
+/* TODO-packed- compare against product of all packed C0 sizes not just SizesFree+0 */
+s_mov_b32 s91, 0x0                                 // STATIC_DIV: divisior=48
+s_mul_i32 s90, 0xaaa, s[sgprSizesFree+0]           // tmp1 = dividend * magic hi
+s_lshl_b64 s[90:91], s[90:91], 0x10                // left shift 16 bits
+s_mul_i32 s82, s[sgprSizesFree+0], 0xaaab          // tmp0 = dividend * magic lo
+s_add_u32 s90, s82, s90                            // add lo
+s_addc_u32 s91, s91, 0x0                           // add hi
+s_lshr_b64 s[90:91], s[90:91], 0x21                // tmp1 = (dividend * magic) << shift
+s_mov_b32 s82, s90                                 // quotient
+s_mul_i32 s90, s82, 0x30                           // quotient*divisor
+s_sub_u32 s[sgprEdgeSelMask0], s[sgprSizesFree+0], s90             // rReg = dividend - quotient*divisor
+s_lshr_b32 s82, s[sgprSizesFree+1], 6              // s58 = s[sgprSizesFree+1] / 64
+s_and_b32 s[sgprEdgeSelMask1], 63, s[sgprSizesFree+1]
+
+
+/* prefetch: global -> local */
+
+s_cmp_eq_u32 s[sgprLoopCounters+0], 0x0            // numIter0I == 0
+s_cbranch_scc1 label_0008                          // skip to ShadowInitStart iter b/c numIter==0
+
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+
+
+/* global read inc A */
+s_add_u32  s[sgprSrdA+0], s[sgprSrdA+0], s[sgprGlobalReadIncsA] // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdA+1], s[sgprSrdA+1], 0        // gra SRD += inc(upper)
+s_sub_u32 s[sgprShadowLimitA+0], s[sgprShadowLimitA+0], s[sgprGlobalReadIncsA] // limit -= inc)
+s_subb_u32 s[sgprShadowLimitA+1], s[sgprShadowLimitA+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitA+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdA+2], s[sgprShadowLimitA+0]    // Move shadow to real if we are within 2^32
+
+
+/* global read inc B */
+s_add_u32  s[sgprSrdB+0], s[sgprSrdB+0], s[sgprGlobalReadIncsB] // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdB+1], s[sgprSrdB+1], 0        // gra SRD += inc(upper)
+s_sub_u32 s[sgprShadowLimitB+0], s[sgprShadowLimitB+0], s[sgprGlobalReadIncsB] // limit -= inc)
+s_subb_u32 s[sgprShadowLimitB+1], s[sgprShadowLimitB+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitB+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdB+2], s[sgprShadowLimitB+0]    // Move shadow to real if we are within 2^32
+
+label_0008: // ShadowInitStart
+
+s_mov_b32 s[sgprSrdD+0], s[sgprAddressD+0]         // init SRD base address (lower)
+s_mov_b32 s[sgprSrdD+1], s[sgprAddressD+1]         // init SRD base address (upper) + other fields
+s_mov_b32 s[sgprSrdD+2], 0x80000000                //
+s_mov_b32 s[sgprSrdD+3], Srd127_96                 // Set bits 127_96 in SRD
+s_mov_b32 s[sgprSrdC+0], s[sgprAddressC+0]         // init SRD base address (lower)
+s_mov_b32 s[sgprSrdC+1], s[sgprAddressC+1]         // init SRD base address (upper) + other fields
+s_mov_b32 s[sgprSrdC+2], 0x80000000                //
+s_mov_b32 s[sgprSrdC+3], Srd127_96                 // Set bits 127_96 in SRD
+
+s_mul_i32 s[sgprTMP1], 0x40, s[sgprWorkGroup1]             // <- wg1*MT1
+s_mul_i32 s[sgprTMP0], 0x30, s[sgprWorkGroup1]             // <- wg1*MT1
+s_mul_hi_u32 s67, s[sgprTMP1], s[sgprStridesC+0]           // Scale s68 by Stride
+s_mul_i32 s66, s[sgprTMP1], s[sgprStridesC+0]              // Scale s68 by Stride
+s_lshl_b64 s[66:67], s[66:67], 3                   // scale by bpe
+s_add_u32 s[sgprSrdD+0], s[sgprSrdD+0], s66        // add lo to SRD
+s_addc_u32 s[sgprSrdD+1], s[sgprSrdD+1], s67       // add hi to SRD
+s_add_u32 s[sgprSrdC+0], s[sgprSrdC+0], s66        // add lo to SRD
+s_addc_u32 s[sgprSrdC+1], s[sgprSrdC+1], s67       // add hi to SRD
+
+s_mul_hi_u32 s67, s[sgprWorkGroup2], s[sgprStridesC+1] // Scale s[sgprWorkGroup2] by Stride
+s_mul_i32 s66, s[sgprWorkGroup2], s[sgprStridesC+1] // Scale s[sgprWorkGroup2] by Stride
+s_lshl_b64 s[66:67], s[66:67], 3                   // scale by bpe
+s_add_u32 s[sgprSrdD+0], s[sgprSrdD+0], s66        // add lo to SRD
+s_addc_u32 s[sgprSrdD+1], s[sgprSrdD+1], s67       // add hi to SRD
+s_add_u32 s[sgprSrdC+0], s[sgprSrdC+0], s66        // add lo to SRD
+s_addc_u32 s[sgprSrdC+1], s[sgprSrdC+1], s67       // add hi to SRD
+
+
+v_mov_b32 v[vgprValuC+0], 0x0                      // initC
+v_mov_b32 v[vgprValuC+1], 0x0                      // initC
+v_mov_b32 v[vgprValuC+2], 0x0                      // initC
+v_mov_b32 v[vgprValuC+3], 0x0                      // initC
+v_mov_b32 v[vgprValuC+4], 0x0                      // initC
+v_mov_b32 v[vgprValuC+5], 0x0                      // initC
+v_mov_b32 v[vgprValuC+6], 0x0                      // initC
+v_mov_b32 v[vgprValuC+7], 0x0                      // initC
+v_mov_b32 v[vgprValuC+8], 0x0                      // initC
+v_mov_b32 v[vgprValuC+9], 0x0                      // initC
+v_mov_b32 v[vgprValuC+10], 0x0                     // initC
+v_mov_b32 v[vgprValuC+11], 0x0                     // initC
+v_mov_b32 v[vgprValuC+12], 0x0                     // initC
+v_mov_b32 v[vgprValuC+13], 0x0                     // initC
+v_mov_b32 v[vgprValuC+14], 0x0                     // initC
+v_mov_b32 v[vgprValuC+15], 0x0                     // initC
+v_mov_b32 v[vgprValuC+16], 0x0                     // initC
+v_mov_b32 v[vgprValuC+17], 0x0                     // initC
+v_mov_b32 v[vgprValuC+18], 0x0                     // initC
+v_mov_b32 v[vgprValuC+19], 0x0                     // initC
+v_mov_b32 v[vgprValuC+20], 0x0                     // initC
+v_mov_b32 v[vgprValuC+21], 0x0                     // initC
+v_mov_b32 v[vgprValuC+22], 0x0                     // initC
+v_mov_b32 v[vgprValuC+23], 0x0                     // initC
+v_mov_b32 v[vgprValuC+24], 0x0                     // initC
+v_mov_b32 v[vgprValuC+25], 0x0                     // initC
+v_mov_b32 v[vgprValuC+26], 0x0                     // initC
+v_mov_b32 v[vgprValuC+27], 0x0                     // initC
+v_mov_b32 v[vgprValuC+28], 0x0                     // initC
+v_mov_b32 v[vgprValuC+29], 0x0                     // initC
+v_mov_b32 v[vgprValuC+30], 0x0                     // initC
+v_mov_b32 v[vgprValuC+31], 0x0                     // initC
+v_mov_b32 v[vgprValuC+32], 0x0                     // initC
+v_mov_b32 v[vgprValuC+33], 0x0                     // initC
+v_mov_b32 v[vgprValuC+34], 0x0                     // initC
+v_mov_b32 v[vgprValuC+35], 0x0                     // initC
+v_mov_b32 v[vgprValuC+36], 0x0                     // initC
+v_mov_b32 v[vgprValuC+37], 0x0                     // initC
+v_mov_b32 v[vgprValuC+38], 0x0                     // initC
+v_mov_b32 v[vgprValuC+39], 0x0                     // initC
+v_mov_b32 v[vgprValuC+40], 0x0                     // initC
+v_mov_b32 v[vgprValuC+41], 0x0                     // initC
+v_mov_b32 v[vgprValuC+42], 0x0                     // initC
+v_mov_b32 v[vgprValuC+43], 0x0                     // initC
+v_mov_b32 v[vgprValuC+44], 0x0                     // initC
+v_mov_b32 v[vgprValuC+45], 0x0                     // initC
+v_mov_b32 v[vgprValuC+46], 0x0                     // initC
+v_mov_b32 v[vgprValuC+47], 0x0                     // initC
+s_cmp_eq_u32 s[sgprLoopCounters+0], 0x0            // numIter0I == 0
+s_cbranch_scc1 label_0004                          // after InitC, skip to end of prefetch last iter b/c numIter==0
+
+s_waitcnt vmcnt(0)                                 // 8wait for global read
+
+
+/* local write a */
+
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:0 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 0
+
+
+/* local write b */
+
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:0 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 0
+
+
+/* local write swap a */
+
+
+
+/* local write swap b */
+
+
+
+/* local write init pointers a */
+
+/* N/A */
+
+
+/* local write init pointers b */
+
+/* N/A */
+
+/******************************************/
+/* Unrolled Loop(s) - Begin               */
+/******************************************/
+
+s_cmp_ge_i32 s[sgprLoopCounters+0], 0x0            // LoopCounterL < EndCounter
+s_cbranch_scc1 label_0004                          // don't enter LoopL
+label_0001:
+
+
+/******************************************/
+/* Unroll Loop 1/2 - Begin                */
+/******************************************/
+
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
+s_barrier //4sync for global read
+
+s_cmp_eq_i32 s[sgprLoopCounters+0], -1             // is this the last iteration
+s_cmov_b32 s[sgprSrdA+2], 0                        // Set limit to 0 for last iteration
+s_cmov_b32 s[sgprSrdB+2], 0                        // Set limit to 0 for last iteration
+
+s_waitcnt lgkmcnt(0)                               // 1wait for local write
+
+
+
+
+/* iter 0 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(2)                               // wait for prior local read old=0 new=0
+//MAC_6x4_X0
+MAC_6x4_X0_part_1
+
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:384 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:512 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* global read inc A */
+s_add_u32  s[sgprSrdA+0], s[sgprSrdA+0], s[sgprGlobalReadIncsA] // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdA+1], s[sgprSrdA+1], 0        // gra SRD += inc(upper)
+s_sub_u32 s[sgprShadowLimitA+0], s[sgprShadowLimitA+0], s[sgprGlobalReadIncsA] // limit -= inc)
+s_subb_u32 s[sgprShadowLimitA+1], s[sgprShadowLimitA+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitA+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdA+2], s[sgprShadowLimitA+0]    // Move shadow to real if we are within 2^32
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:640 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(2)                               // wait for prior local read old=0 new=0
+//MAC_6x4_X0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:768 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* global read inc B */
+s_add_u32  s[sgprSrdB+0], s[sgprSrdB+0], s[sgprGlobalReadIncsB] // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdB+1], s[sgprSrdB+1], 0        // gra SRD += inc(upper)
+s_sub_u32 s[sgprShadowLimitB+0], s[sgprShadowLimitB+0], s[sgprGlobalReadIncsB] // limit -= inc)
+s_subb_u32 s[sgprShadowLimitB+1], s[sgprShadowLimitB+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitB+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdB+2], s[sgprShadowLimitB+0]    // Move shadow to real if we are within 2^32
+
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:896 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1024 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 2 writesPerItem=1 */
+s_waitcnt vmcnt(1)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:4096 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 4096
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(3)                               // wait for prior local read old=0 new=0
+//MAC_6x4_X0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(1)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+/* iter 3 (last) */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:1152 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1280 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1408 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 3 writesPerItem=1 */
+s_waitcnt vmcnt(0)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:4096 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 4096
+
+/* local write swap offsets a */
+
+/* local write swap offsets b */
+
+/* local write init pointers a */
+/* N/A */
+
+/* local write init pointers b */
+/* N/A */
+
+/* local read swap offsets a */
+
+/* local read swap internal offset -> 4096 */
+
+/* local read swap offsets b */
+
+/* local read swap internal offset -> 4096 */
+
+/* local read init pointers a */
+
+/* local read init pointers b */
+s_waitcnt lgkmcnt(3)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(1)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0_part_3
+
+/******************************************/
+/* Unrolled Loop - End 1/2                */
+/******************************************/
+
+s_add_u32 s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+s_cmp_eq_i32 s[sgprLoopCounters+0],  -2            // counterL==0
+s_cbranch_scc1 label_0003                          // exit LoopL
+
+
+/******************************************/
+/* Unroll Loop 2/2 - Begin                */
+/******************************************/
+
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
+s_barrier //4sync for global read
+
+s_cmp_eq_i32 s[sgprLoopCounters+0], -1             // is this the last iteration
+s_cmov_b32 s[sgprSrdA+2], 0                        // Set limit to 0 for last iteration
+s_cmov_b32 s[sgprSrdB+2], 0                        // Set limit to 0 for last iteration
+
+s_waitcnt lgkmcnt(0)                               // 1wait for local write
+
+
+
+
+/* iter 0 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4096 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4224 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4352 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(2)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4480 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4608 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* global read inc A */
+s_add_u32  s[sgprSrdA+0], s[sgprSrdA+0], s[sgprGlobalReadIncsA] // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdA+1], s[sgprSrdA+1], 0        // gra SRD += inc(upper)
+s_sub_u32 s[sgprShadowLimitA+0], s[sgprShadowLimitA+0], s[sgprGlobalReadIncsA] // limit -= inc)
+s_subb_u32 s[sgprShadowLimitA+1], s[sgprShadowLimitA+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitA+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdA+2], s[sgprShadowLimitA+0]    // Move shadow to real if we are within 2^32
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4736 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(2)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4864 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* global read inc B */
+s_add_u32  s[sgprSrdB+0], s[sgprSrdB+0], s[sgprGlobalReadIncsB] // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdB+1], s[sgprSrdB+1], 0        // gra SRD += inc(upper)
+s_sub_u32 s[sgprShadowLimitB+0], s[sgprShadowLimitB+0], s[sgprGlobalReadIncsB] // limit -= inc)
+s_subb_u32 s[sgprShadowLimitB+1], s[sgprShadowLimitB+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitB+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdB+2], s[sgprShadowLimitB+0]    // Move shadow to real if we are within 2^32
+
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4992 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5120 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 2 writesPerItem=1 */
+s_waitcnt vmcnt(1)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:0 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 0
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(3)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(1)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:5248 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=192 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=192 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5376 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5504 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 3 writesPerItem=1 */
+s_waitcnt vmcnt(0)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:0 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 0
+
+/* local write swap offsets a */
+
+/* local write swap offsets b */
+
+/* local write init pointers a */
+/* N/A */
+
+/* local write init pointers b */
+/* N/A */
+
+/* local read swap offsets a */
+
+/* local read swap internal offset -> 0 */
+
+/* local read swap offsets b */
+
+/* local read swap internal offset -> 0 */
+
+/* local read init pointers a */
+
+/* local read init pointers b */
+s_waitcnt lgkmcnt(3)                               // 6wait for local read old=3 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(1)                               // 6wait for local read old=1 new=0
+MAC_6x4_X0_part_3
+
+/******************************************/
+/* Unrolled Loop - End 2/2 (final)        */
+/******************************************/
+
+s_add_u32 s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+s_cmp_eq_i32 s[sgprLoopCounters+0], -2              // counterL==0
+s_cbranch_scc0 label_0001                          // restart LoopL
+s_cbranch_scc1 label_0002                          // restart LoopL
+
+label_0003: // unroll loop odditer exit
+
+//check edge Batch calculation needed
+//for Batch edge jump to different beta loop optimization code
+s_add_u32      s83,-0x1, s[sgprNumWorkGroups0]       //
+s_cmp_lt_u32   s[sgprWorkGroup0], s83                // wg0 < nwg0-1
+s_cmov_b32     s[sgprEdgeSelMask0], 0x0
+s_cmpk_gt_u32  s[sgprEdgeSelMask0], 0x0
+s_cbranch_scc1 label_1003                            // wg1 < nwg1-1 so skip rMT1 = Size1 % MT1
+s_add_u32      s83, -0x1, s[sgprNumWorkGroups1]      //
+s_cmp_lt_u32   s[sgprWorkGroup1], s83                // wg1 < nwg1-1
+s_cmov_b32     s[sgprEdgeSelMask1], 0x0
+s_cmpk_gt_u32  s[sgprEdgeSelMask1], 0x0
+s_cbranch_scc1 label_1003                            // wg1 < nwg1-1 so skip rMT1 = Size1 % MT1
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4224 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4480 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4608 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4736 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4864 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4992 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5120 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:0 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 4096
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(1)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:5248 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5376 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5504 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_mul_i32 s56, 0x30, s[sgprWorkGroup0]             // s56 = wg0*MT0
+s_mul_i32 s58, 0x40, s[sgprWorkGroup1]             // s56 = wg0*MT0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 3 writesPerItem=1 */
+s_waitcnt vmcnt(0)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:0 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 4096
+
+s_waitcnt lgkmcnt(1)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0_unprio_0
+v_lshrrev_b32 v[vgprLocalWriteAddrB], 3, v[vgprSerial]                // vectorStaticDiv: v49 = v[vgprSerial] / 8
+v_and_b32 v[vgprLocalWriteAddrA], 7, v[vgprSerial]                    // vectorStaticDiv: v48 = v[vgprSerial] % 8
+v_lshlrev_b32 v[vgprLocalWriteAddrA], 1, v[vgprLocalWriteAddrA]       // staticMultiply: v48 = v48 * 2
+v_lshlrev_b32 v[vgprLocalWriteAddrB], 1, v[vgprLocalWriteAddrB]       // staticMultiply: v49 = v49 * 2
+v_mul_lo_u32 v[vgprGlobalReadOffsetB], v[vgprLocalWriteAddrB], s[sgprStridesC+0]           // rowStart vgpr
+_v_add_co_u32 v[vgprLocalWriteAddrA], vcc, s56, v[vgprLocalWriteAddrA]                   // coord0 = tid0*VW + wg0*MT0
+_v_add_lshl_u32 v[vgprGlobalReadOffsetA], v[vgprGlobalReadOffsetB], v[vgprLocalWriteAddrA], 0x3                 // init cb addr <-  rowStart + coord0, scaled by BPE
+s_setprio 0
+
+s_add_u32       s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+s_cmp_eq_i32    s[sgprLoopCounters+0], -1             // is this the last iteration
+s_cmov_b32 	s[sgprSrdA+2], 0                        // Set limit to 0 for last iteration
+s_cmov_b32 	s[sgprSrdB+2], 0                        // Set limit to 0 for last iteration
+s_mov_b32 	s85, s[sgprSrdC+0]
+s_mov_b32 	s86, s[sgprSrdC+1]
+s_mov_b32       s87, s[sgprSrdD+0]
+s_mov_b32       s88, s[sgprSrdD+1]
+
+
+//s_waitcnt lgkmcnt(0)                               // 1wait for local write
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
+s_barrier //4sync for global read
+
+/* iter 0,1 */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:384 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part1
+
+/* iter 1 */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:768  // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1152 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part1
+
+
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:512 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+0:vgprValuC+0+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+0:vgprValuC+0+1] // *= alpha
+v_mul_f64 v[vgprValuC+2:vgprValuC+2+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+2:vgprValuC+2+1] // *= alpha
+v_fma_f64 v[vgprValuC+0:vgprValuC+0+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+0:vgprValuC+0+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+2:vgprValuC+2+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+2:vgprValuC+2+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[0:3], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+12:vgprValuC+12+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+12:vgprValuC+12+1] // *= alpha
+v_mul_f64 v[vgprValuC+14:vgprValuC+14+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+14:vgprValuC+14+1] // *= alpha
+v_fma_f64 v[vgprValuC+12:vgprValuC+12+1], v[vgprG2LB+0:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+12:vgprValuC+12+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+14:vgprValuC+14+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+14:vgprValuC+14+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[12:15], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part2
+
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:896 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1280 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part2
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:640 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+4:vgprValuC+4+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+4:vgprValuC+4+1] // *= alpha
+v_mul_f64 v[vgprValuC+6:vgprValuC+6+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+6:vgprValuC+6+1] // *= alpha
+v_fma_f64 v[vgprValuC+4:vgprValuC+4+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+4:vgprValuC+4+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+6:vgprValuC+6+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+6:vgprValuC+6+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[4:7], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+16:vgprValuC+16+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+16:vgprValuC+16+1] // *= alpha
+v_mul_f64 v[vgprValuC+18:vgprValuC+18+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+18:vgprValuC+18+1] // *= alpha
+v_fma_f64 v[vgprValuC+16:vgprValuC+16+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+16:vgprValuC+16+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+18:vgprValuC+18+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+18:vgprValuC+18+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[16:19], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part3
+
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1024 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:1408 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part3
+
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:384 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+8:vgprValuC+8+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+8:vgprValuC+8+1] // *= alpha
+v_mul_f64 v[vgprValuC+10:vgprValuC+10+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+10:vgprValuC+10+1] // *= alpha
+v_fma_f64 v[vgprValuC+8:vgprValuC+8+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+8:vgprValuC+8+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+10:vgprValuC+10+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+10:vgprValuC+10+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[8:11], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+20:vgprValuC+20+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+20:vgprValuC+20+1] // *= alpha
+v_mul_f64 v[vgprValuC+22:vgprValuC+22+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+22:vgprValuC+22+1] // *= alpha
+v_fma_f64 v[vgprValuC+20:vgprValuC+20+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+20:vgprValuC+20+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+22:vgprValuC+22+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+22:vgprValuC+22+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[20:23], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_mul_i32  s56, s[sgprStridesC+0], 248              // Scale by BPE
+s_add_u32   s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+s_mov_b32   s85, s[sgprSrdC+0]
+s_mov_b32   s86, s[sgprSrdC+1]                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part4
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:768 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+s_lshl_b32   s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32   s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1152 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part4
+
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+s_mul_i32   s56, s[sgprStridesD+0], 248              // Scale by BPE
+s_add_u32   s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:512 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+24:vgprValuC+24+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+24:vgprValuC+24+1] // *= alpha
+v_mul_f64 v[vgprValuC+26:vgprValuC+26+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+26:vgprValuC+26+1] // *= alpha
+v_fma_f64 v[vgprValuC+24:vgprValuC+24+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+24:vgprValuC+24+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+26:vgprValuC+26+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+26:vgprValuC+26+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[24:27], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_mov_b32       s87, s[sgprSrdD+0]
+s_mov_b32       s88, s[sgprSrdD+1]                 /* local read init pointers b */
+s_lshl_b32      s56, s[sgprStridesD+0], 3         // Scale     s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_add_u32       s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32      s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+36:vgprValuC+36+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+36:vgprValuC+36+1] // *= alpha
+v_mul_f64 v[vgprValuC+38:vgprValuC+38+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+38:vgprValuC+38+1] // *= alpha
+v_fma_f64 v[vgprValuC+36:vgprValuC+36+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+36:vgprValuC+36+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+38:vgprValuC+38+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+38:vgprValuC+38+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[36:39], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0_part5
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:896 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1280 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part5
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:640 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+28:vgprValuC+28+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+28:vgprValuC+28+1] // *= alpha
+v_mul_f64 v[vgprValuC+30:vgprValuC+30+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+30:vgprValuC+30+1] // *= alpha
+v_fma_f64 v[vgprValuC+28:vgprValuC+28+1], v[vgprG2LA+0:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+28:vgprValuC+28+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+30:vgprValuC+30+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+30:vgprValuC+30+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[28:31], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+40:vgprValuC+40+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+40:vgprValuC+40+1] // *= alpha
+v_mul_f64 v[vgprValuC+42:vgprValuC+42+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+42:vgprValuC+42+1] // *= alpha
+v_fma_f64 v[vgprValuC+40:vgprValuC+40+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+40:vgprValuC+40+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+42:vgprValuC+42+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+42:vgprValuC+42+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[40:43], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part6
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1024 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1408 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part6
+
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+32:vgprValuC+32+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+32:vgprValuC+32+1] // *= alpha
+v_mul_f64 v[vgprValuC+34:vgprValuC+34+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+34:vgprValuC+34+1] // *= alpha
+v_fma_f64 v[vgprValuC+32:vgprValuC+32+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+32:vgprValuC+32+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+34:vgprValuC+34+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+34:vgprValuC+34+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[32:35], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_lshl_b32  s56, 	   s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32   s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+
+v_mul_f64 v[vgprValuC+44:vgprValuC+44+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+44:vgprValuC+44+1] // *= alpha
+v_mul_f64 v[vgprValuC+46:vgprValuC+46+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+46:vgprValuC+46+1] // *= alpha
+v_fma_f64 v[vgprValuC+44:vgprValuC+44+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+44:vgprValuC+44+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+46:vgprValuC+46+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+46:vgprValuC+46+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[44:47], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_add_u32            s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+
+
+s_endpgm
+
+label_0002:
+
+/* TODO-packed- compare against product of all packed C0 sizes not just SizesFree+0 */
+//s_mov_b32 s91, 0x0                                 // STATIC_DIV: divisior=48
+//s_mul_i32 s90, 0xaaa, s[sgprSizesFree+0]           // tmp1 = dividend * magic hi
+//s_lshl_b64 s[90:91], s[90:91], 0x10                // left shift 16 bits
+//s_mul_i32 s82, s[sgprSizesFree+0], 0xaaab          // tmp0 = dividend * magic lo
+//s_add_u32 s90, s82, s90                            // add lo
+//s_addc_u32 s91, s91, 0x0                           // add hi
+//s_lshr_b64 s[90:91], s[90:91], 0x21                // tmp1 = (dividend * magic) << shift
+//s_mov_b32 s82, s90                                 // quotient
+//s_mul_i32 s90, s82, 0x30                           // quotient*divisor
+//s_sub_u32 s[sgprEdgeSelMask0], s[sgprSizesFree+0], s90             // rReg = dividend - quotient*divisor
+//s_lshr_b32 s82, s[sgprSizesFree+1], 6              // s58 = s[sgprSizesFree+1] / 64
+//s_and_b32 s[sgprEdgeSelMask1], 63, s[sgprSizesFree+1]
+
+//check edge Batch calculation needed
+//for Batch edge jump to different beta loop optimization code
+s_add_u32      s83,-0x1, s[sgprNumWorkGroups0]       //
+s_cmp_lt_u32   s[sgprWorkGroup0], s83                // wg0 < nwg0-1
+s_cmov_b32     s[sgprEdgeSelMask0], 0x0
+s_cmpk_gt_u32  s[sgprEdgeSelMask0], 0x0
+s_cbranch_scc1 label_1002                            // wg1 < nwg1-1 so skip rMT1 = Size1 % MT1
+s_add_u32      s83, -0x1, s[sgprNumWorkGroups1]      //
+s_cmp_lt_u32   s[sgprWorkGroup1], s83                // wg1 < nwg1-1
+s_cmov_b32     s[sgprEdgeSelMask1], 0x0
+s_cmpk_gt_u32  s[sgprEdgeSelMask1], 0x0
+s_cbranch_scc1 label_1002                            // wg1 < nwg1-1 so skip rMT1 = Size1 % MT1
+
+/******************************************/
+
+//s_waitcnt lgkmcnt(0)                                 // 1wait for local write
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
+s_barrier //4sync for global read
+
+/* iter 0 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(2)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:384 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:512 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:640 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(2)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:768 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:896 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1024 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:4096 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 4096
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(3)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(1)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:1152 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1280 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+s_mul_i32 s56, 0x30, s[sgprWorkGroup0]             // s56 = wg0*MT0
+s_mul_i32 s58, 0x40, s[sgprWorkGroup1]             // s56 = wg0*MT0
+/* sched write - iter 3 writesPerItem=1 */
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1408 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(0)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:4096 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 4096
+
+s_waitcnt lgkmcnt(1)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0_unprio_0
+v_lshrrev_b32 v[vgprLocalWriteAddrB], 3, v[vgprSerial]                // vectorStaticDiv: v49 = v[vgprSerial] / 8
+v_and_b32 v[vgprLocalWriteAddrA], 7, v[vgprSerial]                    // vectorStaticDiv: v48 = v[vgprSerial] % 8
+v_lshlrev_b32 v[vgprLocalWriteAddrA], 1, v[vgprLocalWriteAddrA]       // staticMultiply: v48 = v48 * 2
+v_lshlrev_b32 v[vgprLocalWriteAddrB], 1, v[vgprLocalWriteAddrB]       // staticMultiply: v49 = v49 * 2
+v_mul_lo_u32 v[vgprGlobalReadOffsetB], v[vgprLocalWriteAddrB], s[sgprStridesC+0]           // rowStart vgpr
+_v_add_co_u32 v[vgprLocalWriteAddrA], vcc, s56, v[vgprLocalWriteAddrA]                   // coord0 = tid0*VW + wg0*MT0
+_v_add_lshl_u32 v[vgprGlobalReadOffsetA], v[vgprGlobalReadOffsetB], v[vgprLocalWriteAddrA], 0x3                 // init cb addr <-  rowStart + coord0, scaled by BPE
+s_setprio 0
+
+s_add_u32       s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+s_cmp_eq_i32    s[sgprLoopCounters+0], -1             // is this the last iteration
+s_cmov_b32 	s[sgprSrdA+2], 0                        // Set limit to 0 for last iteration
+s_cmov_b32 	s[sgprSrdB+2], 0                        // Set limit to 0 for last iteration
+s_mov_b32 	s85, s[sgprSrdC+0]
+s_mov_b32 	s86, s[sgprSrdC+1]
+s_mov_b32       s87, s[sgprSrdD+0]
+s_mov_b32       s88, s[sgprSrdD+1]
+
+
+//s_waitcnt lgkmcnt(0)                               // 1wait for local write
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
+s_barrier //4sync for global read
+
+/* iter 0,1 */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4480 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part1
+
+/* iter 1 */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4864 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5248 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part1
+
+
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4224 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4608 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+0:vgprValuC+0+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+0:vgprValuC+0+1] // *= alpha
+v_mul_f64 v[vgprValuC+2:vgprValuC+2+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+2:vgprValuC+2+1] // *= alpha
+v_fma_f64 v[vgprValuC+0:vgprValuC+0+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+0:vgprValuC+0+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+2:vgprValuC+2+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+2:vgprValuC+2+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[0:3], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+12:vgprValuC+12+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+12:vgprValuC+12+1] // *= alpha
+v_mul_f64 v[vgprValuC+14:vgprValuC+14+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+14:vgprValuC+14+1] // *= alpha
+v_fma_f64 v[vgprValuC+12:vgprValuC+12+1], v[vgprG2LB+0:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+12:vgprValuC+12+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+14:vgprValuC+14+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+14:vgprValuC+14+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[12:15], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part2
+
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4992 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5376 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part2
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4736 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+4:vgprValuC+4+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+4:vgprValuC+4+1] // *= alpha
+v_mul_f64 v[vgprValuC+6:vgprValuC+6+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+6:vgprValuC+6+1] // *= alpha
+v_fma_f64 v[vgprValuC+4:vgprValuC+4+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+4:vgprValuC+4+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+6:vgprValuC+6+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+6:vgprValuC+6+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[4:7], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+16:vgprValuC+16+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+16:vgprValuC+16+1] // *= alpha
+v_mul_f64 v[vgprValuC+18:vgprValuC+18+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+18:vgprValuC+18+1] // *= alpha
+v_fma_f64 v[vgprValuC+16:vgprValuC+16+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+16:vgprValuC+16+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+18:vgprValuC+18+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+18:vgprValuC+18+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[16:19], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part3
+
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5120 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:5504 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part3
+
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4480 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+8:vgprValuC+8+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+8:vgprValuC+8+1] // *= alpha
+v_mul_f64 v[vgprValuC+10:vgprValuC+10+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+10:vgprValuC+10+1] // *= alpha
+v_fma_f64 v[vgprValuC+8:vgprValuC+8+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+8:vgprValuC+8+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+10:vgprValuC+10+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+10:vgprValuC+10+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[8:11], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+20:vgprValuC+20+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+20:vgprValuC+20+1] // *= alpha
+v_mul_f64 v[vgprValuC+22:vgprValuC+22+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+22:vgprValuC+22+1] // *= alpha
+v_fma_f64 v[vgprValuC+20:vgprValuC+20+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+20:vgprValuC+20+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+22:vgprValuC+22+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+22:vgprValuC+22+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[20:23], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_mul_i32  s56, s[sgprStridesC+0], 248              // Scale by BPE
+s_add_u32   s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+s_mov_b32   s85, s[sgprSrdC+0]
+s_mov_b32   s86, s[sgprSrdC+1]                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part4
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4864 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+s_lshl_b32   s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32   s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5248 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part4
+
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4224 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+s_mul_i32   s56, s[sgprStridesD+0], 248              // Scale by BPE
+s_add_u32   s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4608 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+24:vgprValuC+24+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+24:vgprValuC+24+1] // *= alpha
+v_mul_f64 v[vgprValuC+26:vgprValuC+26+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+26:vgprValuC+26+1] // *= alpha
+v_fma_f64 v[vgprValuC+24:vgprValuC+24+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+24:vgprValuC+24+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+26:vgprValuC+26+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+26:vgprValuC+26+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[24:27], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_mov_b32       s87, s[sgprSrdD+0]
+s_mov_b32       s88, s[sgprSrdD+1]                 /* local read init pointers b */
+s_lshl_b32      s56, s[sgprStridesD+0], 3         // Scale     s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_add_u32       s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32      s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+36:vgprValuC+36+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+36:vgprValuC+36+1] // *= alpha
+v_mul_f64 v[vgprValuC+38:vgprValuC+38+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+38:vgprValuC+38+1] // *= alpha
+v_fma_f64 v[vgprValuC+36:vgprValuC+36+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+36:vgprValuC+36+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+38:vgprValuC+38+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+38:vgprValuC+38+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[36:39], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0_part5
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4992 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5376 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part5
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4736 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+28:vgprValuC+28+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+28:vgprValuC+28+1] // *= alpha
+v_mul_f64 v[vgprValuC+30:vgprValuC+30+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+30:vgprValuC+30+1] // *= alpha
+v_fma_f64 v[vgprValuC+28:vgprValuC+28+1], v[vgprG2LA+0:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+28:vgprValuC+28+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+30:vgprValuC+30+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+30:vgprValuC+30+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[28:31], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+40:vgprValuC+40+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+40:vgprValuC+40+1] // *= alpha
+v_mul_f64 v[vgprValuC+42:vgprValuC+42+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+42:vgprValuC+42+1] // *= alpha
+v_fma_f64 v[vgprValuC+40:vgprValuC+40+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+40:vgprValuC+40+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+42:vgprValuC+42+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+42:vgprValuC+42+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[40:43], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part6
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5120 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5504 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part6
+
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+32:vgprValuC+32+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+32:vgprValuC+32+1] // *= alpha
+v_mul_f64 v[vgprValuC+34:vgprValuC+34+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+34:vgprValuC+34+1] // *= alpha
+v_fma_f64 v[vgprValuC+32:vgprValuC+32+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+32:vgprValuC+32+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+34:vgprValuC+34+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+34:vgprValuC+34+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[32:35], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_lshl_b32  s56, 	   s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32   s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+
+v_mul_f64 v[vgprValuC+44:vgprValuC+44+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+44:vgprValuC+44+1] // *= alpha
+v_mul_f64 v[vgprValuC+46:vgprValuC+46+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+46:vgprValuC+46+1] // *= alpha
+v_fma_f64 v[vgprValuC+44:vgprValuC+44+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+44:vgprValuC+44+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+46:vgprValuC+46+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+46:vgprValuC+46+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[44:47], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_add_u32            s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+
+
+s_endpgm
+
+label_1002:
+
+/******************************************/
+//branch logic gets executed for edge MT to use legacy alph_beta code
+
+//s_waitcnt lgkmcnt(0)                                 // 1wait for local write
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
+s_barrier //4sync for global read
+
+/* iter 0 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:384 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:512 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:640 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:768 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:896 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt vmcnt(1)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:4096 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 4096
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1024 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:1152 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1280 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 3 writesPerItem=1 */
+s_waitcnt vmcnt(0)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:4096 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 4096
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1408 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0
+
+
+//s_waitcnt lgkmcnt(0)                               // 1wait for local write
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
+s_barrier //4sync for global read
+
+
+/* iter 0 */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4096 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4224 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4352 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4480 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4608 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4736 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4864 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4992 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5120 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:5248 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5376 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5504 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=192 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=192 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0
+s_add_u32 s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+
+s_branch label_0004
+
+label_1003:
+
+//s_waitcnt lgkmcnt(0)                               // 1wait for local write
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
+s_barrier //4sync for global read
+
+
+/* iter 0 */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4096 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4224 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4352 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4480 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4608 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4736 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4864 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4992 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* sched write - iter 2 writesPerItem=1 */
+s_waitcnt vmcnt(1)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:0 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5120 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:5248 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5376 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 3 writesPerItem=1 */
+s_waitcnt vmcnt(0)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:0 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5504 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=192 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=192 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+
+/* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0
+
+s_add_u32 s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+s_cmp_eq_i32 s[sgprLoopCounters+0], -1             // is this the last iteration
+s_cmov_b32 s[sgprSrdA+2], 0                        // Set limit to 0 for last iteration
+s_cmov_b32 s[sgprSrdB+2], 0                        // Set limit to 0 for last iteration
+
+//s_waitcnt lgkmcnt(0)                               // 1wait for local write
+
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
+s_barrier //4sync for global read
+
+/* iter 0 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:384 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:512 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:640 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:768 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:896 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1024 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:1152 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1280 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1408 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0
+s_add_u32 s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+
+label_0004:
+
+
+/******************************************/
+/* Tail Loop                              */
+/******************************************/
+
+
+/* local write reset offsets a */
+
+
+
+/* local write reset offsets b */
+
+
+
+s_cmp_eq_u32 s[sgprOrigLoopCounter], 0             // completely skipped unroll loop?
+s_cselect_b32 s66, 0, s[sgprGlobalReadIncsA]       // force to 0?
+s_cselect_b32 s67, 0, s[sgprGlobalReadIncsB]       // force to 0?
+s_sub_u32  s[sgprSrdA+0], s[sgprSrdA+0], s66       // gra SRD -= inc(lower)
+s_subb_u32  s[sgprSrdA+1], s[sgprSrdA+1], 0        // gra SRD -= inc(upper)
+s_add_u32 s[sgprShadowLimitA+0], s[sgprShadowLimitA+0], s66 // limit -= inc)
+s_addc_u32 s[sgprShadowLimitA+1], s[sgprShadowLimitA+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitA+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdA+2], s[sgprShadowLimitA+0]    // Move shadow to real if we are within 2^32
+
+s_sub_u32  s[sgprSrdB+0], s[sgprSrdB+0], s67       // gra SRD -= inc(lower)
+s_subb_u32  s[sgprSrdB+1], s[sgprSrdB+1], 0        // gra SRD -= inc(upper)
+s_add_u32 s[sgprShadowLimitB+0], s[sgprShadowLimitB+0], s67 // limit -= inc)
+s_addc_u32 s[sgprShadowLimitB+1], s[sgprShadowLimitB+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitB+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdB+2], s[sgprShadowLimitB+0]    // Move shadow to real if we are within 2^32
+
+//numIterL = (((sizeL % LOCAL_DEPTHU) + LOCAL_SPLITU - 1) / LOCAL_SPLITU)
+s_lshr_b32 s66, s[sgprSizesSum+0], 2               // s66 = s[sgprSizesSum+0] / 4
+s_and_b32 s[sgprLoopCounters+0], 3, s[sgprSizesSum+0] // s[sgprLoopCounters+0] = s[sgprSizesSum+0] % 4
+s_cmp_eq_u32 s[sgprLoopCounters+0], 0x0            // numIterL == 0
+s_cbranch_scc1 label_0006                          // skip to end of tail loop b/c numIter==0
+s_sub_u32 s[sgprLoopCounters+0], 0x0, s[sgprLoopCounters+0] // counterL = -sizeL
+
+
+/* global read a */
+
+/* g2l=0, load component 0 */
+buffer_load_dwordx2 v[vgprG2LA+0+0:vgprG2LA+0+0+1], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // load one buffer value
+/* g2l=0, load component 1 */
+buffer_load_dwordx2 v[vgprG2LA+0+2:vgprG2LA+0+2+1], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:8 // load one buffer value
+_v_add_co_u32 v[vgprGlobalReadOffsetA+0], vcc, v[vgprGlobalReadOffsetA+0], 8 // graOffset += 1 * bpe
+
+
+/* global read b */
+
+/* g2l=0, load component 0 */
+buffer_load_dwordx2 v[vgprG2LB+0+0:vgprG2LB+0+0+1], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // load one buffer value
+/* g2l=0, load component 1 */
+buffer_load_dwordx2 v[vgprG2LB+0+2:vgprG2LB+0+2+1], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:8 // load one buffer value
+_v_add_co_u32 v[vgprGlobalReadOffsetB+0], vcc, v[vgprGlobalReadOffsetB+0], 8 // graOffset += 1 * bpe
+
+//s_waitcnt vmcnt(0)                                 // 2wait for global read
+
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
+s_barrier //
+
+/* local write init pointers a */
+
+/* N/A */
+
+
+/* local write init pointers b */
+
+/* N/A */
+
+
+/* local write a */
+
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:0 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 0
+
+
+/* local write b */
+
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:0 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 0
+
+//s_waitcnt lgkmcnt(0)                               // 5wait for local write
+
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
+s_barrier //
+
+
+/* local read reset offsets a */
+
+/* handled internally */
+v_and_b32 v[vgprLocalReadAddrA], 0xfff, v[vgprLocalReadAddrA] // reset Red,Blk -> Red
+
+
+/* local read reset offsets b */
+
+/* handled internally */
+v_and_b32 v[vgprLocalReadAddrB], 0xfff, v[vgprLocalReadAddrB] // reset Red,Blk -> Red
+
+
+/* local read init pointers a */
+
+
+
+/* local read init pointers b */
+
+
+
+/* tail loop: macs */
+
+s_cmp_ge_i32 s[sgprLoopCounters+0], 0x0            // LoopCounterL < EndCounter
+s_cbranch_scc1 label_0006                          // don't enter LoopL
+s_mov_b32 s[sgprOrigLoopCounter], 0                // repurpose to count each localRead increment
+label_0005:
+
+
+/* local read a */
+
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+
+/* local read b */
+
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+
+/* local read inc a */
+
+s_mov_b32 s65, 0x180                               // inc
+_v_add_co_u32 v[vgprLocalReadAddrA], vcc, s65, v[vgprLocalReadAddrA] // lrA += 384 (LSU*(MT+PAD)*bpe)
+
+
+/* local read inc b */
+
+s_mov_b32 s65, 0x200                               // inc
+_v_add_co_u32 v[vgprLocalReadAddrB], vcc, s65, v[vgprLocalReadAddrB] // lrB += 512 (LSU*(MT+PAD)*bpe)
+
+s_waitcnt lgkmcnt(0)                               // 4wait for local read
+
+MAC_6x4_X0
+s_add_u32 s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+s_add_u32 s[sgprOrigLoopCounter], s[sgprOrigLoopCounter], 0x1 // inc counterL
+s_cmp_eq_i32 s[sgprLoopCounters+0], 0x0            // counterL==0
+s_cbranch_scc0 label_0005                          // restart LoopL
+label_0006:
+
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // wait for all summation activity
+
+
+/* shift vector components d0 */
+
+v_mov_b32 v50, s[sgprWorkGroup0]                   //
+v_mul_i32_i24 v50, -0x30, v50                      // wg*MT
+_v_add_co_u32 v50, vcc, s[sgprSizesFree+0], v50    // wgMT = Size - wg*MT
+v_mov_b32 v48, 0x30                                // MT
+v_cmp_lt_u32 s[56:57], v50, v48                    // wgMT < MT
+v_cndmask_b32 v50, v48, v50, s[56:57]              // wgMT = (wgMT < MT) ? wgMT : MT
+v_lshrrev_b32 v52, 1, v50                          // vectorStaticDiv: v52 = v50 / 2
+v_and_b32 v53, 1, v50                              // vectorStaticDiv: v53 = v50 % 2
+v_lshrrev_b32 v54, 3, v52                          // vectorStaticDiv: v54 = v52 / 8
+v_and_b32 v55, 7, v52                              // vectorStaticDiv: v55 = v52 % 8
+v_and_b32 v56, 7, v[vgprSerial]                    // vectorStaticDiv: v56 = v[vgprSerial] % 8
+v_lshrrev_b32 v57, 4, v50                          // vectorStaticDiv: v57 = v50 / 16
+v_and_b32 v58, 1, v50                              // vectorStaticDiv: v58 = v50 % 2
+v_mov_b32 v59, v58                                 // duplicate
+v_lshrrev_b32 v58, 1, v59                          // vectorStaticDiv: v58 = v59 / 2
+_v_add_co_u32 v58, vcc, v57, v58                   // vId = 2 components
+v_cmp_eq_u32 s[56:57], v56, v55                    // mask
+v_mov_b32 v48, s56                                 //
+v_mov_b32 v49, s57                                 //
+v_cmp_eq_u32 vcc, v53, 0x1                         // wgMT%VW == 1
+s_cbranch_vccnz label_0010                         // shift d0 r=1
+s_branch label_0014                                // no shifting
+
+/******************************************/
+/* shift d0 r=1                           */
+/******************************************/
+label_0010:
+v_cmp_eq_u32 vcc, v58, 0x0                         // wgMT/(SG*VW) == 0
+s_cbranch_vccnz label_0011                         // shift d0, r=1, v=0
+v_cmp_eq_u32 vcc, v58, 0x1                         // wgMT/(SG*VW) == 1
+s_cbranch_vccnz label_0012                         // shift d0, r=1, v=1
+v_cmp_eq_u32 vcc, v58, 0x2                         // wgMT/(SG*VW) == 2
+s_cbranch_vccnz label_0013                         // shift d0, r=1, v=2
+
+/* shift d0 r=1 v=0 */
+label_0011:
+v_cmpx_eq_u32 s[56:57], v56, v55                   // serial % SG == (wgMT/VECTOR_WIDTH)%SG
+// src=1, dst=0
+v_mov_b32 v0, v2                                   // rC[0+0*VW+0*TT0I] = rC[1+0*VW+0*TT0I]
+v_mov_b32 v1, v3                                   // rC[0+0*VW+0*TT0I] = rC[1+0*VW+0*TT0I]
+// src=7, dst=6
+v_mov_b32 v12, v14                                 // rC[0+0*VW+1*TT0I] = rC[1+0*VW+1*TT0I]
+v_mov_b32 v13, v15                                 // rC[0+0*VW+1*TT0I] = rC[1+0*VW+1*TT0I]
+// src=13, dst=12
+v_mov_b32 v24, v26                                 // rC[0+0*VW+2*TT0I] = rC[1+0*VW+2*TT0I]
+v_mov_b32 v25, v27                                 // rC[0+0*VW+2*TT0I] = rC[1+0*VW+2*TT0I]
+// src=19, dst=18
+v_mov_b32 v36, v38                                 // rC[0+0*VW+3*TT0I] = rC[1+0*VW+3*TT0I]
+v_mov_b32 v37, v39                                 // rC[0+0*VW+3*TT0I] = rC[1+0*VW+3*TT0I]
+s_mov_b64 s[56:57], 0xFFFFFFFFFFFFFFFF             // to restore all threads active
+s_or_saveexec_b64 vcc, s[56:57]                    // all threads active
+s_branch label_0014                                // done shifting
+
+/* shift d0 r=1 v=1 */
+label_0012:
+v_cmpx_eq_u32 s[56:57], v56, v55                   // serial % SG == (wgMT/VECTOR_WIDTH)%SG
+// src=3, dst=2
+v_mov_b32 v4, v6                                   // rC[0+1*VW+0*TT0I] = rC[1+1*VW+0*TT0I]
+v_mov_b32 v5, v7                                   // rC[0+1*VW+0*TT0I] = rC[1+1*VW+0*TT0I]
+// src=9, dst=8
+v_mov_b32 v16, v18                                 // rC[0+1*VW+1*TT0I] = rC[1+1*VW+1*TT0I]
+v_mov_b32 v17, v19                                 // rC[0+1*VW+1*TT0I] = rC[1+1*VW+1*TT0I]
+// src=15, dst=14
+v_mov_b32 v28, v30                                 // rC[0+1*VW+2*TT0I] = rC[1+1*VW+2*TT0I]
+v_mov_b32 v29, v31                                 // rC[0+1*VW+2*TT0I] = rC[1+1*VW+2*TT0I]
+// src=21, dst=20
+v_mov_b32 v40, v42                                 // rC[0+1*VW+3*TT0I] = rC[1+1*VW+3*TT0I]
+v_mov_b32 v41, v43                                 // rC[0+1*VW+3*TT0I] = rC[1+1*VW+3*TT0I]
+s_mov_b64 s[56:57], 0xFFFFFFFFFFFFFFFF             // to restore all threads active
+s_or_saveexec_b64 vcc, s[56:57]                    // all threads active
+s_branch label_0014                                // done shifting
+
+/* shift d0 r=1 v=2 */
+label_0013:
+v_cmpx_eq_u32 s[56:57], v56, v55                   // serial % SG == (wgMT/VECTOR_WIDTH)%SG
+// src=5, dst=4
+v_mov_b32 v8, v10                                  // rC[0+2*VW+0*TT0I] = rC[1+2*VW+0*TT0I]
+v_mov_b32 v9, v11                                  // rC[0+2*VW+0*TT0I] = rC[1+2*VW+0*TT0I]
+// src=11, dst=10
+v_mov_b32 v20, v22                                 // rC[0+2*VW+1*TT0I] = rC[1+2*VW+1*TT0I]
+v_mov_b32 v21, v23                                 // rC[0+2*VW+1*TT0I] = rC[1+2*VW+1*TT0I]
+// src=17, dst=16
+v_mov_b32 v32, v34                                 // rC[0+2*VW+2*TT0I] = rC[1+2*VW+2*TT0I]
+v_mov_b32 v33, v35                                 // rC[0+2*VW+2*TT0I] = rC[1+2*VW+2*TT0I]
+// src=23, dst=22
+v_mov_b32 v44, v46                                 // rC[0+2*VW+3*TT0I] = rC[1+2*VW+3*TT0I]
+v_mov_b32 v45, v47                                 // rC[0+2*VW+3*TT0I] = rC[1+2*VW+3*TT0I]
+s_mov_b64 s[56:57], 0xFFFFFFFFFFFFFFFF             // to restore all threads active
+s_or_saveexec_b64 vcc, s[56:57]                    // all threads active
+s_branch label_0014                                // done shifting
+label_0014: // end shift0
+
+
+/* shift vector components d1 */
+
+v_mov_b32 v50, s[sgprWorkGroup1]                   //
+v_mul_i32_i24 v50, -0x40, v50                      // wg*MT
+_v_add_co_u32 v50, vcc, s[sgprSizesFree+1], v50    // wgMT = Size - wg*MT
+v_mov_b32 v48, 0x40                                // MT
+v_cmp_lt_u32 s[56:57], v50, v48                    // wgMT < MT
+v_cndmask_b32 v50, v48, v50, s[56:57]              // wgMT = (wgMT < MT) ? wgMT : MT
+v_lshrrev_b32 v52, 1, v50                          // vectorStaticDiv: v52 = v50 / 2
+v_and_b32 v53, 1, v50                              // vectorStaticDiv: v53 = v50 % 2
+v_lshrrev_b32 v54, 4, v52                          // vectorStaticDiv: v54 = v52 / 16
+v_and_b32 v55, 15, v52                             // vectorStaticDiv: v55 = v52 % 16
+v_lshrrev_b32 v56, 3, v[vgprSerial]                // vectorStaticDiv: v56 = v[vgprSerial] / 8
+v_and_b32 v57, 15, v56                             // vectorStaticDiv: v57 = v56 % 16
+v_lshrrev_b32 v56, 5, v50                          // vectorStaticDiv: v56 = v50 / 32
+v_and_b32 v58, 1, v50                              // vectorStaticDiv: v58 = v50 % 2
+v_mov_b32 v59, v58                                 // duplicate
+v_lshrrev_b32 v58, 1, v59                          // vectorStaticDiv: v58 = v59 / 2
+_v_add_co_u32 v58, vcc, v56, v58                   // vId = 2 components
+v_cmp_eq_u32 s[56:57], v57, v55                    // mask
+v_mov_b32 v48, s56                                 //
+v_mov_b32 v49, s57                                 //
+v_cmp_eq_u32 vcc, v53, 0x1                         // wgMT%VW == 1
+s_cbranch_vccnz label_0018                         // shift d1 r=1
+s_branch label_0021                                // no shifting
+
+/******************************************/
+/* shift d1 r=1                           */
+/******************************************/
+label_0018:
+v_cmp_eq_u32 vcc, v58, 0x0                         // wgMT/(SG*VW) == 0
+s_cbranch_vccnz label_0019                         // shift d1, r=1, v=0
+v_cmp_eq_u32 vcc, v58, 0x1                         // wgMT/(SG*VW) == 1
+s_cbranch_vccnz label_0020                         // shift d1, r=1, v=1
+
+/* shift d1 r=1 v=0 */
+label_0019:
+v_cmpx_eq_u32 s[56:57], v57, v55                   // serial % SG == (wgMT/VECTOR_WIDTH)%SG
+// src=6, dst=0
+v_mov_b32 v0, v12                                  // rC[0+0*TT0I*VW+0*TT0I] = rC[0+0*TT0I*VW+1*TT0I]
+v_mov_b32 v1, v13                                  // rC[0+0*TT0I*VW+0*TT0I] = rC[0+0*TT0I*VW+1*TT0I]
+// src=7, dst=1
+v_mov_b32 v2, v14                                  // rC[1+0*TT0I*VW+0*TT0I] = rC[1+0*TT0I*VW+1*TT0I]
+v_mov_b32 v3, v15                                  // rC[1+0*TT0I*VW+0*TT0I] = rC[1+0*TT0I*VW+1*TT0I]
+// src=8, dst=2
+v_mov_b32 v4, v16                                  // rC[2+0*TT0I*VW+0*TT0I] = rC[2+0*TT0I*VW+1*TT0I]
+v_mov_b32 v5, v17                                  // rC[2+0*TT0I*VW+0*TT0I] = rC[2+0*TT0I*VW+1*TT0I]
+// src=9, dst=3
+v_mov_b32 v6, v18                                  // rC[3+0*TT0I*VW+0*TT0I] = rC[3+0*TT0I*VW+1*TT0I]
+v_mov_b32 v7, v19                                  // rC[3+0*TT0I*VW+0*TT0I] = rC[3+0*TT0I*VW+1*TT0I]
+// src=10, dst=4
+v_mov_b32 v8, v20                                  // rC[4+0*TT0I*VW+0*TT0I] = rC[4+0*TT0I*VW+1*TT0I]
+v_mov_b32 v9, v21                                  // rC[4+0*TT0I*VW+0*TT0I] = rC[4+0*TT0I*VW+1*TT0I]
+// src=11, dst=5
+v_mov_b32 v10, v22                                 // rC[5+0*TT0I*VW+0*TT0I] = rC[5+0*TT0I*VW+1*TT0I]
+v_mov_b32 v11, v23                                 // rC[5+0*TT0I*VW+0*TT0I] = rC[5+0*TT0I*VW+1*TT0I]
+s_mov_b64 s[56:57], 0xFFFFFFFFFFFFFFFF             // to restore all threads active
+s_or_saveexec_b64 vcc, s[56:57]                    // all threads active
+s_branch label_0021                                // done shifting
+
+/* shift d1 r=1 v=1 */
+label_0020:
+v_cmpx_eq_u32 s[56:57], v57, v55                   // serial % SG == (wgMT/VECTOR_WIDTH)%SG
+// src=18, dst=12
+v_mov_b32 v24, v36                                 // rC[0+1*TT0I*VW+0*TT0I] = rC[0+1*TT0I*VW+1*TT0I]
+v_mov_b32 v25, v37                                 // rC[0+1*TT0I*VW+0*TT0I] = rC[0+1*TT0I*VW+1*TT0I]
+// src=19, dst=13
+v_mov_b32 v26, v38                                 // rC[1+1*TT0I*VW+0*TT0I] = rC[1+1*TT0I*VW+1*TT0I]
+v_mov_b32 v27, v39                                 // rC[1+1*TT0I*VW+0*TT0I] = rC[1+1*TT0I*VW+1*TT0I]
+// src=20, dst=14
+v_mov_b32 v28, v40                                 // rC[2+1*TT0I*VW+0*TT0I] = rC[2+1*TT0I*VW+1*TT0I]
+v_mov_b32 v29, v41                                 // rC[2+1*TT0I*VW+0*TT0I] = rC[2+1*TT0I*VW+1*TT0I]
+// src=21, dst=15
+v_mov_b32 v30, v42                                 // rC[3+1*TT0I*VW+0*TT0I] = rC[3+1*TT0I*VW+1*TT0I]
+v_mov_b32 v31, v43                                 // rC[3+1*TT0I*VW+0*TT0I] = rC[3+1*TT0I*VW+1*TT0I]
+// src=22, dst=16
+v_mov_b32 v32, v44                                 // rC[4+1*TT0I*VW+0*TT0I] = rC[4+1*TT0I*VW+1*TT0I]
+v_mov_b32 v33, v45                                 // rC[4+1*TT0I*VW+0*TT0I] = rC[4+1*TT0I*VW+1*TT0I]
+// src=23, dst=17
+v_mov_b32 v34, v46                                 // rC[5+1*TT0I*VW+0*TT0I] = rC[5+1*TT0I*VW+1*TT0I]
+v_mov_b32 v35, v47                                 // rC[5+1*TT0I*VW+0*TT0I] = rC[5+1*TT0I*VW+1*TT0I]
+s_mov_b64 s[56:57], 0xFFFFFFFFFFFFFFFF             // to restore all threads active
+s_or_saveexec_b64 vcc, s[56:57]                    // all threads active
+label_0021: // end shift0
+
+
+
+/* not-LocalSplitU: global write indices */
+
+s_mov_b32 s[sgprSrdD+0], s[sgprAddressD+0]         // init SRD base address (lower)
+s_mov_b32 s[sgprSrdD+1], s[sgprAddressD+1]         // init SRD base address (upper) + other fields
+s_mov_b32 s[sgprSrdD+2], 0x80000000                //
+s_mov_b32 s[sgprSrdD+3], Srd127_96                 // Set bits 127_96 in SRD
+s_mov_b32 s[sgprSrdC+0], s[sgprAddressC+0]         // init SRD base address (lower)
+s_mov_b32 s[sgprSrdC+1], s[sgprAddressC+1]         // init SRD base address (upper) + other fields
+s_mov_b32 s[sgprSrdC+2], 0x80000000                //
+s_mov_b32 s[sgprSrdC+3], Srd127_96                 // Set bits 127_96 in SRD
+
+s_mul_i32 s58, 0x40, s[sgprWorkGroup1]             // <- wg1*MT1
+s_mul_hi_u32 s57, s58, s[sgprStridesC+0]           // Scale s58 by Stride
+s_mul_i32 s56, s58, s[sgprStridesC+0]              // Scale s58 by Stride
+s_lshl_b64 s[56:57], s[56:57], 3                   // scale by bpe
+s_add_u32 s[sgprSrdD+0], s[sgprSrdD+0], s56        // add lo to SRD
+s_addc_u32 s[sgprSrdD+1], s[sgprSrdD+1], s57       // add hi to SRD
+s_add_u32 s[sgprSrdC+0], s[sgprSrdC+0], s56        // add lo to SRD
+s_addc_u32 s[sgprSrdC+1], s[sgprSrdC+1], s57       // add hi to SRD
+
+s_mul_hi_u32 s57, s[sgprWorkGroup2], s[sgprStridesC+1] // Scale s[sgprWorkGroup2] by Stride
+s_mul_i32 s56, s[sgprWorkGroup2], s[sgprStridesC+1] // Scale s[sgprWorkGroup2] by Stride
+s_lshl_b64 s[56:57], s[56:57], 3                   // scale by bpe
+s_add_u32 s[sgprSrdD+0], s[sgprSrdD+0], s56        // add lo to SRD
+s_addc_u32 s[sgprSrdD+1], s[sgprSrdD+1], s57       // add hi to SRD
+s_add_u32 s[sgprSrdC+0], s[sgprSrdC+0], s56        // add lo to SRD
+s_addc_u32 s[sgprSrdC+1], s[sgprSrdC+1], s57       // add hi to SRD
+
+v_lshrrev_b32 v49, 3, v[vgprSerial]                // vectorStaticDiv: v49 = v[vgprSerial] / 8
+v_and_b32 v48, 7, v[vgprSerial]                    // vectorStaticDiv: v48 = v[vgprSerial] % 8
+v_lshlrev_b32 v48, 1, v48                          // staticMultiply: v48 = v48 * 2
+v_lshlrev_b32 v49, 1, v49                          // staticMultiply: v49 = v49 * 2
+v_mul_lo_u32 v50, v49, s[sgprStridesC+0]           // rowStart vgpr
+
+s_mul_i32 s56, 0x30, s[sgprWorkGroup0]             // s56 = wg0*MT0
+_v_add_co_u32 v48, vcc, s56, v48                   // coord0 = tid0*VW + wg0*MT0
+s_mul_i32 s58, 0x40, s[sgprWorkGroup1]             // <- wg1*MT1
+_v_add_co_u32 v49, vcc, s58, v49                   // coord1 = tid1*VW + wg1*MT1
+
+//v_mov_b32 v48,v[vgprLocalWriteAddrA]
+//v_mov_b32 v49,v[vgprLocalWriteAddrB]
+//v_mov_b32 v50,v[vgprGlobalReadOffsetB]           // rowStart vgpr
+//_v_add_lshl_u32 v[vgprGlobalReadOffsetA], v[vgprGlobalReadOffsetB], v[vgprLocalWriteAddrA], 0x3                 // init cb addr <-  rowStart + coord0, scaled by BPE
+
+/* not-LocalSplitU: global write */
+
+s_mov_b32 s56, s[sgprBeta+0]                       // tmp = Beta[0]
+s_or_b32 s56, s[sgprBeta+1], s56                   // tmp |= Beta[1]
+s_cmpk_eq_u32 s56, 0x0                             // Beta == 0
+s_cbranch_scc0 label_0030                          // Beta is not zero; so jump to B nonzero
+
+s_mov_b32 s56, 0x0                                 // rMT0=0
+s_add_u32 s58, -0x1, s[sgprNumWorkGroups0]         //
+s_cmp_lt_u32 s[sgprWorkGroup0], s58                // wg0 < nwg0-1
+s_cbranch_scc1 label_0027                          // wg0 < nwg0-1 so skip rMT0 = Size0 % MT0
+/* TODO-packed- compare against product of all packed C0 sizes not just SizesFree+0 */
+s_mov_b32 s61, 0x0                                 // STATIC_DIV: divisior=48
+s_mul_i32 s60, 0xaaa, s[sgprSizesFree+0]           // tmp1 = dividend * magic hi
+s_lshl_b64 s[60:61], s[60:61], 0x10                // left shift 16 bits
+s_mul_i32 s58, s[sgprSizesFree+0], 0xaaab          // tmp0 = dividend * magic lo
+s_add_u32 s60, s58, s60                            // add lo
+s_addc_u32 s61, s61, 0x0                           // add hi
+s_lshr_b64 s[60:61], s[60:61], 0x21                // tmp1 = (dividend * magic) << shift
+s_mov_b32 s58, s60                                 // quotient
+s_mul_i32 s60, s58, 0x30                           // quotient*divisor
+s_sub_u32 s56, s[sgprSizesFree+0], s60             // rReg = dividend - quotient*divisor
+label_0027:
+s_cmpk_gt_u32 s56, 0x0                             // rMT0 > 0
+s_cbranch_scc1 label_0029                          // edges required so jump to E1
+s_mov_b32 s56, 0x0                                 // rMT1=0
+s_add_u32 s58, -0x1, s[sgprNumWorkGroups1]         //
+s_cmp_lt_u32 s[sgprWorkGroup1], s58                // wg1 < nwg1-1
+s_cbranch_scc1 label_0028                          // wg1 < nwg1-1 so skip rMT1 = Size1 % MT1
+s_lshr_b32 s58, s[sgprSizesFree+1], 6              // s58 = s[sgprSizesFree+1] / 64
+s_and_b32 s56, 63, s[sgprSizesFree+1]              // s56 = s[sgprSizesFree+1] % 64
+label_0028:
+s_cmpk_gt_u32 s56, 0x0                             // rMT1 > 0
+s_cbranch_scc1 label_0029                          // edges required so jump to E1
+label_0026:
+
+/******************************************/
+/* Global Write Batch #0 (d1,d0,vc1,vc0) =
+   (0,0,0,0:vw2); (0,1,0,0:vw2); (0,2,0,0:vw2); (0,0,1,0:vw2); (0,1,1,0:vw2); (0,2,1,0:vw2); (1,0,0,0:vw2); (1,1,0,0:vw2); (1,2,0,0:vw2); (1,0,1,0:vw2); (1,1,1,0:vw2); (1,2,1,0:vw2) */
+/******************************************/
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(0,0,0,0) coordOffset1=0 element-rows coordOffset0=0 rows */
+_v_add_lshl_u32 v54, v50, v48, 0x3                 // init cb addr <-  rowStart + coord0, scaled by BPE
+/* (d1,vc1,d0,vc0)=(0,0,1,0) coordOffset1=0 element-rows coordOffset0=16 rows */
+/* (d1,vc1,d0,vc0)=(0,0,2,0) coordOffset1=0 element-rows coordOffset0=32 rows */
+/* (d1,vc1,d0,vc0)=(0,1,0,0) coordOffset1=1 element-rows coordOffset0=0 rows */
+/* (d1,vc1,d0,vc0)=(0,1,1,0) coordOffset1=1 element-rows coordOffset0=16 rows */
+/* (d1,vc1,d0,vc0)=(0,1,2,0) coordOffset1=1 element-rows coordOffset0=32 rows */
+/* (d1,vc1,d0,vc0)=(1,0,0,0) coordOffset1=32 element-rows coordOffset0=0 rows */
+/* (d1,vc1,d0,vc0)=(1,0,1,0) coordOffset1=32 element-rows coordOffset0=16 rows */
+/* (d1,vc1,d0,vc0)=(1,0,2,0) coordOffset1=32 element-rows coordOffset0=32 rows */
+/* (d1,vc1,d0,vc0)=(1,1,0,0) coordOffset1=33 element-rows coordOffset0=0 rows */
+/* (d1,vc1,d0,vc0)=(1,1,1,0) coordOffset1=33 element-rows coordOffset0=16 rows */
+/* (d1,vc1,d0,vc0)=(1,1,2,0) coordOffset1=33 element-rows coordOffset0=32 rows */
+
+/* rC *= alpha batchEements=[(0, 0, 0, 0), (0, 1, 0, 0), (0, 2, 0, 0), (0, 0, 1, 0), (0, 1, 1, 0), (0, 2, 1, 0), (1, 0, 0, 0), (1, 1, 0, 0), (1, 2, 0, 0), (1, 0, 1, 0), (1, 1, 1, 0), (1, 2, 1, 0)] */
+//v_mul_f64 v[vgprValuC+0:vgprValuC+0+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+0:vgprValuC+0+1] // *= alpha
+//v_mul_f64 v[vgprValuC+2:vgprValuC+2+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+2:vgprValuC+2+1] // *= alpha
+//v_mul_f64 v[vgprValuC+4:vgprValuC+4+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+4:vgprValuC+4+1] // *= alpha
+//v_mul_f64 v[vgprValuC+6:vgprValuC+6+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+6:vgprValuC+6+1] // *= alpha
+//v_mul_f64 v[vgprValuC+8:vgprValuC+8+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+8:vgprValuC+8+1] // *= alpha
+//v_mul_f64 v[vgprValuC+10:vgprValuC+10+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+10:vgprValuC+10+1] // *= alpha
+//v_mul_f64 v[vgprValuC+12:vgprValuC+12+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+12:vgprValuC+12+1] // *= alpha
+//v_mul_f64 v[vgprValuC+14:vgprValuC+14+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+14:vgprValuC+14+1] // *= alpha
+//v_mul_f64 v[vgprValuC+16:vgprValuC+16+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+16:vgprValuC+16+1] // *= alpha
+//v_mul_f64 v[vgprValuC+18:vgprValuC+18+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+18:vgprValuC+18+1] // *= alpha
+//v_mul_f64 v[vgprValuC+20:vgprValuC+20+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+20:vgprValuC+20+1] // *= alpha
+//v_mul_f64 v[vgprValuC+22:vgprValuC+22+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+22:vgprValuC+22+1] // *= alpha
+//v_mul_f64 v[vgprValuC+24:vgprValuC+24+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+24:vgprValuC+24+1] // *= alpha
+//v_mul_f64 v[vgprValuC+26:vgprValuC+26+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+26:vgprValuC+26+1] // *= alpha
+//v_mul_f64 v[vgprValuC+28:vgprValuC+28+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+28:vgprValuC+28+1] // *= alpha
+//v_mul_f64 v[vgprValuC+30:vgprValuC+30+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+30:vgprValuC+30+1] // *= alpha
+//v_mul_f64 v[vgprValuC+32:vgprValuC+32+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+32:vgprValuC+32+1] // *= alpha
+//v_mul_f64 v[vgprValuC+34:vgprValuC+34+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+34:vgprValuC+34+1] // *= alpha
+//v_mul_f64 v[vgprValuC+36:vgprValuC+36+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+36:vgprValuC+36+1] // *= alpha
+//v_mul_f64 v[vgprValuC+38:vgprValuC+38+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+38:vgprValuC+38+1] // *= alpha
+//v_mul_f64 v[vgprValuC+40:vgprValuC+40+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+40:vgprValuC+40+1] // *= alpha
+//v_mul_f64 v[vgprValuC+42:vgprValuC+42+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+42:vgprValuC+42+1] // *= alpha
+//v_mul_f64 v[vgprValuC+44:vgprValuC+44+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+44:vgprValuC+44+1] // *= alpha
+//v_mul_f64 v[vgprValuC+46:vgprValuC+46+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+46:vgprValuC+46+1] // *= alpha
+
+/* apply mask, calc new C and issue write */
+buffer_store_dwordx4 v[0:3], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx4 v[4:7], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+buffer_store_dwordx4 v[8:11], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+buffer_store_dwordx4 v[12:15], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx4 v[16:19], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+buffer_store_dwordx4 v[20:23], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_mul_i32 s56, s[sgprStridesC+0], 248              // scale StrideC *= 31 * bpe
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+buffer_store_dwordx4 v[24:27], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx4 v[28:31], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+buffer_store_dwordx4 v[32:35], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+buffer_store_dwordx4 v[36:39], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx4 v[40:43], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+buffer_store_dwordx4 v[44:47], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_branch label_0037                                // jump to end
+label_0029:
+
+/******************************************/
+/* Global Write Edge Batch #0 (d1,d0,vc1,vc0) =
+   (0,0,0,0:vw1); (0,0,0,1:vw1); (0,1,0,0:vw1); (0,1,0,1:vw1); (0,2,0,0:vw1); (0,2,0,1:vw1); (0,0,1,0:vw1); (0,0,1,1:vw1); (0,1,1,0:vw1); (0,1,1,1:vw1); (0,2,1,0:vw1); (0,2,1,1:vw1); (1,0,0,0:vw1); (1,0,0,1:vw1); (1,1,0,0:vw1); (1,1,0,1:vw1); (1,2,0,0:vw1); (1,2,0,1:vw1) */
+/******************************************/
+
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(0,0,0,0) coordOffset1=0 element-rows coordOffset0=0 rows */
+v_mov_b32 v51, v50                                 // rowPtr <- rowStart (first row)
+_v_add_lshl_u32 v54, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[62:63], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v54, -1, v54, s[62:63]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,0,0,1) coordOffset1=0 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v55, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[64:65], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v55, -1, v55, s[64:65]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,0,1,0) coordOffset1=0 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v56, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[66:67], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v56, -1, v56, s[66:67]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,0,1,1) coordOffset1=0 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v57, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[68:69], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v57, -1, v57, s[68:69]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,0,2,0) coordOffset1=0 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v58, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[70:71], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v58, -1, v58, s[70:71]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,0,2,1) coordOffset1=0 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v59, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[72:73], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v59, -1, v59, s[72:73]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,1,0,0) coordOffset1=1 element-rows coordOffset0=0 rows */
+_v_add_co_u32 v53, vcc, v49, 1                     // coord1 += d1*sg1*VW + vc1
+_v_add_co_u32 v51, vcc, v51, s[sgprStridesC+0]     // rowPtr <- move to start of new row
+_v_add_lshl_u32 v60, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[74:75], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v60, -1, v60, s[74:75]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,1,0,1) coordOffset1=1 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v61, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[76:77], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v61, -1, v61, s[76:77]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,1,1,0) coordOffset1=1 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v62, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[78:79], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v62, -1, v62, s[78:79]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,1,1,1) coordOffset1=1 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v63, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[80:81], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v63, -1, v63, s[80:81]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,1,2,0) coordOffset1=1 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v64, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[82:83], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v64, -1, v64, s[82:83]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,1,2,1) coordOffset1=1 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v65, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[84:85], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v65, -1, v65, s[84:85]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,0,0,0) coordOffset1=32 element-rows coordOffset0=0 rows */
+_v_add_co_u32 v53, vcc, v49, 32                    // coord1 += d1*sg1*VW + vc1
+s_mul_i32 s56, s[sgprStridesC+0], 32               // scale StrideC *= coordOffset1(32)
+_v_add_co_u32 v51, vcc, v50, s56                   // rowPtr <- inc for non-0 (tt1+vc1))
+_v_add_lshl_u32 v66, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[86:87], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v66, -1, v66, s[86:87]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,0,0,1) coordOffset1=32 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v67, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[88:89], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v67, -1, v67, s[88:89]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,0,1,0) coordOffset1=32 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v68, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[90:91], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v68, -1, v68, s[90:91]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,0,1,1) coordOffset1=32 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v69, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[92:93], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v69, -1, v69, s[92:93]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,0,2,0) coordOffset1=32 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v70, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[94:95], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v70, -1, v70, s[94:95]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,0,2,1) coordOffset1=32 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v71, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[96:97], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v71, -1, v71, s[96:97]               // clip if OOB. offset
+
+/* rC *= alpha batchEements=[(0, 0, 0, 0), (0, 0, 0, 1), (0, 1, 0, 0), (0, 1, 0, 1), (0, 2, 0, 0), (0, 2, 0, 1), (0, 0, 1, 0), (0, 0, 1, 1), (0, 1, 1, 0), (0, 1, 1, 1), (0, 2, 1, 0), (0, 2, 1, 1), (1, 0, 0, 0), (1, 0, 0, 1), (1, 1, 0, 0), (1, 1, 0, 1), (1, 2, 0, 0), (1, 2, 0, 1)] */
+//v_mul_f64 v[vgprValuC+0:vgprValuC+0+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+0:vgprValuC+0+1] // *= alpha
+//v_mul_f64 v[vgprValuC+2:vgprValuC+2+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+2:vgprValuC+2+1] // *= alpha
+//v_mul_f64 v[vgprValuC+4:vgprValuC+4+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+4:vgprValuC+4+1] // *= alpha
+//v_mul_f64 v[vgprValuC+6:vgprValuC+6+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+6:vgprValuC+6+1] // *= alpha
+//v_mul_f64 v[vgprValuC+8:vgprValuC+8+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+8:vgprValuC+8+1] // *= alpha
+//v_mul_f64 v[vgprValuC+10:vgprValuC+10+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+10:vgprValuC+10+1] // *= alpha
+//v_mul_f64 v[vgprValuC+12:vgprValuC+12+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+12:vgprValuC+12+1] // *= alpha
+//v_mul_f64 v[vgprValuC+14:vgprValuC+14+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+14:vgprValuC+14+1] // *= alpha
+//v_mul_f64 v[vgprValuC+16:vgprValuC+16+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+16:vgprValuC+16+1] // *= alpha
+//v_mul_f64 v[vgprValuC+18:vgprValuC+18+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+18:vgprValuC+18+1] // *= alpha
+//v_mul_f64 v[vgprValuC+20:vgprValuC+20+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+20:vgprValuC+20+1] // *= alpha
+//v_mul_f64 v[vgprValuC+22:vgprValuC+22+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+22:vgprValuC+22+1] // *= alpha
+//v_mul_f64 v[vgprValuC+24:vgprValuC+24+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+24:vgprValuC+24+1] // *= alpha
+//v_mul_f64 v[vgprValuC+26:vgprValuC+26+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+26:vgprValuC+26+1] // *= alpha
+//v_mul_f64 v[vgprValuC+28:vgprValuC+28+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+28:vgprValuC+28+1] // *= alpha
+//v_mul_f64 v[vgprValuC+30:vgprValuC+30+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+30:vgprValuC+30+1] // *= alpha
+//v_mul_f64 v[vgprValuC+32:vgprValuC+32+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+32:vgprValuC+32+1] // *= alpha
+//v_mul_f64 v[vgprValuC+34:vgprValuC+34+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+34:vgprValuC+34+1] // *= alpha
+
+/* apply mask, calc new C and issue write */
+buffer_store_dwordx2 v[0:1], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[2:3], v55, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[4:5], v56, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[6:7], v57, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[8:9], v58, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[10:11], v59, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[12:13], v60, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[14:15], v61, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[16:17], v62, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[18:19], v63, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[20:21], v64, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[22:23], v65, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[24:25], v66, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[26:27], v67, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[28:29], v68, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[30:31], v69, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[32:33], v70, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[34:35], v71, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+/******************************************/
+/* Global Write Edge Batch #1 (d1,d0,vc1,vc0) =
+   (1,0,1,0:vw1); (1,0,1,1:vw1); (1,1,1,0:vw1); (1,1,1,1:vw1); (1,2,1,0:vw1); (1,2,1,1:vw1) */
+/******************************************/
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(1,1,0,0) coordOffset1=33 element-rows coordOffset0=0 rows */
+_v_add_co_u32 v53, vcc, v49, 33                    // coord1 += d1*sg1*VW + vc1
+_v_add_co_u32 v51, vcc, v51, s[sgprStridesC+0]     // rowPtr <- move to start of new row
+_v_add_lshl_u32 v54, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[62:63], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v54, -1, v54, s[62:63]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,1,0,1) coordOffset1=33 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v55, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[64:65], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v55, -1, v55, s[64:65]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,1,1,0) coordOffset1=33 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v56, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[66:67], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v56, -1, v56, s[66:67]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,1,1,1) coordOffset1=33 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v57, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[68:69], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v57, -1, v57, s[68:69]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,1,2,0) coordOffset1=33 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v58, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[70:71], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v58, -1, v58, s[70:71]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,1,2,1) coordOffset1=33 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v59, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[72:73], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v59, -1, v59, s[72:73]               // clip if OOB. offset
+
+/* rC *= alpha batchEements=[(1, 0, 1, 0), (1, 0, 1, 1), (1, 1, 1, 0), (1, 1, 1, 1), (1, 2, 1, 0), (1, 2, 1, 1)] */
+//v_mul_f64 v[vgprValuC+36:vgprValuC+36+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+36:vgprValuC+36+1] // *= alpha
+//v_mul_f64 v[vgprValuC+38:vgprValuC+38+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+38:vgprValuC+38+1] // *= alpha
+//v_mul_f64 v[vgprValuC+40:vgprValuC+40+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+40:vgprValuC+40+1] // *= alpha
+//v_mul_f64 v[vgprValuC+42:vgprValuC+42+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+42:vgprValuC+42+1] // *= alpha
+//v_mul_f64 v[vgprValuC+44:vgprValuC+44+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+44:vgprValuC+44+1] // *= alpha
+//v_mul_f64 v[vgprValuC+46:vgprValuC+46+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+46:vgprValuC+46+1] // *= alpha
+
+/* apply mask, calc new C and issue write */
+buffer_store_dwordx2 v[36:37], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[38:39], v55, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[40:41], v56, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[42:43], v57, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[44:45], v58, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[46:47], v59, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_branch label_0037                                // jump to end
+label_0030:
+s_mov_b32 s56, 0x0                                 // rMT0=0
+s_add_u32 s58, -0x1, s[sgprNumWorkGroups0]         //
+s_cmp_lt_u32 s[sgprWorkGroup0], s58                // wg0 < nwg0-1
+s_cbranch_scc1 label_0034                          // wg0 < nwg0-1 so skip rMT0 = Size0 % MT0
+/* TODO-packed- compare against product of all packed C0 sizes not just SizesFree+0 */
+s_mov_b32 s61, 0x0                                 // STATIC_DIV: divisior=48
+s_mul_i32 s60, 0xaaa, s[sgprSizesFree+0]           // tmp1 = dividend * magic hi
+s_lshl_b64 s[60:61], s[60:61], 0x10                // left shift 16 bits
+s_mul_i32 s58, s[sgprSizesFree+0], 0xaaab          // tmp0 = dividend * magic lo
+s_add_u32 s60, s58, s60                            // add lo
+s_addc_u32 s61, s61, 0x0                           // add hi
+s_lshr_b64 s[60:61], s[60:61], 0x21                // tmp1 = (dividend * magic) << shift
+s_mov_b32 s58, s60                                 // quotient
+s_mul_i32 s60, s58, 0x30                           // quotient*divisor
+s_sub_u32 s56, s[sgprSizesFree+0], s60             // rReg = dividend - quotient*divisor
+label_0034:
+s_cmpk_gt_u32 s56, 0x0                             // rMT0 > 0
+s_cbranch_scc1 label_0036                          // edges required so jump to E1
+s_mov_b32 s56, 0x0                                 // rMT1=0
+s_add_u32 s58, -0x1, s[sgprNumWorkGroups1]         //
+s_cmp_lt_u32 s[sgprWorkGroup1], s58                // wg1 < nwg1-1
+s_cbranch_scc1 label_0035                          // wg1 < nwg1-1 so skip rMT1 = Size1 % MT1
+s_lshr_b32 s58, s[sgprSizesFree+1], 6              // s58 = s[sgprSizesFree+1] / 64
+s_and_b32 s56, 63, s[sgprSizesFree+1]              // s56 = s[sgprSizesFree+1] % 64
+label_0035:
+s_cmpk_gt_u32 s56, 0x0                             // rMT1 > 0
+s_cbranch_scc1 label_0036                          // edges required so jump to E1
+label_0033:
+
+/******************************************/
+/* Global Write Beta Batch #0 (d1,d0,vc1,vc0) =
+   (0,0,0,0:vw2); (0,1,0,0:vw2); (0,2,0,0:vw2); (0,0,1,0:vw2); (0,1,1,0:vw2); (0,2,1,0:vw2) */
+/******************************************/
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(0,0,0,0) coordOffset1=0 element-rows coordOffset0=0 rows */
+_v_add_lshl_u32 v54, v[vgprGlobalReadOffsetB], v48, 0x3                 // init cb addr <-  rowStart + coord0, scaled by BPE
+buffer_load_dwordx4 v[55:58], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,1,0) coordOffset1=0 element-rows coordOffset0=16 rows */
+buffer_load_dwordx4 v[59:62], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,2,0) coordOffset1=0 element-rows coordOffset0=32 rows */
+buffer_load_dwordx4 v[63:66], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,0,0) coordOffset1=1 element-rows coordOffset0=0 rows */
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+buffer_load_dwordx4 v[67:70], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,1,0) coordOffset1=1 element-rows coordOffset0=16 rows */
+buffer_load_dwordx4 v[71:74], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,2,0) coordOffset1=1 element-rows coordOffset0=32 rows */
+buffer_load_dwordx4 v[75:78], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+
+/* rC *= alpha batchEements=[(0, 0, 0, 0), (0, 1, 0, 0), (0, 2, 0, 0), (0, 0, 1, 0), (0, 1, 1, 0), (0, 2, 1, 0)] */
+v_mul_f64 v[vgprValuC+0:vgprValuC+0+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+0:vgprValuC+0+1] // *= alpha
+v_mul_f64 v[vgprValuC+2:vgprValuC+2+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+2:vgprValuC+2+1] // *= alpha
+v_mul_f64 v[vgprValuC+4:vgprValuC+4+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+4:vgprValuC+4+1] // *= alpha
+v_mul_f64 v[vgprValuC+6:vgprValuC+6+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+6:vgprValuC+6+1] // *= alpha
+v_mul_f64 v[vgprValuC+8:vgprValuC+8+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+8:vgprValuC+8+1] // *= alpha
+v_mul_f64 v[vgprValuC+10:vgprValuC+10+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+10:vgprValuC+10+1] // *= alpha
+v_mul_f64 v[vgprValuC+12:vgprValuC+12+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+12:vgprValuC+12+1] // *= alpha
+v_mul_f64 v[vgprValuC+14:vgprValuC+14+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+14:vgprValuC+14+1] // *= alpha
+v_mul_f64 v[vgprValuC+16:vgprValuC+16+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+16:vgprValuC+16+1] // *= alpha
+v_mul_f64 v[vgprValuC+18:vgprValuC+18+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+18:vgprValuC+18+1] // *= alpha
+v_mul_f64 v[vgprValuC+20:vgprValuC+20+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+20:vgprValuC+20+1] // *= alpha
+v_mul_f64 v[vgprValuC+22:vgprValuC+22+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+22:vgprValuC+22+1] // *= alpha
+
+/* apply mask, calc new C and issue write */
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+0:vgprValuC+0+1], v[55:56], s[sgprBeta:sgprBeta+1], v[vgprValuC+0:vgprValuC+0+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+2:vgprValuC+2+1], v[57:58], s[sgprBeta:sgprBeta+1], v[vgprValuC+2:vgprValuC+2+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[0:3], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+4:vgprValuC+4+1], v[59:60], s[sgprBeta:sgprBeta+1], v[vgprValuC+4:vgprValuC+4+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+6:vgprValuC+6+1], v[61:62], s[sgprBeta:sgprBeta+1], v[vgprValuC+6:vgprValuC+6+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[4:7], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+8:vgprValuC+8+1], v[63:64], s[sgprBeta:sgprBeta+1], v[vgprValuC+8:vgprValuC+8+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+10:vgprValuC+10+1], v[65:66], s[sgprBeta:sgprBeta+1], v[vgprValuC+10:vgprValuC+10+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[8:11], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+12:vgprValuC+12+1], v[67:68], s[sgprBeta:sgprBeta+1], v[vgprValuC+12:vgprValuC+12+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+14:vgprValuC+14+1], v[69:70], s[sgprBeta:sgprBeta+1], v[vgprValuC+14:vgprValuC+14+1] // finalSum = sum*alpha + C*beta
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+buffer_store_dwordx4 v[12:15], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+16:vgprValuC+16+1], v[71:72], s[sgprBeta:sgprBeta+1], v[vgprValuC+16:vgprValuC+16+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+18:vgprValuC+18+1], v[73:74], s[sgprBeta:sgprBeta+1], v[vgprValuC+18:vgprValuC+18+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[16:19], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+20:vgprValuC+20+1], v[75:76], s[sgprBeta:sgprBeta+1], v[vgprValuC+20:vgprValuC+20+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+22:vgprValuC+22+1], v[77:78], s[sgprBeta:sgprBeta+1], v[vgprValuC+22:vgprValuC+22+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[20:23], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+
+/******************************************/
+/* Global Write Beta Batch #1 (d1,d0,vc1,vc0) =
+   (1,0,0,0:vw2); (1,1,0,0:vw2); (1,2,0,0:vw2); (1,0,1,0:vw2); (1,1,1,0:vw2); (1,2,1,0:vw2) */
+/******************************************/
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(1,0,0,0) coordOffset1=32 element-rows coordOffset0=0 rows */
+s_mul_i32 s56, s[sgprStridesD+0], 248              // scale StrideC *= 31 * bpe
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+buffer_load_dwordx4 v[55:58], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,1,0) coordOffset1=32 element-rows coordOffset0=16 rows */
+buffer_load_dwordx4 v[59:62], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,2,0) coordOffset1=32 element-rows coordOffset0=32 rows */
+buffer_load_dwordx4 v[63:66], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,0,0) coordOffset1=33 element-rows coordOffset0=0 rows */
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+buffer_load_dwordx4 v[67:70], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,1,0) coordOffset1=33 element-rows coordOffset0=16 rows */
+buffer_load_dwordx4 v[71:74], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,2,0) coordOffset1=33 element-rows coordOffset0=32 rows */
+buffer_load_dwordx4 v[75:78], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+
+/* rC *= alpha batchEements=[(1, 0, 0, 0), (1, 1, 0, 0), (1, 2, 0, 0), (1, 0, 1, 0), (1, 1, 1, 0), (1, 2, 1, 0)] */
+v_mul_f64 v[vgprValuC+24:vgprValuC+24+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+24:vgprValuC+24+1] // *= alpha
+v_mul_f64 v[vgprValuC+26:vgprValuC+26+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+26:vgprValuC+26+1] // *= alpha
+v_mul_f64 v[vgprValuC+28:vgprValuC+28+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+28:vgprValuC+28+1] // *= alpha
+v_mul_f64 v[vgprValuC+30:vgprValuC+30+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+30:vgprValuC+30+1] // *= alpha
+v_mul_f64 v[vgprValuC+32:vgprValuC+32+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+32:vgprValuC+32+1] // *= alpha
+v_mul_f64 v[vgprValuC+34:vgprValuC+34+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+34:vgprValuC+34+1] // *= alpha
+v_mul_f64 v[vgprValuC+36:vgprValuC+36+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+36:vgprValuC+36+1] // *= alpha
+v_mul_f64 v[vgprValuC+38:vgprValuC+38+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+38:vgprValuC+38+1] // *= alpha
+v_mul_f64 v[vgprValuC+40:vgprValuC+40+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+40:vgprValuC+40+1] // *= alpha
+v_mul_f64 v[vgprValuC+42:vgprValuC+42+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+42:vgprValuC+42+1] // *= alpha
+v_mul_f64 v[vgprValuC+44:vgprValuC+44+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+44:vgprValuC+44+1] // *= alpha
+v_mul_f64 v[vgprValuC+46:vgprValuC+46+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+46:vgprValuC+46+1] // *= alpha
+
+/* apply mask, calc new C and issue write */
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+24:vgprValuC+24+1], v[55:56], s[sgprBeta:sgprBeta+1], v[vgprValuC+24:vgprValuC+24+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+26:vgprValuC+26+1], v[57:58], s[sgprBeta:sgprBeta+1], v[vgprValuC+26:vgprValuC+26+1] // finalSum = sum*alpha + C*beta
+s_mul_i32 s56, s[sgprStridesD+0], 248              // scale StrideC *= 31 * bpe
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+buffer_store_dwordx4 v[24:27], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+28:vgprValuC+28+1], v[59:60], s[sgprBeta:sgprBeta+1], v[vgprValuC+28:vgprValuC+28+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+30:vgprValuC+30+1], v[61:62], s[sgprBeta:sgprBeta+1], v[vgprValuC+30:vgprValuC+30+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[28:31], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+32:vgprValuC+32+1], v[63:64], s[sgprBeta:sgprBeta+1], v[vgprValuC+32:vgprValuC+32+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+34:vgprValuC+34+1], v[65:66], s[sgprBeta:sgprBeta+1], v[vgprValuC+34:vgprValuC+34+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[32:35], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+36:vgprValuC+36+1], v[67:68], s[sgprBeta:sgprBeta+1], v[vgprValuC+36:vgprValuC+36+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+38:vgprValuC+38+1], v[69:70], s[sgprBeta:sgprBeta+1], v[vgprValuC+38:vgprValuC+38+1] // finalSum = sum*alpha + C*beta
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+buffer_store_dwordx4 v[36:39], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+40:vgprValuC+40+1], v[71:72], s[sgprBeta:sgprBeta+1], v[vgprValuC+40:vgprValuC+40+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+42:vgprValuC+42+1], v[73:74], s[sgprBeta:sgprBeta+1], v[vgprValuC+42:vgprValuC+42+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[40:43], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+44:vgprValuC+44+1], v[75:76], s[sgprBeta:sgprBeta+1], v[vgprValuC+44:vgprValuC+44+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+46:vgprValuC+46+1], v[77:78], s[sgprBeta:sgprBeta+1], v[vgprValuC+46:vgprValuC+46+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[44:47], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_branch label_0037                                // jump to end
+label_0036:
+
+/******************************************/
+/* Global Write Beta Edge Batch #0 (d1,d0,vc1,vc0) =
+   (0,0,0,0:vw1); (0,0,0,1:vw1); (0,1,0,0:vw1); (0,1,0,1:vw1); (0,2,0,0:vw1); (0,2,0,1:vw1); (0,0,1,0:vw1); (0,0,1,1:vw1) */
+/******************************************/
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(0,0,0,0) coordOffset1=0 element-rows coordOffset0=0 rows */
+v_mov_b32 v51, v50                                 // rowPtr <- rowStart (first row)
+_v_add_lshl_u32 v54, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[62:63], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v54, -1, v54, s[62:63]               // clip if OOB. offset
+buffer_load_dwordx2 v[55:56], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,0,1) coordOffset1=0 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v57, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[64:65], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v57, -1, v57, s[64:65]               // clip if OOB. offset
+buffer_load_dwordx2 v[58:59], v57, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,1,0) coordOffset1=0 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v60, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[66:67], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v60, -1, v60, s[66:67]               // clip if OOB. offset
+buffer_load_dwordx2 v[61:62], v60, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,1,1) coordOffset1=0 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v63, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[68:69], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v63, -1, v63, s[68:69]               // clip if OOB. offset
+buffer_load_dwordx2 v[64:65], v63, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,2,0) coordOffset1=0 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v66, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[70:71], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v66, -1, v66, s[70:71]               // clip if OOB. offset
+buffer_load_dwordx2 v[67:68], v66, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,2,1) coordOffset1=0 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v69, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[72:73], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v69, -1, v69, s[72:73]               // clip if OOB. offset
+buffer_load_dwordx2 v[70:71], v69, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,0,0) coordOffset1=1 element-rows coordOffset0=0 rows */
+_v_add_co_u32 v53, vcc, v49, 1                     // coord1 += d1*sg1*VW + vc1
+_v_add_co_u32 v51, vcc, v51, s[sgprStridesC+0]     // rowPtr <- move to start of new row
+_v_add_lshl_u32 v72, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[74:75], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v72, -1, v72, s[74:75]               // clip if OOB. offset
+buffer_load_dwordx2 v[73:74], v72, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,0,1) coordOffset1=1 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v75, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[76:77], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v75, -1, v75, s[76:77]               // clip if OOB. offset
+buffer_load_dwordx2 v[76:77], v75, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+
+/* rC *= alpha batchEements=[(0, 0, 0, 0), (0, 0, 0, 1), (0, 1, 0, 0), (0, 1, 0, 1), (0, 2, 0, 0), (0, 2, 0, 1), (0, 0, 1, 0), (0, 0, 1, 1)] */
+v_mul_f64 v[vgprValuC+0:vgprValuC+0+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+0:vgprValuC+0+1] // *= alpha
+v_mul_f64 v[vgprValuC+2:vgprValuC+2+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+2:vgprValuC+2+1] // *= alpha
+v_mul_f64 v[vgprValuC+4:vgprValuC+4+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+4:vgprValuC+4+1] // *= alpha
+v_mul_f64 v[vgprValuC+6:vgprValuC+6+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+6:vgprValuC+6+1] // *= alpha
+v_mul_f64 v[vgprValuC+8:vgprValuC+8+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+8:vgprValuC+8+1] // *= alpha
+v_mul_f64 v[vgprValuC+10:vgprValuC+10+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+10:vgprValuC+10+1] // *= alpha
+v_mul_f64 v[vgprValuC+12:vgprValuC+12+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+12:vgprValuC+12+1] // *= alpha
+v_mul_f64 v[vgprValuC+14:vgprValuC+14+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+14:vgprValuC+14+1] // *= alpha
+s_waitcnt vmcnt(0)                                 // wait C
+
+/* apply mask, calc new C and issue write */
+v_fma_f64 v[vgprValuC+0:vgprValuC+0+1], v[55:56], s[sgprBeta:sgprBeta+1], v[vgprValuC+0:vgprValuC+0+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[0:1], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+2:vgprValuC+2+1], v[58:59], s[sgprBeta:sgprBeta+1], v[vgprValuC+2:vgprValuC+2+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[2:3], v57, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+4:vgprValuC+4+1], v[61:62], s[sgprBeta:sgprBeta+1], v[vgprValuC+4:vgprValuC+4+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[4:5], v60, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+6:vgprValuC+6+1], v[64:65], s[sgprBeta:sgprBeta+1], v[vgprValuC+6:vgprValuC+6+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[6:7], v63, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+8:vgprValuC+8+1], v[67:68], s[sgprBeta:sgprBeta+1], v[vgprValuC+8:vgprValuC+8+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[8:9], v66, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+10:vgprValuC+10+1], v[70:71], s[sgprBeta:sgprBeta+1], v[vgprValuC+10:vgprValuC+10+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[10:11], v69, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+12:vgprValuC+12+1], v[73:74], s[sgprBeta:sgprBeta+1], v[vgprValuC+12:vgprValuC+12+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[12:13], v72, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+14:vgprValuC+14+1], v[76:77], s[sgprBeta:sgprBeta+1], v[vgprValuC+14:vgprValuC+14+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[14:15], v75, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+/******************************************/
+/* Global Write Beta Edge Batch #1 (d1,d0,vc1,vc0) =
+   (0,1,1,0:vw1); (0,1,1,1:vw1); (0,2,1,0:vw1); (0,2,1,1:vw1); (1,0,0,0:vw1); (1,0,0,1:vw1); (1,1,0,0:vw1); (1,1,0,1:vw1) */
+/******************************************/
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(0,1,1,0) coordOffset1=1 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v54, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[62:63], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v54, -1, v54, s[62:63]               // clip if OOB. offset
+buffer_load_dwordx2 v[55:56], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,1,1) coordOffset1=1 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v57, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[64:65], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v57, -1, v57, s[64:65]               // clip if OOB. offset
+buffer_load_dwordx2 v[58:59], v57, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,2,0) coordOffset1=1 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v60, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[66:67], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v60, -1, v60, s[66:67]               // clip if OOB. offset
+buffer_load_dwordx2 v[61:62], v60, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,2,1) coordOffset1=1 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v63, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[68:69], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v63, -1, v63, s[68:69]               // clip if OOB. offset
+buffer_load_dwordx2 v[64:65], v63, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,0,0) coordOffset1=32 element-rows coordOffset0=0 rows */
+_v_add_co_u32 v53, vcc, v49, 32                    // coord1 += d1*sg1*VW + vc1
+s_mul_i32 s56, s[sgprStridesC+0], 32               // scale StrideC *= coordOffset1(32)
+_v_add_co_u32 v51, vcc, v50, s56                   // rowPtr <- inc for non-0 (tt1+vc1))
+_v_add_lshl_u32 v66, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[70:71], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v66, -1, v66, s[70:71]               // clip if OOB. offset
+buffer_load_dwordx2 v[67:68], v66, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,0,1) coordOffset1=32 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v69, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[72:73], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v69, -1, v69, s[72:73]               // clip if OOB. offset
+buffer_load_dwordx2 v[70:71], v69, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,1,0) coordOffset1=32 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v72, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[74:75], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v72, -1, v72, s[74:75]               // clip if OOB. offset
+buffer_load_dwordx2 v[73:74], v72, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,1,1) coordOffset1=32 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v75, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[76:77], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v75, -1, v75, s[76:77]               // clip if OOB. offset
+buffer_load_dwordx2 v[76:77], v75, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+
+/* rC *= alpha batchEements=[(0, 1, 1, 0), (0, 1, 1, 1), (0, 2, 1, 0), (0, 2, 1, 1), (1, 0, 0, 0), (1, 0, 0, 1), (1, 1, 0, 0), (1, 1, 0, 1)] */
+v_mul_f64 v[vgprValuC+16:vgprValuC+16+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+16:vgprValuC+16+1] // *= alpha
+v_mul_f64 v[vgprValuC+18:vgprValuC+18+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+18:vgprValuC+18+1] // *= alpha
+v_mul_f64 v[vgprValuC+20:vgprValuC+20+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+20:vgprValuC+20+1] // *= alpha
+v_mul_f64 v[vgprValuC+22:vgprValuC+22+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+22:vgprValuC+22+1] // *= alpha
+v_mul_f64 v[vgprValuC+24:vgprValuC+24+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+24:vgprValuC+24+1] // *= alpha
+v_mul_f64 v[vgprValuC+26:vgprValuC+26+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+26:vgprValuC+26+1] // *= alpha
+v_mul_f64 v[vgprValuC+28:vgprValuC+28+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+28:vgprValuC+28+1] // *= alpha
+v_mul_f64 v[vgprValuC+30:vgprValuC+30+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+30:vgprValuC+30+1] // *= alpha
+s_waitcnt vmcnt(0)                                 // wait C
+
+/* apply mask, calc new C and issue write */
+v_fma_f64 v[vgprValuC+16:vgprValuC+16+1], v[55:56], s[sgprBeta:sgprBeta+1], v[vgprValuC+16:vgprValuC+16+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[16:17], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+18:vgprValuC+18+1], v[58:59], s[sgprBeta:sgprBeta+1], v[vgprValuC+18:vgprValuC+18+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[18:19], v57, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+20:vgprValuC+20+1], v[61:62], s[sgprBeta:sgprBeta+1], v[vgprValuC+20:vgprValuC+20+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[20:21], v60, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+22:vgprValuC+22+1], v[64:65], s[sgprBeta:sgprBeta+1], v[vgprValuC+22:vgprValuC+22+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[22:23], v63, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+24:vgprValuC+24+1], v[67:68], s[sgprBeta:sgprBeta+1], v[vgprValuC+24:vgprValuC+24+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[24:25], v66, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+26:vgprValuC+26+1], v[70:71], s[sgprBeta:sgprBeta+1], v[vgprValuC+26:vgprValuC+26+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[26:27], v69, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+28:vgprValuC+28+1], v[73:74], s[sgprBeta:sgprBeta+1], v[vgprValuC+28:vgprValuC+28+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[28:29], v72, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+30:vgprValuC+30+1], v[76:77], s[sgprBeta:sgprBeta+1], v[vgprValuC+30:vgprValuC+30+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[30:31], v75, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+/******************************************/
+/* Global Write Beta Edge Batch #2 (d1,d0,vc1,vc0) =
+   (1,2,0,0:vw1); (1,2,0,1:vw1); (1,0,1,0:vw1); (1,0,1,1:vw1); (1,1,1,0:vw1); (1,1,1,1:vw1); (1,2,1,0:vw1); (1,2,1,1:vw1) */
+/******************************************/
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(1,0,2,0) coordOffset1=32 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v54, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[62:63], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v54, -1, v54, s[62:63]               // clip if OOB. offset
+buffer_load_dwordx2 v[55:56], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,2,1) coordOffset1=32 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v57, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[64:65], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v57, -1, v57, s[64:65]               // clip if OOB. offset
+buffer_load_dwordx2 v[58:59], v57, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,0,0) coordOffset1=33 element-rows coordOffset0=0 rows */
+_v_add_co_u32 v53, vcc, v49, 33                    // coord1 += d1*sg1*VW + vc1
+_v_add_co_u32 v51, vcc, v51, s[sgprStridesC+0]     // rowPtr <- move to start of new row
+_v_add_lshl_u32 v60, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[66:67], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v60, -1, v60, s[66:67]               // clip if OOB. offset
+buffer_load_dwordx2 v[61:62], v60, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,0,1) coordOffset1=33 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v63, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[68:69], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v63, -1, v63, s[68:69]               // clip if OOB. offset
+buffer_load_dwordx2 v[64:65], v63, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,1,0) coordOffset1=33 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v66, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[70:71], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v66, -1, v66, s[70:71]               // clip if OOB. offset
+buffer_load_dwordx2 v[67:68], v66, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,1,1) coordOffset1=33 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v69, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[72:73], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v69, -1, v69, s[72:73]               // clip if OOB. offset
+buffer_load_dwordx2 v[70:71], v69, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,2,0) coordOffset1=33 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v72, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[74:75], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v72, -1, v72, s[74:75]               // clip if OOB. offset
+buffer_load_dwordx2 v[73:74], v72, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,2,1) coordOffset1=33 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v75, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[76:77], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v75, -1, v75, s[76:77]               // clip if OOB. offset
+buffer_load_dwordx2 v[76:77], v75, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+
+/* rC *= alpha batchEements=[(1, 2, 0, 0), (1, 2, 0, 1), (1, 0, 1, 0), (1, 0, 1, 1), (1, 1, 1, 0), (1, 1, 1, 1), (1, 2, 1, 0), (1, 2, 1, 1)] */
+v_mul_f64 v[vgprValuC+32:vgprValuC+32+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+32:vgprValuC+32+1] // *= alpha
+v_mul_f64 v[vgprValuC+34:vgprValuC+34+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+34:vgprValuC+34+1] // *= alpha
+v_mul_f64 v[vgprValuC+36:vgprValuC+36+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+36:vgprValuC+36+1] // *= alpha
+v_mul_f64 v[vgprValuC+38:vgprValuC+38+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+38:vgprValuC+38+1] // *= alpha
+v_mul_f64 v[vgprValuC+40:vgprValuC+40+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+40:vgprValuC+40+1] // *= alpha
+v_mul_f64 v[vgprValuC+42:vgprValuC+42+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+42:vgprValuC+42+1] // *= alpha
+v_mul_f64 v[vgprValuC+44:vgprValuC+44+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+44:vgprValuC+44+1] // *= alpha
+v_mul_f64 v[vgprValuC+46:vgprValuC+46+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+46:vgprValuC+46+1] // *= alpha
+s_waitcnt vmcnt(0)                                 // wait C
+
+/* apply mask, calc new C and issue write */
+v_fma_f64 v[vgprValuC+32:vgprValuC+32+1], v[55:56], s[sgprBeta:sgprBeta+1], v[vgprValuC+32:vgprValuC+32+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[32:33], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+34:vgprValuC+34+1], v[58:59], s[sgprBeta:sgprBeta+1], v[vgprValuC+34:vgprValuC+34+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[34:35], v57, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+36:vgprValuC+36+1], v[61:62], s[sgprBeta:sgprBeta+1], v[vgprValuC+36:vgprValuC+36+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[36:37], v60, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+38:vgprValuC+38+1], v[64:65], s[sgprBeta:sgprBeta+1], v[vgprValuC+38:vgprValuC+38+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[38:39], v63, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+40:vgprValuC+40+1], v[67:68], s[sgprBeta:sgprBeta+1], v[vgprValuC+40:vgprValuC+40+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[40:41], v66, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+42:vgprValuC+42+1], v[70:71], s[sgprBeta:sgprBeta+1], v[vgprValuC+42:vgprValuC+42+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[42:43], v69, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+44:vgprValuC+44+1], v[73:74], s[sgprBeta:sgprBeta+1], v[vgprValuC+44:vgprValuC+44+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[44:45], v72, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+46:vgprValuC+46+1], v[76:77], s[sgprBeta:sgprBeta+1], v[vgprValuC+46:vgprValuC+46+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[46:47], v75, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_branch label_0037                                // jump to end
+label_0037:
+
+label_0038:  /// KernelEnd
+s_endpgm                                           // Kernel End
+
+

--- a/Tensile/ReplacementKernels/Cijk_Ailk_Bjlk_DB_MT48x64x4_AF0EM1_ASEM1_FL1_GRVW2_ISA908_MDA2_PGR1_PLR0_SU0_TT6_4_VAW1_VW2_WG8_16_1_WGM8.s.txt
+++ b/Tensile/ReplacementKernels/Cijk_Ailk_Bjlk_DB_MT48x64x4_AF0EM1_ASEM1_FL1_GRVW2_ISA908_MDA2_PGR1_PLR0_SU0_TT6_4_VAW1_VW2_WG8_16_1_WGM8.s.txt
@@ -1,0 +1,3896 @@
+
+
+/******************************************/
+/* Function Prefix                        */
+/******************************************/
+
+
+
+/******************************************/
+/* Begin Kernel                           */
+/******************************************/
+
+.hsa_code_object_version 2,0
+.hsa_code_object_isa 9, 0, 8, "AMD", "AMDGPU"
+.text
+.protected Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM8
+.globl Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM8
+.p2align 8
+.type Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM8,@function
+.amdgpu_hsa_kernel Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM8
+Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM8:
+.amd_kernel_code_t
+  is_ptr64 = 1
+  enable_sgpr_kernarg_segment_ptr = 1
+  kernarg_segment_byte_size = 92 // bytes of kern args
+  workitem_vgpr_count = 84 // vgprs
+  wavefront_sgpr_count = 98 // sgprs
+  compute_pgm_rsrc1_vgprs = 20 // floor((83-1)/4)
+  compute_pgm_rsrc1_sgprs = 13 // floor((98-1)/8)
+  compute_pgm_rsrc2_tidig_comp_cnt = 0 // 1D wg
+  compute_pgm_rsrc2_tgid_x_en = 1 // wg.x
+  compute_pgm_rsrc2_tgid_y_en = 1 // wg.y
+  compute_pgm_rsrc2_tgid_z_en = 1 // wg.z
+  workgroup_group_segment_byte_size = 7680 // lds bytes
+  compute_pgm_rsrc2_user_sgpr = 2 // vcc
+  kernarg_segment_alignment = 4
+  group_segment_alignment = 4
+  private_segment_alignment = 4
+.end_amd_kernel_code_t
+
+.amd_amdgpu_hsa_metadata
+Version: [ 1, 0 ]
+Kernels:
+  - Name: Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM8
+    SymbolName: 'Cijk_Ailk_Bjlk_DB_MT48x64x4_SE_APM1_AF0EM1_AF1EM1_AMAS3_ASBE01_ASEM1_BL1_DTL0_EPS1_FL1_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR0_RK1_SIA1_SU0_SUM0_SUS256_SRVW0_SNLL0_TT6_4_TLDS0_USFGRO0_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG8_16_1_WGM8@kd'
+    Language: OpenCL C
+    LanguageVersion: [ 2, 0 ]
+    Args:
+      - Name:            sizeC
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            sizeA
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            sizeB
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            D
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       F64
+        AddrSpaceQual:   Generic
+      - Name:            C
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       F64
+        AddrSpaceQual:   Generic
+      - Name:            A
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       F64
+        AddrSpaceQual:   Generic
+      - Name:            B
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       F64
+        AddrSpaceQual:   Generic
+      - Name:            alpha
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       F64
+      - Name:            beta
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       F64
+      - Name:            strideD0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideD1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideC0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideC1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideA0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideA1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideB0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideB1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree2
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesSum0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            OrigStaggerUIter
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       I32
+      - Name:            NumWorkGroups0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            NumWorkGroups1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            MagicNumberProblemNumGroupTiles0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            GridNumWorkGroups0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            NumFullBlocks
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            WgmRemainder1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            MagicNumberWgmRemainder1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            padding
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+    CodeProps:
+      KernargSegmentSize: 156
+      GroupSegmentFixedSize: 7680
+      PrivateSegmentFixedSize: 0
+      KernargSegmentAlign:  8
+      WavefrontSize:        64
+      NumSGPRs:             98
+      NumVGPRs:             84
+      MaxFlatWorkGroupSize: 128
+.end_amd_amdgpu_hsa_metadata
+
+/******************************************/
+/* Optimizations and Config:              */
+/******************************************/
+/* ThreadTile= 6 x 4 */
+/* SubGroup= 8 x 16 */
+/* VectorWidth=2 */
+/* GlobalLoadVectorWidthA=2, GlobalLoadVectorWidthB=2 */
+/* DirectToLdsA=False */
+/* DirectToLdsB=False */
+/* UseSgprForGRO=False */
+
+/******************************************/
+/* Asm syntax workarounds                 */
+/******************************************/
+.macro _v_add_co_u32 dst, cc, src0, src1, dpp=
+   v_add_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+.macro _v_sub_co_u32 dst, cc, src0, src1, dpp=
+   v_sub_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+.macro _v_addc_co_u32 dst, ccOut, src0, ccIn, src1, dpp=
+   v_addc_co_u32 \dst, \ccOut, \src0, \ccIn, \src1 \dpp
+.endm
+.macro _v_add_lshl_u32 dst, src0, src1, shiftCnt
+    v_add_lshl_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+.macro _v_lshl_add_u32 dst, src0, src1, shiftCnt
+    v_lshl_add_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+/******************************************/
+/* Magic div and mod functions            */
+/******************************************/
+.macro V_MAGIC_DIV dstIdx, dividend, magicNumber, magicShift
+    v_mul_lo_u32 v[\dstIdx+0], \dividend, \magicNumber
+    v_mul_hi_u32 v[\dstIdx+1], \dividend, \magicNumber
+    v_lshrrev_b64 v[\dstIdx:\dstIdx+1], \magicShift, v[\dstIdx:\dstIdx+1]
+.endm
+
+/******************************************/
+/* VGPR Assignments                       */
+/******************************************/
+.set vgprValuC, 0
+/* ValuA/B   Xn=PLR buffer idx,  In=InnerUnroll idx */
+.set vgprValuA_X0_I0, 48
+.set vgprG2LA, 60
+.set vgprValuB_X0_I0, 64
+.set vgprG2LB, 72
+.set vgprLocalWriteAddrA, 76
+.set vgprLocalWriteAddrB, 77
+.set vgprGlobalReadOffsetA, 78
+.set vgprGlobalReadOffsetB, 79
+.set vgprLocalReadAddrA, 80
+.set vgprLocalReadAddrB, 81
+.set vgprSerial, 82
+/* Num VGPR=83 */
+
+/******************************************/
+/* SGPR Assignments                       */
+/******************************************/
+.set sgprKernArgAddress, 0
+.set sgprWorkGroup0, 2
+.set sgprWorkGroup1, 3
+.set sgprWorkGroup2, 4
+.set sgprNumWorkGroups0, 5
+.set sgprNumWorkGroups1, 6
+.set sgprSrdA, 8
+.set sgprSrdB, 12
+.set sgprSrdD, 16
+.set sgprSrdC, 20
+.set sgprTensor2dSizeC, 24
+.set sgprTensor2dSizeA, 26
+.set sgprTensor2dSizeB, 28
+.set sgprSaveExecMask, 30
+.set sgprAddressD, 32
+.set sgprAddressC, 34
+.set sgprStridesC, 36
+.set sgprAlpha, 38
+.set sgprBeta, 40
+.set sgprSizesFree, 42
+.set sgprSizesSum, 45
+.set sgprLoopCounters, 46
+.set sgprOrigLoopCounter, 47
+.set sgprStridesA, 48
+.set sgprStridesB, 50
+.set sgprAddressA, 52
+.set sgprAddressB, 54
+.set sgprShadowLimitA, 56
+.set sgprShadowLimitB, 58
+.set sgprNumFullBlocks, 60
+.set sgprWgmRemainder1, 61
+.set sgprMagicNumberWgmRemainder1, 62
+.set sgprGlobalReadIncsA, 63
+.set sgprGlobalReadIncsB, 64
+.set sgprStridesD, 74
+.set sgprTMP0, 90
+.set sgprTMP1, 91
+.set sgprEdgeSelMask0, 93
+.set sgprEdgeSelMask1, 94
+/* max SGPR=98 */
+
+/******************************************/
+/* 2GB limit - set offsets to -1 to exceed this and clamp */
+/******************************************/
+.set BufferLimit, 0x80000000
+
+/******************************************/
+/* Bits 127:96 of SRD.  Set DataFormat = 32 bit */
+/******************************************/
+.set Srd127_96, 0x0020000
+.set BufferOOB, 0x80000000
+
+/* Global Offset A */
+.macro GLOBAL_OFFSET_A vgprAddr vgprOffset0I vgprOffsetL vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStridesA+0], v[\vgprOffsetL] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprTmp+0], v[\vgprOffset0I] // accumulate d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, 0x2, v[\vgprAddr+0] // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x3, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/* Global Offset B */
+.macro GLOBAL_OFFSET_B vgprAddr vgprOffset1J vgprOffsetL vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStridesB+0], v[\vgprOffsetL] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprTmp+0], v[\vgprOffset1J] // accumulate d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, 0x2, v[\vgprAddr+0] // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x3, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/******************************************/
+/* Dynamic Scalar Divide: vQuotient=vDividend/vDivisor; vRemainder=vDividend%vDivisor; */
+/******************************************/
+.macro DYNAMIC_VECTOR_DIVIDE vQuotient vRemainder vDividend vDivisor vTmp0 vTmp1 sTmp
+v_cvt_f32_u32 v[\vQuotient], v[\vDivisor]          //
+v_rcp_f32 v[\vQuotient], v[\vQuotient]             //
+v_mul_f32 v[\vQuotient], 0x4f800000, v[\vQuotient] //
+v_cvt_u32_f32 v[\vQuotient], v[\vQuotient]         //
+v_mul_lo_u32 v[\vRemainder], v[\vDivisor], v[\vQuotient] //
+v_mul_hi_u32 v[\vTmp0], v[\vDivisor], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp1], vcc, 0x0, v[\vRemainder]  //
+v_cmp_ne_i32 s[\sTmp:\sTmp+1], 0x0, v[\vTmp0]      //
+v_cndmask_b32 v[\vRemainder], v[\vTmp1], v[\vRemainder], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vRemainder], v[\vRemainder], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vQuotient], v[\vRemainder] //
+_v_add_co_u32 v[\vQuotient], vcc, v[\vQuotient], v[\vRemainder] //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vTmp0], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vQuotient], v[\vQuotient], v[\vDividend] //
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vDividend], v[\vRemainder] //
+v_cmp_ge_u32 s[\sTmp:\sTmp+1], v[\vDividend], v[\vRemainder] //
+_v_add_co_u32 v[\vRemainder], vcc, 0x1, v[\vQuotient] //
+_v_add_co_u32 v[\vTmp1], vcc, -1, v[\vQuotient]    //
+v_cmp_le_u32 vcc, v[\vDivisor], v[\vTmp0]          //
+s_and_b64 vcc, s[\sTmp:\sTmp+1], vcc               //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vRemainder], vcc //
+v_cndmask_b32 v[\vQuotient], v[\vTmp1], v[\vQuotient], s[\sTmp:\sTmp+1] //
+v_cmp_ne_i32 vcc, 0x0, v[\vDivisor]                //
+v_cndmask_b32 v[\vQuotient], -1, v[\vQuotient], vcc // final result
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vRemainder], vcc, v[\vDividend], v[\vRemainder] // final result
+.endm
+
+/******************************************/
+/* 6x4 thread-tile                        */
+/******************************************/
+.macro MAC_6x4_X0
+v_fma_f64 v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1]
+s_setprio 1 // Raise priority while processing macs
+v_fma_f64 v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1]
+s_setprio 0 // Reset priority after macs
+.endm
+
+.macro MAC_6x4_X0_part_1
+v_fma_f64 v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1]
+s_setprio 1 // Raise priority while processing macs
+v_fma_f64 v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1]
+.endm
+
+.macro MAC_6x4_X0_part_2
+.endm
+
+.macro MAC_6x4_X0_part_3
+v_fma_f64 v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1]
+s_setprio 0 // Reset Priority
+.endm
+
+.macro MAC_6x4_X0_unprio_0
+v_fma_f64 v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1]
+s_setprio 1 // Raise priority while processing macs
+v_fma_f64 v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1]
+.endm
+
+
+.macro MAC_6x4_X0_part1
+v_fma_f64 v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1]
+s_setprio 1
+v_fma_f64 v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(0+0*6)*2:(vgprValuC+0+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(1+0*6)*2:(vgprValuC+1+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(0+1*6)*2:(vgprValuC+0+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(1+1*6)*2:(vgprValuC+1+1*6)*2+1]
+s_setprio 0
+.endm
+
+
+.macro MAC_6x4_X0_part2
+v_fma_f64 v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1]
+s_setprio 1
+v_fma_f64 v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(2+0*6)*2:(vgprValuC+2+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(3+0*6)*2:(vgprValuC+3+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(2+1*6)*2:(vgprValuC+2+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(3+1*6)*2:(vgprValuC+3+1*6)*2+1]
+s_setprio 0
+.endm
+.macro MAC_6x4_X0_part3
+v_fma_f64 v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1]
+s_setprio 1
+v_fma_f64 v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(4+0*6)*2:(vgprValuC+4+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(5+0*6)*2:(vgprValuC+5+0*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(4+1*6)*2:(vgprValuC+4+1*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(5+1*6)*2:(vgprValuC+5+1*6)*2+1]
+s_setprio 0
+.endm
+.macro MAC_6x4_X0_part4
+v_fma_f64 v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1]
+s_setprio 1
+v_fma_f64 v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1], v[vgprValuA_X0_I0+0*2:vgprValuA_X0_I0+0*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1], v[vgprValuA_X0_I0+1*2:vgprValuA_X0_I0+1*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(0+2*6)*2:(vgprValuC+0+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(1+2*6)*2:(vgprValuC+1+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(0+3*6)*2:(vgprValuC+0+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(1+3*6)*2:(vgprValuC+1+3*6)*2+1]
+//vnop_4
+s_setprio 0
+.endm
+.macro MAC_6x4_X0_part5
+v_fma_f64 v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1]
+s_setprio 1
+v_fma_f64 v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(2+2*6)*2:(vgprValuC+2+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(3+2*6)*2:(vgprValuC+3+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(2+3*6)*2:(vgprValuC+2+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(3+3*6)*2:(vgprValuC+3+3*6)*2+1]
+//vnop_4
+s_setprio 0
+.endm
+.macro MAC_6x4_X0_part6
+v_fma_f64 v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1]
+s_setprio 1
+v_fma_f64 v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+2*2:vgprValuB_X0_I0+2*2+1], v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1], v[vgprValuA_X0_I0+4*2:vgprValuA_X0_I0+4*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1], v[vgprValuA_X0_I0+5*2:vgprValuA_X0_I0+5*2+1], v[vgprValuB_X0_I0+3*2:vgprValuB_X0_I0+3*2+1], v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(4+2*6)*2:(vgprValuC+4+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+0*2:vgprValuB_X0_I0+0*2+1], v[vgprValuC+(5+2*6)*2:(vgprValuC+5+2*6)*2+1]
+v_fma_f64 v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1], v[vgprValuA_X0_I0+2*2:vgprValuA_X0_I0+2*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(4+3*6)*2:(vgprValuC+4+3*6)*2+1]
+v_fma_f64 v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1], v[vgprValuA_X0_I0+3*2:vgprValuA_X0_I0+3*2+1], v[vgprValuB_X0_I0+1*2:vgprValuB_X0_I0+1*2+1], v[vgprValuC+(5+3*6)*2:(vgprValuC+5+3*6)*2+1]
+s_setprio 0
+.endm
+
+/******************************************/
+/* Allocate Resources                     */
+/******************************************/
+
+s_mov_b32 m0, 0x1e00                               // LDS clamp at 7680 bytes
+v_mov_b32 v[vgprSerial], v0                        // thread serial id
+
+/* Load Kernel Args */
+s_load_dword s[sgprTensor2dSizeC+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x0 //
+s_load_dword s[sgprTensor2dSizeC+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x4 //
+s_load_dword s[sgprTensor2dSizeA+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x8 //
+s_load_dword s[sgprTensor2dSizeA+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0xc //
+s_load_dword s[sgprTensor2dSizeB+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x10 //
+s_load_dword s[sgprTensor2dSizeB+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x14 //
+s_load_dword s[sgprAddressD], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x18 //
+s_load_dword s[sgprAddressD+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x1c //
+s_load_dword s[sgprAddressC], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x20 //
+s_load_dword s[sgprAddressC+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x24 //
+s_load_dword s[sgprAddressA], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x28 //
+s_load_dword s[sgprAddressA+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x2c //
+s_load_dword s[sgprAddressB], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x30 //
+s_load_dword s[sgprAddressB+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x34 //
+s_load_dword s[sgprAlpha+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x38 //
+s_load_dword s[sgprAlpha+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x3c //
+s_load_dword s[sgprBeta+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x40 //
+s_load_dword s[sgprBeta+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x44 //
+s_load_dword s[sgprStridesD+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x48 //
+s_load_dword s[sgprStridesD+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x4c //
+s_load_dword s[sgprStridesC+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x50 //
+s_load_dword s[sgprStridesC+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x54 //
+s_load_dword s[sgprStridesA+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x58 //
+s_load_dword s[sgprStridesA+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x5c //
+s_load_dword s[sgprStridesB+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x60 //
+s_load_dword s[sgprStridesB+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x64 //
+s_load_dword s[sgprSizesFree+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x68 //
+s_load_dword s[sgprSizesFree+1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x6c //
+s_load_dword s[sgprSizesFree+2], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x70 //
+s_load_dword s[sgprSizesSum+0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x74 //
+s_load_dword s[sgprNumWorkGroups0], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x7c //
+s_load_dword s[sgprNumWorkGroups1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x80 //
+s_load_dword s[sgprNumFullBlocks], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x8c //
+s_load_dword s[sgprWgmRemainder1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x90 //
+s_load_dword s[sgprMagicNumberWgmRemainder1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x94 //
+s_waitcnt lgkmcnt(0)                               // wait for 144 bytes of kern args
+
+
+/******************************************/
+/* Local Read Addresses                   */
+/******************************************/
+
+
+/* local read addresses: tile assignments a */
+
+/*lr0I = serial % SG0I*/
+v_lshrrev_b32 v0, 3, v[vgprSerial]                 // vectorStaticDiv: v0 = v[vgprSerial] / 8
+v_and_b32 v1, 7, v[vgprSerial]                     // vectorStaticDiv: v1 = v[vgprSerial] % 8
+
+
+/* local read addresses: tile assignments b */
+
+/*lr1J = (serial / SG1J) % SG1J*/
+v_lshrrev_b32 v2, 4, v0                            // vectorStaticDiv: v2 = v0 / 16
+v_and_b32 v3, 15, v0                               // vectorStaticDiv: v3 = v0 % 16
+
+
+/* local read addresses: final offsets a */
+
+v_lshrrev_b32 v0, 7, v[vgprSerial]                 // vectorStaticDiv: v0 = v[vgprSerial] / 128
+v_and_b32 v2, 127, v[vgprSerial]                   // vectorStaticDiv: v2 = v[vgprSerial] % 128
+s_mov_b32 s65, 0x30                                // MT0+PAD
+v_mul_lo_u32 v0, s65, v0                           // sgid=sgid*(MT0+PAD)
+v_lshlrev_b32 v1, 1, v1                            // staticMultiply: v1 = v1 * 2
+_v_add_lshl_u32 v[vgprLocalReadAddrA], v0, v1, 0x3 // o = (lroA*VW+sgid*MT0)*bpe
+
+
+/* local read addresses: final offsets b */
+
+v_lshrrev_b32 v0, 7, v[vgprSerial]                 // vectorStaticDiv: v0 = v[vgprSerial] / 128
+v_and_b32 v1, 127, v[vgprSerial]                   // vectorStaticDiv: v1 = v[vgprSerial] % 128
+s_mov_b32 s65, 0x40                                // MT1+PAD
+v_mul_lo_u32 v0, s65, v0                           // sgid=sgid*(MT1+PAD)
+v_lshlrev_b32 v3, 1, v3                            // staticMultiply: v3 = v3 * 2
+_v_add_lshl_u32 v[vgprLocalReadAddrB], v0, v3, 0x3 // o = (lroB*VW+sgid*MT1)*bpe
+
+
+/* local read addresses: declare addresses a */
+
+/* N/A */
+
+
+/* local read addresses: declare addresses b */
+
+_v_add_co_u32 v[vgprLocalReadAddrB+0], vcc, 0x600, v[vgprLocalReadAddrB+0] //  += LdsOffsetB (lower)
+
+
+s_load_dword s[sgprNumWorkGroups1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x80 //
+s_load_dword s[sgprNumFullBlocks], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x8c //
+s_load_dword s[sgprWgmRemainder1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x90 //
+s_load_dword s[sgprMagicNumberWgmRemainder1], s[sgprKernArgAddress:sgprKernArgAddress+1], 0x94 //
+/******************************************/
+/* Global Read Addresses                  */
+/******************************************/
+
+
+/* global read addresses: work-group */
+
+/* graWorkGroup mapping */
+s_mov_b32 s69, 0x10000001L                         // magic number for WGM==4
+s_mul_hi_u32 s67, s[sgprWorkGroup1], s69           // s_magic mul
+s_mul_i32 s66, s[sgprWorkGroup1], s69              // s_magic mul
+s_lshr_b64 s[66:67], s[66:67], 31                  // sMagicDiv
+s_mul_i32 s67, s66, 8                              // quotient * non-magic divisor
+s_sub_u32 s67, s[sgprWorkGroup1], s67              // WorkGroup1=remainder
+s_mul_i32 s67, s67, s[sgprNumWorkGroups0]          // (wg1 % WGM)*nwg0
+s_add_u32 s67, s67, s[sgprWorkGroup0]              // wgSerial = wg0 + (wg1 % WGM)*nwg0
+s_cmp_ge_u32 s66, s[sgprNumFullBlocks]             // blockId >= numFullBlocks ?
+s_cmov_b32 s69, s[sgprMagicNumberWgmRemainder1]    //
+s_cselect_b32 s68, s[sgprWgmRemainder1], 8         //
+s_mul_hi_u32 s3, s67, s69                          // s_magic mul
+s_mul_i32 s2, s67, s69                             // s_magic mul
+s_lshr_b64 s[2:3], s[2:3], 31                      // sMagicDiv
+s_mul_i32 s[sgprWorkGroup1], s[sgprWorkGroup0], s68 // quotient * non-magic divisor
+s_sub_u32 s[sgprWorkGroup1], s67, s[sgprWorkGroup1] // WorkGroup1=remainder
+s_mul_i32 s66, s66, 8                              // blockId * WGM
+s_add_u32 s[sgprWorkGroup1], s[sgprWorkGroup1], s66 // wg1 += blockId * WGM
+
+
+/* global read addresses: tile offset assignment a */
+
+/* LVCA = 24 */
+/* v0 = (local)groA-tile = serial%LVCA (note (wgA*MTA) will be added to SRD) */
+/* v1 = groA-unroll = serial/LVCA */
+s_mov_b32 s65, 0x15555556                          //
+v_mul_hi_u32 v3, v[vgprSerial], s65                //
+v_mul_lo_u32 v2, v[vgprSerial], s65                //
+v_lshrrev_b64 v[2:3], 0x21, v[2:3]                 //
+v_mov_b32 v1, v2                                   // vectorStaticDiv: quotient
+s_mov_b32 s65, 0x18                                // divisor
+v_mul_lo_u32 v2, v1, s65                           // vectorStaticDiv: product = quotient * divisor
+_v_sub_co_u32 v0, vcc, v[vgprSerial], v2           // vectorStaticDiv: remainder = dividend - product
+/* gro-tile *= glvw */
+v_lshlrev_b32 v0, 1, v0                            // staticMultiply: v0 = v0 * 2
+
+
+/* global read addresses: tile offset assignment b */
+
+/* LVCB = 32 */
+/* v2 = (local)groB-tile = serial%LVCB (note (wgB*MTB) will be added to SRD) */
+/* v3 = groB-unroll = serial/LVCB */
+v_lshrrev_b32 v3, 5, v[vgprSerial]                 // vectorStaticDiv: v3 = v[vgprSerial] / 32
+v_and_b32 v2, 31, v[vgprSerial]                    // vectorStaticDiv: v2 = v[vgprSerial] % 32
+/* gro-tile *= glvw */
+v_lshlrev_b32 v2, 1, v2                            // staticMultiply: v2 = v2 * 2
+
+
+/* global read addresses: unroll assignment a */
+
+/* v1 */
+
+
+/* global read addresses: unroll assignment b */
+
+/* v3 */
+
+
+/* global read addresses: other free assignments */
+
+/* s[sgprWorkGroup2] */
+
+
+/* global read addresses: tile offsets a */
+
+v_mov_b32 v4, v0                                   // groA0I_0
+
+
+/* global read addresses: tile offsets b */
+
+v_mov_b32 v5, v2                                   // groB1J_0
+
+
+/* global read addresses: unroll offsets a */
+
+v_mov_b32 v6, v1                                   // groAL_0
+
+
+/* global read addresses: unroll offsets b */
+
+v_mov_b32 v7, v3                                   // groBL_0
+
+
+/* global read addresses: shift a */
+
+s_mul_i32 s65, s[sgprWorkGroup0], 48               // WorkGroup[01] * MT
+s_sub_u32 s65, s[sgprSizesFree+0], s65             // edge = Size0I - WG*MT
+s_sub_u32 s65, s65, 2                              // edge -= margin
+v_mov_b32 v8, s65                                  // edge vgpr = Size0I-2
+_v_add_co_u32 v9, vcc, v8, 2                       // add srdShiftLift
+_v_add_co_u32 v10, vcc, v4, 2                      //
+v_cmp_lt_u32 s[66:67], v10, v9                     // offset < edge
+v_cndmask_b32 v4, v8, v4, s[66:67]                 // offset = (offset < edge) ? offset : edge
+
+
+/* global read addresses: shift b */
+
+s_mul_i32 s65, s[sgprWorkGroup1], 64               // WorkGroup[01] * MT
+s_sub_u32 s65, s[sgprSizesFree+1], s65             // edge = Size1J - WG*MT
+s_sub_u32 s65, s65, 2                              // edge -= margin
+v_mov_b32 v8, s65                                  // edge vgpr = Size1J-2
+_v_add_co_u32 v9, vcc, v8, 2                       // add srdShiftLift
+_v_add_co_u32 v10, vcc, v5, 2                      //
+v_cmp_lt_u32 s[66:67], v10, v9                     // offset < edge
+v_cndmask_b32 v5, v8, v5, s[66:67]                 // offset = (offset < edge) ? offset : edge
+
+
+/* global read addresses: final offsets a */
+
+GLOBAL_OFFSET_A vgprGlobalReadOffsetA+0,  4,  6, 8 // gROA_0_0_0_0
+// Offset only valid for 96/128 threads inside the PerLoadTile
+s_mov_b32 s66, 96                                  //
+v_cmp_lt_u32 vcc, v[vgprSerial], s66               // tid < valid-tid
+s_mov_b32 s66, BufferOOB                           //
+v_mov_b32 v11, s66                                 //
+v_cndmask_b32 v[vgprGlobalReadOffsetA+0], v11, v[vgprGlobalReadOffsetA+0], vcc // Mask load so OOB will return 0
+
+
+/* global read addresses: final offsets b */
+
+GLOBAL_OFFSET_B vgprGlobalReadOffsetB+0,  5,  7, 8 // gROB_0_0_0_0
+
+
+/* global read addresses: addresses a */
+
+/* max read offset = size[n] * stride[n-1] */
+s_mul_hi_u32 s69, s[sgprWorkGroup0], 48            // WorkGroup[01] * MT
+s_mul_i32 s68, s[sgprWorkGroup0], 48               // WorkGroup[01] * MT
+s_sub_u32 s[sgprShadowLimitA+0], s[sgprTensor2dSizeA], s68 // sub tileStart
+s_subb_u32 s[sgprShadowLimitA+1], s[sgprTensor2dSizeA+1], s69 // sub tileStart
+s_lshl_b64 s[sgprShadowLimitA:sgprShadowLimitA+1], s[sgprShadowLimitA:sgprShadowLimitA+1], 0x3 // Set limit to use bytes
+s_add_u32 s[sgprShadowLimitA+0], s[sgprShadowLimitA+0], 16 // extend limit for pre-pad
+s_addc_u32 s[sgprShadowLimitA+1], s[sgprShadowLimitA+1], 0 // extend limit for pre-pad
+s_cmp_eq_u32 s[sgprShadowLimitA+1], 0              // are we within 2^32?
+s_cselect_b32 s[sgprSrdA+2], s[sgprShadowLimitA+0], BufferLimit // Move shadow to real if we are within 2^32
+s_mul_hi_u32 s67, s[sgprStridesA+1], s[sgprWorkGroup2] // Stride*WG
+s_mul_i32 s66, s[sgprStridesA+1], s[sgprWorkGroup2] // Stride*WG
+s_add_u32 s68, s68, s66                            // accum wg term to tilestart
+s_addc_u32 s69, s69, s67                           // accum wg term to tilestart
+s_lshl_b64 s[68:69], s[68:69], 3                   // tileStart *= BPE
+s_add_u32 s[sgprSrdA+0], s[sgprAddressA+0], s68    // SRD base = Address+ tileStart0
+s_addc_u32 s[sgprSrdA+1], s[sgprAddressA+1], s69   // SRD base = Address+ tileStart1
+s_sub_u32 s[sgprSrdA+0], s[sgprSrdA+0], 16         // pre-pad to make room for possible pointer shift
+s_subb_u32 s[sgprSrdA+1], s[sgprSrdA+1], 0         // pre-pad to make room for possible pointer shift
+s_mov_b32 s[sgprSrdA+3], Srd127_96                 // Set bits 127_96 in SRD
+
+
+/* global read addresses: addresses b */
+
+/* max read offset = size[n] * stride[n-1] */
+s_mul_hi_u32 s69, s[sgprWorkGroup1], 64            // WorkGroup[01] * MT
+s_mul_i32 s68, s[sgprWorkGroup1], 64               // WorkGroup[01] * MT
+s_sub_u32 s[sgprShadowLimitB+0], s[sgprTensor2dSizeB], s68 // sub tileStart
+s_subb_u32 s[sgprShadowLimitB+1], s[sgprTensor2dSizeB+1], s69 // sub tileStart
+s_lshl_b64 s[sgprShadowLimitB:sgprShadowLimitB+1], s[sgprShadowLimitB:sgprShadowLimitB+1], 0x3 // Set limit to use bytes
+s_add_u32 s[sgprShadowLimitB+0], s[sgprShadowLimitB+0], 16 // extend limit for pre-pad
+s_addc_u32 s[sgprShadowLimitB+1], s[sgprShadowLimitB+1], 0 // extend limit for pre-pad
+s_cmp_eq_u32 s[sgprShadowLimitB+1], 0              // are we within 2^32?
+s_cselect_b32 s[sgprSrdB+2], s[sgprShadowLimitB+0], BufferLimit // Move shadow to real if we are within 2^32
+s_mul_hi_u32 s67, s[sgprStridesB+1], s[sgprWorkGroup2] // Stride*WG
+s_mul_i32 s66, s[sgprStridesB+1], s[sgprWorkGroup2] // Stride*WG
+s_add_u32 s68, s68, s66                            // accum wg term to tilestart
+s_addc_u32 s69, s69, s67                           // accum wg term to tilestart
+s_lshl_b64 s[68:69], s[68:69], 3                   // tileStart *= BPE
+s_add_u32 s[sgprSrdB+0], s[sgprAddressB+0], s68    // SRD base = Address+ tileStart0
+s_addc_u32 s[sgprSrdB+1], s[sgprAddressB+1], s69   // SRD base = Address+ tileStart1
+s_sub_u32 s[sgprSrdB+0], s[sgprSrdB+0], 16         // pre-pad to make room for possible pointer shift
+s_subb_u32 s[sgprSrdB+1], s[sgprSrdB+1], 0         // pre-pad to make room for possible pointer shift
+s_mov_b32 s[sgprSrdB+3], Srd127_96                 // Set bits 127_96 in SRD
+
+
+/* global read addresses: increments a */
+
+s_mul_i32 s[sgprGlobalReadIncsA+0], 0x20, s[sgprStridesA] // incr = stride*4*bytes
+
+
+/* global read addresses: increments b */
+
+s_mul_i32 s[sgprGlobalReadIncsB+0], 0x20, s[sgprStridesB] // incr = stride*4*bytes
+
+
+/******************************************/
+/* Local Write Addresses                  */
+/******************************************/
+
+
+/* local write addresses: tile assignment a */
+
+/* lwaTileA = v0 */
+
+
+/* local write addresses: tile assignment b */
+
+/* lwaTileB = v2 */
+
+
+/* local write addresses: unroll assignment a */
+
+/* lwaUnrollA = v1 */
+
+
+/* local write addresses: unroll assignment b */
+
+/* lwaUnrollB = v3 */
+
+
+/* local write addresses: first offset a */
+
+v_mul_u32_u24 v[vgprLocalWriteAddrA], 0x30, v1     // lwAL**(MTA + PAD)
+_v_add_lshl_u32 v[vgprLocalWriteAddrA], v0, v[vgprLocalWriteAddrA], 0x3 // lwFOA = (lwAA + lwAL*(MT0I+PAD))*bpe
+s_mov_b32 s65, 96                                  // lsc*lsp=48*4
+v_cmp_lt_u32 vcc, v[vgprSerial], s65               // fractional: ensure tid < global read tile elements
+v_mov_b32 v0, 0xf00000                             //
+v_cndmask_b32 v[vgprLocalWriteAddrA], v0, v[vgprLocalWriteAddrA], vcc // Mask load so out-of-gr-tile bounds returns 0
+
+
+/* local write addresses: first offset b */
+
+v_mul_u32_u24 v[vgprLocalWriteAddrB], 0x40, v3     // lwBL**(MTB + PAD)
+_v_add_lshl_u32 v[vgprLocalWriteAddrB], v2, v[vgprLocalWriteAddrB], 0x3 // lwFOB = (lwBB + lwBL*(MT1J+PAD))*bpe
+_v_add_co_u32 v[vgprLocalWriteAddrB], vcc, 0x600, v[vgprLocalWriteAddrB] // lwFOB = lwB1J + lwBL*MT1J + LDS_OFFSET_B=192*8
+
+
+/* local write addresses: final offsets a */
+
+
+/* N/A */
+
+
+/* local write addresses: final offsets b */
+
+
+/* N/A */
+
+
+/* local write addresses: declare addresses a */
+
+/* N/A */
+
+
+/* local write addresses: declare addresses b */
+
+/* N/A */
+
+
+/* local write addresses: init pointers a */
+
+/* N/A */
+
+
+/* local write addresses: init pointers b */
+
+/* N/A */
+
+
+/* declare loop num iterations */
+
+
+s_lshr_b32 s[sgprLoopCounters+0], s[sgprSizesSum+0], 2 // s[sgprLoopCounters+0] = s[sgprSizesSum+0] / 4
+s_mov_b32 s[sgprOrigLoopCounter], s[sgprLoopCounters+0] // copy loop counter
+s_sub_u32 s[sgprLoopCounters+0], 0x0, s[sgprLoopCounters+0] // counterL = -sizeL
+
+
+/* local read addresses: init pointers a */
+
+
+
+/* local read addresses: init pointers b */
+
+
+
+/* TODO-packed- compare against product of all packed C0 sizes not just SizesFree+0 */
+s_mov_b32 s91, 0x0                                 // STATIC_DIV: divisior=48
+s_mul_i32 s90, 0xaaa, s[sgprSizesFree+0]           // tmp1 = dividend * magic hi
+s_lshl_b64 s[90:91], s[90:91], 0x10                // left shift 16 bits
+s_mul_i32 s82, s[sgprSizesFree+0], 0xaaab          // tmp0 = dividend * magic lo
+s_add_u32 s90, s82, s90                            // add lo
+s_addc_u32 s91, s91, 0x0                           // add hi
+s_lshr_b64 s[90:91], s[90:91], 0x21                // tmp1 = (dividend * magic) << shift
+s_mov_b32 s82, s90                                 // quotient
+s_mul_i32 s90, s82, 0x30                           // quotient*divisor
+s_sub_u32 s[sgprEdgeSelMask0], s[sgprSizesFree+0], s90             // rReg = dividend - quotient*divisor
+s_lshr_b32 s82, s[sgprSizesFree+1], 6              // s58 = s[sgprSizesFree+1] / 64
+s_and_b32 s[sgprEdgeSelMask1], 63, s[sgprSizesFree+1]
+
+
+/* prefetch: global -> local */
+
+s_cmp_eq_u32 s[sgprLoopCounters+0], 0x0            // numIter0I == 0
+s_cbranch_scc1 label_0008                          // skip to ShadowInitStart iter b/c numIter==0
+
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+
+
+/* global read inc A */
+s_add_u32  s[sgprSrdA+0], s[sgprSrdA+0], s[sgprGlobalReadIncsA] // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdA+1], s[sgprSrdA+1], 0        // gra SRD += inc(upper)
+s_sub_u32 s[sgprShadowLimitA+0], s[sgprShadowLimitA+0], s[sgprGlobalReadIncsA] // limit -= inc)
+s_subb_u32 s[sgprShadowLimitA+1], s[sgprShadowLimitA+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitA+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdA+2], s[sgprShadowLimitA+0]    // Move shadow to real if we are within 2^32
+
+
+/* global read inc B */
+s_add_u32  s[sgprSrdB+0], s[sgprSrdB+0], s[sgprGlobalReadIncsB] // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdB+1], s[sgprSrdB+1], 0        // gra SRD += inc(upper)
+s_sub_u32 s[sgprShadowLimitB+0], s[sgprShadowLimitB+0], s[sgprGlobalReadIncsB] // limit -= inc)
+s_subb_u32 s[sgprShadowLimitB+1], s[sgprShadowLimitB+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitB+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdB+2], s[sgprShadowLimitB+0]    // Move shadow to real if we are within 2^32
+
+label_0008: // ShadowInitStart
+
+s_mov_b32 s[sgprSrdD+0], s[sgprAddressD+0]         // init SRD base address (lower)
+s_mov_b32 s[sgprSrdD+1], s[sgprAddressD+1]         // init SRD base address (upper) + other fields
+s_mov_b32 s[sgprSrdD+2], 0x80000000                //
+s_mov_b32 s[sgprSrdD+3], Srd127_96                 // Set bits 127_96 in SRD
+s_mov_b32 s[sgprSrdC+0], s[sgprAddressC+0]         // init SRD base address (lower)
+s_mov_b32 s[sgprSrdC+1], s[sgprAddressC+1]         // init SRD base address (upper) + other fields
+s_mov_b32 s[sgprSrdC+2], 0x80000000                //
+s_mov_b32 s[sgprSrdC+3], Srd127_96                 // Set bits 127_96 in SRD
+
+s_mul_i32 s[sgprTMP1], 0x40, s[sgprWorkGroup1]             // <- wg1*MT1
+s_mul_i32 s[sgprTMP0], 0x30, s[sgprWorkGroup1]             // <- wg1*MT1
+s_mul_hi_u32 s67, s[sgprTMP1], s[sgprStridesC+0]           // Scale s68 by Stride
+s_mul_i32 s66, s[sgprTMP1], s[sgprStridesC+0]              // Scale s68 by Stride
+s_lshl_b64 s[66:67], s[66:67], 3                   // scale by bpe
+s_add_u32 s[sgprSrdD+0], s[sgprSrdD+0], s66        // add lo to SRD
+s_addc_u32 s[sgprSrdD+1], s[sgprSrdD+1], s67       // add hi to SRD
+s_add_u32 s[sgprSrdC+0], s[sgprSrdC+0], s66        // add lo to SRD
+s_addc_u32 s[sgprSrdC+1], s[sgprSrdC+1], s67       // add hi to SRD
+
+s_mul_hi_u32 s67, s[sgprWorkGroup2], s[sgprStridesC+1] // Scale s[sgprWorkGroup2] by Stride
+s_mul_i32 s66, s[sgprWorkGroup2], s[sgprStridesC+1] // Scale s[sgprWorkGroup2] by Stride
+s_lshl_b64 s[66:67], s[66:67], 3                   // scale by bpe
+s_add_u32 s[sgprSrdD+0], s[sgprSrdD+0], s66        // add lo to SRD
+s_addc_u32 s[sgprSrdD+1], s[sgprSrdD+1], s67       // add hi to SRD
+s_add_u32 s[sgprSrdC+0], s[sgprSrdC+0], s66        // add lo to SRD
+s_addc_u32 s[sgprSrdC+1], s[sgprSrdC+1], s67       // add hi to SRD
+
+
+v_mov_b32 v[vgprValuC+0], 0x0                      // initC
+v_mov_b32 v[vgprValuC+1], 0x0                      // initC
+v_mov_b32 v[vgprValuC+2], 0x0                      // initC
+v_mov_b32 v[vgprValuC+3], 0x0                      // initC
+v_mov_b32 v[vgprValuC+4], 0x0                      // initC
+v_mov_b32 v[vgprValuC+5], 0x0                      // initC
+v_mov_b32 v[vgprValuC+6], 0x0                      // initC
+v_mov_b32 v[vgprValuC+7], 0x0                      // initC
+v_mov_b32 v[vgprValuC+8], 0x0                      // initC
+v_mov_b32 v[vgprValuC+9], 0x0                      // initC
+v_mov_b32 v[vgprValuC+10], 0x0                     // initC
+v_mov_b32 v[vgprValuC+11], 0x0                     // initC
+v_mov_b32 v[vgprValuC+12], 0x0                     // initC
+v_mov_b32 v[vgprValuC+13], 0x0                     // initC
+v_mov_b32 v[vgprValuC+14], 0x0                     // initC
+v_mov_b32 v[vgprValuC+15], 0x0                     // initC
+v_mov_b32 v[vgprValuC+16], 0x0                     // initC
+v_mov_b32 v[vgprValuC+17], 0x0                     // initC
+v_mov_b32 v[vgprValuC+18], 0x0                     // initC
+v_mov_b32 v[vgprValuC+19], 0x0                     // initC
+v_mov_b32 v[vgprValuC+20], 0x0                     // initC
+v_mov_b32 v[vgprValuC+21], 0x0                     // initC
+v_mov_b32 v[vgprValuC+22], 0x0                     // initC
+v_mov_b32 v[vgprValuC+23], 0x0                     // initC
+v_mov_b32 v[vgprValuC+24], 0x0                     // initC
+v_mov_b32 v[vgprValuC+25], 0x0                     // initC
+v_mov_b32 v[vgprValuC+26], 0x0                     // initC
+v_mov_b32 v[vgprValuC+27], 0x0                     // initC
+v_mov_b32 v[vgprValuC+28], 0x0                     // initC
+v_mov_b32 v[vgprValuC+29], 0x0                     // initC
+v_mov_b32 v[vgprValuC+30], 0x0                     // initC
+v_mov_b32 v[vgprValuC+31], 0x0                     // initC
+v_mov_b32 v[vgprValuC+32], 0x0                     // initC
+v_mov_b32 v[vgprValuC+33], 0x0                     // initC
+v_mov_b32 v[vgprValuC+34], 0x0                     // initC
+v_mov_b32 v[vgprValuC+35], 0x0                     // initC
+v_mov_b32 v[vgprValuC+36], 0x0                     // initC
+v_mov_b32 v[vgprValuC+37], 0x0                     // initC
+v_mov_b32 v[vgprValuC+38], 0x0                     // initC
+v_mov_b32 v[vgprValuC+39], 0x0                     // initC
+v_mov_b32 v[vgprValuC+40], 0x0                     // initC
+v_mov_b32 v[vgprValuC+41], 0x0                     // initC
+v_mov_b32 v[vgprValuC+42], 0x0                     // initC
+v_mov_b32 v[vgprValuC+43], 0x0                     // initC
+v_mov_b32 v[vgprValuC+44], 0x0                     // initC
+v_mov_b32 v[vgprValuC+45], 0x0                     // initC
+v_mov_b32 v[vgprValuC+46], 0x0                     // initC
+v_mov_b32 v[vgprValuC+47], 0x0                     // initC
+s_cmp_eq_u32 s[sgprLoopCounters+0], 0x0            // numIter0I == 0
+s_cbranch_scc1 label_0004                          // after InitC, skip to end of prefetch last iter b/c numIter==0
+
+s_waitcnt vmcnt(0)                                 // 8wait for global read
+
+
+/* local write a */
+
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:0 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 0
+
+
+/* local write b */
+
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:0 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 0
+
+
+/* local write swap a */
+
+
+
+/* local write swap b */
+
+
+
+/* local write init pointers a */
+
+/* N/A */
+
+
+/* local write init pointers b */
+
+/* N/A */
+
+/******************************************/
+/* Unrolled Loop(s) - Begin               */
+/******************************************/
+
+s_cmp_ge_i32 s[sgprLoopCounters+0], 0x0            // LoopCounterL < EndCounter
+s_cbranch_scc1 label_0004                          // don't enter LoopL
+label_0001:
+
+
+/******************************************/
+/* Unroll Loop 1/2 - Begin                */
+/******************************************/
+
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
+s_barrier //4sync for global read
+
+s_cmp_eq_i32 s[sgprLoopCounters+0], -1             // is this the last iteration
+s_cmov_b32 s[sgprSrdA+2], 0                        // Set limit to 0 for last iteration
+s_cmov_b32 s[sgprSrdB+2], 0                        // Set limit to 0 for last iteration
+
+s_waitcnt lgkmcnt(0)                               // 1wait for local write
+
+
+
+
+/* iter 0 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(2)                               // wait for prior local read old=0 new=0
+//MAC_6x4_X0
+MAC_6x4_X0_part_1
+
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:384 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:512 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* global read inc A */
+s_add_u32  s[sgprSrdA+0], s[sgprSrdA+0], s[sgprGlobalReadIncsA] // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdA+1], s[sgprSrdA+1], 0        // gra SRD += inc(upper)
+s_sub_u32 s[sgprShadowLimitA+0], s[sgprShadowLimitA+0], s[sgprGlobalReadIncsA] // limit -= inc)
+s_subb_u32 s[sgprShadowLimitA+1], s[sgprShadowLimitA+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitA+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdA+2], s[sgprShadowLimitA+0]    // Move shadow to real if we are within 2^32
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:640 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(2)                               // wait for prior local read old=0 new=0
+//MAC_6x4_X0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:768 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* global read inc B */
+s_add_u32  s[sgprSrdB+0], s[sgprSrdB+0], s[sgprGlobalReadIncsB] // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdB+1], s[sgprSrdB+1], 0        // gra SRD += inc(upper)
+s_sub_u32 s[sgprShadowLimitB+0], s[sgprShadowLimitB+0], s[sgprGlobalReadIncsB] // limit -= inc)
+s_subb_u32 s[sgprShadowLimitB+1], s[sgprShadowLimitB+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitB+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdB+2], s[sgprShadowLimitB+0]    // Move shadow to real if we are within 2^32
+
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:896 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1024 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 2 writesPerItem=1 */
+s_waitcnt vmcnt(1)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:4096 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 4096
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(3)                               // wait for prior local read old=0 new=0
+//MAC_6x4_X0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(1)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+/* iter 3 (last) */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:1152 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1280 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1408 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 3 writesPerItem=1 */
+s_waitcnt vmcnt(0)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:4096 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 4096
+
+/* local write swap offsets a */
+
+/* local write swap offsets b */
+
+/* local write init pointers a */
+/* N/A */
+
+/* local write init pointers b */
+/* N/A */
+
+/* local read swap offsets a */
+
+/* local read swap internal offset -> 4096 */
+
+/* local read swap offsets b */
+
+/* local read swap internal offset -> 4096 */
+
+/* local read init pointers a */
+
+/* local read init pointers b */
+s_waitcnt lgkmcnt(3)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(1)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0_part_3
+
+/******************************************/
+/* Unrolled Loop - End 1/2                */
+/******************************************/
+
+s_add_u32 s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+s_cmp_eq_i32 s[sgprLoopCounters+0],  -2            // counterL==0
+s_cbranch_scc1 label_0003                          // exit LoopL
+
+
+/******************************************/
+/* Unroll Loop 2/2 - Begin                */
+/******************************************/
+
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
+s_barrier //4sync for global read
+
+s_cmp_eq_i32 s[sgprLoopCounters+0], -1             // is this the last iteration
+s_cmov_b32 s[sgprSrdA+2], 0                        // Set limit to 0 for last iteration
+s_cmov_b32 s[sgprSrdB+2], 0                        // Set limit to 0 for last iteration
+
+s_waitcnt lgkmcnt(0)                               // 1wait for local write
+
+
+
+
+/* iter 0 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4096 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4224 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4352 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(2)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4480 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4608 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* global read inc A */
+s_add_u32  s[sgprSrdA+0], s[sgprSrdA+0], s[sgprGlobalReadIncsA] // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdA+1], s[sgprSrdA+1], 0        // gra SRD += inc(upper)
+s_sub_u32 s[sgprShadowLimitA+0], s[sgprShadowLimitA+0], s[sgprGlobalReadIncsA] // limit -= inc)
+s_subb_u32 s[sgprShadowLimitA+1], s[sgprShadowLimitA+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitA+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdA+2], s[sgprShadowLimitA+0]    // Move shadow to real if we are within 2^32
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4736 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(2)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4864 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* global read inc B */
+s_add_u32  s[sgprSrdB+0], s[sgprSrdB+0], s[sgprGlobalReadIncsB] // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdB+1], s[sgprSrdB+1], 0        // gra SRD += inc(upper)
+s_sub_u32 s[sgprShadowLimitB+0], s[sgprShadowLimitB+0], s[sgprGlobalReadIncsB] // limit -= inc)
+s_subb_u32 s[sgprShadowLimitB+1], s[sgprShadowLimitB+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitB+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdB+2], s[sgprShadowLimitB+0]    // Move shadow to real if we are within 2^32
+
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4992 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5120 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 2 writesPerItem=1 */
+s_waitcnt vmcnt(1)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:0 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 0
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(3)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(1)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:5248 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=192 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=192 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5376 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5504 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 3 writesPerItem=1 */
+s_waitcnt vmcnt(0)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:0 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 0
+
+/* local write swap offsets a */
+
+/* local write swap offsets b */
+
+/* local write init pointers a */
+/* N/A */
+
+/* local write init pointers b */
+/* N/A */
+
+/* local read swap offsets a */
+
+/* local read swap internal offset -> 0 */
+
+/* local read swap offsets b */
+
+/* local read swap internal offset -> 0 */
+
+/* local read init pointers a */
+
+/* local read init pointers b */
+s_waitcnt lgkmcnt(3)                               // 6wait for local read old=3 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(1)                               // 6wait for local read old=1 new=0
+MAC_6x4_X0_part_3
+
+/******************************************/
+/* Unrolled Loop - End 2/2 (final)        */
+/******************************************/
+
+s_add_u32 s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+s_cmp_eq_i32 s[sgprLoopCounters+0], -2              // counterL==0
+s_cbranch_scc0 label_0001                          // restart LoopL
+s_cbranch_scc1 label_0002                          // restart LoopL
+
+label_0003: // unroll loop odditer exit
+
+//check edge Batch calculation needed
+//for Batch edge jump to different beta loop optimization code
+s_add_u32      s83,-0x1, s[sgprNumWorkGroups0]       //
+s_cmp_lt_u32   s[sgprWorkGroup0], s83                // wg0 < nwg0-1
+s_cmov_b32     s[sgprEdgeSelMask0], 0x0
+s_cmpk_gt_u32  s[sgprEdgeSelMask0], 0x0
+s_cbranch_scc1 label_1003                            // wg1 < nwg1-1 so skip rMT1 = Size1 % MT1
+s_add_u32      s83, -0x1, s[sgprNumWorkGroups1]      //
+s_cmp_lt_u32   s[sgprWorkGroup1], s83                // wg1 < nwg1-1
+s_cmov_b32     s[sgprEdgeSelMask1], 0x0
+s_cmpk_gt_u32  s[sgprEdgeSelMask1], 0x0
+s_cbranch_scc1 label_1003                            // wg1 < nwg1-1 so skip rMT1 = Size1 % MT1
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4224 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4480 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4608 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4736 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4864 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4992 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5120 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:0 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 4096
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(1)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:5248 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5376 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5504 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_mul_i32 s56, 0x30, s[sgprWorkGroup0]             // s56 = wg0*MT0
+s_mul_i32 s58, 0x40, s[sgprWorkGroup1]             // s56 = wg0*MT0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 3 writesPerItem=1 */
+s_waitcnt vmcnt(0)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:0 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 4096
+
+s_waitcnt lgkmcnt(1)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0_unprio_0
+v_lshrrev_b32 v[vgprLocalWriteAddrB], 3, v[vgprSerial]                // vectorStaticDiv: v49 = v[vgprSerial] / 8
+v_and_b32 v[vgprLocalWriteAddrA], 7, v[vgprSerial]                    // vectorStaticDiv: v48 = v[vgprSerial] % 8
+v_lshlrev_b32 v[vgprLocalWriteAddrA], 1, v[vgprLocalWriteAddrA]       // staticMultiply: v48 = v48 * 2
+v_lshlrev_b32 v[vgprLocalWriteAddrB], 1, v[vgprLocalWriteAddrB]       // staticMultiply: v49 = v49 * 2
+v_mul_lo_u32 v[vgprGlobalReadOffsetB], v[vgprLocalWriteAddrB], s[sgprStridesC+0]           // rowStart vgpr
+_v_add_co_u32 v[vgprLocalWriteAddrA], vcc, s56, v[vgprLocalWriteAddrA]                   // coord0 = tid0*VW + wg0*MT0
+_v_add_lshl_u32 v[vgprGlobalReadOffsetA], v[vgprGlobalReadOffsetB], v[vgprLocalWriteAddrA], 0x3                 // init cb addr <-  rowStart + coord0, scaled by BPE
+s_setprio 0
+
+s_add_u32       s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+s_cmp_eq_i32    s[sgprLoopCounters+0], -1             // is this the last iteration
+s_cmov_b32 	s[sgprSrdA+2], 0                        // Set limit to 0 for last iteration
+s_cmov_b32 	s[sgprSrdB+2], 0                        // Set limit to 0 for last iteration
+s_mov_b32 	s85, s[sgprSrdC+0]
+s_mov_b32 	s86, s[sgprSrdC+1]
+s_mov_b32       s87, s[sgprSrdD+0]
+s_mov_b32       s88, s[sgprSrdD+1]
+
+
+//s_waitcnt lgkmcnt(0)                               // 1wait for local write
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
+s_barrier //4sync for global read
+
+/* iter 0,1 */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:384 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part1
+
+/* iter 1 */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:768  // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1152 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part1
+
+
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:512 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+0:vgprValuC+0+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+0:vgprValuC+0+1] // *= alpha
+v_mul_f64 v[vgprValuC+2:vgprValuC+2+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+2:vgprValuC+2+1] // *= alpha
+v_fma_f64 v[vgprValuC+0:vgprValuC+0+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+0:vgprValuC+0+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+2:vgprValuC+2+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+2:vgprValuC+2+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[0:3], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+12:vgprValuC+12+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+12:vgprValuC+12+1] // *= alpha
+v_mul_f64 v[vgprValuC+14:vgprValuC+14+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+14:vgprValuC+14+1] // *= alpha
+v_fma_f64 v[vgprValuC+12:vgprValuC+12+1], v[vgprG2LB+0:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+12:vgprValuC+12+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+14:vgprValuC+14+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+14:vgprValuC+14+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[12:15], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part2
+
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:896 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1280 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part2
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:640 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+4:vgprValuC+4+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+4:vgprValuC+4+1] // *= alpha
+v_mul_f64 v[vgprValuC+6:vgprValuC+6+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+6:vgprValuC+6+1] // *= alpha
+v_fma_f64 v[vgprValuC+4:vgprValuC+4+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+4:vgprValuC+4+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+6:vgprValuC+6+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+6:vgprValuC+6+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[4:7], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+16:vgprValuC+16+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+16:vgprValuC+16+1] // *= alpha
+v_mul_f64 v[vgprValuC+18:vgprValuC+18+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+18:vgprValuC+18+1] // *= alpha
+v_fma_f64 v[vgprValuC+16:vgprValuC+16+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+16:vgprValuC+16+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+18:vgprValuC+18+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+18:vgprValuC+18+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[16:19], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part3
+
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1024 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:1408 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part3
+
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:384 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+8:vgprValuC+8+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+8:vgprValuC+8+1] // *= alpha
+v_mul_f64 v[vgprValuC+10:vgprValuC+10+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+10:vgprValuC+10+1] // *= alpha
+v_fma_f64 v[vgprValuC+8:vgprValuC+8+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+8:vgprValuC+8+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+10:vgprValuC+10+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+10:vgprValuC+10+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[8:11], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+20:vgprValuC+20+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+20:vgprValuC+20+1] // *= alpha
+v_mul_f64 v[vgprValuC+22:vgprValuC+22+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+22:vgprValuC+22+1] // *= alpha
+v_fma_f64 v[vgprValuC+20:vgprValuC+20+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+20:vgprValuC+20+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+22:vgprValuC+22+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+22:vgprValuC+22+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[20:23], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_mul_i32  s56, s[sgprStridesC+0], 248              // Scale by BPE
+s_add_u32   s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+s_mov_b32   s85, s[sgprSrdC+0]
+s_mov_b32   s86, s[sgprSrdC+1]                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part4
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:768 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+s_lshl_b32   s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32   s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1152 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part4
+
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+s_mul_i32   s56, s[sgprStridesD+0], 248              // Scale by BPE
+s_add_u32   s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:512 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+24:vgprValuC+24+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+24:vgprValuC+24+1] // *= alpha
+v_mul_f64 v[vgprValuC+26:vgprValuC+26+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+26:vgprValuC+26+1] // *= alpha
+v_fma_f64 v[vgprValuC+24:vgprValuC+24+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+24:vgprValuC+24+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+26:vgprValuC+26+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+26:vgprValuC+26+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[24:27], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_mov_b32       s87, s[sgprSrdD+0]
+s_mov_b32       s88, s[sgprSrdD+1]                 /* local read init pointers b */
+s_lshl_b32      s56, s[sgprStridesD+0], 3         // Scale     s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_add_u32       s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32      s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+36:vgprValuC+36+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+36:vgprValuC+36+1] // *= alpha
+v_mul_f64 v[vgprValuC+38:vgprValuC+38+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+38:vgprValuC+38+1] // *= alpha
+v_fma_f64 v[vgprValuC+36:vgprValuC+36+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+36:vgprValuC+36+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+38:vgprValuC+38+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+38:vgprValuC+38+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[36:39], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0_part5
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:896 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1280 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part5
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:640 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+28:vgprValuC+28+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+28:vgprValuC+28+1] // *= alpha
+v_mul_f64 v[vgprValuC+30:vgprValuC+30+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+30:vgprValuC+30+1] // *= alpha
+v_fma_f64 v[vgprValuC+28:vgprValuC+28+1], v[vgprG2LA+0:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+28:vgprValuC+28+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+30:vgprValuC+30+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+30:vgprValuC+30+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[28:31], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+40:vgprValuC+40+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+40:vgprValuC+40+1] // *= alpha
+v_mul_f64 v[vgprValuC+42:vgprValuC+42+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+42:vgprValuC+42+1] // *= alpha
+v_fma_f64 v[vgprValuC+40:vgprValuC+40+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+40:vgprValuC+40+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+42:vgprValuC+42+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+42:vgprValuC+42+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[40:43], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part6
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1024 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1408 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part6
+
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+32:vgprValuC+32+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+32:vgprValuC+32+1] // *= alpha
+v_mul_f64 v[vgprValuC+34:vgprValuC+34+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+34:vgprValuC+34+1] // *= alpha
+v_fma_f64 v[vgprValuC+32:vgprValuC+32+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+32:vgprValuC+32+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+34:vgprValuC+34+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+34:vgprValuC+34+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[32:35], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_lshl_b32  s56, 	   s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32   s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+
+v_mul_f64 v[vgprValuC+44:vgprValuC+44+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+44:vgprValuC+44+1] // *= alpha
+v_mul_f64 v[vgprValuC+46:vgprValuC+46+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+46:vgprValuC+46+1] // *= alpha
+v_fma_f64 v[vgprValuC+44:vgprValuC+44+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+44:vgprValuC+44+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+46:vgprValuC+46+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+46:vgprValuC+46+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[44:47], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_add_u32            s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+
+
+s_endpgm
+
+label_0002:
+
+/* TODO-packed- compare against product of all packed C0 sizes not just SizesFree+0 */
+//s_mov_b32 s91, 0x0                                 // STATIC_DIV: divisior=48
+//s_mul_i32 s90, 0xaaa, s[sgprSizesFree+0]           // tmp1 = dividend * magic hi
+//s_lshl_b64 s[90:91], s[90:91], 0x10                // left shift 16 bits
+//s_mul_i32 s82, s[sgprSizesFree+0], 0xaaab          // tmp0 = dividend * magic lo
+//s_add_u32 s90, s82, s90                            // add lo
+//s_addc_u32 s91, s91, 0x0                           // add hi
+//s_lshr_b64 s[90:91], s[90:91], 0x21                // tmp1 = (dividend * magic) << shift
+//s_mov_b32 s82, s90                                 // quotient
+//s_mul_i32 s90, s82, 0x30                           // quotient*divisor
+//s_sub_u32 s[sgprEdgeSelMask0], s[sgprSizesFree+0], s90             // rReg = dividend - quotient*divisor
+//s_lshr_b32 s82, s[sgprSizesFree+1], 6              // s58 = s[sgprSizesFree+1] / 64
+//s_and_b32 s[sgprEdgeSelMask1], 63, s[sgprSizesFree+1]
+
+//check edge Batch calculation needed
+//for Batch edge jump to different beta loop optimization code
+s_add_u32      s83,-0x1, s[sgprNumWorkGroups0]       //
+s_cmp_lt_u32   s[sgprWorkGroup0], s83                // wg0 < nwg0-1
+s_cmov_b32     s[sgprEdgeSelMask0], 0x0
+s_cmpk_gt_u32  s[sgprEdgeSelMask0], 0x0
+s_cbranch_scc1 label_1002                            // wg1 < nwg1-1 so skip rMT1 = Size1 % MT1
+s_add_u32      s83, -0x1, s[sgprNumWorkGroups1]      //
+s_cmp_lt_u32   s[sgprWorkGroup1], s83                // wg1 < nwg1-1
+s_cmov_b32     s[sgprEdgeSelMask1], 0x0
+s_cmpk_gt_u32  s[sgprEdgeSelMask1], 0x0
+s_cbranch_scc1 label_1002                            // wg1 < nwg1-1 so skip rMT1 = Size1 % MT1
+
+/******************************************/
+
+//s_waitcnt lgkmcnt(0)                                 // 1wait for local write
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
+s_barrier //4sync for global read
+
+/* iter 0 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(2)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:384 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:512 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:640 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(2)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:768 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:896 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1024 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:4096 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 4096
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(3)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_1
+s_waitcnt lgkmcnt(1)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part_3
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:1152 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1280 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+s_mul_i32 s56, 0x30, s[sgprWorkGroup0]             // s56 = wg0*MT0
+s_mul_i32 s58, 0x40, s[sgprWorkGroup1]             // s56 = wg0*MT0
+/* sched write - iter 3 writesPerItem=1 */
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1408 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(0)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:4096 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 4096
+
+s_waitcnt lgkmcnt(1)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0_unprio_0
+v_lshrrev_b32 v[vgprLocalWriteAddrB], 3, v[vgprSerial]                // vectorStaticDiv: v49 = v[vgprSerial] / 8
+v_and_b32 v[vgprLocalWriteAddrA], 7, v[vgprSerial]                    // vectorStaticDiv: v48 = v[vgprSerial] % 8
+v_lshlrev_b32 v[vgprLocalWriteAddrA], 1, v[vgprLocalWriteAddrA]       // staticMultiply: v48 = v48 * 2
+v_lshlrev_b32 v[vgprLocalWriteAddrB], 1, v[vgprLocalWriteAddrB]       // staticMultiply: v49 = v49 * 2
+v_mul_lo_u32 v[vgprGlobalReadOffsetB], v[vgprLocalWriteAddrB], s[sgprStridesC+0]           // rowStart vgpr
+_v_add_co_u32 v[vgprLocalWriteAddrA], vcc, s56, v[vgprLocalWriteAddrA]                   // coord0 = tid0*VW + wg0*MT0
+_v_add_lshl_u32 v[vgprGlobalReadOffsetA], v[vgprGlobalReadOffsetB], v[vgprLocalWriteAddrA], 0x3                 // init cb addr <-  rowStart + coord0, scaled by BPE
+s_setprio 0
+
+s_add_u32       s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+s_cmp_eq_i32    s[sgprLoopCounters+0], -1             // is this the last iteration
+s_cmov_b32 	s[sgprSrdA+2], 0                        // Set limit to 0 for last iteration
+s_cmov_b32 	s[sgprSrdB+2], 0                        // Set limit to 0 for last iteration
+s_mov_b32 	s85, s[sgprSrdC+0]
+s_mov_b32 	s86, s[sgprSrdC+1]
+s_mov_b32       s87, s[sgprSrdD+0]
+s_mov_b32       s88, s[sgprSrdD+1]
+
+
+//s_waitcnt lgkmcnt(0)                               // 1wait for local write
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
+s_barrier //4sync for global read
+
+/* iter 0,1 */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4480 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part1
+
+/* iter 1 */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4864 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5248 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0_part1
+
+
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4224 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4608 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+0:vgprValuC+0+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+0:vgprValuC+0+1] // *= alpha
+v_mul_f64 v[vgprValuC+2:vgprValuC+2+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+2:vgprValuC+2+1] // *= alpha
+v_fma_f64 v[vgprValuC+0:vgprValuC+0+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+0:vgprValuC+0+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+2:vgprValuC+2+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+2:vgprValuC+2+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[0:3], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+12:vgprValuC+12+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+12:vgprValuC+12+1] // *= alpha
+v_mul_f64 v[vgprValuC+14:vgprValuC+14+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+14:vgprValuC+14+1] // *= alpha
+v_fma_f64 v[vgprValuC+12:vgprValuC+12+1], v[vgprG2LB+0:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+12:vgprValuC+12+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+14:vgprValuC+14+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+14:vgprValuC+14+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[12:15], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part2
+
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4992 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5376 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part2
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4736 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+4:vgprValuC+4+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+4:vgprValuC+4+1] // *= alpha
+v_mul_f64 v[vgprValuC+6:vgprValuC+6+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+6:vgprValuC+6+1] // *= alpha
+v_fma_f64 v[vgprValuC+4:vgprValuC+4+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+4:vgprValuC+4+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+6:vgprValuC+6+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+6:vgprValuC+6+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[4:7], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+16:vgprValuC+16+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+16:vgprValuC+16+1] // *= alpha
+v_mul_f64 v[vgprValuC+18:vgprValuC+18+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+18:vgprValuC+18+1] // *= alpha
+v_fma_f64 v[vgprValuC+16:vgprValuC+16+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+16:vgprValuC+16+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+18:vgprValuC+18+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+18:vgprValuC+18+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[16:19], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part3
+
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5120 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:5504 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part3
+
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4096 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4480 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+8:vgprValuC+8+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+8:vgprValuC+8+1] // *= alpha
+v_mul_f64 v[vgprValuC+10:vgprValuC+10+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+10:vgprValuC+10+1] // *= alpha
+v_fma_f64 v[vgprValuC+8:vgprValuC+8+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+8:vgprValuC+8+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+10:vgprValuC+10+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+10:vgprValuC+10+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[8:11], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+20:vgprValuC+20+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+20:vgprValuC+20+1] // *= alpha
+v_mul_f64 v[vgprValuC+22:vgprValuC+22+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+22:vgprValuC+22+1] // *= alpha
+v_fma_f64 v[vgprValuC+20:vgprValuC+20+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+20:vgprValuC+20+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+22:vgprValuC+22+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+22:vgprValuC+22+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[20:23], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_mul_i32  s56, s[sgprStridesC+0], 248              // Scale by BPE
+s_add_u32   s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+s_mov_b32   s85, s[sgprSrdC+0]
+s_mov_b32   s86, s[sgprSrdC+1]                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part4
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4864 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+s_lshl_b32   s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32   s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5248 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part4
+
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4224 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+s_mul_i32   s56, s[sgprStridesD+0], 248              // Scale by BPE
+s_add_u32   s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4608 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+24:vgprValuC+24+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+24:vgprValuC+24+1] // *= alpha
+v_mul_f64 v[vgprValuC+26:vgprValuC+26+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+26:vgprValuC+26+1] // *= alpha
+v_fma_f64 v[vgprValuC+24:vgprValuC+24+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+24:vgprValuC+24+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+26:vgprValuC+26+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+26:vgprValuC+26+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[24:27], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_mov_b32       s87, s[sgprSrdD+0]
+s_mov_b32       s88, s[sgprSrdD+1]                 /* local read init pointers b */
+s_lshl_b32      s56, s[sgprStridesD+0], 3         // Scale     s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_add_u32       s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32      s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+36:vgprValuC+36+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+36:vgprValuC+36+1] // *= alpha
+v_mul_f64 v[vgprValuC+38:vgprValuC+38+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+38:vgprValuC+38+1] // *= alpha
+v_fma_f64 v[vgprValuC+36:vgprValuC+36+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+36:vgprValuC+36+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+38:vgprValuC+38+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+38:vgprValuC+38+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[36:39], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0_part5
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4992 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5376 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part5
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4736 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+28:vgprValuC+28+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+28:vgprValuC+28+1] // *= alpha
+v_mul_f64 v[vgprValuC+30:vgprValuC+30+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+30:vgprValuC+30+1] // *= alpha
+v_fma_f64 v[vgprValuC+28:vgprValuC+28+1], v[vgprG2LA+0:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+28:vgprValuC+28+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+30:vgprValuC+30+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+30:vgprValuC+30+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[28:31], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+40:vgprValuC+40+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+40:vgprValuC+40+1] // *= alpha
+v_mul_f64 v[vgprValuC+42:vgprValuC+42+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+42:vgprValuC+42+1] // *= alpha
+v_fma_f64 v[vgprValuC+40:vgprValuC+40+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+40:vgprValuC+40+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+42:vgprValuC+42+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+42:vgprValuC+42+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[40:43], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_mov_b32       s[sgprSrdC+0], s85
+s_mov_b32       s[sgprSrdC+1], s86                 /* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part6
+
+/* local read b */
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5120 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA:vgprG2LA+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5504 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+
+MAC_6x4_X0_part6
+
+s_mov_b32       s[sgprSrdD+0], s87
+s_mov_b32       s[sgprSrdD+1], s88
+buffer_load_dwordx4 v[vgprG2LB:vgprG2LB+3], v[vgprGlobalReadOffsetA], s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+s_waitcnt vmcnt(1)
+
+v_mul_f64 v[vgprValuC+32:vgprValuC+32+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+32:vgprValuC+32+1] // *= alpha
+v_mul_f64 v[vgprValuC+34:vgprValuC+34+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+34:vgprValuC+34+1] // *= alpha
+v_fma_f64 v[vgprValuC+32:vgprValuC+32+1], v[vgprG2LA:vgprG2LA+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+32:vgprValuC+32+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+34:vgprValuC+34+1], v[vgprG2LA+2:vgprG2LA+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+34:vgprValuC+34+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[32:35], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_lshl_b32  s56, 	   s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32   s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+s_waitcnt vmcnt(1)
+
+
+v_mul_f64 v[vgprValuC+44:vgprValuC+44+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+44:vgprValuC+44+1] // *= alpha
+v_mul_f64 v[vgprValuC+46:vgprValuC+46+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+46:vgprValuC+46+1] // *= alpha
+v_fma_f64 v[vgprValuC+44:vgprValuC+44+1], v[vgprG2LB:vgprG2LB+1], s[sgprBeta:sgprBeta+1], v[vgprValuC+44:vgprValuC+44+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+46:vgprValuC+46+1], v[vgprG2LB+2:vgprG2LB+3], s[sgprBeta:sgprBeta+1], v[vgprValuC+46:vgprValuC+46+1] // finalSum = sum*alpha + C*beta
+
+buffer_store_dwordx4 v[44:47], v[vgprGlobalReadOffsetA], s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_add_u32            s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+
+
+s_endpgm
+
+label_1002:
+
+/******************************************/
+//branch logic gets executed for edge MT to use legacy alph_beta code
+
+//s_waitcnt lgkmcnt(0)                                 // 1wait for local write
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
+s_barrier //4sync for global read
+
+/* iter 0 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:384 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:512 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:640 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:768 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:896 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt vmcnt(1)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:4096 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 4096
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1024 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:1152 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1280 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 3 writesPerItem=1 */
+s_waitcnt vmcnt(0)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:4096 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 4096
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1408 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0
+
+
+//s_waitcnt lgkmcnt(0)                               // 1wait for local write
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
+s_barrier //4sync for global read
+
+
+/* iter 0 */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4096 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4224 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4352 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4480 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4608 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4736 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4864 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4992 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5120 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:5248 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5376 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5504 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=192 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=192 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0
+s_add_u32 s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+
+s_branch label_0004
+
+label_1003:
+
+//s_waitcnt lgkmcnt(0)                               // 1wait for local write
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
+s_barrier //4sync for global read
+
+
+/* iter 0 */
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4096 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4224 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+buffer_load_dwordx4 v[vgprG2LA+0:vgprG2LA+0+3], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // G -> Reg 0_0_0_0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4352 // L -> Reg lro=0 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4096 // L -> Reg lro=0 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4352 // L -> Reg lro=0 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4480 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4608 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:4736 // L -> Reg lro=48 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:4608 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:4864 // L -> Reg lro=64 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:4864 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:4992 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* sched write - iter 2 writesPerItem=1 */
+s_waitcnt vmcnt(1)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:0 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5120 // L -> Reg lro=96 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5120 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5376 // L -> Reg lro=128 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:5248 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:5376 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+/* sched write - iter 3 writesPerItem=1 */
+s_waitcnt vmcnt(0)                                 // wait for global read before writing to local
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:0 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:5504 // L -> Reg lro=144 swapByteOffset=4096 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:5632 // L -> Reg lro=192 swapByteOffset=4096 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:5888 // L -> Reg lro=192 swapByteOffset=4096 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+
+/* local read init pointers b */
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0
+
+s_add_u32 s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+s_cmp_eq_i32 s[sgprLoopCounters+0], -1             // is this the last iteration
+s_cmov_b32 s[sgprSrdA+2], 0                        // Set limit to 0 for last iteration
+s_cmov_b32 s[sgprSrdB+2], 0                        // Set limit to 0 for last iteration
+
+//s_waitcnt lgkmcnt(0)                               // 1wait for local write
+
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
+s_barrier //4sync for global read
+
+/* iter 0 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->48 */
+
+/* local read increment b */
+/* N/A, lro->64 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 1 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:384 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:512 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:640 // L -> Reg lro=48 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:512 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:768 // L -> Reg lro=64 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->96 */
+
+/* local read increment b */
+/* N/A, lro->128 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+/* iter 2 */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:768 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:896 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1024 // L -> Reg lro=96 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1024 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1280 // L -> Reg lro=128 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read increment a */
+/* N/A, lro->144 */
+
+/* local read increment b */
+/* N/A, lro->192 */
+s_waitcnt lgkmcnt(0)                               // wait for prior local read old=0 new=0
+MAC_6x4_X0
+
+
+
+/* iter 3 (last) */
+
+
+/* local read a */
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:1152 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:1280 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:1408 // L -> Reg lro=144 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+/* local read b */
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:1536 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:1792 // L -> Reg lro=192 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2 new=0
+MAC_6x4_X0
+s_add_u32 s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+
+label_0004:
+
+
+/******************************************/
+/* Tail Loop                              */
+/******************************************/
+
+
+/* local write reset offsets a */
+
+
+
+/* local write reset offsets b */
+
+
+
+s_cmp_eq_u32 s[sgprOrigLoopCounter], 0             // completely skipped unroll loop?
+s_cselect_b32 s66, 0, s[sgprGlobalReadIncsA]       // force to 0?
+s_cselect_b32 s67, 0, s[sgprGlobalReadIncsB]       // force to 0?
+s_sub_u32  s[sgprSrdA+0], s[sgprSrdA+0], s66       // gra SRD -= inc(lower)
+s_subb_u32  s[sgprSrdA+1], s[sgprSrdA+1], 0        // gra SRD -= inc(upper)
+s_add_u32 s[sgprShadowLimitA+0], s[sgprShadowLimitA+0], s66 // limit -= inc)
+s_addc_u32 s[sgprShadowLimitA+1], s[sgprShadowLimitA+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitA+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdA+2], s[sgprShadowLimitA+0]    // Move shadow to real if we are within 2^32
+
+s_sub_u32  s[sgprSrdB+0], s[sgprSrdB+0], s67       // gra SRD -= inc(lower)
+s_subb_u32  s[sgprSrdB+1], s[sgprSrdB+1], 0        // gra SRD -= inc(upper)
+s_add_u32 s[sgprShadowLimitB+0], s[sgprShadowLimitB+0], s67 // limit -= inc)
+s_addc_u32 s[sgprShadowLimitB+1], s[sgprShadowLimitB+1], 0 // limit -= inc)
+s_cmp_eq_u32 s[sgprShadowLimitB+1], 0              // are we within 2^32?
+s_cmov_b32 s[sgprSrdB+2], s[sgprShadowLimitB+0]    // Move shadow to real if we are within 2^32
+
+//numIterL = (((sizeL % LOCAL_DEPTHU) + LOCAL_SPLITU - 1) / LOCAL_SPLITU)
+s_lshr_b32 s66, s[sgprSizesSum+0], 2               // s66 = s[sgprSizesSum+0] / 4
+s_and_b32 s[sgprLoopCounters+0], 3, s[sgprSizesSum+0] // s[sgprLoopCounters+0] = s[sgprSizesSum+0] % 4
+s_cmp_eq_u32 s[sgprLoopCounters+0], 0x0            // numIterL == 0
+s_cbranch_scc1 label_0006                          // skip to end of tail loop b/c numIter==0
+s_sub_u32 s[sgprLoopCounters+0], 0x0, s[sgprLoopCounters+0] // counterL = -sizeL
+
+
+/* global read a */
+
+/* g2l=0, load component 0 */
+buffer_load_dwordx2 v[vgprG2LA+0+0:vgprG2LA+0+0+1], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:0 // load one buffer value
+/* g2l=0, load component 1 */
+buffer_load_dwordx2 v[vgprG2LA+0+2:vgprG2LA+0+2+1], v[vgprGlobalReadOffsetA+0], s[sgprSrdA:sgprSrdA+3], 0, offen offset:8 // load one buffer value
+_v_add_co_u32 v[vgprGlobalReadOffsetA+0], vcc, v[vgprGlobalReadOffsetA+0], 8 // graOffset += 1 * bpe
+
+
+/* global read b */
+
+/* g2l=0, load component 0 */
+buffer_load_dwordx2 v[vgprG2LB+0+0:vgprG2LB+0+0+1], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:0 // load one buffer value
+/* g2l=0, load component 1 */
+buffer_load_dwordx2 v[vgprG2LB+0+2:vgprG2LB+0+2+1], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:8 // load one buffer value
+_v_add_co_u32 v[vgprGlobalReadOffsetB+0], vcc, v[vgprGlobalReadOffsetB+0], 8 // graOffset += 1 * bpe
+
+//s_waitcnt vmcnt(0)                                 // 2wait for global read
+
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
+s_barrier //
+
+/* local write init pointers a */
+
+/* N/A */
+
+
+/* local write init pointers b */
+
+/* N/A */
+
+
+/* local write a */
+
+ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:0 // lwoA_0_0_0_0 = (0*LSCA) + (0*LSPA)(*MT0I+PAD) = 0
+
+
+/* local write b */
+
+ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:0 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 0
+
+//s_waitcnt lgkmcnt(0)                               // 5wait for local write
+
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
+s_barrier //
+
+
+/* local read reset offsets a */
+
+/* handled internally */
+v_and_b32 v[vgprLocalReadAddrA], 0xfff, v[vgprLocalReadAddrA] // reset Red,Blk -> Red
+
+
+/* local read reset offsets b */
+
+/* handled internally */
+v_and_b32 v[vgprLocalReadAddrB], 0xfff, v[vgprLocalReadAddrB] // reset Red,Blk -> Red
+
+
+/* local read init pointers a */
+
+
+
+/* local read init pointers b */
+
+
+
+/* tail loop: macs */
+
+s_cmp_ge_i32 s[sgprLoopCounters+0], 0x0            // LoopCounterL < EndCounter
+s_cbranch_scc1 label_0006                          // don't enter LoopL
+s_mov_b32 s[sgprOrigLoopCounter], 0                // repurpose to count each localRead increment
+label_0005:
+
+
+/* local read a */
+
+ds_read_b128 v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+3], v[vgprLocalReadAddrA] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+4:vgprValuA_X0_I0+4+3], v[vgprLocalReadAddrA] offset:128 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuA_X0_I0+8:vgprValuA_X0_I0+8+3], v[vgprLocalReadAddrA] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=8 vIdx=2 rIdx=0 oIdx=0 buffer=0 iui=0
+
+
+/* local read b */
+
+ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
+ds_read_b128 v[vgprValuB_X0_I0+4:vgprValuB_X0_I0+4+3], v[vgprLocalReadAddrB] offset:256 // L -> Reg lro=0 swapByteOffset=0 ti=16 vIdx=1 rIdx=0 oIdx=0 buffer=0 iui=0
+
+
+/* local read inc a */
+
+s_mov_b32 s65, 0x180                               // inc
+_v_add_co_u32 v[vgprLocalReadAddrA], vcc, s65, v[vgprLocalReadAddrA] // lrA += 384 (LSU*(MT+PAD)*bpe)
+
+
+/* local read inc b */
+
+s_mov_b32 s65, 0x200                               // inc
+_v_add_co_u32 v[vgprLocalReadAddrB], vcc, s65, v[vgprLocalReadAddrB] // lrB += 512 (LSU*(MT+PAD)*bpe)
+
+s_waitcnt lgkmcnt(0)                               // 4wait for local read
+
+MAC_6x4_X0
+s_add_u32 s[sgprLoopCounters+0], s[sgprLoopCounters+0], 0x1 // inc counterL
+s_add_u32 s[sgprOrigLoopCounter], s[sgprOrigLoopCounter], 0x1 // inc counterL
+s_cmp_eq_i32 s[sgprLoopCounters+0], 0x0            // counterL==0
+s_cbranch_scc0 label_0005                          // restart LoopL
+label_0006:
+
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // wait for all summation activity
+
+
+/* shift vector components d0 */
+
+v_mov_b32 v50, s[sgprWorkGroup0]                   //
+v_mul_i32_i24 v50, -0x30, v50                      // wg*MT
+_v_add_co_u32 v50, vcc, s[sgprSizesFree+0], v50    // wgMT = Size - wg*MT
+v_mov_b32 v48, 0x30                                // MT
+v_cmp_lt_u32 s[56:57], v50, v48                    // wgMT < MT
+v_cndmask_b32 v50, v48, v50, s[56:57]              // wgMT = (wgMT < MT) ? wgMT : MT
+v_lshrrev_b32 v52, 1, v50                          // vectorStaticDiv: v52 = v50 / 2
+v_and_b32 v53, 1, v50                              // vectorStaticDiv: v53 = v50 % 2
+v_lshrrev_b32 v54, 3, v52                          // vectorStaticDiv: v54 = v52 / 8
+v_and_b32 v55, 7, v52                              // vectorStaticDiv: v55 = v52 % 8
+v_and_b32 v56, 7, v[vgprSerial]                    // vectorStaticDiv: v56 = v[vgprSerial] % 8
+v_lshrrev_b32 v57, 4, v50                          // vectorStaticDiv: v57 = v50 / 16
+v_and_b32 v58, 1, v50                              // vectorStaticDiv: v58 = v50 % 2
+v_mov_b32 v59, v58                                 // duplicate
+v_lshrrev_b32 v58, 1, v59                          // vectorStaticDiv: v58 = v59 / 2
+_v_add_co_u32 v58, vcc, v57, v58                   // vId = 2 components
+v_cmp_eq_u32 s[56:57], v56, v55                    // mask
+v_mov_b32 v48, s56                                 //
+v_mov_b32 v49, s57                                 //
+v_cmp_eq_u32 vcc, v53, 0x1                         // wgMT%VW == 1
+s_cbranch_vccnz label_0010                         // shift d0 r=1
+s_branch label_0014                                // no shifting
+
+/******************************************/
+/* shift d0 r=1                           */
+/******************************************/
+label_0010:
+v_cmp_eq_u32 vcc, v58, 0x0                         // wgMT/(SG*VW) == 0
+s_cbranch_vccnz label_0011                         // shift d0, r=1, v=0
+v_cmp_eq_u32 vcc, v58, 0x1                         // wgMT/(SG*VW) == 1
+s_cbranch_vccnz label_0012                         // shift d0, r=1, v=1
+v_cmp_eq_u32 vcc, v58, 0x2                         // wgMT/(SG*VW) == 2
+s_cbranch_vccnz label_0013                         // shift d0, r=1, v=2
+
+/* shift d0 r=1 v=0 */
+label_0011:
+v_cmpx_eq_u32 s[56:57], v56, v55                   // serial % SG == (wgMT/VECTOR_WIDTH)%SG
+// src=1, dst=0
+v_mov_b32 v0, v2                                   // rC[0+0*VW+0*TT0I] = rC[1+0*VW+0*TT0I]
+v_mov_b32 v1, v3                                   // rC[0+0*VW+0*TT0I] = rC[1+0*VW+0*TT0I]
+// src=7, dst=6
+v_mov_b32 v12, v14                                 // rC[0+0*VW+1*TT0I] = rC[1+0*VW+1*TT0I]
+v_mov_b32 v13, v15                                 // rC[0+0*VW+1*TT0I] = rC[1+0*VW+1*TT0I]
+// src=13, dst=12
+v_mov_b32 v24, v26                                 // rC[0+0*VW+2*TT0I] = rC[1+0*VW+2*TT0I]
+v_mov_b32 v25, v27                                 // rC[0+0*VW+2*TT0I] = rC[1+0*VW+2*TT0I]
+// src=19, dst=18
+v_mov_b32 v36, v38                                 // rC[0+0*VW+3*TT0I] = rC[1+0*VW+3*TT0I]
+v_mov_b32 v37, v39                                 // rC[0+0*VW+3*TT0I] = rC[1+0*VW+3*TT0I]
+s_mov_b64 s[56:57], 0xFFFFFFFFFFFFFFFF             // to restore all threads active
+s_or_saveexec_b64 vcc, s[56:57]                    // all threads active
+s_branch label_0014                                // done shifting
+
+/* shift d0 r=1 v=1 */
+label_0012:
+v_cmpx_eq_u32 s[56:57], v56, v55                   // serial % SG == (wgMT/VECTOR_WIDTH)%SG
+// src=3, dst=2
+v_mov_b32 v4, v6                                   // rC[0+1*VW+0*TT0I] = rC[1+1*VW+0*TT0I]
+v_mov_b32 v5, v7                                   // rC[0+1*VW+0*TT0I] = rC[1+1*VW+0*TT0I]
+// src=9, dst=8
+v_mov_b32 v16, v18                                 // rC[0+1*VW+1*TT0I] = rC[1+1*VW+1*TT0I]
+v_mov_b32 v17, v19                                 // rC[0+1*VW+1*TT0I] = rC[1+1*VW+1*TT0I]
+// src=15, dst=14
+v_mov_b32 v28, v30                                 // rC[0+1*VW+2*TT0I] = rC[1+1*VW+2*TT0I]
+v_mov_b32 v29, v31                                 // rC[0+1*VW+2*TT0I] = rC[1+1*VW+2*TT0I]
+// src=21, dst=20
+v_mov_b32 v40, v42                                 // rC[0+1*VW+3*TT0I] = rC[1+1*VW+3*TT0I]
+v_mov_b32 v41, v43                                 // rC[0+1*VW+3*TT0I] = rC[1+1*VW+3*TT0I]
+s_mov_b64 s[56:57], 0xFFFFFFFFFFFFFFFF             // to restore all threads active
+s_or_saveexec_b64 vcc, s[56:57]                    // all threads active
+s_branch label_0014                                // done shifting
+
+/* shift d0 r=1 v=2 */
+label_0013:
+v_cmpx_eq_u32 s[56:57], v56, v55                   // serial % SG == (wgMT/VECTOR_WIDTH)%SG
+// src=5, dst=4
+v_mov_b32 v8, v10                                  // rC[0+2*VW+0*TT0I] = rC[1+2*VW+0*TT0I]
+v_mov_b32 v9, v11                                  // rC[0+2*VW+0*TT0I] = rC[1+2*VW+0*TT0I]
+// src=11, dst=10
+v_mov_b32 v20, v22                                 // rC[0+2*VW+1*TT0I] = rC[1+2*VW+1*TT0I]
+v_mov_b32 v21, v23                                 // rC[0+2*VW+1*TT0I] = rC[1+2*VW+1*TT0I]
+// src=17, dst=16
+v_mov_b32 v32, v34                                 // rC[0+2*VW+2*TT0I] = rC[1+2*VW+2*TT0I]
+v_mov_b32 v33, v35                                 // rC[0+2*VW+2*TT0I] = rC[1+2*VW+2*TT0I]
+// src=23, dst=22
+v_mov_b32 v44, v46                                 // rC[0+2*VW+3*TT0I] = rC[1+2*VW+3*TT0I]
+v_mov_b32 v45, v47                                 // rC[0+2*VW+3*TT0I] = rC[1+2*VW+3*TT0I]
+s_mov_b64 s[56:57], 0xFFFFFFFFFFFFFFFF             // to restore all threads active
+s_or_saveexec_b64 vcc, s[56:57]                    // all threads active
+s_branch label_0014                                // done shifting
+label_0014: // end shift0
+
+
+/* shift vector components d1 */
+
+v_mov_b32 v50, s[sgprWorkGroup1]                   //
+v_mul_i32_i24 v50, -0x40, v50                      // wg*MT
+_v_add_co_u32 v50, vcc, s[sgprSizesFree+1], v50    // wgMT = Size - wg*MT
+v_mov_b32 v48, 0x40                                // MT
+v_cmp_lt_u32 s[56:57], v50, v48                    // wgMT < MT
+v_cndmask_b32 v50, v48, v50, s[56:57]              // wgMT = (wgMT < MT) ? wgMT : MT
+v_lshrrev_b32 v52, 1, v50                          // vectorStaticDiv: v52 = v50 / 2
+v_and_b32 v53, 1, v50                              // vectorStaticDiv: v53 = v50 % 2
+v_lshrrev_b32 v54, 4, v52                          // vectorStaticDiv: v54 = v52 / 16
+v_and_b32 v55, 15, v52                             // vectorStaticDiv: v55 = v52 % 16
+v_lshrrev_b32 v56, 3, v[vgprSerial]                // vectorStaticDiv: v56 = v[vgprSerial] / 8
+v_and_b32 v57, 15, v56                             // vectorStaticDiv: v57 = v56 % 16
+v_lshrrev_b32 v56, 5, v50                          // vectorStaticDiv: v56 = v50 / 32
+v_and_b32 v58, 1, v50                              // vectorStaticDiv: v58 = v50 % 2
+v_mov_b32 v59, v58                                 // duplicate
+v_lshrrev_b32 v58, 1, v59                          // vectorStaticDiv: v58 = v59 / 2
+_v_add_co_u32 v58, vcc, v56, v58                   // vId = 2 components
+v_cmp_eq_u32 s[56:57], v57, v55                    // mask
+v_mov_b32 v48, s56                                 //
+v_mov_b32 v49, s57                                 //
+v_cmp_eq_u32 vcc, v53, 0x1                         // wgMT%VW == 1
+s_cbranch_vccnz label_0018                         // shift d1 r=1
+s_branch label_0021                                // no shifting
+
+/******************************************/
+/* shift d1 r=1                           */
+/******************************************/
+label_0018:
+v_cmp_eq_u32 vcc, v58, 0x0                         // wgMT/(SG*VW) == 0
+s_cbranch_vccnz label_0019                         // shift d1, r=1, v=0
+v_cmp_eq_u32 vcc, v58, 0x1                         // wgMT/(SG*VW) == 1
+s_cbranch_vccnz label_0020                         // shift d1, r=1, v=1
+
+/* shift d1 r=1 v=0 */
+label_0019:
+v_cmpx_eq_u32 s[56:57], v57, v55                   // serial % SG == (wgMT/VECTOR_WIDTH)%SG
+// src=6, dst=0
+v_mov_b32 v0, v12                                  // rC[0+0*TT0I*VW+0*TT0I] = rC[0+0*TT0I*VW+1*TT0I]
+v_mov_b32 v1, v13                                  // rC[0+0*TT0I*VW+0*TT0I] = rC[0+0*TT0I*VW+1*TT0I]
+// src=7, dst=1
+v_mov_b32 v2, v14                                  // rC[1+0*TT0I*VW+0*TT0I] = rC[1+0*TT0I*VW+1*TT0I]
+v_mov_b32 v3, v15                                  // rC[1+0*TT0I*VW+0*TT0I] = rC[1+0*TT0I*VW+1*TT0I]
+// src=8, dst=2
+v_mov_b32 v4, v16                                  // rC[2+0*TT0I*VW+0*TT0I] = rC[2+0*TT0I*VW+1*TT0I]
+v_mov_b32 v5, v17                                  // rC[2+0*TT0I*VW+0*TT0I] = rC[2+0*TT0I*VW+1*TT0I]
+// src=9, dst=3
+v_mov_b32 v6, v18                                  // rC[3+0*TT0I*VW+0*TT0I] = rC[3+0*TT0I*VW+1*TT0I]
+v_mov_b32 v7, v19                                  // rC[3+0*TT0I*VW+0*TT0I] = rC[3+0*TT0I*VW+1*TT0I]
+// src=10, dst=4
+v_mov_b32 v8, v20                                  // rC[4+0*TT0I*VW+0*TT0I] = rC[4+0*TT0I*VW+1*TT0I]
+v_mov_b32 v9, v21                                  // rC[4+0*TT0I*VW+0*TT0I] = rC[4+0*TT0I*VW+1*TT0I]
+// src=11, dst=5
+v_mov_b32 v10, v22                                 // rC[5+0*TT0I*VW+0*TT0I] = rC[5+0*TT0I*VW+1*TT0I]
+v_mov_b32 v11, v23                                 // rC[5+0*TT0I*VW+0*TT0I] = rC[5+0*TT0I*VW+1*TT0I]
+s_mov_b64 s[56:57], 0xFFFFFFFFFFFFFFFF             // to restore all threads active
+s_or_saveexec_b64 vcc, s[56:57]                    // all threads active
+s_branch label_0021                                // done shifting
+
+/* shift d1 r=1 v=1 */
+label_0020:
+v_cmpx_eq_u32 s[56:57], v57, v55                   // serial % SG == (wgMT/VECTOR_WIDTH)%SG
+// src=18, dst=12
+v_mov_b32 v24, v36                                 // rC[0+1*TT0I*VW+0*TT0I] = rC[0+1*TT0I*VW+1*TT0I]
+v_mov_b32 v25, v37                                 // rC[0+1*TT0I*VW+0*TT0I] = rC[0+1*TT0I*VW+1*TT0I]
+// src=19, dst=13
+v_mov_b32 v26, v38                                 // rC[1+1*TT0I*VW+0*TT0I] = rC[1+1*TT0I*VW+1*TT0I]
+v_mov_b32 v27, v39                                 // rC[1+1*TT0I*VW+0*TT0I] = rC[1+1*TT0I*VW+1*TT0I]
+// src=20, dst=14
+v_mov_b32 v28, v40                                 // rC[2+1*TT0I*VW+0*TT0I] = rC[2+1*TT0I*VW+1*TT0I]
+v_mov_b32 v29, v41                                 // rC[2+1*TT0I*VW+0*TT0I] = rC[2+1*TT0I*VW+1*TT0I]
+// src=21, dst=15
+v_mov_b32 v30, v42                                 // rC[3+1*TT0I*VW+0*TT0I] = rC[3+1*TT0I*VW+1*TT0I]
+v_mov_b32 v31, v43                                 // rC[3+1*TT0I*VW+0*TT0I] = rC[3+1*TT0I*VW+1*TT0I]
+// src=22, dst=16
+v_mov_b32 v32, v44                                 // rC[4+1*TT0I*VW+0*TT0I] = rC[4+1*TT0I*VW+1*TT0I]
+v_mov_b32 v33, v45                                 // rC[4+1*TT0I*VW+0*TT0I] = rC[4+1*TT0I*VW+1*TT0I]
+// src=23, dst=17
+v_mov_b32 v34, v46                                 // rC[5+1*TT0I*VW+0*TT0I] = rC[5+1*TT0I*VW+1*TT0I]
+v_mov_b32 v35, v47                                 // rC[5+1*TT0I*VW+0*TT0I] = rC[5+1*TT0I*VW+1*TT0I]
+s_mov_b64 s[56:57], 0xFFFFFFFFFFFFFFFF             // to restore all threads active
+s_or_saveexec_b64 vcc, s[56:57]                    // all threads active
+label_0021: // end shift0
+
+
+
+/* not-LocalSplitU: global write indices */
+
+s_mov_b32 s[sgprSrdD+0], s[sgprAddressD+0]         // init SRD base address (lower)
+s_mov_b32 s[sgprSrdD+1], s[sgprAddressD+1]         // init SRD base address (upper) + other fields
+s_mov_b32 s[sgprSrdD+2], 0x80000000                //
+s_mov_b32 s[sgprSrdD+3], Srd127_96                 // Set bits 127_96 in SRD
+s_mov_b32 s[sgprSrdC+0], s[sgprAddressC+0]         // init SRD base address (lower)
+s_mov_b32 s[sgprSrdC+1], s[sgprAddressC+1]         // init SRD base address (upper) + other fields
+s_mov_b32 s[sgprSrdC+2], 0x80000000                //
+s_mov_b32 s[sgprSrdC+3], Srd127_96                 // Set bits 127_96 in SRD
+
+s_mul_i32 s58, 0x40, s[sgprWorkGroup1]             // <- wg1*MT1
+s_mul_hi_u32 s57, s58, s[sgprStridesC+0]           // Scale s58 by Stride
+s_mul_i32 s56, s58, s[sgprStridesC+0]              // Scale s58 by Stride
+s_lshl_b64 s[56:57], s[56:57], 3                   // scale by bpe
+s_add_u32 s[sgprSrdD+0], s[sgprSrdD+0], s56        // add lo to SRD
+s_addc_u32 s[sgprSrdD+1], s[sgprSrdD+1], s57       // add hi to SRD
+s_add_u32 s[sgprSrdC+0], s[sgprSrdC+0], s56        // add lo to SRD
+s_addc_u32 s[sgprSrdC+1], s[sgprSrdC+1], s57       // add hi to SRD
+
+s_mul_hi_u32 s57, s[sgprWorkGroup2], s[sgprStridesC+1] // Scale s[sgprWorkGroup2] by Stride
+s_mul_i32 s56, s[sgprWorkGroup2], s[sgprStridesC+1] // Scale s[sgprWorkGroup2] by Stride
+s_lshl_b64 s[56:57], s[56:57], 3                   // scale by bpe
+s_add_u32 s[sgprSrdD+0], s[sgprSrdD+0], s56        // add lo to SRD
+s_addc_u32 s[sgprSrdD+1], s[sgprSrdD+1], s57       // add hi to SRD
+s_add_u32 s[sgprSrdC+0], s[sgprSrdC+0], s56        // add lo to SRD
+s_addc_u32 s[sgprSrdC+1], s[sgprSrdC+1], s57       // add hi to SRD
+
+v_lshrrev_b32 v49, 3, v[vgprSerial]                // vectorStaticDiv: v49 = v[vgprSerial] / 8
+v_and_b32 v48, 7, v[vgprSerial]                    // vectorStaticDiv: v48 = v[vgprSerial] % 8
+v_lshlrev_b32 v48, 1, v48                          // staticMultiply: v48 = v48 * 2
+v_lshlrev_b32 v49, 1, v49                          // staticMultiply: v49 = v49 * 2
+v_mul_lo_u32 v50, v49, s[sgprStridesC+0]           // rowStart vgpr
+
+s_mul_i32 s56, 0x30, s[sgprWorkGroup0]             // s56 = wg0*MT0
+_v_add_co_u32 v48, vcc, s56, v48                   // coord0 = tid0*VW + wg0*MT0
+s_mul_i32 s58, 0x40, s[sgprWorkGroup1]             // <- wg1*MT1
+_v_add_co_u32 v49, vcc, s58, v49                   // coord1 = tid1*VW + wg1*MT1
+
+//v_mov_b32 v48,v[vgprLocalWriteAddrA]
+//v_mov_b32 v49,v[vgprLocalWriteAddrB]
+//v_mov_b32 v50,v[vgprGlobalReadOffsetB]           // rowStart vgpr
+//_v_add_lshl_u32 v[vgprGlobalReadOffsetA], v[vgprGlobalReadOffsetB], v[vgprLocalWriteAddrA], 0x3                 // init cb addr <-  rowStart + coord0, scaled by BPE
+
+/* not-LocalSplitU: global write */
+
+s_mov_b32 s56, s[sgprBeta+0]                       // tmp = Beta[0]
+s_or_b32 s56, s[sgprBeta+1], s56                   // tmp |= Beta[1]
+s_cmpk_eq_u32 s56, 0x0                             // Beta == 0
+s_cbranch_scc0 label_0030                          // Beta is not zero; so jump to B nonzero
+
+s_mov_b32 s56, 0x0                                 // rMT0=0
+s_add_u32 s58, -0x1, s[sgprNumWorkGroups0]         //
+s_cmp_lt_u32 s[sgprWorkGroup0], s58                // wg0 < nwg0-1
+s_cbranch_scc1 label_0027                          // wg0 < nwg0-1 so skip rMT0 = Size0 % MT0
+/* TODO-packed- compare against product of all packed C0 sizes not just SizesFree+0 */
+s_mov_b32 s61, 0x0                                 // STATIC_DIV: divisior=48
+s_mul_i32 s60, 0xaaa, s[sgprSizesFree+0]           // tmp1 = dividend * magic hi
+s_lshl_b64 s[60:61], s[60:61], 0x10                // left shift 16 bits
+s_mul_i32 s58, s[sgprSizesFree+0], 0xaaab          // tmp0 = dividend * magic lo
+s_add_u32 s60, s58, s60                            // add lo
+s_addc_u32 s61, s61, 0x0                           // add hi
+s_lshr_b64 s[60:61], s[60:61], 0x21                // tmp1 = (dividend * magic) << shift
+s_mov_b32 s58, s60                                 // quotient
+s_mul_i32 s60, s58, 0x30                           // quotient*divisor
+s_sub_u32 s56, s[sgprSizesFree+0], s60             // rReg = dividend - quotient*divisor
+label_0027:
+s_cmpk_gt_u32 s56, 0x0                             // rMT0 > 0
+s_cbranch_scc1 label_0029                          // edges required so jump to E1
+s_mov_b32 s56, 0x0                                 // rMT1=0
+s_add_u32 s58, -0x1, s[sgprNumWorkGroups1]         //
+s_cmp_lt_u32 s[sgprWorkGroup1], s58                // wg1 < nwg1-1
+s_cbranch_scc1 label_0028                          // wg1 < nwg1-1 so skip rMT1 = Size1 % MT1
+s_lshr_b32 s58, s[sgprSizesFree+1], 6              // s58 = s[sgprSizesFree+1] / 64
+s_and_b32 s56, 63, s[sgprSizesFree+1]              // s56 = s[sgprSizesFree+1] % 64
+label_0028:
+s_cmpk_gt_u32 s56, 0x0                             // rMT1 > 0
+s_cbranch_scc1 label_0029                          // edges required so jump to E1
+label_0026:
+
+/******************************************/
+/* Global Write Batch #0 (d1,d0,vc1,vc0) =
+   (0,0,0,0:vw2); (0,1,0,0:vw2); (0,2,0,0:vw2); (0,0,1,0:vw2); (0,1,1,0:vw2); (0,2,1,0:vw2); (1,0,0,0:vw2); (1,1,0,0:vw2); (1,2,0,0:vw2); (1,0,1,0:vw2); (1,1,1,0:vw2); (1,2,1,0:vw2) */
+/******************************************/
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(0,0,0,0) coordOffset1=0 element-rows coordOffset0=0 rows */
+_v_add_lshl_u32 v54, v50, v48, 0x3                 // init cb addr <-  rowStart + coord0, scaled by BPE
+/* (d1,vc1,d0,vc0)=(0,0,1,0) coordOffset1=0 element-rows coordOffset0=16 rows */
+/* (d1,vc1,d0,vc0)=(0,0,2,0) coordOffset1=0 element-rows coordOffset0=32 rows */
+/* (d1,vc1,d0,vc0)=(0,1,0,0) coordOffset1=1 element-rows coordOffset0=0 rows */
+/* (d1,vc1,d0,vc0)=(0,1,1,0) coordOffset1=1 element-rows coordOffset0=16 rows */
+/* (d1,vc1,d0,vc0)=(0,1,2,0) coordOffset1=1 element-rows coordOffset0=32 rows */
+/* (d1,vc1,d0,vc0)=(1,0,0,0) coordOffset1=32 element-rows coordOffset0=0 rows */
+/* (d1,vc1,d0,vc0)=(1,0,1,0) coordOffset1=32 element-rows coordOffset0=16 rows */
+/* (d1,vc1,d0,vc0)=(1,0,2,0) coordOffset1=32 element-rows coordOffset0=32 rows */
+/* (d1,vc1,d0,vc0)=(1,1,0,0) coordOffset1=33 element-rows coordOffset0=0 rows */
+/* (d1,vc1,d0,vc0)=(1,1,1,0) coordOffset1=33 element-rows coordOffset0=16 rows */
+/* (d1,vc1,d0,vc0)=(1,1,2,0) coordOffset1=33 element-rows coordOffset0=32 rows */
+
+/* rC *= alpha batchEements=[(0, 0, 0, 0), (0, 1, 0, 0), (0, 2, 0, 0), (0, 0, 1, 0), (0, 1, 1, 0), (0, 2, 1, 0), (1, 0, 0, 0), (1, 1, 0, 0), (1, 2, 0, 0), (1, 0, 1, 0), (1, 1, 1, 0), (1, 2, 1, 0)] */
+//v_mul_f64 v[vgprValuC+0:vgprValuC+0+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+0:vgprValuC+0+1] // *= alpha
+//v_mul_f64 v[vgprValuC+2:vgprValuC+2+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+2:vgprValuC+2+1] // *= alpha
+//v_mul_f64 v[vgprValuC+4:vgprValuC+4+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+4:vgprValuC+4+1] // *= alpha
+//v_mul_f64 v[vgprValuC+6:vgprValuC+6+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+6:vgprValuC+6+1] // *= alpha
+//v_mul_f64 v[vgprValuC+8:vgprValuC+8+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+8:vgprValuC+8+1] // *= alpha
+//v_mul_f64 v[vgprValuC+10:vgprValuC+10+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+10:vgprValuC+10+1] // *= alpha
+//v_mul_f64 v[vgprValuC+12:vgprValuC+12+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+12:vgprValuC+12+1] // *= alpha
+//v_mul_f64 v[vgprValuC+14:vgprValuC+14+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+14:vgprValuC+14+1] // *= alpha
+//v_mul_f64 v[vgprValuC+16:vgprValuC+16+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+16:vgprValuC+16+1] // *= alpha
+//v_mul_f64 v[vgprValuC+18:vgprValuC+18+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+18:vgprValuC+18+1] // *= alpha
+//v_mul_f64 v[vgprValuC+20:vgprValuC+20+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+20:vgprValuC+20+1] // *= alpha
+//v_mul_f64 v[vgprValuC+22:vgprValuC+22+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+22:vgprValuC+22+1] // *= alpha
+//v_mul_f64 v[vgprValuC+24:vgprValuC+24+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+24:vgprValuC+24+1] // *= alpha
+//v_mul_f64 v[vgprValuC+26:vgprValuC+26+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+26:vgprValuC+26+1] // *= alpha
+//v_mul_f64 v[vgprValuC+28:vgprValuC+28+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+28:vgprValuC+28+1] // *= alpha
+//v_mul_f64 v[vgprValuC+30:vgprValuC+30+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+30:vgprValuC+30+1] // *= alpha
+//v_mul_f64 v[vgprValuC+32:vgprValuC+32+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+32:vgprValuC+32+1] // *= alpha
+//v_mul_f64 v[vgprValuC+34:vgprValuC+34+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+34:vgprValuC+34+1] // *= alpha
+//v_mul_f64 v[vgprValuC+36:vgprValuC+36+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+36:vgprValuC+36+1] // *= alpha
+//v_mul_f64 v[vgprValuC+38:vgprValuC+38+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+38:vgprValuC+38+1] // *= alpha
+//v_mul_f64 v[vgprValuC+40:vgprValuC+40+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+40:vgprValuC+40+1] // *= alpha
+//v_mul_f64 v[vgprValuC+42:vgprValuC+42+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+42:vgprValuC+42+1] // *= alpha
+//v_mul_f64 v[vgprValuC+44:vgprValuC+44+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+44:vgprValuC+44+1] // *= alpha
+//v_mul_f64 v[vgprValuC+46:vgprValuC+46+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+46:vgprValuC+46+1] // *= alpha
+
+/* apply mask, calc new C and issue write */
+buffer_store_dwordx4 v[0:3], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx4 v[4:7], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+buffer_store_dwordx4 v[8:11], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+buffer_store_dwordx4 v[12:15], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx4 v[16:19], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+buffer_store_dwordx4 v[20:23], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_mul_i32 s56, s[sgprStridesC+0], 248              // scale StrideC *= 31 * bpe
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+buffer_store_dwordx4 v[24:27], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx4 v[28:31], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+buffer_store_dwordx4 v[32:35], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+buffer_store_dwordx4 v[36:39], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx4 v[40:43], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+buffer_store_dwordx4 v[44:47], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_branch label_0037                                // jump to end
+label_0029:
+
+/******************************************/
+/* Global Write Edge Batch #0 (d1,d0,vc1,vc0) =
+   (0,0,0,0:vw1); (0,0,0,1:vw1); (0,1,0,0:vw1); (0,1,0,1:vw1); (0,2,0,0:vw1); (0,2,0,1:vw1); (0,0,1,0:vw1); (0,0,1,1:vw1); (0,1,1,0:vw1); (0,1,1,1:vw1); (0,2,1,0:vw1); (0,2,1,1:vw1); (1,0,0,0:vw1); (1,0,0,1:vw1); (1,1,0,0:vw1); (1,1,0,1:vw1); (1,2,0,0:vw1); (1,2,0,1:vw1) */
+/******************************************/
+
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(0,0,0,0) coordOffset1=0 element-rows coordOffset0=0 rows */
+v_mov_b32 v51, v50                                 // rowPtr <- rowStart (first row)
+_v_add_lshl_u32 v54, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[62:63], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v54, -1, v54, s[62:63]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,0,0,1) coordOffset1=0 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v55, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[64:65], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v55, -1, v55, s[64:65]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,0,1,0) coordOffset1=0 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v56, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[66:67], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v56, -1, v56, s[66:67]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,0,1,1) coordOffset1=0 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v57, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[68:69], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v57, -1, v57, s[68:69]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,0,2,0) coordOffset1=0 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v58, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[70:71], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v58, -1, v58, s[70:71]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,0,2,1) coordOffset1=0 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v59, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[72:73], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v59, -1, v59, s[72:73]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,1,0,0) coordOffset1=1 element-rows coordOffset0=0 rows */
+_v_add_co_u32 v53, vcc, v49, 1                     // coord1 += d1*sg1*VW + vc1
+_v_add_co_u32 v51, vcc, v51, s[sgprStridesC+0]     // rowPtr <- move to start of new row
+_v_add_lshl_u32 v60, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[74:75], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v60, -1, v60, s[74:75]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,1,0,1) coordOffset1=1 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v61, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[76:77], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v61, -1, v61, s[76:77]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,1,1,0) coordOffset1=1 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v62, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[78:79], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v62, -1, v62, s[78:79]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,1,1,1) coordOffset1=1 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v63, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[80:81], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v63, -1, v63, s[80:81]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,1,2,0) coordOffset1=1 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v64, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[82:83], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v64, -1, v64, s[82:83]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(0,1,2,1) coordOffset1=1 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v65, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[84:85], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v65, -1, v65, s[84:85]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,0,0,0) coordOffset1=32 element-rows coordOffset0=0 rows */
+_v_add_co_u32 v53, vcc, v49, 32                    // coord1 += d1*sg1*VW + vc1
+s_mul_i32 s56, s[sgprStridesC+0], 32               // scale StrideC *= coordOffset1(32)
+_v_add_co_u32 v51, vcc, v50, s56                   // rowPtr <- inc for non-0 (tt1+vc1))
+_v_add_lshl_u32 v66, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[86:87], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v66, -1, v66, s[86:87]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,0,0,1) coordOffset1=32 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v67, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[88:89], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v67, -1, v67, s[88:89]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,0,1,0) coordOffset1=32 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v68, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[90:91], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v68, -1, v68, s[90:91]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,0,1,1) coordOffset1=32 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v69, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[92:93], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v69, -1, v69, s[92:93]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,0,2,0) coordOffset1=32 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v70, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[94:95], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v70, -1, v70, s[94:95]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,0,2,1) coordOffset1=32 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v71, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[96:97], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v71, -1, v71, s[96:97]               // clip if OOB. offset
+
+/* rC *= alpha batchEements=[(0, 0, 0, 0), (0, 0, 0, 1), (0, 1, 0, 0), (0, 1, 0, 1), (0, 2, 0, 0), (0, 2, 0, 1), (0, 0, 1, 0), (0, 0, 1, 1), (0, 1, 1, 0), (0, 1, 1, 1), (0, 2, 1, 0), (0, 2, 1, 1), (1, 0, 0, 0), (1, 0, 0, 1), (1, 1, 0, 0), (1, 1, 0, 1), (1, 2, 0, 0), (1, 2, 0, 1)] */
+//v_mul_f64 v[vgprValuC+0:vgprValuC+0+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+0:vgprValuC+0+1] // *= alpha
+//v_mul_f64 v[vgprValuC+2:vgprValuC+2+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+2:vgprValuC+2+1] // *= alpha
+//v_mul_f64 v[vgprValuC+4:vgprValuC+4+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+4:vgprValuC+4+1] // *= alpha
+//v_mul_f64 v[vgprValuC+6:vgprValuC+6+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+6:vgprValuC+6+1] // *= alpha
+//v_mul_f64 v[vgprValuC+8:vgprValuC+8+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+8:vgprValuC+8+1] // *= alpha
+//v_mul_f64 v[vgprValuC+10:vgprValuC+10+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+10:vgprValuC+10+1] // *= alpha
+//v_mul_f64 v[vgprValuC+12:vgprValuC+12+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+12:vgprValuC+12+1] // *= alpha
+//v_mul_f64 v[vgprValuC+14:vgprValuC+14+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+14:vgprValuC+14+1] // *= alpha
+//v_mul_f64 v[vgprValuC+16:vgprValuC+16+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+16:vgprValuC+16+1] // *= alpha
+//v_mul_f64 v[vgprValuC+18:vgprValuC+18+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+18:vgprValuC+18+1] // *= alpha
+//v_mul_f64 v[vgprValuC+20:vgprValuC+20+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+20:vgprValuC+20+1] // *= alpha
+//v_mul_f64 v[vgprValuC+22:vgprValuC+22+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+22:vgprValuC+22+1] // *= alpha
+//v_mul_f64 v[vgprValuC+24:vgprValuC+24+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+24:vgprValuC+24+1] // *= alpha
+//v_mul_f64 v[vgprValuC+26:vgprValuC+26+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+26:vgprValuC+26+1] // *= alpha
+//v_mul_f64 v[vgprValuC+28:vgprValuC+28+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+28:vgprValuC+28+1] // *= alpha
+//v_mul_f64 v[vgprValuC+30:vgprValuC+30+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+30:vgprValuC+30+1] // *= alpha
+//v_mul_f64 v[vgprValuC+32:vgprValuC+32+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+32:vgprValuC+32+1] // *= alpha
+//v_mul_f64 v[vgprValuC+34:vgprValuC+34+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+34:vgprValuC+34+1] // *= alpha
+
+/* apply mask, calc new C and issue write */
+buffer_store_dwordx2 v[0:1], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[2:3], v55, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[4:5], v56, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[6:7], v57, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[8:9], v58, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[10:11], v59, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[12:13], v60, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[14:15], v61, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[16:17], v62, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[18:19], v63, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[20:21], v64, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[22:23], v65, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[24:25], v66, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[26:27], v67, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[28:29], v68, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[30:31], v69, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[32:33], v70, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[34:35], v71, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+/******************************************/
+/* Global Write Edge Batch #1 (d1,d0,vc1,vc0) =
+   (1,0,1,0:vw1); (1,0,1,1:vw1); (1,1,1,0:vw1); (1,1,1,1:vw1); (1,2,1,0:vw1); (1,2,1,1:vw1) */
+/******************************************/
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(1,1,0,0) coordOffset1=33 element-rows coordOffset0=0 rows */
+_v_add_co_u32 v53, vcc, v49, 33                    // coord1 += d1*sg1*VW + vc1
+_v_add_co_u32 v51, vcc, v51, s[sgprStridesC+0]     // rowPtr <- move to start of new row
+_v_add_lshl_u32 v54, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[62:63], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v54, -1, v54, s[62:63]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,1,0,1) coordOffset1=33 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v55, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[64:65], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v55, -1, v55, s[64:65]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,1,1,0) coordOffset1=33 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v56, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[66:67], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v56, -1, v56, s[66:67]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,1,1,1) coordOffset1=33 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v57, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[68:69], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v57, -1, v57, s[68:69]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,1,2,0) coordOffset1=33 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v58, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[70:71], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v58, -1, v58, s[70:71]               // clip if OOB. offset
+/* (d1,vc1,d0,vc0)=(1,1,2,1) coordOffset1=33 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v59, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[72:73], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v59, -1, v59, s[72:73]               // clip if OOB. offset
+
+/* rC *= alpha batchEements=[(1, 0, 1, 0), (1, 0, 1, 1), (1, 1, 1, 0), (1, 1, 1, 1), (1, 2, 1, 0), (1, 2, 1, 1)] */
+//v_mul_f64 v[vgprValuC+36:vgprValuC+36+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+36:vgprValuC+36+1] // *= alpha
+//v_mul_f64 v[vgprValuC+38:vgprValuC+38+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+38:vgprValuC+38+1] // *= alpha
+//v_mul_f64 v[vgprValuC+40:vgprValuC+40+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+40:vgprValuC+40+1] // *= alpha
+//v_mul_f64 v[vgprValuC+42:vgprValuC+42+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+42:vgprValuC+42+1] // *= alpha
+//v_mul_f64 v[vgprValuC+44:vgprValuC+44+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+44:vgprValuC+44+1] // *= alpha
+//v_mul_f64 v[vgprValuC+46:vgprValuC+46+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+46:vgprValuC+46+1] // *= alpha
+
+/* apply mask, calc new C and issue write */
+buffer_store_dwordx2 v[36:37], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[38:39], v55, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[40:41], v56, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[42:43], v57, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[44:45], v58, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+buffer_store_dwordx2 v[46:47], v59, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_branch label_0037                                // jump to end
+label_0030:
+s_mov_b32 s56, 0x0                                 // rMT0=0
+s_add_u32 s58, -0x1, s[sgprNumWorkGroups0]         //
+s_cmp_lt_u32 s[sgprWorkGroup0], s58                // wg0 < nwg0-1
+s_cbranch_scc1 label_0034                          // wg0 < nwg0-1 so skip rMT0 = Size0 % MT0
+/* TODO-packed- compare against product of all packed C0 sizes not just SizesFree+0 */
+s_mov_b32 s61, 0x0                                 // STATIC_DIV: divisior=48
+s_mul_i32 s60, 0xaaa, s[sgprSizesFree+0]           // tmp1 = dividend * magic hi
+s_lshl_b64 s[60:61], s[60:61], 0x10                // left shift 16 bits
+s_mul_i32 s58, s[sgprSizesFree+0], 0xaaab          // tmp0 = dividend * magic lo
+s_add_u32 s60, s58, s60                            // add lo
+s_addc_u32 s61, s61, 0x0                           // add hi
+s_lshr_b64 s[60:61], s[60:61], 0x21                // tmp1 = (dividend * magic) << shift
+s_mov_b32 s58, s60                                 // quotient
+s_mul_i32 s60, s58, 0x30                           // quotient*divisor
+s_sub_u32 s56, s[sgprSizesFree+0], s60             // rReg = dividend - quotient*divisor
+label_0034:
+s_cmpk_gt_u32 s56, 0x0                             // rMT0 > 0
+s_cbranch_scc1 label_0036                          // edges required so jump to E1
+s_mov_b32 s56, 0x0                                 // rMT1=0
+s_add_u32 s58, -0x1, s[sgprNumWorkGroups1]         //
+s_cmp_lt_u32 s[sgprWorkGroup1], s58                // wg1 < nwg1-1
+s_cbranch_scc1 label_0035                          // wg1 < nwg1-1 so skip rMT1 = Size1 % MT1
+s_lshr_b32 s58, s[sgprSizesFree+1], 6              // s58 = s[sgprSizesFree+1] / 64
+s_and_b32 s56, 63, s[sgprSizesFree+1]              // s56 = s[sgprSizesFree+1] % 64
+label_0035:
+s_cmpk_gt_u32 s56, 0x0                             // rMT1 > 0
+s_cbranch_scc1 label_0036                          // edges required so jump to E1
+label_0033:
+
+/******************************************/
+/* Global Write Beta Batch #0 (d1,d0,vc1,vc0) =
+   (0,0,0,0:vw2); (0,1,0,0:vw2); (0,2,0,0:vw2); (0,0,1,0:vw2); (0,1,1,0:vw2); (0,2,1,0:vw2) */
+/******************************************/
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(0,0,0,0) coordOffset1=0 element-rows coordOffset0=0 rows */
+_v_add_lshl_u32 v54, v[vgprGlobalReadOffsetB], v48, 0x3                 // init cb addr <-  rowStart + coord0, scaled by BPE
+buffer_load_dwordx4 v[55:58], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,1,0) coordOffset1=0 element-rows coordOffset0=16 rows */
+buffer_load_dwordx4 v[59:62], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,2,0) coordOffset1=0 element-rows coordOffset0=32 rows */
+buffer_load_dwordx4 v[63:66], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,0,0) coordOffset1=1 element-rows coordOffset0=0 rows */
+s_lshl_b32  s56, s[sgprStridesC+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+buffer_load_dwordx4 v[67:70], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,1,0) coordOffset1=1 element-rows coordOffset0=16 rows */
+buffer_load_dwordx4 v[71:74], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,2,0) coordOffset1=1 element-rows coordOffset0=32 rows */
+buffer_load_dwordx4 v[75:78], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+
+/* rC *= alpha batchEements=[(0, 0, 0, 0), (0, 1, 0, 0), (0, 2, 0, 0), (0, 0, 1, 0), (0, 1, 1, 0), (0, 2, 1, 0)] */
+v_mul_f64 v[vgprValuC+0:vgprValuC+0+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+0:vgprValuC+0+1] // *= alpha
+v_mul_f64 v[vgprValuC+2:vgprValuC+2+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+2:vgprValuC+2+1] // *= alpha
+v_mul_f64 v[vgprValuC+4:vgprValuC+4+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+4:vgprValuC+4+1] // *= alpha
+v_mul_f64 v[vgprValuC+6:vgprValuC+6+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+6:vgprValuC+6+1] // *= alpha
+v_mul_f64 v[vgprValuC+8:vgprValuC+8+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+8:vgprValuC+8+1] // *= alpha
+v_mul_f64 v[vgprValuC+10:vgprValuC+10+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+10:vgprValuC+10+1] // *= alpha
+v_mul_f64 v[vgprValuC+12:vgprValuC+12+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+12:vgprValuC+12+1] // *= alpha
+v_mul_f64 v[vgprValuC+14:vgprValuC+14+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+14:vgprValuC+14+1] // *= alpha
+v_mul_f64 v[vgprValuC+16:vgprValuC+16+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+16:vgprValuC+16+1] // *= alpha
+v_mul_f64 v[vgprValuC+18:vgprValuC+18+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+18:vgprValuC+18+1] // *= alpha
+v_mul_f64 v[vgprValuC+20:vgprValuC+20+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+20:vgprValuC+20+1] // *= alpha
+v_mul_f64 v[vgprValuC+22:vgprValuC+22+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+22:vgprValuC+22+1] // *= alpha
+
+/* apply mask, calc new C and issue write */
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+0:vgprValuC+0+1], v[55:56], s[sgprBeta:sgprBeta+1], v[vgprValuC+0:vgprValuC+0+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+2:vgprValuC+2+1], v[57:58], s[sgprBeta:sgprBeta+1], v[vgprValuC+2:vgprValuC+2+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[0:3], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+4:vgprValuC+4+1], v[59:60], s[sgprBeta:sgprBeta+1], v[vgprValuC+4:vgprValuC+4+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+6:vgprValuC+6+1], v[61:62], s[sgprBeta:sgprBeta+1], v[vgprValuC+6:vgprValuC+6+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[4:7], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+8:vgprValuC+8+1], v[63:64], s[sgprBeta:sgprBeta+1], v[vgprValuC+8:vgprValuC+8+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+10:vgprValuC+10+1], v[65:66], s[sgprBeta:sgprBeta+1], v[vgprValuC+10:vgprValuC+10+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[8:11], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+12:vgprValuC+12+1], v[67:68], s[sgprBeta:sgprBeta+1], v[vgprValuC+12:vgprValuC+12+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+14:vgprValuC+14+1], v[69:70], s[sgprBeta:sgprBeta+1], v[vgprValuC+14:vgprValuC+14+1] // finalSum = sum*alpha + C*beta
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+buffer_store_dwordx4 v[12:15], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+16:vgprValuC+16+1], v[71:72], s[sgprBeta:sgprBeta+1], v[vgprValuC+16:vgprValuC+16+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+18:vgprValuC+18+1], v[73:74], s[sgprBeta:sgprBeta+1], v[vgprValuC+18:vgprValuC+18+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[16:19], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+20:vgprValuC+20+1], v[75:76], s[sgprBeta:sgprBeta+1], v[vgprValuC+20:vgprValuC+20+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+22:vgprValuC+22+1], v[77:78], s[sgprBeta:sgprBeta+1], v[vgprValuC+22:vgprValuC+22+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[20:23], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+
+/******************************************/
+/* Global Write Beta Batch #1 (d1,d0,vc1,vc0) =
+   (1,0,0,0:vw2); (1,1,0,0:vw2); (1,2,0,0:vw2); (1,0,1,0:vw2); (1,1,1,0:vw2); (1,2,1,0:vw2) */
+/******************************************/
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(1,0,0,0) coordOffset1=32 element-rows coordOffset0=0 rows */
+s_mul_i32 s56, s[sgprStridesD+0], 248              // scale StrideC *= 31 * bpe
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+buffer_load_dwordx4 v[55:58], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,1,0) coordOffset1=32 element-rows coordOffset0=16 rows */
+buffer_load_dwordx4 v[59:62], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,2,0) coordOffset1=32 element-rows coordOffset0=32 rows */
+buffer_load_dwordx4 v[63:66], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,0,0) coordOffset1=33 element-rows coordOffset0=0 rows */
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdC+0], s[sgprSrdC+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdC+1], s[sgprSrdC+1], 0        // gra SRD += inc(upper)
+buffer_load_dwordx4 v[67:70], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,1,0) coordOffset1=33 element-rows coordOffset0=16 rows */
+buffer_load_dwordx4 v[71:74], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:128 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,2,0) coordOffset1=33 element-rows coordOffset0=32 rows */
+buffer_load_dwordx4 v[75:78], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:256 // load C for beta calc
+
+/* rC *= alpha batchEements=[(1, 0, 0, 0), (1, 1, 0, 0), (1, 2, 0, 0), (1, 0, 1, 0), (1, 1, 1, 0), (1, 2, 1, 0)] */
+v_mul_f64 v[vgprValuC+24:vgprValuC+24+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+24:vgprValuC+24+1] // *= alpha
+v_mul_f64 v[vgprValuC+26:vgprValuC+26+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+26:vgprValuC+26+1] // *= alpha
+v_mul_f64 v[vgprValuC+28:vgprValuC+28+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+28:vgprValuC+28+1] // *= alpha
+v_mul_f64 v[vgprValuC+30:vgprValuC+30+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+30:vgprValuC+30+1] // *= alpha
+v_mul_f64 v[vgprValuC+32:vgprValuC+32+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+32:vgprValuC+32+1] // *= alpha
+v_mul_f64 v[vgprValuC+34:vgprValuC+34+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+34:vgprValuC+34+1] // *= alpha
+v_mul_f64 v[vgprValuC+36:vgprValuC+36+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+36:vgprValuC+36+1] // *= alpha
+v_mul_f64 v[vgprValuC+38:vgprValuC+38+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+38:vgprValuC+38+1] // *= alpha
+v_mul_f64 v[vgprValuC+40:vgprValuC+40+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+40:vgprValuC+40+1] // *= alpha
+v_mul_f64 v[vgprValuC+42:vgprValuC+42+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+42:vgprValuC+42+1] // *= alpha
+v_mul_f64 v[vgprValuC+44:vgprValuC+44+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+44:vgprValuC+44+1] // *= alpha
+v_mul_f64 v[vgprValuC+46:vgprValuC+46+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+46:vgprValuC+46+1] // *= alpha
+
+/* apply mask, calc new C and issue write */
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+24:vgprValuC+24+1], v[55:56], s[sgprBeta:sgprBeta+1], v[vgprValuC+24:vgprValuC+24+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+26:vgprValuC+26+1], v[57:58], s[sgprBeta:sgprBeta+1], v[vgprValuC+26:vgprValuC+26+1] // finalSum = sum*alpha + C*beta
+s_mul_i32 s56, s[sgprStridesD+0], 248              // scale StrideC *= 31 * bpe
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+buffer_store_dwordx4 v[24:27], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+28:vgprValuC+28+1], v[59:60], s[sgprBeta:sgprBeta+1], v[vgprValuC+28:vgprValuC+28+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+30:vgprValuC+30+1], v[61:62], s[sgprBeta:sgprBeta+1], v[vgprValuC+30:vgprValuC+30+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[28:31], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+32:vgprValuC+32+1], v[63:64], s[sgprBeta:sgprBeta+1], v[vgprValuC+32:vgprValuC+32+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+34:vgprValuC+34+1], v[65:66], s[sgprBeta:sgprBeta+1], v[vgprValuC+34:vgprValuC+34+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[32:35], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+36:vgprValuC+36+1], v[67:68], s[sgprBeta:sgprBeta+1], v[vgprValuC+36:vgprValuC+36+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+38:vgprValuC+38+1], v[69:70], s[sgprBeta:sgprBeta+1], v[vgprValuC+38:vgprValuC+38+1] // finalSum = sum*alpha + C*beta
+s_lshl_b32  s56, s[sgprStridesD+0], 3              // Scale by BPE
+s_add_u32  s[sgprSrdD+0], s[sgprSrdD+0], s56       // gra SRD += inc(lower)
+s_addc_u32  s[sgprSrdD+1], s[sgprSrdD+1], 0        // gra SRD += inc(upper)
+buffer_store_dwordx4 v[36:39], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+40:vgprValuC+40+1], v[71:72], s[sgprBeta:sgprBeta+1], v[vgprValuC+40:vgprValuC+40+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+42:vgprValuC+42+1], v[73:74], s[sgprBeta:sgprBeta+1], v[vgprValuC+42:vgprValuC+42+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[40:43], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:128 // store C
+
+s_waitcnt vmcnt(5)                                 // wait C (interleaved)
+v_fma_f64 v[vgprValuC+44:vgprValuC+44+1], v[75:76], s[sgprBeta:sgprBeta+1], v[vgprValuC+44:vgprValuC+44+1] // finalSum = sum*alpha + C*beta
+v_fma_f64 v[vgprValuC+46:vgprValuC+46+1], v[77:78], s[sgprBeta:sgprBeta+1], v[vgprValuC+46:vgprValuC+46+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx4 v[44:47], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:256 // store C
+s_branch label_0037                                // jump to end
+label_0036:
+
+/******************************************/
+/* Global Write Beta Edge Batch #0 (d1,d0,vc1,vc0) =
+   (0,0,0,0:vw1); (0,0,0,1:vw1); (0,1,0,0:vw1); (0,1,0,1:vw1); (0,2,0,0:vw1); (0,2,0,1:vw1); (0,0,1,0:vw1); (0,0,1,1:vw1) */
+/******************************************/
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(0,0,0,0) coordOffset1=0 element-rows coordOffset0=0 rows */
+v_mov_b32 v51, v50                                 // rowPtr <- rowStart (first row)
+_v_add_lshl_u32 v54, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[62:63], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v54, -1, v54, s[62:63]               // clip if OOB. offset
+buffer_load_dwordx2 v[55:56], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,0,1) coordOffset1=0 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v57, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[64:65], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v57, -1, v57, s[64:65]               // clip if OOB. offset
+buffer_load_dwordx2 v[58:59], v57, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,1,0) coordOffset1=0 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v60, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[66:67], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v60, -1, v60, s[66:67]               // clip if OOB. offset
+buffer_load_dwordx2 v[61:62], v60, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,1,1) coordOffset1=0 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v63, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[68:69], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v63, -1, v63, s[68:69]               // clip if OOB. offset
+buffer_load_dwordx2 v[64:65], v63, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,2,0) coordOffset1=0 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v66, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[70:71], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v66, -1, v66, s[70:71]               // clip if OOB. offset
+buffer_load_dwordx2 v[67:68], v66, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,0,2,1) coordOffset1=0 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v69, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v49, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[72:73], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v69, -1, v69, s[72:73]               // clip if OOB. offset
+buffer_load_dwordx2 v[70:71], v69, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,0,0) coordOffset1=1 element-rows coordOffset0=0 rows */
+_v_add_co_u32 v53, vcc, v49, 1                     // coord1 += d1*sg1*VW + vc1
+_v_add_co_u32 v51, vcc, v51, s[sgprStridesC+0]     // rowPtr <- move to start of new row
+_v_add_lshl_u32 v72, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[74:75], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v72, -1, v72, s[74:75]               // clip if OOB. offset
+buffer_load_dwordx2 v[73:74], v72, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,0,1) coordOffset1=1 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v75, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[76:77], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v75, -1, v75, s[76:77]               // clip if OOB. offset
+buffer_load_dwordx2 v[76:77], v75, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+
+/* rC *= alpha batchEements=[(0, 0, 0, 0), (0, 0, 0, 1), (0, 1, 0, 0), (0, 1, 0, 1), (0, 2, 0, 0), (0, 2, 0, 1), (0, 0, 1, 0), (0, 0, 1, 1)] */
+v_mul_f64 v[vgprValuC+0:vgprValuC+0+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+0:vgprValuC+0+1] // *= alpha
+v_mul_f64 v[vgprValuC+2:vgprValuC+2+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+2:vgprValuC+2+1] // *= alpha
+v_mul_f64 v[vgprValuC+4:vgprValuC+4+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+4:vgprValuC+4+1] // *= alpha
+v_mul_f64 v[vgprValuC+6:vgprValuC+6+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+6:vgprValuC+6+1] // *= alpha
+v_mul_f64 v[vgprValuC+8:vgprValuC+8+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+8:vgprValuC+8+1] // *= alpha
+v_mul_f64 v[vgprValuC+10:vgprValuC+10+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+10:vgprValuC+10+1] // *= alpha
+v_mul_f64 v[vgprValuC+12:vgprValuC+12+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+12:vgprValuC+12+1] // *= alpha
+v_mul_f64 v[vgprValuC+14:vgprValuC+14+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+14:vgprValuC+14+1] // *= alpha
+s_waitcnt vmcnt(0)                                 // wait C
+
+/* apply mask, calc new C and issue write */
+v_fma_f64 v[vgprValuC+0:vgprValuC+0+1], v[55:56], s[sgprBeta:sgprBeta+1], v[vgprValuC+0:vgprValuC+0+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[0:1], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+2:vgprValuC+2+1], v[58:59], s[sgprBeta:sgprBeta+1], v[vgprValuC+2:vgprValuC+2+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[2:3], v57, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+4:vgprValuC+4+1], v[61:62], s[sgprBeta:sgprBeta+1], v[vgprValuC+4:vgprValuC+4+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[4:5], v60, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+6:vgprValuC+6+1], v[64:65], s[sgprBeta:sgprBeta+1], v[vgprValuC+6:vgprValuC+6+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[6:7], v63, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+8:vgprValuC+8+1], v[67:68], s[sgprBeta:sgprBeta+1], v[vgprValuC+8:vgprValuC+8+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[8:9], v66, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+10:vgprValuC+10+1], v[70:71], s[sgprBeta:sgprBeta+1], v[vgprValuC+10:vgprValuC+10+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[10:11], v69, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+12:vgprValuC+12+1], v[73:74], s[sgprBeta:sgprBeta+1], v[vgprValuC+12:vgprValuC+12+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[12:13], v72, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+14:vgprValuC+14+1], v[76:77], s[sgprBeta:sgprBeta+1], v[vgprValuC+14:vgprValuC+14+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[14:15], v75, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+/******************************************/
+/* Global Write Beta Edge Batch #1 (d1,d0,vc1,vc0) =
+   (0,1,1,0:vw1); (0,1,1,1:vw1); (0,2,1,0:vw1); (0,2,1,1:vw1); (1,0,0,0:vw1); (1,0,0,1:vw1); (1,1,0,0:vw1); (1,1,0,1:vw1) */
+/******************************************/
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(0,1,1,0) coordOffset1=1 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v54, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[62:63], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v54, -1, v54, s[62:63]               // clip if OOB. offset
+buffer_load_dwordx2 v[55:56], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,1,1) coordOffset1=1 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v57, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[64:65], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v57, -1, v57, s[64:65]               // clip if OOB. offset
+buffer_load_dwordx2 v[58:59], v57, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,2,0) coordOffset1=1 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v60, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[66:67], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v60, -1, v60, s[66:67]               // clip if OOB. offset
+buffer_load_dwordx2 v[61:62], v60, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(0,1,2,1) coordOffset1=1 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v63, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[68:69], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v63, -1, v63, s[68:69]               // clip if OOB. offset
+buffer_load_dwordx2 v[64:65], v63, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,0,0) coordOffset1=32 element-rows coordOffset0=0 rows */
+_v_add_co_u32 v53, vcc, v49, 32                    // coord1 += d1*sg1*VW + vc1
+s_mul_i32 s56, s[sgprStridesC+0], 32               // scale StrideC *= coordOffset1(32)
+_v_add_co_u32 v51, vcc, v50, s56                   // rowPtr <- inc for non-0 (tt1+vc1))
+_v_add_lshl_u32 v66, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[70:71], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v66, -1, v66, s[70:71]               // clip if OOB. offset
+buffer_load_dwordx2 v[67:68], v66, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,0,1) coordOffset1=32 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v69, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[72:73], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v69, -1, v69, s[72:73]               // clip if OOB. offset
+buffer_load_dwordx2 v[70:71], v69, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,1,0) coordOffset1=32 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v72, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[74:75], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v72, -1, v72, s[74:75]               // clip if OOB. offset
+buffer_load_dwordx2 v[73:74], v72, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,1,1) coordOffset1=32 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v75, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[76:77], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v75, -1, v75, s[76:77]               // clip if OOB. offset
+buffer_load_dwordx2 v[76:77], v75, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+
+/* rC *= alpha batchEements=[(0, 1, 1, 0), (0, 1, 1, 1), (0, 2, 1, 0), (0, 2, 1, 1), (1, 0, 0, 0), (1, 0, 0, 1), (1, 1, 0, 0), (1, 1, 0, 1)] */
+v_mul_f64 v[vgprValuC+16:vgprValuC+16+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+16:vgprValuC+16+1] // *= alpha
+v_mul_f64 v[vgprValuC+18:vgprValuC+18+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+18:vgprValuC+18+1] // *= alpha
+v_mul_f64 v[vgprValuC+20:vgprValuC+20+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+20:vgprValuC+20+1] // *= alpha
+v_mul_f64 v[vgprValuC+22:vgprValuC+22+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+22:vgprValuC+22+1] // *= alpha
+v_mul_f64 v[vgprValuC+24:vgprValuC+24+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+24:vgprValuC+24+1] // *= alpha
+v_mul_f64 v[vgprValuC+26:vgprValuC+26+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+26:vgprValuC+26+1] // *= alpha
+v_mul_f64 v[vgprValuC+28:vgprValuC+28+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+28:vgprValuC+28+1] // *= alpha
+v_mul_f64 v[vgprValuC+30:vgprValuC+30+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+30:vgprValuC+30+1] // *= alpha
+s_waitcnt vmcnt(0)                                 // wait C
+
+/* apply mask, calc new C and issue write */
+v_fma_f64 v[vgprValuC+16:vgprValuC+16+1], v[55:56], s[sgprBeta:sgprBeta+1], v[vgprValuC+16:vgprValuC+16+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[16:17], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+18:vgprValuC+18+1], v[58:59], s[sgprBeta:sgprBeta+1], v[vgprValuC+18:vgprValuC+18+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[18:19], v57, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+20:vgprValuC+20+1], v[61:62], s[sgprBeta:sgprBeta+1], v[vgprValuC+20:vgprValuC+20+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[20:21], v60, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+22:vgprValuC+22+1], v[64:65], s[sgprBeta:sgprBeta+1], v[vgprValuC+22:vgprValuC+22+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[22:23], v63, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+24:vgprValuC+24+1], v[67:68], s[sgprBeta:sgprBeta+1], v[vgprValuC+24:vgprValuC+24+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[24:25], v66, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+26:vgprValuC+26+1], v[70:71], s[sgprBeta:sgprBeta+1], v[vgprValuC+26:vgprValuC+26+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[26:27], v69, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+28:vgprValuC+28+1], v[73:74], s[sgprBeta:sgprBeta+1], v[vgprValuC+28:vgprValuC+28+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[28:29], v72, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+30:vgprValuC+30+1], v[76:77], s[sgprBeta:sgprBeta+1], v[vgprValuC+30:vgprValuC+30+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[30:31], v75, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+
+/******************************************/
+/* Global Write Beta Edge Batch #2 (d1,d0,vc1,vc0) =
+   (1,2,0,0:vw1); (1,2,0,1:vw1); (1,0,1,0:vw1); (1,0,1,1:vw1); (1,1,1,0:vw1); (1,1,1,1:vw1); (1,2,1,0:vw1); (1,2,1,1:vw1) */
+/******************************************/
+
+/* calc coords, apply mask, and issue loads (if necessary) */
+/* (d1,vc1,d0,vc0)=(1,0,2,0) coordOffset1=32 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v54, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[62:63], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v54, -1, v54, s[62:63]               // clip if OOB. offset
+buffer_load_dwordx2 v[55:56], v54, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,0,2,1) coordOffset1=32 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v57, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[64:65], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v57, -1, v57, s[64:65]               // clip if OOB. offset
+buffer_load_dwordx2 v[58:59], v57, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,0,0) coordOffset1=33 element-rows coordOffset0=0 rows */
+_v_add_co_u32 v53, vcc, v49, 33                    // coord1 += d1*sg1*VW + vc1
+_v_add_co_u32 v51, vcc, v51, s[sgprStridesC+0]     // rowPtr <- move to start of new row
+_v_add_lshl_u32 v60, v51, v48, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v48, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[66:67], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v60, -1, v60, s[66:67]               // clip if OOB. offset
+buffer_load_dwordx2 v[61:62], v60, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,0,1) coordOffset1=33 element-rows coordOffset0=1 rows */
+_v_add_co_u32 v52, vcc, v48, 1                     // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v63, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[68:69], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v63, -1, v63, s[68:69]               // clip if OOB. offset
+buffer_load_dwordx2 v[64:65], v63, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,1,0) coordOffset1=33 element-rows coordOffset0=16 rows */
+_v_add_co_u32 v52, vcc, v48, 16                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v66, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[70:71], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v66, -1, v66, s[70:71]               // clip if OOB. offset
+buffer_load_dwordx2 v[67:68], v66, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,1,1) coordOffset1=33 element-rows coordOffset0=17 rows */
+_v_add_co_u32 v52, vcc, v48, 17                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v69, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[72:73], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v69, -1, v69, s[72:73]               // clip if OOB. offset
+buffer_load_dwordx2 v[70:71], v69, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,2,0) coordOffset1=33 element-rows coordOffset0=32 rows */
+_v_add_co_u32 v52, vcc, v48, 32                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v72, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[74:75], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v72, -1, v72, s[74:75]               // clip if OOB. offset
+buffer_load_dwordx2 v[73:74], v72, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+/* (d1,vc1,d0,vc0)=(1,1,2,1) coordOffset1=33 element-rows coordOffset0=33 rows */
+_v_add_co_u32 v52, vcc, v48, 33                    // coord0 += d0*sg0*VW + vc0
+_v_add_lshl_u32 v75, v51, v52, 0x3                 // accumulate d0 lower and *= bpe into addr
+/* TODO-packed: compare against product of packed sizes */
+v_cmp_lt_u32 s[56:57], v52, s[sgprSizesFree+0]     // coord0 < size0
+v_cmp_lt_u32 s[58:59], v53, s[sgprSizesFree+1]     // coord1 < size1
+s_and_b64 s[76:77], s[56:57], s[58:59]             // in0 && in1
+v_cndmask_b32 v75, -1, v75, s[76:77]               // clip if OOB. offset
+buffer_load_dwordx2 v[76:77], v75, s[sgprSrdC:sgprSrdC+3], 0, offen offset:0 // load C for beta calc
+
+/* rC *= alpha batchEements=[(1, 2, 0, 0), (1, 2, 0, 1), (1, 0, 1, 0), (1, 0, 1, 1), (1, 1, 1, 0), (1, 1, 1, 1), (1, 2, 1, 0), (1, 2, 1, 1)] */
+v_mul_f64 v[vgprValuC+32:vgprValuC+32+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+32:vgprValuC+32+1] // *= alpha
+v_mul_f64 v[vgprValuC+34:vgprValuC+34+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+34:vgprValuC+34+1] // *= alpha
+v_mul_f64 v[vgprValuC+36:vgprValuC+36+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+36:vgprValuC+36+1] // *= alpha
+v_mul_f64 v[vgprValuC+38:vgprValuC+38+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+38:vgprValuC+38+1] // *= alpha
+v_mul_f64 v[vgprValuC+40:vgprValuC+40+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+40:vgprValuC+40+1] // *= alpha
+v_mul_f64 v[vgprValuC+42:vgprValuC+42+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+42:vgprValuC+42+1] // *= alpha
+v_mul_f64 v[vgprValuC+44:vgprValuC+44+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+44:vgprValuC+44+1] // *= alpha
+v_mul_f64 v[vgprValuC+46:vgprValuC+46+1], s[sgprAlpha:sgprAlpha+1], v[vgprValuC+46:vgprValuC+46+1] // *= alpha
+s_waitcnt vmcnt(0)                                 // wait C
+
+/* apply mask, calc new C and issue write */
+v_fma_f64 v[vgprValuC+32:vgprValuC+32+1], v[55:56], s[sgprBeta:sgprBeta+1], v[vgprValuC+32:vgprValuC+32+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[32:33], v54, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+34:vgprValuC+34+1], v[58:59], s[sgprBeta:sgprBeta+1], v[vgprValuC+34:vgprValuC+34+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[34:35], v57, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+36:vgprValuC+36+1], v[61:62], s[sgprBeta:sgprBeta+1], v[vgprValuC+36:vgprValuC+36+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[36:37], v60, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+38:vgprValuC+38+1], v[64:65], s[sgprBeta:sgprBeta+1], v[vgprValuC+38:vgprValuC+38+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[38:39], v63, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+40:vgprValuC+40+1], v[67:68], s[sgprBeta:sgprBeta+1], v[vgprValuC+40:vgprValuC+40+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[40:41], v66, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+42:vgprValuC+42+1], v[70:71], s[sgprBeta:sgprBeta+1], v[vgprValuC+42:vgprValuC+42+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[42:43], v69, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+44:vgprValuC+44+1], v[73:74], s[sgprBeta:sgprBeta+1], v[vgprValuC+44:vgprValuC+44+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[44:45], v72, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+v_fma_f64 v[vgprValuC+46:vgprValuC+46+1], v[76:77], s[sgprBeta:sgprBeta+1], v[vgprValuC+46:vgprValuC+46+1] // finalSum = sum*alpha + C*beta
+buffer_store_dwordx2 v[46:47], v75, s[sgprSrdD:sgprSrdD+3], 0, offen, offset:0 // store C
+s_branch label_0037                                // jump to end
+label_0037:
+
+label_0038:  /// KernelEnd
+s_endpgm                                           // Kernel End
+
+

--- a/Tensile/ReplacementKernels/Cijk_Ailk_Bjlk_DB_MT48x64x4_AF0EM1_ASEM1_FL1_GRVW2_ISA908_PGR1_PLR0_SU0_TT6_4_VAW1_VW2_WG8_16_1_WGM4.s.txt
+++ b/Tensile/ReplacementKernels/Cijk_Ailk_Bjlk_DB_MT48x64x4_AF0EM1_ASEM1_FL1_GRVW2_ISA908_PGR1_PLR0_SU0_TT6_4_VAW1_VW2_WG8_16_1_WGM4.s.txt
@@ -1089,6 +1089,7 @@ label_0001:
 /* Unroll Loop 1/2 - Begin                */
 /******************************************/
 
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
 s_barrier //4sync for global read
 
 s_cmp_eq_i32 s[sgprLoopCounters+0], -1             // is this the last iteration
@@ -1246,6 +1247,7 @@ s_cbranch_scc1 label_0003                          // exit LoopL
 /* Unroll Loop 2/2 - Begin                */
 /******************************************/
 
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
 s_barrier //4sync for global read
 
 s_cmp_eq_i32 s[sgprLoopCounters+0], -1             // is this the last iteration
@@ -1516,7 +1518,8 @@ s_mov_b32       s87, s[sgprSrdD+0]
 s_mov_b32       s88, s[sgprSrdD+1]
 
 
-s_waitcnt lgkmcnt(0)                               // 1wait for local write
+//s_waitcnt lgkmcnt(0)                               // 1wait for local write
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
 s_barrier //4sync for global read
 
 /* iter 0,1 */
@@ -1844,7 +1847,8 @@ s_cbranch_scc1 label_1002                            // wg1 < nwg1-1 so skip rMT
 
 /******************************************/
 
-s_waitcnt lgkmcnt(0)                                 // 1wait for local write
+//s_waitcnt lgkmcnt(0)                                 // 1wait for local write
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
 s_barrier //4sync for global read
 
 /* iter 0 */
@@ -1959,7 +1963,8 @@ s_mov_b32       s87, s[sgprSrdD+0]
 s_mov_b32       s88, s[sgprSrdD+1]
 
 
-s_waitcnt lgkmcnt(0)                               // 1wait for local write
+//s_waitcnt lgkmcnt(0)                               // 1wait for local write
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
 s_barrier //4sync for global read
 
 /* iter 0,1 */
@@ -2261,7 +2266,8 @@ label_1002:
 /******************************************/
 //branch logic gets executed for edge MT to use legacy alph_beta code
 
-s_waitcnt lgkmcnt(0)                                 // 1wait for local write
+//s_waitcnt lgkmcnt(0)                                 // 1wait for local write
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
 s_barrier //4sync for global read
 
 /* iter 0 */
@@ -2351,7 +2357,8 @@ s_waitcnt lgkmcnt(0)                               // 6wait for local read old=2
 MAC_6x4_X0
 
 
-s_waitcnt lgkmcnt(0)                               // 1wait for local write
+//s_waitcnt lgkmcnt(0)                               // 1wait for local write
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
 s_barrier //4sync for global read
 
 
@@ -2438,7 +2445,8 @@ s_branch label_0004
 
 label_1003:
 
-s_waitcnt lgkmcnt(0)                               // 1wait for local write
+//s_waitcnt lgkmcnt(0)                               // 1wait for local write
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
 s_barrier //4sync for global read
 
 
@@ -2535,8 +2543,9 @@ s_cmp_eq_i32 s[sgprLoopCounters+0], -1             // is this the last iteration
 s_cmov_b32 s[sgprSrdA+2], 0                        // Set limit to 0 for last iteration
 s_cmov_b32 s[sgprSrdB+2], 0                        // Set limit to 0 for last iteration
 
-s_waitcnt lgkmcnt(0)                               // 1wait for local write
+//s_waitcnt lgkmcnt(0)                               // 1wait for local write
 
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
 s_barrier //4sync for global read
 
 /* iter 0 */
@@ -2677,8 +2686,9 @@ buffer_load_dwordx2 v[vgprG2LB+0+0:vgprG2LB+0+0+1], v[vgprGlobalReadOffsetB+0], 
 buffer_load_dwordx2 v[vgprG2LB+0+2:vgprG2LB+0+2+1], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0, offen offset:8 // load one buffer value
 _v_add_co_u32 v[vgprGlobalReadOffsetB+0], vcc, v[vgprGlobalReadOffsetB+0], 8 // graOffset += 1 * bpe
 
-s_waitcnt vmcnt(0)                                 // 2wait for global read
+//s_waitcnt vmcnt(0)                                 // 2wait for global read
 
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
 s_barrier //
 
 /* local write init pointers a */
@@ -2700,8 +2710,9 @@ ds_write_b128 v[vgprLocalWriteAddrA], v[vgprG2LA+0:vgprG2LA+0+3] offset:0 // lwo
 
 ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+0:vgprG2LB+0+3] offset:0 // lwoB_0_0_0_0 = (0*LSCB) + (0*LSPB)(*MT1J+PAD) = 0
 
-s_waitcnt lgkmcnt(0)                               // 5wait for local write
+//s_waitcnt lgkmcnt(0)                               // 5wait for local write
 
+s_waitcnt lgkmcnt(0) & vmcnt(0)                    // force waitcnt0
 s_barrier //
 
 

--- a/Tensile/ReplacementKernels/Cijk_Alik_Bljk_BBH_MT32x32x32_AF0EM8_ASEM8_FL0_GRVW2_ISA908_MDA2_PGR1_PLR1_SU32_TT2_2_VAW1_VW2_WG16_16_1_WGM8.s.txt
+++ b/Tensile/ReplacementKernels/Cijk_Alik_Bljk_BBH_MT32x32x32_AF0EM8_ASEM8_FL0_GRVW2_ISA908_MDA2_PGR1_PLR1_SU32_TT2_2_VAW1_VW2_WG16_16_1_WGM8.s.txt
@@ -1,0 +1,1100 @@
+
+
+/******************************************/
+/* Function Prefix                        */
+/******************************************/
+
+
+
+/******************************************/
+/* Begin Kernel                           */
+/******************************************/
+
+.hsa_code_object_version 2,0
+.hsa_code_object_isa 9, 0, 8, "AMD", "AMDGPU"
+.text
+.p2align 8
+.amdgpu_hsa_kernel Cijk_Alik_Bljk_BBH_MT32x32x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGRO1_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG16_16_1_WGM8
+Cijk_Alik_Bljk_BBH_MT32x32x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGRO1_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG16_16_1_WGM8:
+.amd_kernel_code_t
+  is_ptr64 = 1
+  enable_sgpr_kernarg_segment_ptr = 1
+  kernarg_segment_byte_size = 76 // bytes of kern args
+  workitem_vgpr_count = 108 // vgprs
+  wavefront_sgpr_count = 98 // sgprs
+  compute_pgm_rsrc1_vgprs = 26 // floor((108-1)/4)
+  compute_pgm_rsrc1_sgprs = 12 // floor((98-1)/8)
+  compute_pgm_rsrc2_tidig_comp_cnt = 0 // 1D wg
+  compute_pgm_rsrc2_tgid_x_en = 1 // wg.x
+  compute_pgm_rsrc2_tgid_y_en = 1 // wg.y
+  compute_pgm_rsrc2_tgid_z_en = 1 // wg.z
+  workgroup_group_segment_byte_size = 36000// lds bytes
+  compute_pgm_rsrc2_user_sgpr = 2 // vcc
+  kernarg_segment_alignment = 4
+  group_segment_alignment = 4
+  private_segment_alignment = 4
+.end_amd_kernel_code_t
+
+/******************************************/
+/* Optimizations and Config:              */
+/******************************************/
+/* ThreadTile= 2 x 2 */
+/* SubGroup= 16 x 16 */
+/* VectorWidth=4 */
+/* GlobalLoadVectorWidthA=4, GlobalLoadVectorWidthB=4 */
+/* DirectToLdsA=False */
+/* DirectToLdsB=False */
+/* UseSgprForGRO=False */
+.amd_amdgpu_hsa_metadata
+Version: [ 1, 0 ]
+Kernels:
+  - Name: Cijk_Alik_Bljk_BBH_MT32x32x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGRO1_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG16_16_1_WGM8
+    SymbolName: 'Cijk_Alik_Bljk_BBH_MT32x32x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGRO1_VAW1_VS1_VW2_WSGRA0_WSGRB0_WG16_16_1_WGM8@kd'
+    Language: OpenCL C
+    LanguageVersion: [ 2, 0 ]
+    Args:
+      - Name:            sizeC
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            sizeA
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            sizeB
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            D
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       Struct
+        AddrSpaceQual:   Generic
+      - Name:            C
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       Struct
+        AddrSpaceQual:   Generic
+      - Name:            A
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       Struct
+        AddrSpaceQual:   Generic
+      - Name:            B
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       Struct
+        AddrSpaceQual:   Generic
+      - Name:            alpha
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       F32
+      - Name:            beta
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       F32
+      - Name:            strideD0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideD1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideC0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideC1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideA0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideA1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideB0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideB1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree2
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesSum0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            OrigStaggerUIter
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       I32
+      - Name:            NumWorkGroups0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            NumWorkGroups1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            NumFullBlocks
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            WgmRemainder1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            MagicNumberWgmRemainder1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+    CodeProps:
+      KernargSegmentSize: 148
+      GroupSegmentFixedSize: 28672
+      PrivateSegmentFixedSize: 0
+      KernargSegmentAlign:  8
+      WavefrontSize:        64
+      NumSGPRs:             98
+      NumVGPRs:             108
+      MaxFlatWorkGroupSize: 256
+.end_amd_amdgpu_hsa_metadata
+
+/******************************************/
+/* Asm syntax workarounds                 */
+/******************************************/
+.macro _v_add_co_u32 dst, cc, src0, src1, dpp=
+   v_add_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+.macro _v_sub_co_u32 dst, cc, src0, src1, dpp=
+   v_sub_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+.macro _v_addc_co_u32 dst, ccOut, src0, ccIn, src1, dpp=
+   v_addc_co_u32 \dst, \ccOut, \src0, \ccIn, \src1 \dpp
+.endm
+.macro _v_add_lshl_u32 dst, src0, src1, shiftCnt
+    v_add_lshl_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+.macro _v_lshl_add_u32 dst, src0, src1, shiftCnt
+    v_lshl_add_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+/******************************************/
+/* Bits 127:96 of SRD.  Set DataFormat = 32 bit */
+/******************************************/
+.set Srd127_96, 0x0020000
+.set BufferOOB, 0x80000000
+/******************************************/
+/* 2GB limit - set offsets to -1 to exceed this and clamp */
+/******************************************/
+.set BufferLimit, 0x80000000
+
+.macro GLOBAL_OFFSET_A vgprAddr vgprOffsetL vgprOffset0I vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStridesA+0], v[\vgprOffset0I] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprTmp+0], v[\vgprOffsetL] // accumulate d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, 0x4, v[\vgprAddr+0] // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/* Global Offset B */
+.macro GLOBAL_OFFSET_B vgprAddr vgprOffset1J vgprOffsetL vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStridesB+0], v[\vgprOffsetL] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprTmp+0], v[\vgprOffset1J] // accumulate d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, 0x4, v[\vgprAddr+0] // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+  //tail-kernel start
+  //tail kernel problem size 64x1024
+  // use 64 CU(s) for tail kernel
+  // tile size = 32x32
+  // 64 CU(s) are split into 2 groups of 32
+  // CU[0-31] = A[0-31]xB[0-1024]  CU[32-63] = A[32-63]xB[0-1024]
+  // B matrix organized as 32 tiles of 32x1024 mapped to CU[0-63], each cU working on 32 columns (y dimension)
+  // A matrix organized as 2 tiles of 32x1024  , each CU[0-31] responsible for 32 rows
+  // Sub-tile/SIMD organization
+  // each 32x32 tile in CU split into 2 groups of 16x16  and simds split into 2 groups
+  // simd(s) use 16x16 mfma instruction to solve 32x32 tile simd[0,1] multiply first [0-15] rows with B[0-31]
+
+   //TODO
+   // convert buffer_load_dword into bufffer_load_dwordx4
+   // Use SGPR for offset to avoid using 4 VALU global fetch pointer increment
+   // move Store C address calculation interleaved with noLoadLoop
+
+//////sreg def/////////////
+.set sgprKernArgAddress , 0
+.set sgprWorkGroup0 , 2
+.set sgprWorkGroup1 , 3
+.set sgprWorkGroup2 , 4
+.set sgprNumWorkGroups0,5
+.set sgprNumWorkGroups1,6
+.set sgprSrdA,8
+.set sgprSrdB,12
+.set sgprSrdC,16
+.set sgprSrdD,20
+.set sgprTensor2dSizeC, 24
+.set sgprTensor2dSizeA, 26
+.set sgprTensor2dSizeB, 28
+.set sgprSaveExecMask, 30
+.set sgprAddressD, 32
+.set sgprAddressC, 34
+.set sgprStridesD, 36
+.set sgprStridesC, 38
+.set sgprAlpha, 40
+.set sgprBeta, 41
+.set sgprSizesFree , 42
+.set sgprSizesSum  , 45
+.set sgprLoopCounters, 46
+.set sgprOrigLoopCounter, 47
+.set sgprStridesA, 48
+.set sgprStridesB, 50
+.set sgprAddressA, 52
+.set sgprAddressB, 54
+.set sgprShadowLimitA, 56
+.set sgprShadowLimitB, 58
+.set sgprOrigStaggerUIter, 60
+.set sgprStaggerUIter, 61
+.set sgprWrapUA, 62
+.set sgprWrapUB, 64
+.set sgprNumFullBlocks, 66
+.set sgprWgmRemainder1, 67
+.set sgprMagicNumberWgmRemainder1, 68
+.set sgprGlobalReadIncsA, 69
+.set sgprGlobalReadIncsB, 70
+.set sgprScalarGlobalReadOffsetA,71
+.set sgprScalarGlobalReadOffsetB,73
+.set sgprLocalWriteAddrA,75
+.set sgprLocalWriteAddrB,77
+.set sgprGlobalFetchSubGrpId,79
+.set sgprWorkGrpIdFlatten , 80
+.set sgprtailWorkGrp0,81
+.set sgprtailWorkGrp1,82
+//sgprs[83-87] used as temp
+.set sgprtailSimdTileX,88
+.set sgprtailSimdTileY,89
+
+/////vreg def////////////////
+
+.set vgprValuC,0
+.set vgprAcc,0
+.set vgprValuA_X0_I0,32
+.set vgprG2LA,48
+.set vgprValuB_X0_I0,52
+.set vgprG2LB,68
+.set vgprLocalWriteAddrA,76
+.set vgprLocalWriteAddrB,78
+.set vgprGlobalReadOfvarA,82
+.set vgprGlobalReadOfvarB,86
+.set vgprLocalReadAddrA,94
+.set vgprLocalReadAddrB,96
+.set vgprSerial,100
+.set vgprGlobalWriteOfvarC,104
+.set vgprTmp,105
+
+//** maxVGPR 112 **/
+.set lds_pad_tail       , 16
+.set lds_pad_qw_tail    , lds_pad_tail >> 2
+.set lds_Asize_per_wr_tail   , 256+lds_pad_tail           //each load inst load one 32X4 block.    need contiunous 32X4X2,256    bytes in LDS
+.set lds_Asize_per_tailwave , lds_Asize_per_wr_tail * 2   //each wave load 2 32X4 block one time.  need contiunous 32X4X4X2,1024 bytes in LDS
+.set lds_Asize_per_tailwg   , lds_Asize_per_tailwave * 4  //WG load 8 32X4 block(64X32) Matrix A to lds for pingpong.
+.set lds_Bsize_per_wr_tail   , 256+lds_pad_tail           //each load inst load one 32X4  block.    need contiunous 32X4X2,256     bytes in LDS
+.set lds_Bsize_per_tailwave , lds_Bsize_per_wr_tail * 2   //each wave load seperate 32X64 block.    need contiunous 32X4X2X2,512 bytes in LDS
+.set lds_Bsize_per_tailwg   , lds_Bsize_per_tailwave * 4  //WG load 64 32X4 block(32X256) Matrix B to lds for pingpong.
+.set A_lds_base_addr    , 0
+.set B_lds_base_addr_tail    , A_lds_base_addr+lds_Asize_per_tailwg * 8  //in bytes
+.set A_lds_simd_offset_tail  , lds_Asize_per_wr_tail*2*2 	//2 loads * 2 SIMD
+
+
+ //****************
+ // start kernel
+
+  s_mov_b32     m0, 0x00003000                          // 000000000000: BEFC00FF 00003000
+  v_mov_b32     v100, v0                                // 000000000008: 7EC80300
+  v_and_b32     v101, 63, v0                            // 00000000000C: 26CA00BF
+  s_load_dword  s26, s[0:1], 0x08                       // 000000000010: C0020680 00000008
+  s_load_dword  s27, s[0:1], 0x0c                       // 000000000018: C00206C0 0000000C
+  s_load_dword  s52, s[0:1], 0x28                       // 000000000020: C0020D00 00000028
+  s_load_dword  s53, s[0:1], 0x2c                       // 000000000028: C0020D40 0000002C
+  s_load_dword  s48, s[0:1], 0x50                       // 000000000030: C0020C00 00000050
+  s_load_dword  s49, s[0:1], 0x54                       // 000000000038: C0020C40 00000054
+  s_load_dword  s50, s[0:1], 0x58                       // 000000000040: C0020C80 00000058
+  s_load_dword  s51, s[0:1], 0x5c                       // 000000000048: C0020CC0 0000005C
+  s_load_dword  s54, s[0:1], 0x30                       // 000000000050: C0020D80 00000030
+  s_load_dword  s55, s[0:1], 0x34                       // 000000000058: C0020DC0 00000034
+  s_load_dword  s28, s[0:1], 0x10                       // 000000000060: C0020700 00000010
+  s_load_dword  s29, s[0:1], 0x14                       // 000000000068: C0020740 00000014
+  v_lshrrev_b32  v2, 6, v100                            // 000000000070: 2004C886
+  v_readfirstlane_b32  s79, v2                          // 000000000074: 7E9E0502
+  s_and_b32     s88, s79, 1                             // 000000000078: 8658814F
+  s_lshr_b32    s89, s79, 1                             // 00000000007C: 8F59814F
+  s_mul_i32     s80, s3, 2                              // 000000000080: 92508203
+  s_add_i32     s80, s2, s80                            // 000000000084: 81505002
+  s_mov_b32     s82, s3                                 // 000000000088: BED20003
+  s_mov_b32     s81, s2                                 // 00000000008C: BED10002
+  v_accvgpr_write  a0, 0                              // 000000000090: D3D94000 18000080
+  v_accvgpr_write  a1, 0                              // 000000000098: D3D94001 18000080
+  v_accvgpr_write  a2, 0                              // 0000000000A0: D3D94002 18000080
+  v_accvgpr_write  a3, 0                              // 0000000000A8: D3D94003 18000080
+  s_waitcnt     lgkmcnt(0)                              // 0000000000B0: BF8CC07F
+  s_mov_b32     s8, s52                                 // 0000000000B4: BE880034
+  s_mov_b32     s9, s53                                 // 0000000000B8: BE890035
+  s_mov_b32     s11, 0x00020000                         // 0000000000BC: BE8B00FF 00020000
+  s_sub_u32     s56, s26, s84                           // 0000000000C4: 80B8541A
+  s_sub_u32     s57, s26, s85                           // 0000000000C8: 80B9551A
+  s_lshl_b64    s[56:57], s[56:57], 1                   // 0000000000CC: 8EB88138
+  s_add_u32     s56, s56, 4                             // 0000000000D0: 80388438
+  s_addc_u32    s57, s57, 0                             // 0000000000D4: 82398039
+  s_cmp_eq_u32  s57, 0                                  // 0000000000D8: BF068039
+  s_cselect_b32  s10, s56, 0x80000000                   // 0000000000DC: 850AFF38 80000000
+  s_mov_b32     s10, 0x80000000                         // 0000000000E4: BE8A00FF 80000000
+  s_mul_i32     s84, s81, 32                            // 0000000000EC: 9254A051
+  s_mul_i32     s84, s48, s84                           // 0000000000F0: 92545430
+  s_lshl_b32    s83, s79, 3                             // 0000000000F4: 8E53834F
+  s_mul_i32     s83, s48, s83                           // 0000000000F8: 92535330
+  s_add_i32     s84, s84, s83                           // 0000000000FC: 81545354
+  v_lshrrev_b32  v0, 4, v101                            // 000000000100: 2000CA84
+  v_mul_lo_u32  v4, s48, v0                             // 000000000104: D2850004 00020030
+  v_and_b32     v1, 15, v101                            // 00000000010C: 2602CA8F
+  v_lshlrev_b32  v1, 1, v1                              // 000000000110: 24020281
+  v_add_co_u32  v82, vcc, v4, v1                        // 000000000114: 32A40304
+  v_add_u32     v82, s84, v82                           // 000000000118: 68A4A454
+  v_lshlrev_b32  v82, 1, v82                            // 00000000011C: 24A4A481
+  s_lshl_b32    s71, s48, 3                             // 000000000120: 8E478330
+  s_sub_u32     s71, s71, 0x00000110                    // 000000000124: 80C7FF47 00000110
+  v_add_u32     v83, s71, v82                           // 00000000012C: 68A6A447
+  s_mov_b32     s75, 0x00000220                         // 000000000130: BECB00FF 00000220
+  s_mul_i32     s75, s79, s75                           // 000000000138: 924B4B4F
+  s_mov_b32     s12, s54                                // 00000000013C: BE8C0036
+  s_mov_b32     s13, s55                                // 000000000140: BE8D0037
+  s_mov_b32     s15, 0x00020000                         // 000000000144: BE8F00FF 00020000
+  s_sub_u32     s58, s28, s84                           // 00000000014C: 80BA541C
+  s_sub_u32     s59, s28, s85                           // 000000000150: 80BB551C
+  s_lshl_b64    s[58:59], s[58:59], 1                   // 000000000154: 8EBA813A
+  s_add_u32     s58, s58, 4                             // 000000000158: 803A843A
+  s_addc_u32    s59, s59, 0                             // 00000000015C: 823B803B
+  s_cmp_eq_u32  s59, 0                                  // 000000000160: BF06803B
+  s_cselect_b32  s14, s58, 0x80000000                   // 000000000164: 850EFF3A 80000000
+  s_mov_b32     s14, 0x80000000                         // 00000000016C: BE8E00FF 80000000
+  s_mul_i32     s84, s82, 32                            // 000000000174: 9254A052
+  s_mul_i32     s84, s50, s84                           // 000000000178: 92545432
+  s_lshl_b32    s83, s79, 3                             // 00000000017C: 8E53834F
+  s_mul_i32     s83, s50, s83                           // 000000000180: 92535332
+  s_add_i32     s84, s84, s83                           // 000000000184: 81545354
+  v_lshrrev_b32  v2, 4, v101                            // 000000000188: 2004CA84
+  v_and_b32     v3, 15, v101                            // 00000000018C: 2606CA8F
+  v_lshlrev_b32  v3, 1, v3                              // 000000000190: 24060681
+  v_mul_lo_u32  v4, s50, v2                             // 000000000194: D2850004 00020432
+  v_add_co_u32  v86, vcc, v4, v3                        // 00000000019C: 32AC0704
+  v_add_u32     v86, s84, v86                           // 0000000001A0: 68ACAC54
+  v_lshlrev_b32  v86, 1, v86                            // 0000000001A4: 24ACAC81
+  s_lshl_b32    s73, s50, 3                             // 0000000001A8: 8E498332
+  s_sub_u32     s73, s73, 0x00000110                    // 0000000001AC: 80C9FF49 00000110
+  v_add_u32     v87, s73, v86                           // 0000000001B4: 68AEAC49
+  s_mov_b32     s77, 0x00000220                         // 0000000001B8: BECD00FF 00000220
+  s_mul_i32     s77, s79, s77                           // 0000000001C0: 924D4D4F
+  s_add_i32     s77, s77, 0x00004400                    // 0000000001C4: 814DFF4D 00004400
+  s_mov_b32     m0, s75                                 // 0000000001CC: BEFC004B
+  s_add_i32     s76, s75, 0x00000880                    // 0000000001D0: 814CFF4B 00000880
+  buffer_load_dword  v48, v82, s[8:11], 0 offen lds     // 0000000001D8: E0511000 80023052
+  buffer_load_dword  v49, v83, s[8:11], 0 offen offset:272 lds // 0000000001E0: E0511110 80023153
+  s_mov_b32     m0, s77                                 // 0000000001E8: BEFC004D
+  s_add_i32     s78, s77, 0x00000880                    // 0000000001EC: 814EFF4D 00000880
+  buffer_load_dword  v68, v86, s[12:15], 0 offen lds    // 0000000001F4: E0511000 80034456
+  buffer_load_dword  v69, v87, s[12:15], 0 offen offset:272 lds // 0000000001FC: E0511110 80034557
+  s_load_dword  s32, s[0:1], 0x18                       // 000000000204: C0020800 00000018
+  s_load_dword  s33, s[0:1], 0x1c                       // 00000000020C: C0020840 0000001C
+  s_load_dword  s34, s[0:1], 0x20                       // 000000000214: C0020880 00000020
+  s_load_dword  s35, s[0:1], 0x24                       // 00000000021C: C00208C0 00000024
+  s_load_dword  s24, s[0:1], 0x00                       // 000000000224: C0020600 00000000
+  s_load_dword  s25, s[0:1], 0x04                       // 00000000022C: C0020640 00000004
+  s_load_dword  s40, s[0:1], 0x38                       // 000000000234: C0020A00 00000038
+  s_load_dword  s36, s[0:1], 0x40                       // 00000000023C: C0020900 00000040
+  s_load_dword  s37, s[0:1], 0x44                       // 000000000244: C0020940 00000044
+  s_load_dword  s38, s[0:1], 0x48                       // 00000000024C: C0020980 00000048
+  s_load_dword  s39, s[0:1], 0x4c                       // 000000000254: C00209C0 0000004C
+  s_load_dword  s42, s[0:1], 0x60                       // 00000000025C: C0020A80 00000060
+  s_load_dword  s43, s[0:1], 0x64                       // 000000000264: C0020AC0 00000064
+  s_load_dword  s44, s[0:1], 0x68                       // 00000000026C: C0020B00 00000068
+  s_load_dword  s45, s[0:1], 0x6c                       // 000000000274: C0020B40 0000006C
+  v_and_b32     v105, v101, 15                          // 00000000027C: D1130069 00011F65
+  v_mul_lo_u32  v94, 16, v105                           // 000000000284: D285005E 0002D290
+  v_lshrrev_b32  v105, 2, v105                          // 00000000028C: 20D2D282
+  v_mul_lo_u32  v105, 4, v105                           // 000000000290: D2850069 0002D284
+  v_add_u32     v94, v105, v94                          // 000000000298: 68BCBD69
+  v_lshrrev_b32  v105, 4, v101                          // 00000000029C: 20D2CA84
+  v_add_u32     v94, v105, v94                          // 0000000002A0: 68BCBD69
+  v_lshlrev_b32  v94, 2, v94                            // 0000000002A4: 24BCBC82
+  v_mov_b32     v96, v94                                // 0000000002A8: 7EC0035E
+  s_mul_i32     s83, s89, 0x00000440                    // 0000000002AC: 9253FF59 00000440
+  v_add_u32     v94, s83, v94                           // 0000000002B4: 68BCBC53
+  v_add_u32     v94, 0, v94                             // 0000000002B8: 68BCBC80
+  v_add_u32     v95, 0x00000880, v94                    // 0000000002BC: 68BEBCFF 00000880
+  s_mul_i32     s83, s88, 0x00000440                    // 0000000002C4: 9253FF58 00000440
+  v_add_u32     v96, s83, v96                           // 0000000002CC: 68C0C053
+  v_add_u32     v96, 0x00004400, v96                    // 0000000002D0: 68C0C0FF 00004400
+  v_add_u32     v97, 0x00000880, v96                    // 0000000002D8: 68C2C0FF 00000880
+  s_mul_i32     s83, 0x00000880, 1                      // 0000000002E0: 925381FF 00000880
+  s_add_i32     m0, s75, s83                            // 0000000002E8: 817C534B
+  v_add_u32     v82, 64, v82                            // 0000000002EC: 68A4A4C0
+  v_add_u32     v83, 64, v83                            // 0000000002F0: 68A6A6C0
+  v_add_u32     v86, 64, v86                            // 0000000002F4: 68ACACC0
+  v_add_u32     v87, 64, v87                            // 0000000002F8: 68AEAEC0
+  buffer_load_dword  v48, v82, s[8:11], 0 offen lds     // 0000000002FC: E0511000 80023052
+  buffer_load_dword  v49, v83, s[8:11], 0 offen offset:272 lds // 000000000304: E0511110 80023153
+  s_add_i32     m0, s77, s83                            // 00000000030C: 817C534D
+  s_nop         0x0000                                  // 000000000310: BF800000
+  buffer_load_dword  v68, v86, s[12:15], 0 offen lds    // 000000000314: E0511000 80034456
+  buffer_load_dword  v69, v87, s[12:15], 0 offen offset:272 lds // 00000000031C: E0511110 80034557
+  s_mul_i32     s83, 0x00000880, 2                      // 000000000324: 925382FF 00000880
+  s_add_i32     m0, s75, s83                            // 00000000032C: 817C534B
+  v_add_u32     v82, 64, v82                            // 000000000330: 68A4A4C0
+  v_add_u32     v83, 64, v83                            // 000000000334: 68A6A6C0
+  v_add_u32     v86, 64, v86                            // 000000000338: 68ACACC0
+  v_add_u32     v87, 64, v87                            // 00000000033C: 68AEAEC0
+  buffer_load_dword  v48, v82, s[8:11], 0 offen lds     // 000000000340: E0511000 80023052
+  buffer_load_dword  v49, v83, s[8:11], 0 offen offset:272 lds // 000000000348: E0511110 80023153
+  s_add_i32     m0, s77, s83                            // 000000000350: 817C534D
+  s_nop         0x0000                                  // 000000000354: BF800000
+  buffer_load_dword  v68, v86, s[12:15], 0 offen lds    // 000000000358: E0511000 80034456
+  buffer_load_dword  v69, v87, s[12:15], 0 offen offset:272 lds // 000000000360: E0511110 80034557
+  s_mul_i32     s83, 0x00000880, 3                      // 000000000368: 925383FF 00000880
+  s_add_i32     m0, s75, s83                            // 000000000370: 817C534B
+  v_add_u32     v82, 64, v82                            // 000000000374: 68A4A4C0
+  v_add_u32     v83, 64, v83                            // 000000000378: 68A6A6C0
+  v_add_u32     v86, 64, v86                            // 00000000037C: 68ACACC0
+  v_add_u32     v87, 64, v87                            // 000000000380: 68AEAEC0
+  buffer_load_dword  v48, v82, s[8:11], 0 offen lds     // 000000000384: E0511000 80023052
+  buffer_load_dword  v49, v83, s[8:11], 0 offen offset:272 lds // 00000000038C: E0511110 80023153
+  s_add_i32     m0, s77, s83                            // 000000000394: 817C534D
+  s_nop         0x0000                                  // 000000000398: BF800000
+  buffer_load_dword  v68, v86, s[12:15], 0 offen lds    // 00000000039C: E0511000 80034456
+  buffer_load_dword  v69, v87, s[12:15], 0 offen offset:272 lds // 0000000003A4: E0511110 80034557
+  s_mul_i32     s83, 0x00000880, 4                      // 0000000003AC: 925384FF 00000880
+  s_add_i32     m0, s75, s83                            // 0000000003B4: 817C534B
+  v_add_u32     v82, 64, v82                            // 0000000003B8: 68A4A4C0
+  v_add_u32     v83, 64, v83                            // 0000000003BC: 68A6A6C0
+  v_add_u32     v86, 64, v86                            // 0000000003C0: 68ACACC0
+  v_add_u32     v87, 64, v87                            // 0000000003C4: 68AEAEC0
+  buffer_load_dword  v48, v82, s[8:11], 0 offen lds     // 0000000003C8: E0511000 80023052
+  buffer_load_dword  v49, v83, s[8:11], 0 offen offset:272 lds // 0000000003D0: E0511110 80023153
+  s_add_i32     m0, s77, s83                            // 0000000003D8: 817C534D
+  s_nop         0x0000                                  // 0000000003DC: BF800000
+  buffer_load_dword  v68, v86, s[12:15], 0 offen lds    // 0000000003E0: E0511000 80034456
+  buffer_load_dword  v69, v87, s[12:15], 0 offen offset:272 lds // 0000000003E8: E0511110 80034557
+  s_mul_i32     s83, 0x00000880, 5                      // 0000000003F0: 925385FF 00000880
+  s_add_i32     m0, s75, s83                            // 0000000003F8: 817C534B
+  v_add_u32     v82, 64, v82                            // 0000000003FC: 68A4A4C0
+  v_add_u32     v83, 64, v83                            // 000000000400: 68A6A6C0
+  v_add_u32     v86, 64, v86                            // 000000000404: 68ACACC0
+  v_add_u32     v87, 64, v87                            // 000000000408: 68AEAEC0
+  buffer_load_dword  v48, v82, s[8:11], 0 offen lds     // 00000000040C: E0511000 80023052
+  buffer_load_dword  v49, v83, s[8:11], 0 offen offset:272 lds // 000000000414: E0511110 80023153
+  s_add_i32     m0, s77, s83                            // 00000000041C: 817C534D
+  s_nop         0x0000                                  // 000000000420: BF800000
+  buffer_load_dword  v68, v86, s[12:15], 0 offen lds    // 000000000424: E0511000 80034456
+  buffer_load_dword  v69, v87, s[12:15], 0 offen offset:272 lds // 00000000042C: E0511110 80034557
+  s_mul_i32     s83, 0x00000880, 6                      // 000000000434: 925386FF 00000880
+  s_add_i32     m0, s75, s83                            // 00000000043C: 817C534B
+  v_add_u32     v82, 64, v82                            // 000000000440: 68A4A4C0
+  v_add_u32     v83, 64, v83                            // 000000000444: 68A6A6C0
+  v_add_u32     v86, 64, v86                            // 000000000448: 68ACACC0
+  v_add_u32     v87, 64, v87                            // 00000000044C: 68AEAEC0
+  buffer_load_dword  v48, v82, s[8:11], 0 offen lds     // 000000000450: E0511000 80023052
+  buffer_load_dword  v49, v83, s[8:11], 0 offen offset:272 lds // 000000000458: E0511110 80023153
+  s_add_i32     m0, s77, s83                            // 000000000460: 817C534D
+  s_nop         0x0000                                  // 000000000464: BF800000
+  buffer_load_dword  v68, v86, s[12:15], 0 offen lds    // 000000000468: E0511000 80034456
+  buffer_load_dword  v69, v87, s[12:15], 0 offen offset:272 lds // 000000000470: E0511110 80034557
+  s_mul_i32     s83, 0x00000880, 7                      // 000000000478: 925387FF 00000880
+  s_add_i32     m0, s75, s83                            // 000000000480: 817C534B
+  v_add_u32     v82, 64, v82                            // 000000000484: 68A4A4C0
+  v_add_u32     v83, 64, v83                            // 000000000488: 68A6A6C0
+  v_add_u32     v86, 64, v86                            // 00000000048C: 68ACACC0
+  v_add_u32     v87, 64, v87                            // 000000000490: 68AEAEC0
+  buffer_load_dword  v48, v82, s[8:11], 0 offen lds     // 000000000494: E0511000 80023052
+  buffer_load_dword  v49, v83, s[8:11], 0 offen offset:272 lds // 00000000049C: E0511110 80023153
+  s_add_i32     m0, s77, s83                            // 0000000004A4: 817C534D
+  s_nop         0x0000                                  // 0000000004A8: BF800000
+  buffer_load_dword  v68, v86, s[12:15], 0 offen lds    // 0000000004AC: E0511000 80034456
+  buffer_load_dword  v69, v87, s[12:15], 0 offen offset:272 lds // 0000000004B4: E0511110 80034557
+  v_add_u32     v82, 64, v82                            // 0000000004BC: 68A4A4C0
+  v_add_u32     v83, 64, v83                            // 0000000004C0: 68A6A6C0
+  v_add_u32     v86, 64, v86                            // 0000000004C4: 68ACACC0
+  v_add_u32     v87, 64, v87                            // 0000000004C8: 68AEAEC0
+  s_waitcnt     lgkmcnt(0)                              // 0000000004CC: BF8CC07F
+  s_waitcnt     vmcnt(30)                               // 0000000004D0: BF8C4F7E
+  s_barrier                                             // 0000000004D4: BF8A0000
+  ds_read_b32   v32, v94                                // 0000000004D8: D86C0000 2000005E
+  ds_read_b32   v33, v94 offset:16                      // 0000000004E0: D86C0010 2100005E
+  ds_read_b32   v34, v94 offset:32                      // 0000000004E8: D86C0020 2200005E
+  ds_read_b32   v35, v94 offset:48                      // 0000000004F0: D86C0030 2300005E
+  s_waitcnt     vmcnt(28)                               // 0000000004F8: BF8C4F7C
+  s_barrier                                             // 0000000004FC: BF8A0000
+  ds_read_b32   v52, v96                                // 000000000500: D86C0000 34000060
+  ds_read_b32   v53, v96 offset:16                      // 000000000508: D86C0010 35000060
+  ds_read_b32   v54, v96 offset:32                      // 000000000510: D86C0020 36000060
+  ds_read_b32   v55, v96 offset:48                      // 000000000518: D86C0030 37000060
+  s_mul_i32     s83, 0x00000880, 1                      // 000000000520: 925381FF 00000880
+  v_add_u32     v105, s83, v94                          // 000000000528: 68D2BC53
+  s_waitcnt     vmcnt(26)                               // 00000000052C: BF8C4F7A
+  s_barrier                                             // 000000000530: BF8A0000
+  ds_read_b32   v36, v105                               // 000000000534: D86C0000 24000069
+  ds_read_b32   v37, v105 offset:16                     // 00000000053C: D86C0010 25000069
+  ds_read_b32   v38, v105 offset:32                     // 000000000544: D86C0020 26000069
+  ds_read_b32   v39, v105 offset:48                     // 00000000054C: D86C0030 27000069
+  v_add_u32     v106, s83, v96                          // 000000000554: 68D4C053
+  s_waitcnt     vmcnt(24)                               // 000000000558: BF8C4F78
+  s_barrier                                             // 00000000055C: BF8A0000
+  ds_read_b32   v56, v106                               // 000000000560: D86C0000 3800006A
+  ds_read_b32   v57, v106 offset:16                     // 000000000568: D86C0010 3900006A
+  ds_read_b32   v58, v106 offset:32                     // 000000000570: D86C0020 3A00006A
+  ds_read_b32   v59, v106 offset:48                     // 000000000578: D86C0030 3B00006A
+  s_mul_i32     s83, 0x00000880, 2                      // 000000000580: 925382FF 00000880
+  v_add_u32     v105, s83, v94                          // 000000000588: 68D2BC53
+  v_add_u32     v106, s83, v96                          // 00000000058C: 68D4C053
+  s_waitcnt     vmcnt(22)                               // 000000000590: BF8C4F76
+  s_barrier                                             // 000000000594: BF8A0000
+  ds_read_b32   v40, v105                               // 000000000598: D86C0000 28000069
+  ds_read_b32   v41, v105 offset:16                     // 0000000005A0: D86C0010 29000069
+  ds_read_b32   v42, v105 offset:32                     // 0000000005A8: D86C0020 2A000069
+  ds_read_b32   v43, v105 offset:48                     // 0000000005B0: D86C0030 2B000069
+  s_waitcnt     vmcnt(20)                               // 0000000005B8: BF8C4F74
+  s_barrier                                             // 0000000005BC: BF8A0000
+  ds_read_b32   v60, v106                               // 0000000005C0: D86C0000 3C00006A
+  ds_read_b32   v61, v106 offset:16                     // 0000000005C8: D86C0010 3D00006A
+  ds_read_b32   v62, v106 offset:32                     // 0000000005D0: D86C0020 3E00006A
+  ds_read_b32   v63, v106 offset:48                     // 0000000005D8: D86C0030 3F00006A
+  s_lshr_b32    s46, s45, 5                             // 0000000005E0: 8F2E852D
+  s_sub_u32     s46, 0, s46                             // 0000000005E4: 80AE2E80
+  s_cmp_eq_u32  s46, 0                                  // 0000000005E8: BF06802E
+  s_cbranch_scc1  label_0447                            // 0000000005EC: BF8502CB
+label_017C:
+  s_waitcnt     0xcf7f                                  // 0000000005F0: BF8CCF7F
+  v_mfma_f32_16x16x8bf16  a[0:3], v32, v52, acc[0:3]          // 0000000005F4: D3ED0000 04026920
+  s_mul_i32     s83, 0x00000880, 0                      // 0000000005FC: 925380FF 00000880
+  s_add_i32     m0, s75, s83                            // 000000000604: 817C534B
+  s_nop         0x0000                                  // 000000000608: BF800000
+  buffer_load_dword  v48, v82, s[8:11], 0 offen lds     // 00000000060C: E0511000 80023052
+  buffer_load_dword  v49, v83, s[8:11], 0 offen offset:272 lds // 000000000614: E0511110 80023153
+  s_add_i32     m0, s77, s83                            // 00000000061C: 817C534D
+  v_add_u32     v82, 64, v82                            // 000000000620: 68A4A4C0
+  v_add_u32     v83, 64, v83                            // 000000000624: 68A6A6C0
+  s_waitcnt     lgkmcnt(12)                             // 000000000628: BF8CCC7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v33, v53, acc[0:3]          // 00000000062C: D3ED0000 04026B21
+  buffer_load_dword  v68, v86, s[12:15], 0 offen lds    // 000000000634: E0511000 80034456
+  buffer_load_dword  v69, v87, s[12:15], 0 offen offset:272 lds // 00000000063C: E0511110 80034557
+  v_add_u32     v86, 64, v86                            // 000000000644: 68ACACC0
+  v_add_u32     v87, 64, v87                            // 000000000648: 68AEAEC0
+  s_waitcnt     lgkmcnt(10)                             // 00000000064C: BF8CCA7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v34, v54, acc[0:3]          // 000000000650: D3ED0000 04026D22
+  s_mul_i32     s83, 0x00000880, 3                      // 000000000658: 925383FF 00000880
+  v_add_u32     v105, s83, v94                          // 000000000660: 68D2BC53
+  s_waitcnt     vmcnt(22)                               // 000000000664: BF8C4F76
+  s_barrier                                             // 000000000668: BF8A0000
+  ds_read_b32   v44, v105                               // 00000000066C: D86C0000 2C000069
+  ds_read_b32   v45, v105 offset:16                     // 000000000674: D86C0010 2D000069
+  ds_read_b32   v46, v105 offset:32                     // 00000000067C: D86C0020 2E000069
+  ds_read_b32   v47, v105 offset:48                     // 000000000684: D86C0030 2F000069
+  s_waitcnt     lgkmcnt(12)                             // 00000000068C: BF8CCC7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v35, v55, acc[0:3]          // 000000000690: D3ED0000 04026F23
+  v_add_u32     v106, s83, v96                          // 000000000698: 68D4C053
+  s_waitcnt     vmcnt(20)                               // 00000000069C: BF8C4F74
+  s_barrier                                             // 0000000006A0: BF8A0000
+  ds_read_b32   v64, v106                               // 0000000006A4: D86C0000 4000006A
+  ds_read_b32   v65, v106 offset:16                     // 0000000006AC: D86C0010 4100006A
+  ds_read_b32   v66, v106 offset:32                     // 0000000006B4: D86C0020 4200006A
+  ds_read_b32   v67, v106 offset:48                     // 0000000006BC: D86C0030 4300006A
+  s_add_u32     s46, s46, 1                             // 0000000006C4: 802E812E
+  s_waitcnt     0xcf7f                                  // 0000000006C8: BF8CCF7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v36, v56, acc[0:3]          // 0000000006CC: D3ED0000 04027124
+  s_mul_i32     s83, 0x00000880, 1                      // 0000000006D4: 925381FF 00000880
+  s_add_i32     m0, s75, s83                            // 0000000006DC: 817C534B
+  s_nop         0x0000                                  // 0000000006E0: BF800000
+  buffer_load_dword  v48, v82, s[8:11], 0 offen lds     // 0000000006E4: E0511000 80023052
+  buffer_load_dword  v49, v83, s[8:11], 0 offen offset:272 lds // 0000000006EC: E0511110 80023153
+  s_add_i32     m0, s77, s83                            // 0000000006F4: 817C534D
+  v_add_u32     v82, 64, v82                            // 0000000006F8: 68A4A4C0
+  v_add_u32     v83, 64, v83                            // 0000000006FC: 68A6A6C0
+  s_waitcnt     lgkmcnt(12)                             // 000000000700: BF8CCC7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v37, v57, acc[0:3]          // 000000000704: D3ED0000 04027325
+  buffer_load_dword  v68, v86, s[12:15], 0 offen lds    // 00000000070C: E0511000 80034456
+  buffer_load_dword  v69, v87, s[12:15], 0 offen offset:272 lds // 000000000714: E0511110 80034557
+  v_add_u32     v86, 64, v86                            // 00000000071C: 68ACACC0
+  v_add_u32     v87, 64, v87                            // 000000000720: 68AEAEC0
+  s_waitcnt     lgkmcnt(10)                             // 000000000724: BF8CCA7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v38, v58, acc[0:3]          // 000000000728: D3ED0000 04027526
+  s_mul_i32     s83, 0x00000880, 4                      // 000000000730: 925384FF 00000880
+  v_add_u32     v105, s83, v94                          // 000000000738: 68D2BC53
+  s_waitcnt     vmcnt(22)                               // 00000000073C: BF8C4F76
+  s_barrier                                             // 000000000740: BF8A0000
+  ds_read_b32   v32, v105                               // 000000000744: D86C0000 20000069
+  ds_read_b32   v33, v105 offset:16                     // 00000000074C: D86C0010 21000069
+  ds_read_b32   v34, v105 offset:32                     // 000000000754: D86C0020 22000069
+  ds_read_b32   v35, v105 offset:48                     // 00000000075C: D86C0030 23000069
+  s_waitcnt     lgkmcnt(12)                             // 000000000764: BF8CCC7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v39, v59, acc[0:3]          // 000000000768: D3ED0000 04027727
+  v_add_u32     v106, s83, v96                          // 000000000770: 68D4C053
+  s_waitcnt     vmcnt(20)                               // 000000000774: BF8C4F74
+  s_barrier                                             // 000000000778: BF8A0000
+  ds_read_b32   v52, v106                               // 00000000077C: D86C0000 3400006A
+  ds_read_b32   v53, v106 offset:16                     // 000000000784: D86C0010 3500006A
+  ds_read_b32   v54, v106 offset:32                     // 00000000078C: D86C0020 3600006A
+  ds_read_b32   v55, v106 offset:48                     // 000000000794: D86C0030 3700006A
+  s_add_u32     s46, s46, 1                             // 00000000079C: 802E812E
+  s_waitcnt     0xcf7f                                  // 0000000007A0: BF8CCF7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v40, v60, acc[0:3]          // 0000000007A4: D3ED0000 04027928
+  s_mul_i32     s83, 0x00000880, 2                      // 0000000007AC: 925382FF 00000880
+  s_add_i32     m0, s75, s83                            // 0000000007B4: 817C534B
+  s_nop         0x0000                                  // 0000000007B8: BF800000
+  buffer_load_dword  v48, v82, s[8:11], 0 offen lds     // 0000000007BC: E0511000 80023052
+  buffer_load_dword  v49, v83, s[8:11], 0 offen offset:272 lds // 0000000007C4: E0511110 80023153
+  s_add_i32     m0, s77, s83                            // 0000000007CC: 817C534D
+  v_add_u32     v82, 64, v82                            // 0000000007D0: 68A4A4C0
+  v_add_u32     v83, 64, v83                            // 0000000007D4: 68A6A6C0
+  s_waitcnt     lgkmcnt(12)                             // 0000000007D8: BF8CCC7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v41, v61, acc[0:3]          // 0000000007DC: D3ED0000 04027B29
+  buffer_load_dword  v68, v86, s[12:15], 0 offen lds    // 0000000007E4: E0511000 80034456
+  buffer_load_dword  v69, v87, s[12:15], 0 offen offset:272 lds // 0000000007EC: E0511110 80034557
+  v_add_u32     v86, 64, v86                            // 0000000007F4: 68ACACC0
+  v_add_u32     v87, 64, v87                            // 0000000007F8: 68AEAEC0
+  s_waitcnt     lgkmcnt(10)                             // 0000000007FC: BF8CCA7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v42, v62, acc[0:3]          // 000000000800: D3ED0000 04027D2A
+  s_mul_i32     s83, 0x00000880, 5                      // 000000000808: 925385FF 00000880
+  v_add_u32     v105, s83, v94                          // 000000000810: 68D2BC53
+  s_waitcnt     vmcnt(22)                               // 000000000814: BF8C4F76
+  s_barrier                                             // 000000000818: BF8A0000
+  ds_read_b32   v36, v105                               // 00000000081C: D86C0000 24000069
+  ds_read_b32   v37, v105 offset:16                     // 000000000824: D86C0010 25000069
+  ds_read_b32   v38, v105 offset:32                     // 00000000082C: D86C0020 26000069
+  ds_read_b32   v39, v105 offset:48                     // 000000000834: D86C0030 27000069
+  s_waitcnt     lgkmcnt(12)                             // 00000000083C: BF8CCC7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v43, v63, acc[0:3]          // 000000000840: D3ED0000 04027F2B
+  v_add_u32     v106, s83, v96                          // 000000000848: 68D4C053
+  s_waitcnt     vmcnt(20)                               // 00000000084C: BF8C4F74
+  s_barrier                                             // 000000000850: BF8A0000
+  ds_read_b32   v56, v106                               // 000000000854: D86C0000 3800006A
+  ds_read_b32   v57, v106 offset:16                     // 00000000085C: D86C0010 3900006A
+  ds_read_b32   v58, v106 offset:32                     // 000000000864: D86C0020 3A00006A
+  ds_read_b32   v59, v106 offset:48                     // 00000000086C: D86C0030 3B00006A
+  s_add_u32     s46, s46, 1                             // 000000000874: 802E812E
+  s_waitcnt     0xcf7f                                  // 000000000878: BF8CCF7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v44, v64, acc[0:3]          // 00000000087C: D3ED0000 0402812C
+  s_mul_i32     s83, 0x00000880, 3                      // 000000000884: 925383FF 00000880
+  s_add_i32     m0, s75, s83                            // 00000000088C: 817C534B
+  s_nop         0x0000                                  // 000000000890: BF800000
+  buffer_load_dword  v48, v82, s[8:11], 0 offen lds     // 000000000894: E0511000 80023052
+  buffer_load_dword  v49, v83, s[8:11], 0 offen offset:272 lds // 00000000089C: E0511110 80023153
+  s_add_i32     m0, s77, s83                            // 0000000008A4: 817C534D
+  v_add_u32     v82, 64, v82                            // 0000000008A8: 68A4A4C0
+  v_add_u32     v83, 64, v83                            // 0000000008AC: 68A6A6C0
+  s_waitcnt     lgkmcnt(12)                             // 0000000008B0: BF8CCC7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v45, v65, acc[0:3]          // 0000000008B4: D3ED0000 0402832D
+  buffer_load_dword  v68, v86, s[12:15], 0 offen lds    // 0000000008BC: E0511000 80034456
+  buffer_load_dword  v69, v87, s[12:15], 0 offen offset:272 lds // 0000000008C4: E0511110 80034557
+  v_add_u32     v86, 64, v86                            // 0000000008CC: 68ACACC0
+  v_add_u32     v87, 64, v87                            // 0000000008D0: 68AEAEC0
+  s_waitcnt     lgkmcnt(10)                             // 0000000008D4: BF8CCA7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v46, v66, acc[0:3]          // 0000000008D8: D3ED0000 0402852E
+  s_mul_i32     s83, 0x00000880, 6                      // 0000000008E0: 925386FF 00000880
+  v_add_u32     v105, s83, v94                          // 0000000008E8: 68D2BC53
+  s_waitcnt     vmcnt(22)                               // 0000000008EC: BF8C4F76
+  s_barrier                                             // 0000000008F0: BF8A0000
+  ds_read_b32   v40, v105                               // 0000000008F4: D86C0000 28000069
+  ds_read_b32   v41, v105 offset:16                     // 0000000008FC: D86C0010 29000069
+  ds_read_b32   v42, v105 offset:32                     // 000000000904: D86C0020 2A000069
+  ds_read_b32   v43, v105 offset:48                     // 00000000090C: D86C0030 2B000069
+  s_waitcnt     lgkmcnt(12)                             // 000000000914: BF8CCC7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v47, v67, acc[0:3]          // 000000000918: D3ED0000 0402872F
+  v_add_u32     v106, s83, v96                          // 000000000920: 68D4C053
+  s_waitcnt     vmcnt(20)                               // 000000000924: BF8C4F74
+  s_barrier                                             // 000000000928: BF8A0000
+  ds_read_b32   v60, v106                               // 00000000092C: D86C0000 3C00006A
+  ds_read_b32   v61, v106 offset:16                     // 000000000934: D86C0010 3D00006A
+  ds_read_b32   v62, v106 offset:32                     // 00000000093C: D86C0020 3E00006A
+  ds_read_b32   v63, v106 offset:48                     // 000000000944: D86C0030 3F00006A
+  s_add_u32     s46, s46, 1                             // 00000000094C: 802E812E
+  s_waitcnt     0xcf7f                                  // 000000000950: BF8CCF7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v32, v52, acc[0:3]          // 000000000954: D3ED0000 04026920
+  s_mul_i32     s83, 0x00000880, 4                      // 00000000095C: 925384FF 00000880
+  s_add_i32     m0, s75, s83                            // 000000000964: 817C534B
+  s_nop         0x0000                                  // 000000000968: BF800000
+  buffer_load_dword  v48, v82, s[8:11], 0 offen lds     // 00000000096C: E0511000 80023052
+  buffer_load_dword  v49, v83, s[8:11], 0 offen offset:272 lds // 000000000974: E0511110 80023153
+  s_add_i32     m0, s77, s83                            // 00000000097C: 817C534D
+  v_add_u32     v82, 64, v82                            // 000000000980: 68A4A4C0
+  v_add_u32     v83, 64, v83                            // 000000000984: 68A6A6C0
+  s_waitcnt     lgkmcnt(12)                             // 000000000988: BF8CCC7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v33, v53, acc[0:3]          // 00000000098C: D3ED0000 04026B21
+  buffer_load_dword  v68, v86, s[12:15], 0 offen lds    // 000000000994: E0511000 80034456
+  buffer_load_dword  v69, v87, s[12:15], 0 offen offset:272 lds // 00000000099C: E0511110 80034557
+  v_add_u32     v86, 64, v86                            // 0000000009A4: 68ACACC0
+  v_add_u32     v87, 64, v87                            // 0000000009A8: 68AEAEC0
+  s_waitcnt     lgkmcnt(10)                             // 0000000009AC: BF8CCA7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v34, v54, acc[0:3]          // 0000000009B0: D3ED0000 04026D22
+  s_mul_i32     s83, 0x00000880, 7                      // 0000000009B8: 925387FF 00000880
+  v_add_u32     v105, s83, v94                          // 0000000009C0: 68D2BC53
+  s_waitcnt     vmcnt(22)                               // 0000000009C4: BF8C4F76
+  s_barrier                                             // 0000000009C8: BF8A0000
+  ds_read_b32   v44, v105                               // 0000000009CC: D86C0000 2C000069
+  ds_read_b32   v45, v105 offset:16                     // 0000000009D4: D86C0010 2D000069
+  ds_read_b32   v46, v105 offset:32                     // 0000000009DC: D86C0020 2E000069
+  ds_read_b32   v47, v105 offset:48                     // 0000000009E4: D86C0030 2F000069
+  s_waitcnt     lgkmcnt(12)                             // 0000000009EC: BF8CCC7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v35, v55, acc[0:3]          // 0000000009F0: D3ED0000 04026F23
+  v_add_u32     v106, s83, v96                          // 0000000009F8: 68D4C053
+  s_waitcnt     vmcnt(20)                               // 0000000009FC: BF8C4F74
+  s_barrier                                             // 000000000A00: BF8A0000
+  ds_read_b32   v64, v106                               // 000000000A04: D86C0000 4000006A
+  ds_read_b32   v65, v106 offset:16                     // 000000000A0C: D86C0010 4100006A
+  ds_read_b32   v66, v106 offset:32                     // 000000000A14: D86C0020 4200006A
+  ds_read_b32   v67, v106 offset:48                     // 000000000A1C: D86C0030 4300006A
+  s_add_u32     s46, s46, 1                             // 000000000A24: 802E812E
+  s_waitcnt     0xcf7f                                  // 000000000A28: BF8CCF7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v36, v56, acc[0:3]          // 000000000A2C: D3ED0000 04027124
+  s_mul_i32     s83, 0x00000880, 5                      // 000000000A34: 925385FF 00000880
+  s_add_i32     m0, s75, s83                            // 000000000A3C: 817C534B
+  s_nop         0x0000                                  // 000000000A40: BF800000
+  buffer_load_dword  v48, v82, s[8:11], 0 offen lds     // 000000000A44: E0511000 80023052
+  buffer_load_dword  v49, v83, s[8:11], 0 offen offset:272 lds // 000000000A4C: E0511110 80023153
+  s_add_i32     m0, s77, s83                            // 000000000A54: 817C534D
+  v_add_u32     v82, 64, v82                            // 000000000A58: 68A4A4C0
+  v_add_u32     v83, 64, v83                            // 000000000A5C: 68A6A6C0
+  s_waitcnt     lgkmcnt(12)                             // 000000000A60: BF8CCC7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v37, v57, acc[0:3]          // 000000000A64: D3ED0000 04027325
+  buffer_load_dword  v68, v86, s[12:15], 0 offen lds    // 000000000A6C: E0511000 80034456
+  buffer_load_dword  v69, v87, s[12:15], 0 offen offset:272 lds // 000000000A74: E0511110 80034557
+  v_add_u32     v86, 64, v86                            // 000000000A7C: 68ACACC0
+  v_add_u32     v87, 64, v87                            // 000000000A80: 68AEAEC0
+  s_waitcnt     lgkmcnt(10)                             // 000000000A84: BF8CCA7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v38, v58, acc[0:3]          // 000000000A88: D3ED0000 04027526
+  s_mul_i32     s83, 0x00000880, 0                      // 000000000A90: 925380FF 00000880
+  v_add_u32     v105, s83, v94                          // 000000000A98: 68D2BC53
+  s_waitcnt     vmcnt(22)                               // 000000000A9C: BF8C4F76
+  s_barrier                                             // 000000000AA0: BF8A0000
+  ds_read_b32   v32, v105                               // 000000000AA4: D86C0000 20000069
+  ds_read_b32   v33, v105 offset:16                     // 000000000AAC: D86C0010 21000069
+  ds_read_b32   v34, v105 offset:32                     // 000000000AB4: D86C0020 22000069
+  ds_read_b32   v35, v105 offset:48                     // 000000000ABC: D86C0030 23000069
+  s_waitcnt     lgkmcnt(12)                             // 000000000AC4: BF8CCC7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v39, v59, acc[0:3]          // 000000000AC8: D3ED0000 04027727
+  v_add_u32     v106, s83, v96                          // 000000000AD0: 68D4C053
+  s_waitcnt     vmcnt(20)                               // 000000000AD4: BF8C4F74
+  s_barrier                                             // 000000000AD8: BF8A0000
+  ds_read_b32   v52, v106                               // 000000000ADC: D86C0000 3400006A
+  ds_read_b32   v53, v106 offset:16                     // 000000000AE4: D86C0010 3500006A
+  ds_read_b32   v54, v106 offset:32                     // 000000000AEC: D86C0020 3600006A
+  ds_read_b32   v55, v106 offset:48                     // 000000000AF4: D86C0030 3700006A
+  s_add_u32     s46, s46, 1                             // 000000000AFC: 802E812E
+  s_waitcnt     0xcf7f                                  // 000000000B00: BF8CCF7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v40, v60, acc[0:3]          // 000000000B04: D3ED0000 04027928
+  s_mul_i32     s83, 0x00000880, 6                      // 000000000B0C: 925386FF 00000880
+  s_add_i32     m0, s75, s83                            // 000000000B14: 817C534B
+  s_nop         0x0000                                  // 000000000B18: BF800000
+  buffer_load_dword  v48, v82, s[8:11], 0 offen lds     // 000000000B1C: E0511000 80023052
+  buffer_load_dword  v49, v83, s[8:11], 0 offen offset:272 lds // 000000000B24: E0511110 80023153
+  s_add_i32     m0, s77, s83                            // 000000000B2C: 817C534D
+  v_add_u32     v82, 64, v82                            // 000000000B30: 68A4A4C0
+  v_add_u32     v83, 64, v83                            // 000000000B34: 68A6A6C0
+  s_waitcnt     lgkmcnt(12)                             // 000000000B38: BF8CCC7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v41, v61, acc[0:3]          // 000000000B3C: D3ED0000 04027B29
+  buffer_load_dword  v68, v86, s[12:15], 0 offen lds    // 000000000B44: E0511000 80034456
+  buffer_load_dword  v69, v87, s[12:15], 0 offen offset:272 lds // 000000000B4C: E0511110 80034557
+  v_add_u32     v86, 64, v86                            // 000000000B54: 68ACACC0
+  v_add_u32     v87, 64, v87                            // 000000000B58: 68AEAEC0
+  s_waitcnt     lgkmcnt(10)                             // 000000000B5C: BF8CCA7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v42, v62, acc[0:3]          // 000000000B60: D3ED0000 04027D2A
+  s_mul_i32     s83, 0x00000880, 1                      // 000000000B68: 925381FF 00000880
+  v_add_u32     v105, s83, v94                          // 000000000B70: 68D2BC53
+  s_waitcnt     vmcnt(22)                               // 000000000B74: BF8C4F76
+  s_barrier                                             // 000000000B78: BF8A0000
+  ds_read_b32   v36, v105                               // 000000000B7C: D86C0000 24000069
+  ds_read_b32   v37, v105 offset:16                     // 000000000B84: D86C0010 25000069
+  ds_read_b32   v38, v105 offset:32                     // 000000000B8C: D86C0020 26000069
+  ds_read_b32   v39, v105 offset:48                     // 000000000B94: D86C0030 27000069
+  s_waitcnt     lgkmcnt(12)                             // 000000000B9C: BF8CCC7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v43, v63, acc[0:3]          // 000000000BA0: D3ED0000 04027F2B
+  v_add_u32     v106, s83, v96                          // 000000000BA8: 68D4C053
+  s_waitcnt     vmcnt(20)                               // 000000000BAC: BF8C4F74
+  s_barrier                                             // 000000000BB0: BF8A0000
+  ds_read_b32   v56, v106                               // 000000000BB4: D86C0000 3800006A
+  ds_read_b32   v57, v106 offset:16                     // 000000000BBC: D86C0010 3900006A
+  ds_read_b32   v58, v106 offset:32                     // 000000000BC4: D86C0020 3A00006A
+  ds_read_b32   v59, v106 offset:48                     // 000000000BCC: D86C0030 3B00006A
+  s_add_u32     s46, s46, 1                             // 000000000BD4: 802E812E
+  s_waitcnt     0xcf7f                                  // 000000000BD8: BF8CCF7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v44, v64, acc[0:3]          // 000000000BDC: D3ED0000 0402812C
+  s_mul_i32     s83, 0x00000880, 7                      // 000000000BE4: 925387FF 00000880
+  s_add_i32     m0, s75, s83                            // 000000000BEC: 817C534B
+  s_nop         0x0000                                  // 000000000BF0: BF800000
+  buffer_load_dword  v48, v82, s[8:11], 0 offen lds     // 000000000BF4: E0511000 80023052
+  buffer_load_dword  v49, v83, s[8:11], 0 offen offset:272 lds // 000000000BFC: E0511110 80023153
+  s_add_i32     m0, s77, s83                            // 000000000C04: 817C534D
+  v_add_u32     v82, 64, v82                            // 000000000C08: 68A4A4C0
+  v_add_u32     v83, 64, v83                            // 000000000C0C: 68A6A6C0
+  s_waitcnt     lgkmcnt(12)                             // 000000000C10: BF8CCC7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v45, v65, acc[0:3]          // 000000000C14: D3ED0000 0402832D
+  buffer_load_dword  v68, v86, s[12:15], 0 offen lds    // 000000000C1C: E0511000 80034456
+  buffer_load_dword  v69, v87, s[12:15], 0 offen offset:272 lds // 000000000C24: E0511110 80034557
+  v_add_u32     v86, 64, v86                            // 000000000C2C: 68ACACC0
+  v_add_u32     v87, 64, v87                            // 000000000C30: 68AEAEC0
+  s_waitcnt     lgkmcnt(10)                             // 000000000C34: BF8CCA7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v46, v66, acc[0:3]          // 000000000C38: D3ED0000 0402852E
+  s_mul_i32     s83, 0x00000880, 2                      // 000000000C40: 925382FF 00000880
+  v_add_u32     v105, s83, v94                          // 000000000C48: 68D2BC53
+  s_waitcnt     vmcnt(22)                               // 000000000C4C: BF8C4F76
+  s_barrier                                             // 000000000C50: BF8A0000
+  ds_read_b32   v40, v105                               // 000000000C54: D86C0000 28000069
+  ds_read_b32   v41, v105 offset:16                     // 000000000C5C: D86C0010 29000069
+  ds_read_b32   v42, v105 offset:32                     // 000000000C64: D86C0020 2A000069
+  ds_read_b32   v43, v105 offset:48                     // 000000000C6C: D86C0030 2B000069
+  s_waitcnt     lgkmcnt(12)                             // 000000000C74: BF8CCC7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v47, v67, acc[0:3]          // 000000000C78: D3ED0000 0402872F
+  v_add_u32     v106, s83, v96                          // 000000000C80: 68D4C053
+  s_waitcnt     vmcnt(20)                               // 000000000C84: BF8C4F74
+  s_barrier                                             // 000000000C88: BF8A0000
+  ds_read_b32   v60, v106                               // 000000000C8C: D86C0000 3C00006A
+  ds_read_b32   v61, v106 offset:16                     // 000000000C94: D86C0010 3D00006A
+  ds_read_b32   v62, v106 offset:32                     // 000000000C9C: D86C0020 3E00006A
+  ds_read_b32   v63, v106 offset:48                     // 000000000CA4: D86C0030 3F00006A
+  s_add_u32     s46, s46, 1                             // 000000000CAC: 802E812E
+  s_cmp_eq_i32  s46, -8                                 // 000000000CB0: BF00C82E
+  s_cbranch_scc0  label_017C                            // 000000000CB4: BF84FE4E
+  s_waitcnt     lgkmcnt(14)                             // 000000000CB8: BF8CCE7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v32, v52, acc[0:3]          // 000000000CBC: D3ED0000 04026920
+  s_waitcnt     lgkmcnt(13)                             // 000000000CC4: BF8CCD7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v33, v53, acc[0:3]          // 000000000CC8: D3ED0000 04026B21
+  s_add_u32     s46, s46, 1                             // 000000000CD0: 802E812E
+  s_waitcnt     lgkmcnt(12)                             // 000000000CD4: BF8CCC7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v34, v54, acc[0:3]          // 000000000CD8: D3ED0000 04026D22
+  s_mul_i32     s83, 0x00000880, 3                      // 000000000CE0: 925383FF 00000880
+  v_add_u32     v105, s83, v94                          // 000000000CE8: 68D2BC53
+  s_waitcnt     vmcnt(18)                               // 000000000CEC: BF8C4F72
+  s_barrier                                             // 000000000CF0: BF8A0000
+  ds_read_b32   v44, v105                               // 000000000CF4: D86C0000 2C000069
+  ds_read_b32   v45, v105 offset:16                     // 000000000CFC: D86C0010 2D000069
+  ds_read_b32   v46, v105 offset:32                     // 000000000D04: D86C0020 2E000069
+  ds_read_b32   v47, v105 offset:48                     // 000000000D0C: D86C0030 2F000069
+  s_waitcnt     0xcf7f                                  // 000000000D14: BF8CCF7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v35, v55, acc[0:3]          // 000000000D18: D3ED0000 04026F23
+  v_add_u32     v106, s83, v96                          // 000000000D20: 68D4C053
+  s_waitcnt     vmcnt(16)                               // 000000000D24: BF8C4F70
+  s_barrier                                             // 000000000D28: BF8A0000
+  ds_read_b32   v64, v106                               // 000000000D2C: D86C0000 4000006A
+  ds_read_b32   v65, v106 offset:16                     // 000000000D34: D86C0010 4100006A
+  ds_read_b32   v66, v106 offset:32                     // 000000000D3C: D86C0020 4200006A
+  ds_read_b32   v67, v106 offset:48                     // 000000000D44: D86C0030 4300006A
+  s_waitcnt     lgkmcnt(14)                             // 000000000D4C: BF8CCE7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v36, v56, acc[0:3]          // 000000000D50: D3ED0000 04027124
+  s_waitcnt     lgkmcnt(13)                             // 000000000D58: BF8CCD7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v37, v57, acc[0:3]          // 000000000D5C: D3ED0000 04027325
+  s_add_u32     s46, s46, 1                             // 000000000D64: 802E812E
+  s_waitcnt     lgkmcnt(12)                             // 000000000D68: BF8CCC7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v38, v58, acc[0:3]          // 000000000D6C: D3ED0000 04027526
+  s_mul_i32     s83, 0x00000880, 4                      // 000000000D74: 925384FF 00000880
+  v_add_u32     v105, s83, v94                          // 000000000D7C: 68D2BC53
+  s_waitcnt     vmcnt(14)                               // 000000000D80: BF8C0F7E
+  s_barrier                                             // 000000000D84: BF8A0000
+  ds_read_b32   v32, v105                               // 000000000D88: D86C0000 20000069
+  ds_read_b32   v33, v105 offset:16                     // 000000000D90: D86C0010 21000069
+  ds_read_b32   v34, v105 offset:32                     // 000000000D98: D86C0020 22000069
+  ds_read_b32   v35, v105 offset:48                     // 000000000DA0: D86C0030 23000069
+  s_waitcnt     0xcf7f                                  // 000000000DA8: BF8CCF7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v39, v59, acc[0:3]          // 000000000DAC: D3ED0000 04027727
+  v_add_u32     v106, s83, v96                          // 000000000DB4: 68D4C053
+  s_waitcnt     vmcnt(12)                               // 000000000DB8: BF8C0F7C
+  s_barrier                                             // 000000000DBC: BF8A0000
+  ds_read_b32   v52, v106                               // 000000000DC0: D86C0000 3400006A
+  ds_read_b32   v53, v106 offset:16                     // 000000000DC8: D86C0010 3500006A
+  ds_read_b32   v54, v106 offset:32                     // 000000000DD0: D86C0020 3600006A
+  ds_read_b32   v55, v106 offset:48                     // 000000000DD8: D86C0030 3700006A
+  s_waitcnt     lgkmcnt(14)                             // 000000000DE0: BF8CCE7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v40, v60, acc[0:3]          // 000000000DE4: D3ED0000 04027928
+  s_waitcnt     lgkmcnt(13)                             // 000000000DEC: BF8CCD7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v41, v61, acc[0:3]          // 000000000DF0: D3ED0000 04027B29
+  s_add_u32     s46, s46, 1                             // 000000000DF8: 802E812E
+  s_waitcnt     lgkmcnt(12)                             // 000000000DFC: BF8CCC7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v42, v62, acc[0:3]          // 000000000E00: D3ED0000 04027D2A
+  s_mul_i32     s83, 0x00000880, 5                      // 000000000E08: 925385FF 00000880
+  v_add_u32     v105, s83, v94                          // 000000000E10: 68D2BC53
+  s_waitcnt     vmcnt(10)                               // 000000000E14: BF8C0F7A
+  s_barrier                                             // 000000000E18: BF8A0000
+  ds_read_b32   v36, v105                               // 000000000E1C: D86C0000 24000069
+  ds_read_b32   v37, v105 offset:16                     // 000000000E24: D86C0010 25000069
+  ds_read_b32   v38, v105 offset:32                     // 000000000E2C: D86C0020 26000069
+  ds_read_b32   v39, v105 offset:48                     // 000000000E34: D86C0030 27000069
+  s_waitcnt     0xcf7f                                  // 000000000E3C: BF8CCF7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v43, v63, acc[0:3]          // 000000000E40: D3ED0000 04027F2B
+  v_add_u32     v106, s83, v96                          // 000000000E48: 68D4C053
+  s_waitcnt     vmcnt(8)                                // 000000000E4C: BF8C0F78
+  s_barrier                                             // 000000000E50: BF8A0000
+  ds_read_b32   v56, v106                               // 000000000E54: D86C0000 3800006A
+  ds_read_b32   v57, v106 offset:16                     // 000000000E5C: D86C0010 3900006A
+  ds_read_b32   v58, v106 offset:32                     // 000000000E64: D86C0020 3A00006A
+  ds_read_b32   v59, v106 offset:48                     // 000000000E6C: D86C0030 3B00006A
+  s_waitcnt     lgkmcnt(14)                             // 000000000E74: BF8CCE7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v44, v64, acc[0:3]          // 000000000E78: D3ED0000 0402812C
+  s_waitcnt     lgkmcnt(13)                             // 000000000E80: BF8CCD7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v45, v65, acc[0:3]          // 000000000E84: D3ED0000 0402832D
+  s_add_u32     s46, s46, 1                             // 000000000E8C: 802E812E
+  s_waitcnt     lgkmcnt(12)                             // 000000000E90: BF8CCC7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v46, v66, acc[0:3]          // 000000000E94: D3ED0000 0402852E
+  s_mul_i32     s83, 0x00000880, 6                      // 000000000E9C: 925386FF 00000880
+  v_add_u32     v105, s83, v94                          // 000000000EA4: 68D2BC53
+  s_waitcnt     vmcnt(6)                                // 000000000EA8: BF8C0F76
+  s_barrier                                             // 000000000EAC: BF8A0000
+  ds_read_b32   v40, v105                               // 000000000EB0: D86C0000 28000069
+  ds_read_b32   v41, v105 offset:16                     // 000000000EB8: D86C0010 29000069
+  ds_read_b32   v42, v105 offset:32                     // 000000000EC0: D86C0020 2A000069
+  ds_read_b32   v43, v105 offset:48                     // 000000000EC8: D86C0030 2B000069
+  s_waitcnt     0xcf7f                                  // 000000000ED0: BF8CCF7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v47, v67, acc[0:3]          // 000000000ED4: D3ED0000 0402872F
+  v_add_u32     v106, s83, v96                          // 000000000EDC: 68D4C053
+  s_waitcnt     vmcnt(4)                                // 000000000EE0: BF8C0F74
+  s_barrier                                             // 000000000EE4: BF8A0000
+  ds_read_b32   v60, v106                               // 000000000EE8: D86C0000 3C00006A
+  ds_read_b32   v61, v106 offset:16                     // 000000000EF0: D86C0010 3D00006A
+  ds_read_b32   v62, v106 offset:32                     // 000000000EF8: D86C0020 3E00006A
+  ds_read_b32   v63, v106 offset:48                     // 000000000F00: D86C0030 3F00006A
+  s_waitcnt     lgkmcnt(14)                             // 000000000F08: BF8CCE7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v32, v52, acc[0:3]          // 000000000F0C: D3ED0000 04026920
+  s_waitcnt     lgkmcnt(13)                             // 000000000F14: BF8CCD7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v33, v53, acc[0:3]          // 000000000F18: D3ED0000 04026B21
+  s_add_u32     s46, s46, 1                             // 000000000F20: 802E812E
+  s_waitcnt     lgkmcnt(12)                             // 000000000F24: BF8CCC7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v34, v54, acc[0:3]          // 000000000F28: D3ED0000 04026D22
+  s_mul_i32     s83, 0x00000880, 7                      // 000000000F30: 925387FF 00000880
+  v_add_u32     v105, s83, v94                          // 000000000F38: 68D2BC53
+  s_waitcnt     vmcnt(2)                                // 000000000F3C: BF8C0F72
+  s_barrier                                             // 000000000F40: BF8A0000
+  ds_read_b32   v44, v105                               // 000000000F44: D86C0000 2C000069
+  ds_read_b32   v45, v105 offset:16                     // 000000000F4C: D86C0010 2D000069
+  ds_read_b32   v46, v105 offset:32                     // 000000000F54: D86C0020 2E000069
+  ds_read_b32   v47, v105 offset:48                     // 000000000F5C: D86C0030 2F000069
+  s_waitcnt     0xcf7f                                  // 000000000F64: BF8CCF7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v35, v55, acc[0:3]          // 000000000F68: D3ED0000 04026F23
+  v_add_u32     v106, s83, v96                          // 000000000F70: 68D4C053
+  s_waitcnt     vmcnt(0)                                // 000000000F74: BF8C0F70
+  s_barrier                                             // 000000000F78: BF8A0000
+  ds_read_b32   v64, v106                               // 000000000F7C: D86C0000 4000006A
+  ds_read_b32   v65, v106 offset:16                     // 000000000F84: D86C0010 4100006A
+  ds_read_b32   v66, v106 offset:32                     // 000000000F8C: D86C0020 4200006A
+  ds_read_b32   v67, v106 offset:48                     // 000000000F94: D86C0030 4300006A
+  s_waitcnt     lgkmcnt(14)                             // 000000000F9C: BF8CCE7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v36, v56, acc[0:3]          // 000000000FA0: D3ED0000 04027124
+  s_waitcnt     lgkmcnt(13)                             // 000000000FA8: BF8CCD7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v37, v57, acc[0:3]          // 000000000FAC: D3ED0000 04027325
+  s_waitcnt     lgkmcnt(12)                             // 000000000FB4: BF8CCC7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v38, v58, acc[0:3]          // 000000000FB8: D3ED0000 04027526
+  s_waitcnt     lgkmcnt(11)                             // 000000000FC0: BF8CCB7F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v39, v59, acc[0:3]          // 000000000FC4: D3ED0000 04027727
+  s_waitcnt     lgkmcnt(8)                              // 000000000FCC: BF8CC87F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v40, v60, acc[0:3]          // 000000000FD0: D3ED0000 04027928
+  s_waitcnt     lgkmcnt(7)                              // 000000000FD8: BF8CC77F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v41, v61, acc[0:3]          // 000000000FDC: D3ED0000 04027B29
+  s_waitcnt     lgkmcnt(6)                              // 000000000FE4: BF8CC67F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v42, v62, acc[0:3]          // 000000000FE8: D3ED0000 04027D2A
+  s_waitcnt     lgkmcnt(5)                              // 000000000FF0: BF8CC57F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v43, v63, acc[0:3]          // 000000000FF4: D3ED0000 04027F2B
+  s_waitcnt     lgkmcnt(3)                              // 000000000FFC: BF8CC37F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v44, v64, acc[0:3]          // 000000001000: D3ED0000 0402812C
+  s_waitcnt     lgkmcnt(2)                              // 000000001008: BF8CC27F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v45, v65, acc[0:3]          // 00000000100C: D3ED0000 0402832D
+  s_waitcnt     lgkmcnt(1)                              // 000000001014: BF8CC17F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v46, v66, acc[0:3]          // 000000001018: D3ED0000 0402852E
+  s_waitcnt     lgkmcnt(0)                              // 000000001020: BF8CC07F
+  v_mfma_f32_16x16x8bf16  acc[0:3], v47, v67, acc[0:3]          // 000000001024: D3ED0000 0402872F
+  s_mov_b32     s16, s34                                // 00000000102C: BE900022
+  s_mov_b32     s17, s35                                // 000000001030: BE910023
+  s_mov_b32     s18, 0x80000000                         // 000000001034: BE9200FF 80000000
+  s_mov_b32     s19, 0x00020000                         // 00000000103C: BE9300FF 00020000
+  s_mov_b32     s20, s32                                // 000000001044: BE940020
+  s_mov_b32     s21, s33                                // 000000001048: BE950021
+  s_mov_b32     s22, 0x80000000                         // 00000000104C: BE9600FF 80000000
+  s_mov_b32     s23, 0x00020000                         // 000000001054: BE9700FF 00020000
+  s_mul_hi_u32  s85, s4, s39                            // 00000000105C: 96552704
+  s_mul_i32     s84, s4, s39                            // 000000001060: 92542704
+  s_lshl_b64    s[84:85], s[84:85], 1                   // 000000001064: 8ED48154
+  s_add_u32     s16, s16, s84                           // 000000001068: 80105410
+  s_addc_u32    s17, s17, s85                           // 00000000106C: 82115511
+  s_add_u32     s20, s20, s84                           // 000000001070: 80145414
+  s_addc_u32    s21, s21, s85                           // 000000001074: 82155515
+  s_mul_i32     s86, 32, s82                            // 000000001078: 925652A0
+  s_mul_hi_u32  s85, s86, s38                           // 00000000107C: 96552656
+  s_mul_i32     s84, s86, s38                           // 000000001080: 92542656
+  s_lshl_b64    s[84:85], s[84:85], 1                   // 000000001084: 8ED48154
+  s_add_u32     s16, s16, s84                           // 000000001088: 80105410
+  s_addc_u32    s17, s17, s85                           // 00000000108C: 82115511
+  s_add_u32     s20, s20, s84                           // 000000001090: 80145414
+  s_addc_u32    s21, s21, s85                           // 000000001094: 82155515
+  s_mul_i32     s85, 32, s81                            // 000000001098: 925551A0
+  s_mul_i32     s84, s89, 16                            // 00000000109C: 92549059
+  s_add_i32     s85, s84, s85                           // 0000000010A0: 81555554
+  s_mul_i32     s84, s88, 16                            // 0000000010A4: 92549058
+  s_mul_i32     s83, s84, s38                           // 0000000010A8: 92532654
+  s_add_i32     s85, s85, s83                           // 0000000010AC: 81555355
+  v_and_b32     v3, v101, 15                            // 0000000010B0: D1130003 00011F65
+  v_mul_lo_u32  v5, s38, v3                             // 0000000010B8: D2850005 00020626
+  v_lshrrev_b32  v4, 4, v101                            // 0000000010C0: 2008CA84
+  v_lshlrev_b32  v4, 2, v4                              // 0000000010C4: 24080882
+  v_add_u32     v104, v4, v5                            // 0000000010C8: 68D00B04
+  v_add_u32     v104, s85, v104                         // 0000000010CC: 68D0D055
+  v_lshlrev_b32  v104, 1, v104                          // 0000000010D0: 24D0D081
+  v_accvgpr_read  v0, a0                              // 0000000010D4: D3D84000 18000100
+  v_accvgpr_read  v1, a1                              // 0000000010DC: D3D84001 18000101
+  v_accvgpr_read  v2, a2                              // 0000000010E4: D3D84002 18000102
+  v_accvgpr_read  v3, a3                              // 0000000010EC: D3D84003 18000103
+  v_lshrrev_b32  v0, 16, v0                             // 0000000010F4: 20000090
+  v_lshrrev_b32  v1, 16, v1                             // 0000000010F8: 20020290
+  v_lshlrev_b32  v1, 16, v1                             // 0000000010FC: 24020290
+  v_or_b32      v0, v0, v1                              // 000000001100: 28000300
+  v_lshrrev_b32  v2, 16, v2                             // 000000001104: 20040490
+  v_lshrrev_b32  v3, 16, v3                             // 000000001108: 20060690
+  v_lshlrev_b32  v3, 16, v3                             // 00000000110C: 24060690
+  v_or_b32      v1, v2, v3                              // 000000001110: 28020702
+  buffer_store_dwordx2  v[0:1], v104, s[20:23], 0 offen // 000000001114: E0741000 80050068
+label_0447:
+  s_waitcnt     0x0000                                  // 00000000111C: BF8C0000
+  s_endpgm                                              // 000000001120: BF810000

--- a/Tensile/ReplacementKernels/Cijk_Alik_Bljk_BBH_MT32x64x64_AF0EM8_ASEM8_FL0_GRVW2_ISA908_MDA2_PGR1_PLR1_SU32_TT2_2_VAW1_VW2_WG16_32_1_WGM8.s.txt
+++ b/Tensile/ReplacementKernels/Cijk_Alik_Bljk_BBH_MT32x64x64_AF0EM8_ASEM8_FL0_GRVW2_ISA908_MDA2_PGR1_PLR1_SU32_TT2_2_VAW1_VW2_WG16_32_1_WGM8.s.txt
@@ -1,0 +1,913 @@
+
+
+/******************************************/
+/* Function Prefix                        */
+/******************************************/
+
+
+
+/******************************************/
+/* Begin Kernel                           */
+/******************************************/
+
+.hsa_code_object_version 2,0
+.hsa_code_object_isa 9, 0, 8, "AMD", "AMDGPU"
+.text
+.protected Cijk_Alik_Bljk_BBH_MT32x64x64_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG16_32_1_WGM8
+.globl Cijk_Alik_Bljk_BBH_MT32x64x64_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG16_32_1_WGM8
+.p2align 8
+.type Cijk_Alik_Bljk_BBH_MT32x64x64_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG16_32_1_WGM8,@function
+.amdgpu_hsa_kernel Cijk_Alik_Bljk_BBH_MT32x64x64_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG16_32_1_WGM8
+Cijk_Alik_Bljk_BBH_MT32x64x64_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG16_32_1_WGM8:
+.amd_kernel_code_t
+  is_ptr64 = 1
+  enable_sgpr_kernarg_segment_ptr = 1
+  kernarg_segment_byte_size = 148 // bytes of kern args
+  workitem_vgpr_count = 108 // vgprs
+  wavefront_sgpr_count = 98 // sgprs
+  compute_pgm_rsrc1_vgprs = 26 // floor((108-1)/4)
+  compute_pgm_rsrc1_sgprs = 12 // floor((98-1)/8)
+  compute_pgm_rsrc2_tidig_comp_cnt = 0 // 1D wg
+  compute_pgm_rsrc2_tgid_x_en = 1 // wg.x
+  compute_pgm_rsrc2_tgid_y_en = 1 // wg.y
+  compute_pgm_rsrc2_tgid_z_en = 1 // wg.z
+  workgroup_group_segment_byte_size = 30000// lds bytes
+  compute_pgm_rsrc2_user_sgpr = 2 // vcc
+  kernarg_segment_alignment = 4
+  group_segment_alignment = 4
+  private_segment_alignment = 4
+.end_amd_kernel_code_t
+
+/******************************************/
+/* Optimizations and Config:              */
+/******************************************/
+/* ThreadTile= 4 x 4 */
+/* SubGroup= 16 x 32 */
+/* VectorWidth=4 */
+/* GlobalLoadVectorWidthA=4, GlobalLoadVectorWidthB=4 */
+/* DirectToLdsA=False */
+/* DirectToLdsB=False */
+/* UseSgprForGRO=1 */
+.amd_amdgpu_hsa_metadata
+Version: [ 1, 0 ]
+Kernels:
+  - Name: Cijk_Alik_Bljk_BBH_MT32x64x64_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG16_32_1_WGM8
+    SymbolName: 'Cijk_Alik_Bljk_BBH_MT32x64x64_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG16_32_1_WGM8@kd'
+    Language: OpenCL C
+    LanguageVersion: [ 2, 0 ]
+    Args:
+      - Name:            sizeC
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            sizeA
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            sizeB
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            D
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       Struct
+        AddrSpaceQual:   Generic
+      - Name:            C
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       Struct
+        AddrSpaceQual:   Generic
+      - Name:            A
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       Struct
+        AddrSpaceQual:   Generic
+      - Name:            B
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       Struct
+        AddrSpaceQual:   Generic
+      - Name:            alpha
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       F32
+      - Name:            beta
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       F32
+      - Name:            strideD0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideD1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideC0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideC1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideA0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideA1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideB0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideB1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree2
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesSum0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            OrigStaggerUIter
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       I32
+      - Name:            NumWorkGroups0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            NumWorkGroups1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            NumFullBlocks
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            WgmRemainder1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            MagicNumberWgmRemainder1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+    CodeProps:
+      KernargSegmentSize: 148
+      GroupSegmentFixedSize: 28672
+      PrivateSegmentFixedSize: 0
+      KernargSegmentAlign:  8
+      WavefrontSize:        64
+      NumSGPRs:             98
+      NumVGPRs:             108
+      MaxFlatWorkGroupSize: 512
+.end_amd_amdgpu_hsa_metadata
+
+/******************************************/
+/* Asm syntax workarounds                 */
+/******************************************/
+.macro _v_add_co_u32 dst, cc, src0, src1, dpp=
+   v_add_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+
+.macro _v_add_u32 dst, src0, src1, dpp=
+   v_add_u32 \dst, \src0, \src1 \dpp
+.endm
+
+.macro _v_sub_co_u32 dst, cc, src0, src1, dpp=
+   v_sub_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+
+.macro _v_sub_u32 dst, src0, src1, dpp=
+   v_sub_u32 \dst, \src0, \src1 \dpp
+.endm
+
+.macro _v_addc_co_u32 dst, ccOut, src0, ccIn, src1, dpp=
+   v_addc_co_u32 \dst, \ccOut, \src0, \ccIn, \src1 \dpp
+.endm
+
+.macro _v_add_lshl_u32 dst, src0, src1, shiftCnt
+    v_add_lshl_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+.macro _v_lshl_add_u32 dst, src0, src1, shiftCnt
+    v_lshl_add_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+/******************************************/
+/* Magic div and mod functions            */
+/******************************************/
+.macro V_MAGIC_DIV dstIdx, dividend, magicNumber, magicShift
+    v_mul_hi_u32 v[\dstIdx+1], \dividend, \magicNumber
+    v_mul_lo_u32 v[\dstIdx+0], \dividend, \magicNumber
+    v_lshrrev_b64 v[\dstIdx:\dstIdx+1], \magicShift, v[\dstIdx:\dstIdx+1]
+.endm
+
+/******************************************/
+/* VGPR Assignments                       */
+/******************************************/
+.set vgprValuC, 0
+/* ValuA/B   Xn=PLR buffer idx,  In=InnerUnroll idx */
+.set vgprValuA_X0_I0, 32
+.set vgprValuA_X1_I0, 34
+.set vgprG2LA, 36
+.set vgprValuB_X0_I0, 40
+.set vgprValuB_X1_I0, 44
+.set vgprG2LB, 48
+.set vgprLocalWriteAddrA, 56
+.set vgprLocalWriteAddrB, 57
+.set vgprGlobalReadOffsetA, 58
+.set vgprGlobalReadOffsetB, 59
+.set vgprLocalReadAddrA, 60
+.set vgprLocalReadAddrB, 61
+.set vgprSerial, 62
+/* Num VGPR=63 */
+
+/******************************************/
+/* SGPR Assignments                       */
+/******************************************/
+.set sgprKernArgAddress, 0
+.set sgprWorkGroup0, 2
+.set sgprWorkGroup1, 3
+.set sgprWorkGroup2, 4
+.set sgprNumWorkGroups0, 5
+.set sgprNumWorkGroups1, 6
+.set sgprSrdA, 8
+.set sgprSrdB, 12
+.set sgprSrdD, 16
+.set sgprSrdC, 20
+.set sgprTensor2dSizeC, 24
+.set sgprTensor2dSizeA, 26
+.set sgprTensor2dSizeB, 28
+.set sgprSaveExecMask, 30
+.set sgprAddressD, 32
+.set sgprAddressC, 34
+.set sgprStridesD, 36
+.set sgprStridesC, 38
+.set sgprAlpha, 40
+.set sgprBeta, 41
+.set sgprSizesFree, 42
+.set sgprSizesSum, 45
+.set sgprLoopCounters, 46
+.set sgprOrigLoopCounter, 47
+.set sgprStridesA, 48
+.set sgprStridesB, 50
+.set sgprAddressA, 52
+.set sgprAddressB, 54
+.set sgprShadowLimitA, 56
+.set sgprShadowLimitB, 58
+.set sgprOrigStaggerUIter, 60
+.set sgprStaggerUIter, 61
+.set sgprWrapUA, 62
+.set sgprWrapUB, 64
+.set sgprNumFullBlocks, 66
+.set sgprWgmRemainder1, 67
+.set sgprMagicNumberWgmRemainder1, 68
+.set sgprGlobalReadIncsA, 69
+.set sgprGlobalReadIncsB, 70
+.set sgprScalarGlobalReadOffsetA, 71
+.set sgprScalarGlobalReadOffsetB, 72
+/* max SGPR=98 */
+
+/* Size Assignments */
+.set sgprSizeD0I, sgprSizesFree+0
+.set sgprSizeD1J, sgprSizesFree+1
+.set sgprSizeDK, sgprSizesFree+2
+.set sgprSizeC0I, sgprSizesFree+0
+.set sgprSizeC1J, sgprSizesFree+1
+.set sgprSizeCK, sgprSizesFree+2
+.set sgprSizeAL, sgprSizesSum+0
+.set sgprSizeA0I, sgprSizesFree+0
+.set sgprSizeAK, sgprSizesFree+2
+.set sgprSizeBL, sgprSizesSum+0
+.set sgprSizeB1J, sgprSizesFree+1
+.set sgprSizeBK, sgprSizesFree+2
+
+/* Stride Assignments */
+.set constStrideD0I, 1
+.set sgprStrideD1J, sgprStridesD+0
+.set sgprStrideDK, sgprStridesD+1
+.set constStrideC0I, 1
+.set sgprStrideC1J, sgprStridesC+0
+.set sgprStrideCK, sgprStridesC+1
+.set constStrideAL, 1
+.set sgprStrideA0I, sgprStridesA+0
+.set sgprStrideAK, sgprStridesA+1
+.set constStrideBL, 1
+.set sgprStrideB1J, sgprStridesB+0
+.set sgprStrideBK, sgprStridesB+1
+
+.set DepthU, 32
+/* Number of elements to shift-left SRD */
+.set SrdShiftLeftA, 4
+.set SrdShiftLeftB, 4
+/* 2GB limit - set offsets to -1 to exceed this and clamp */
+.set BufferLimit, 0x80000000
+/* Bits 127:96 of SRD.  Set DataFormat = 32 bit */
+.set Srd127_96, 0x0020000
+.set BufferOOB, 0x80000000
+
+/* Global Offset A */
+.macro GLOBAL_OFFSET_A vgprAddr vgprOffsetL vgprOffset0I vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStrideA0I], v[\vgprOffset0I] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprOffsetL], v[\vgprTmp+0] // accumulate d1 lower
+_v_add_u32 v[\vgprAddr+0], 0x4, v[\vgprAddr+0]     // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/* Global Offset B */
+.macro GLOBAL_OFFSET_B vgprAddr vgprOffsetL vgprOffset1J vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStrideB1J], v[\vgprOffset1J] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprOffsetL], v[\vgprTmp+0] // accumulate d1 lower
+_v_add_u32 v[\vgprAddr+0], 0x4, v[\vgprAddr+0]     // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/******************************************/
+/* Dynamic Scalar Divide: vQuotient=vDividend/vDivisor; vRemainder=vDividend%vDivisor; */
+/******************************************/
+.macro DYNAMIC_VECTOR_DIVIDE vQuotient vRemainder vDividend vDivisor vTmp0 vTmp1 sTmp
+v_cvt_f32_u32 v[\vQuotient], v[\vDivisor]          //
+v_rcp_f32 v[\vQuotient], v[\vQuotient]             //
+v_mul_f32 v[\vQuotient], 0x4f800000, v[\vQuotient] //
+v_cvt_u32_f32 v[\vQuotient], v[\vQuotient]         //
+v_mul_lo_u32 v[\vRemainder], v[\vDivisor], v[\vQuotient] //
+v_mul_hi_u32 v[\vTmp0], v[\vDivisor], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp1], vcc, 0x0, v[\vRemainder]  //
+v_cmp_ne_i32 s[\sTmp:\sTmp+1], 0x0, v[\vTmp0]      //
+v_cndmask_b32 v[\vRemainder], v[\vTmp1], v[\vRemainder], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vRemainder], v[\vRemainder], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vQuotient], v[\vRemainder] //
+_v_add_co_u32 v[\vQuotient], vcc, v[\vQuotient], v[\vRemainder] //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vTmp0], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vQuotient], v[\vQuotient], v[\vDividend] //
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vDividend], v[\vRemainder] //
+v_cmp_ge_u32 s[\sTmp:\sTmp+1], v[\vDividend], v[\vRemainder] //
+_v_add_co_u32 v[\vRemainder], vcc, 0x1, v[\vQuotient] //
+_v_add_co_u32 v[\vTmp1], vcc, -1, v[\vQuotient]    //
+v_cmp_le_u32 vcc, v[\vDivisor], v[\vTmp0]          //
+s_and_b64 vcc, s[\sTmp:\sTmp+1], vcc               //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vRemainder], vcc //
+v_cndmask_b32 v[\vQuotient], v[\vTmp1], v[\vQuotient], s[\sTmp:\sTmp+1] //
+v_cmp_ne_i32 vcc, 0x0, v[\vDivisor]                //
+v_cndmask_b32 v[\vQuotient], -1, v[\vQuotient], vcc // final result
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vRemainder], vcc, v[\vDividend], v[\vRemainder] // final result
+.endm
+
+/******************************************/
+/* 4x8 thread-tile                        */
+/******************************************/
+.macro MAC_4x8_X0
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[0] iui=0
+s_setprio 1 // Raise priority while processing macs
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[1]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[4]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[5]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[2] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[3]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[6]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[7]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[8] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[9]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[12]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[13]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[10] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[11]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[14]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[15]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[16] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[17]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[20]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[21]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[18] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[19]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[22]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[23]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[24] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[25]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[28]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[29]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[26] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[27]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[30]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[31]
+s_setprio 0 // Reset priority after macs
+.endm
+.macro MAC_4x8_X1
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[0] iui=0
+s_setprio 1 // Raise priority while processing macs
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[1]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[4]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[5]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[2] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[3]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[6]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[7]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[8] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[9]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[12]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[13]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[10] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[11]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[14]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[15]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[16] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[17]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[20]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[21]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[18] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[19]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[22]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[23]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[24] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[25]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[28]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[29]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[26] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[27]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[30]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[31]
+s_setprio 0 // Reset priority after macs
+.endm
+
+
+
+
+/***** program start from here *****/
+
+.long 0xC00A0600, 0x00000008
+.long 0xC00A0D00, 0x00000028
+.long 0xC00A0C00, 0x00000050
+.long 0xC0020B40, 0x0000006C
+.long 0x7EC80300
+.long 0x26CA00BF
+.long 0xB8D0F804
+.long 0xD1130004, 0x0000A0B0
+.long 0x20CC0884
+.long 0x7EA40566
+.long 0xD1130067, 0x0000A08F
+.long 0x7EA20567
+.long 0xBF068151
+.long 0xBF8400EC
+.long 0xBF8CC07F
+.long 0xBE880034
+.long 0xBE890035
+.long 0xBE8A00FF, 0x80000000
+.long 0xBE8B00FF, 0x00020000
+.long 0x96553104
+.long 0x92543104
+.long 0x8ED48154
+.long 0x80085408
+.long 0x82095509
+.long 0x9254A030
+.long 0x92545402
+.long 0x92558830
+.long 0x92555552
+.long 0x81545554
+.long 0x2000CA85
+.long 0xD2850004, 0x00020030
+.long 0x2602CA9F
+.long 0x24020281
+.long 0x32A40304
+.long 0x68A4A454
+.long 0x24A4A481
+.long 0x8E478230
+.long 0x80C7FF47, 0x00000120
+.long 0x68A6A447
+.long 0x68A8A647
+.long 0x68AAA847
+.long 0xBECC00FF, 0x00000480
+.long 0x924C4C52
+.long 0xBE8C0036
+.long 0xBE8D0037
+.long 0xBE8E00FF, 0x80000000
+.long 0xBE8F00FF, 0x00020000
+.long 0x96553304
+.long 0x92543304
+.long 0x8ED48154
+.long 0x800C540C
+.long 0x820D550D
+.long 0x9254C032
+.long 0x92545403
+.long 0x92559032
+.long 0x92555552
+.long 0x81545554
+.long 0x2004CA85
+.long 0xD2850004, 0x00020432
+.long 0x2606CA9F
+.long 0x24060681
+.long 0x32AC0704
+.long 0x68ACAC54
+.long 0x24ACAC81
+.long 0x8E4A8232
+.long 0x80CAFF4A, 0x00000120
+.long 0x68AEAC4A
+.long 0x68B0AE4A
+.long 0x68B2B04A
+.long 0x68B4B24A
+.long 0x68B6B44A
+.long 0x68B8B64A
+.long 0x68BAB84A
+.long 0xBECE00FF, 0x00000900
+.long 0x924E4E52
+.long 0x814EFF4E, 0x00002400
+.long 0xBF8A0000
+.long 0xBEFC004C
+.long 0x814DFF4C, 0x00001200
+.long 0xE0511000, 0x80023052
+.long 0xE0511120, 0x80023153
+.long 0xE0511240, 0x80023254
+.long 0xE0511360, 0x80023355
+.long 0xBEFC004E
+.long 0x814FFF4E, 0x00002400
+.long 0xE0511000, 0x80034456
+.long 0xE0511120, 0x80034557
+.long 0xE0511240, 0x80034658
+.long 0xE0511360, 0x80034759
+.long 0xE0511480, 0x8003485A
+.long 0xE05115A0, 0x8003495B
+.long 0xE05116C0, 0x80034A5C
+.long 0xE05117E0, 0x80034B5D
+.long 0xBEFC004D
+.long 0x8008FF08, 0x00000080
+.long 0x82098009
+.long 0x800CFF0C, 0x00000080
+.long 0x820D800D
+.long 0xE0511000, 0x80023052
+.long 0xE0511120, 0x80023153
+.long 0xE0511240, 0x80023254
+.long 0xE0511360, 0x80023355
+.long 0xBEFC004F
+.long 0xBF800000
+.long 0xE0511000, 0x80034456
+.long 0xE0511120, 0x80034557
+.long 0xE0511240, 0x80034658
+.long 0xE0511360, 0x80034759
+.long 0xE0511480, 0x8003485A
+.long 0xE05115A0, 0x8003495B
+.long 0xE05116C0, 0x80034A5C
+.long 0xE05117E0, 0x80034B5D
+.long 0x8008FF08, 0x00000080
+.long 0x82098009
+.long 0x800CFF0C, 0x00000080
+.long 0x820D800D
+.long 0xBEFC004C
+.long 0xBF8C4F74
+.long 0xBF8A0000
+.long 0xBF8C0F7C
+.long 0xBF8A0000
+.long 0x8F2E862D
+.long 0x80AE2E80
+.long 0xBF03C22E
+.long 0xBF85004F
+.long 0xBF8A0000
+.long 0xE0511000, 0x80023052
+.long 0xE0511120, 0x80023153
+.long 0xE0511240, 0x80023254
+.long 0xE0511360, 0x80023355
+.long 0xBEFC004E
+.long 0xBF800000
+.long 0xE0511000, 0x80034456
+.long 0xE0511120, 0x80034557
+.long 0xE0511240, 0x80034658
+.long 0xE0511360, 0x80034759
+.long 0xE0511480, 0x8003485A
+.long 0xE05115A0, 0x8003495B
+.long 0xE05116C0, 0x80034A5C
+.long 0xE05117E0, 0x80034B5D
+.long 0xBF8C4F74
+.long 0xBF8A0000
+.long 0x8008FF08, 0x00000080
+.long 0x82098009
+.long 0xBF8C0F7C
+.long 0xBF8A0000
+.long 0x800CFF0C, 0x00000080
+.long 0x820D800D
+.long 0xBEFC004D
+.long 0xBF8A0000
+.long 0xE0511000, 0x80023052
+.long 0xE0511120, 0x80023153
+.long 0xE0511240, 0x80023254
+.long 0xE0511360, 0x80023355
+.long 0xBEFC004F
+.long 0xBF800000
+.long 0xE0511000, 0x80034456
+.long 0xE0511120, 0x80034557
+.long 0xE0511240, 0x80034658
+.long 0xE0511360, 0x80034759
+.long 0xE0511480, 0x8003485A
+.long 0xE05115A0, 0x8003495B
+.long 0xE05116C0, 0x80034A5C
+.long 0xE05117E0, 0x80034B5D
+.long 0xBF8C4F74
+.long 0xBF8A0000
+.long 0x8008FF08, 0x00000080
+.long 0x82098009
+.long 0xBF8C0F7C
+.long 0xBF8A0000
+.long 0x800CFF0C, 0x00000080
+.long 0x820D800D
+.long 0xBEFC004C
+.long 0x802E822E
+.long 0xBF03C22E
+.long 0xBF84FFB1
+.long 0xBF8C0F78
+.long 0xBF8A0000
+.long 0xBF8C0F70
+.long 0xBF8A0000
+.long 0xBF810000
+.long 0xC0060700, 0x00000000
+.long 0xC00A0800, 0x00000018
+.long 0xC00A0A00, 0x00000038
+.long 0xC00A0900, 0x00000040
+.long 0xD3D94000, 0x18000080
+.long 0xD3D94001, 0x18000080
+.long 0xD3D94002, 0x18000080
+.long 0xD3D94003, 0x18000080
+.long 0xD3D94004, 0x18000080
+.long 0xD3D94005, 0x18000080
+.long 0xD3D94006, 0x18000080
+.long 0xD3D94007, 0x18000080
+.long 0xD1130001, 0x00011F65
+.long 0xD285005E, 0x000202C0
+.long 0x20040281
+.long 0xD2850002, 0x000204A0
+.long 0x2002CA84
+.long 0x24020283
+.long 0x68BCBD01
+.long 0x24BCBC81
+.long 0x68BCBD02
+.long 0x68BCBC80
+.long 0x68BEBCFF, 0x00001200
+.long 0xBF8A0000
+.long 0xD1130001, 0x00011F65
+.long 0xD2850060, 0x000202C0
+.long 0x20040281
+.long 0xD2850002, 0x000204A0
+.long 0x2002CA84
+.long 0x24020283
+.long 0x68C0C101
+.long 0x24C0C081
+.long 0x68C0C102
+.long 0x9254FF52, 0x00000900
+.long 0x68C0C054
+.long 0x68C0C0FF, 0x00002400
+.long 0x68C2C0FF, 0x00002400
+.long 0xBF8CC07F
+.long 0xBE900022
+.long 0xBE910023
+.long 0xBE9200FF, 0x80000000
+.long 0xBE9300FF, 0x00020000
+.long 0x925603C0
+.long 0x96552656
+.long 0x92542656
+.long 0x8ED48154
+.long 0x80105410
+.long 0x82115511
+.long 0x96552704
+.long 0x92542704
+.long 0x8ED48154
+.long 0x80105410
+.long 0x82115511
+.long 0xD2850004, 0x0002CC90
+.long 0xD2850003, 0x00004D04
+.long 0x2608CA8F
+.long 0xD2850005, 0x00004D04
+.long 0x200CCA84
+.long 0x240C0C82
+.long 0x68D60B03
+.long 0x925402A0
+.long 0x32D40C54
+.long 0xD1FE0068, 0x0206D76A
+.long 0xBE940020
+.long 0xBE950021
+.long 0xBE9600FF, 0x80000000
+.long 0xBE9700FF, 0x00020000
+.long 0x925603C0
+.long 0x96552456
+.long 0x92542456
+.long 0x8ED48154
+.long 0x80145414
+.long 0x82155515
+.long 0x96552504
+.long 0x92542504
+.long 0x8ED48154
+.long 0x80145414
+.long 0x82155515
+.long 0xD2850004, 0x0002CC90
+.long 0xD2850003, 0x00004904
+.long 0x2608CA8F
+.long 0xD2850005, 0x00004904
+.long 0x200CCA84
+.long 0x240C0C82
+.long 0x68D60B03
+.long 0x925402A0
+.long 0x32D40C54
+.long 0xD1FE0069, 0x0206D76A
+.long 0xBF8A0000
+.long 0xD9FE0000, 0x2000005E
+.long 0xD9FE0900, 0x2800005E
+.long 0xD9FE0040, 0x2400005E
+.long 0xD9FE0940, 0x2C00005E
+.long 0xBF8A0000
+.long 0xD9FE0000, 0x44000060
+.long 0xD9FE0040, 0x48000060
+.long 0x8F2E862D
+.long 0x80AE2E80
+.long 0xBF03C22E
+.long 0xBF850065
+.long 0xBF8A0000
+.long 0xBF8CC17F
+.long 0xD3ED0000, 0x04028920
+.long 0xD3ED0004, 0x04128928
+.long 0xD3ED0000, 0x04028B21
+.long 0xD3ED0004, 0x04128B29
+.long 0xD3ED0000, 0x04028D22
+.long 0xBF8A0000
+.long 0xD3ED0004, 0x04128D2A
+.long 0xD9FE0000, 0x3000005F
+.long 0xD3ED0000, 0x04028F23
+.long 0xD9FE0900, 0x3800005F
+.long 0xD3ED0004, 0x04128F2B
+.long 0xD9FE0040, 0x3400005F
+.long 0xBF8CC37F
+.long 0xD3ED0000, 0x04029124
+.long 0xD9FE0940, 0x3C00005F
+.long 0xD3ED0004, 0x0412912C
+.long 0xD3ED0000, 0x04029325
+.long 0xD3ED0004, 0x0412932D
+.long 0xD3ED0000, 0x04029526
+.long 0xD3ED0004, 0x0412952E
+.long 0xBF8A0000
+.long 0xD9FE0000, 0x4C000061
+.long 0xD3ED0000, 0x04029727
+.long 0xD9FE0040, 0x50000061
+.long 0xD3ED0004, 0x0412972F
+.long 0xBF8A0000
+.long 0xBF8CC17F
+.long 0xD3ED0000, 0x04029930
+.long 0xD3ED0004, 0x04129938
+.long 0xD3ED0000, 0x04029B31
+.long 0xD3ED0004, 0x04129B39
+.long 0xD3ED0000, 0x04029D32
+.long 0xBF8A0000
+.long 0xD3ED0004, 0x04129D3A
+.long 0xD9FE0000, 0x2000005E
+.long 0xD3ED0000, 0x04029F33
+.long 0xD9FE0900, 0x2800005E
+.long 0xD3ED0004, 0x04129F3B
+.long 0xD9FE0040, 0x2400005E
+.long 0xBF8CC37F
+.long 0xD3ED0000, 0x0402A134
+.long 0xD9FE0940, 0x2C00005E
+.long 0xD3ED0004, 0x0412A13C
+.long 0xD3ED0000, 0x0402A335
+.long 0xD3ED0004, 0x0412A33D
+.long 0xD3ED0000, 0x0402A536
+.long 0xD3ED0004, 0x0412A53E
+.long 0xBF8A0000
+.long 0xD9FE0000, 0x44000060
+.long 0xD3ED0000, 0x0402A737
+.long 0xD9FE0040, 0x48000060
+.long 0xD3ED0004, 0x0412A73F
+.long 0x802E822E
+.long 0xBF03C22E
+.long 0xBF84FF9B
+.long 0xBF8CC17F
+.long 0xD3ED0000, 0x04028920
+.long 0xE0541000, 0x80041068
+.long 0xE0541020, 0x80041268
+.long 0xD3ED0004, 0x04128928
+.long 0xD3ED0000, 0x04028B21
+.long 0xBF8A0000
+.long 0xD3ED0004, 0x04128B29
+.long 0xD9FE0000, 0x3000005F
+.long 0xD3ED0000, 0x04028D22
+.long 0xD9FE0900, 0x3800005F
+.long 0xD3ED0004, 0x04128D2A
+.long 0xD9FE0040, 0x3400005F
+.long 0xD3ED0000, 0x04028F23
+.long 0xD9FE0940, 0x3C00005F
+.long 0xD3ED0004, 0x04128F2B
+.long 0xBF8CC37F
+.long 0xD3ED0000, 0x04029124
+.long 0xD3ED0004, 0x0412912C
+.long 0xD3ED0000, 0x04029325
+.long 0xD3ED0004, 0x0412932D
+.long 0xD3ED0000, 0x04029526
+.long 0xBF8A0000
+.long 0xD9FE0000, 0x4C000061
+.long 0xD3ED0004, 0x0412952E
+.long 0xD9FE0040, 0x50000061
+.long 0xD3ED0000, 0x04029727
+.long 0xD3ED0004, 0x0412972F
+.long 0xBF8CC17F
+.long 0xD3ED0000, 0x04029930
+.long 0xD3ED0004, 0x04129938
+.long 0xD3ED0000, 0x04029B31
+.long 0xD3ED0004, 0x04129B39
+.long 0xD3ED0000, 0x04029D32
+.long 0xD3ED0004, 0x04129D3A
+.long 0xD3ED0000, 0x04029F33
+.long 0xD3ED0004, 0x04129F3B
+.long 0xBF8CC07F
+.long 0xD3ED0000, 0x0402A134
+.long 0xD3ED0000, 0x0402A335
+.long 0xD3ED0000, 0x0402A536
+.long 0xD3ED0000, 0x0402A737
+.long 0xD3ED0004, 0x0412A13C
+.long 0xD3ED0004, 0x0412A33D
+.long 0xD3ED0004, 0x0412A53E
+.long 0xD3ED0004, 0x0412A73F
+.long 0x7ED602FF, 0xFFFF0000
+.long 0xD3D84000, 0x18000100
+.long 0x0A000028
+.long 0xD3D84001, 0x18000101
+.long 0x0A020228
+.long 0xD3D84002, 0x18000102
+.long 0x0A040428
+.long 0xD3D84003, 0x18000103
+.long 0x0A060628
+.long 0xBF8C0F71
+.long 0x24D42090
+.long 0xD1CB0000, 0x0400536A
+.long 0x26D420FF, 0xFFFF0000
+.long 0xD1CB0001, 0x0404536A
+.long 0x20000090
+.long 0xD2010000, 0x0402D701
+.long 0x24D42290
+.long 0xD1CB0002, 0x0408536A
+.long 0x26D422FF, 0xFFFF0000
+.long 0xD1CB0003, 0x040C536A
+.long 0x20040490
+.long 0xD2010001, 0x040AD703
+.long 0xE0741000, 0x80050069
+.long 0xD3D84004, 0x18000104
+.long 0x0A080828
+.long 0xD3D84005, 0x18000105
+.long 0x0A0A0A28
+.long 0xD3D84006, 0x18000106
+.long 0x0A0C0C28
+.long 0xD3D84007, 0x18000107
+.long 0x0A0E0E28
+.long 0xBF8C0F71
+.long 0x24D42490
+.long 0xD1CB0004, 0x0410536A
+.long 0x26D424FF, 0xFFFF0000
+.long 0xD1CB0005, 0x0414536A
+.long 0x20080890
+.long 0xD2010002, 0x0412D705
+.long 0x24D42690
+.long 0xD1CB0006, 0x0418536A
+.long 0x26D426FF, 0xFFFF0000
+.long 0xD1CB0007, 0x041C536A
+.long 0x200C0C90
+.long 0xD2010003, 0x041AD707
+.long 0xE0741020, 0x80050269
+.long 0xBF8C0000
+.long 0xBF810000

--- a/Tensile/ReplacementKernels/Cijk_Alik_Bljk_BBH_MT64x128x32_AF0EM8_ASEM8_FL0_GRVW4_ISA908_MDA2_PGR1_PLR1_SU32_TT4_8_VAW1_VW4_WG16_16_1_WGM8.s.txt
+++ b/Tensile/ReplacementKernels/Cijk_Alik_Bljk_BBH_MT64x128x32_AF0EM8_ASEM8_FL0_GRVW4_ISA908_MDA2_PGR1_PLR1_SU32_TT4_8_VAW1_VW4_WG16_16_1_WGM8.s.txt
@@ -1,0 +1,911 @@
+
+
+/******************************************/
+/* Function Prefix                        */
+/******************************************/
+
+
+
+/******************************************/
+/* Begin Kernel                           */
+/******************************************/
+
+.hsa_code_object_version 2,0
+.hsa_code_object_isa 9, 0, 8, "AMD", "AMDGPU"
+.text
+.p2align 8
+.amdgpu_hsa_kernel Cijk_Alik_Bljk_BBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT4_8_TLDS0_USFGRO1_VAW1_VS1_VW4_WSGRA0_WSGRB0_WG16_16_1_WGM8
+Cijk_Alik_Bljk_BBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT4_8_TLDS0_USFGRO1_VAW1_VS1_VW4_WSGRA0_WSGRB0_WG16_16_1_WGM8:
+.amd_kernel_code_t
+  is_ptr64 = 1
+  enable_sgpr_kernarg_segment_ptr = 1
+  kernarg_segment_byte_size = 148 // bytes of kern args
+  workitem_vgpr_count = 108 // vgprs
+  wavefront_sgpr_count = 98 // sgprs
+  compute_pgm_rsrc1_vgprs = 26 // floor((108-1)/4)
+  compute_pgm_rsrc1_sgprs = 12 // floor((98-1)/8)
+  compute_pgm_rsrc2_tidig_comp_cnt = 0 // 1D wg
+  compute_pgm_rsrc2_tgid_x_en = 1 // wg.x
+  compute_pgm_rsrc2_tgid_y_en = 1 // wg.y
+  compute_pgm_rsrc2_tgid_z_en = 1 // wg.z
+  workgroup_group_segment_byte_size = 30000// lds bytes
+  compute_pgm_rsrc2_user_sgpr = 2 // vcc
+  kernarg_segment_alignment = 4
+  group_segment_alignment = 4
+  private_segment_alignment = 4
+.end_amd_kernel_code_t
+
+/******************************************/
+/* Optimizations and Config:              */
+/******************************************/
+/* ThreadTile= 4 x 8 */
+/* SubGroup= 16 x 16 */
+/* VectorWidth=4 */
+/* GlobalLoadVectorWidthA=4, GlobalLoadVectorWidthB=4 */
+/* DirectToLdsA=False */
+/* DirectToLdsB=False */
+/* UseSgprForGRO=False */
+.amd_amdgpu_hsa_metadata
+Version: [ 1, 0 ]
+Kernels:
+  - Name: Cijk_Alik_Bljk_BBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT4_8_TLDS0_USFGRO1_VAW1_VS1_VW4_WSGRA0_WSGRB0_WG16_16_1_WGM8
+    SymbolName: 'Cijk_Alik_Bljk_BBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT4_8_TLDS0_USFGRO1_VAW1_VS1_VW4_WSGRA0_WSGRB0_WG16_16_1_WGM8@kd'
+    Language: OpenCL C
+    LanguageVersion: [ 2, 0 ]
+    Args:
+      - Name:            sizeC
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            sizeA
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            sizeB
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            D
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       Struct
+        AddrSpaceQual:   Generic
+      - Name:            C
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       Struct
+        AddrSpaceQual:   Generic
+      - Name:            A
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       Struct
+        AddrSpaceQual:   Generic
+      - Name:            B
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       Struct
+        AddrSpaceQual:   Generic
+      - Name:            alpha
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       F32
+      - Name:            beta
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       F32
+      - Name:            strideD0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideD1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideC0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideC1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideA0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideA1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideB0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideB1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree2
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesSum0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            OrigStaggerUIter
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       I32
+      - Name:            NumWorkGroups0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            NumWorkGroups1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            NumFullBlocks
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            WgmRemainder1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            MagicNumberWgmRemainder1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+    CodeProps:
+      KernargSegmentSize: 148
+      GroupSegmentFixedSize: 28672
+      PrivateSegmentFixedSize: 0
+      KernargSegmentAlign:  8
+      WavefrontSize:        64
+      NumSGPRs:             98
+      NumVGPRs:             108
+      MaxFlatWorkGroupSize: 256
+.end_amd_amdgpu_hsa_metadata
+
+/******************************************/
+/* Asm syntax workarounds                 */
+/******************************************/
+.macro _v_add_co_u32 dst, cc, src0, src1, dpp=
+   v_add_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+.macro _v_sub_co_u32 dst, cc, src0, src1, dpp=
+   v_sub_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+.macro _v_addc_co_u32 dst, ccOut, src0, ccIn, src1, dpp=
+   v_addc_co_u32 \dst, \ccOut, \src0, \ccIn, \src1 \dpp
+.endm
+.macro _v_add_lshl_u32 dst, src0, src1, shiftCnt
+    v_add_lshl_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+.macro _v_lshl_add_u32 dst, src0, src1, shiftCnt
+    v_lshl_add_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+/******************************************/
+/* Magic div and mod functions            */
+/******************************************/
+.macro V_MAGIC_DIV dstIdx, dividend, magicNumber, magicShift
+    v_mul_lo_u32 v[\dstIdx+0], \dividend, \magicNumber
+    v_mul_hi_u32 v[\dstIdx+1], \dividend, \magicNumber
+    v_lshrrev_b64 v[\dstIdx:\dstIdx+1], \magicShift, v[\dstIdx:\dstIdx+1]
+.endm
+
+/******************************************/
+/* VGPR Assignments                       */
+/******************************************/
+.set vgprValuC, 0
+/* ValuA/B   Xn=PLR buffer idx,  In=InnerUnroll idx */
+.set vgprValuA_X0_I0, 32
+.set vgprValuA_X1_I0, 34
+.set vgprG2LA, 36
+.set vgprValuB_X0_I0, 40
+.set vgprValuB_X1_I0, 44
+.set vgprG2LB, 48
+.set vgprLocalWriteAddrA, 56
+.set vgprLocalWriteAddrB, 57
+.set vgprGlobalReadOffsetA, 58
+.set vgprGlobalReadOffsetB, 60
+.set vgprLocalReadAddrA, 64
+.set vgprLocalReadAddrB, 65
+.set vgprSerial, 66
+/* Num VGPR=67 */
+
+/******************************************/
+/* SGPR Assignments                       */
+/******************************************/
+.set sgprKernArgAddress, 0
+.set sgprWorkGroup0, 2
+.set sgprWorkGroup1, 3
+.set sgprWorkGroup2, 4
+.set sgprNumWorkGroups0, 5
+.set sgprNumWorkGroups1, 6
+.set sgprSrdA, 8
+.set sgprSrdB, 12
+.set sgprSrdD, 16
+.set sgprSrdC, 20
+.set sgprTensor2dSizeC, 24
+.set sgprTensor2dSizeA, 26
+.set sgprTensor2dSizeB, 28
+.set sgprSaveExecMask, 30
+.set sgprAddressD, 32
+.set sgprAddressC, 34
+.set sgprStridesD, 36
+.set sgprStridesC, 38
+.set sgprAlpha, 40
+.set sgprSizesFree, 41
+.set sgprSizesSum, 44
+.set sgprLoopCounters, 45
+.set sgprOrigLoopCounter, 46
+.set sgprStridesA, 47
+.set sgprStridesB, 49
+.set sgprAddressA, 51
+.set sgprAddressB, 53
+.set sgprShadowLimitA, 56
+.set sgprShadowLimitB, 58
+.set sgprOrigStaggerUIter, 60
+.set sgprStaggerUIter, 61
+.set sgprWrapUA, 62
+.set sgprWrapUB, 64
+.set sgprNumFullBlocks, 66
+.set sgprWgmRemainder1, 67
+.set sgprMagicNumberWgmRemainder1, 68
+.set sgprGlobalReadIncsA, 69
+.set sgprGlobalReadIncsB, 70
+/* max SGPR=98 */
+
+/******************************************/
+/* 2GB limit - set offsets to -1 to exceed this and clamp */
+/******************************************/
+.set BufferLimit, 0x80000000
+
+/******************************************/
+/* Bits 127:96 of SRD.  Set DataFormat = 32 bit */
+/******************************************/
+.set Srd127_96, 0x0020000
+.set BufferOOB, 0x80000000
+
+/* Global Offset A */
+.macro GLOBAL_OFFSET_A vgprAddr vgprOffsetL vgprOffset0I vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStridesA+0], v[\vgprOffset0I] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprTmp+0], v[\vgprOffsetL] // accumulate d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, 0x4, v[\vgprAddr+0] // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/* Global Offset B */
+.macro GLOBAL_OFFSET_B vgprAddr vgprOffset1J vgprOffsetL vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStridesB+0], v[\vgprOffsetL] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprTmp+0], v[\vgprOffset1J] // accumulate d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, 0x4, v[\vgprAddr+0] // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+ //****************
+ // start kernel
+
+.long 0xC0020680, 0x00000008
+.long 0xC00206C0, 0x0000000C
+.long 0xC0020D00, 0x00000028
+.long 0xC0020D40, 0x0000002C
+.long 0xC0020C00, 0x00000050
+.long 0xC0020C40, 0x00000054
+.long 0xBEFC00FF, 0x00003000
+.long 0x7EC80300
+.long 0x26CA00BF
+.long 0x2004C886
+.long 0x7E9C0502
+.long 0xBF8CC07F
+.long 0xC0020C80, 0x00000058
+.long 0xC0020CC0, 0x0000005C
+.long 0xC0020D80, 0x00000030
+.long 0xC0020DC0, 0x00000034
+.long 0xC0020700, 0x00000010
+.long 0xC0020740, 0x00000014
+.long 0xBE880034
+.long 0xBE890035
+.long 0xBE8B00FF, 0x00020000
+.long 0xBE8A00FF, 0x80000000
+.long 0x9254C030
+.long 0x92545402
+.long 0x8E55844E
+.long 0x92533055
+.long 0x81545354
+.long 0x2000CA84
+.long 0xD2850004, 0x00020030
+.long 0x2602CA8F
+.long 0x24020281
+.long 0x32A40304
+.long 0x68A4A454
+.long 0x24A4A481
+.long 0x8E478330
+.long 0x80C7FF47, 0x00000108
+.long 0x68A6A447
+.long 0x68A8A647
+.long 0x68AAA847
+.long 0xBED800FF, 0x00000420
+.long 0x9258584E
+.long 0xBEFC0058
+.long 0x8159FF58, 0x00001080
+.long 0xE0511000, 0x80023052
+.long 0xE0511108, 0x80023153
+.long 0xE0511210, 0x80023254
+.long 0xE0511318, 0x80023355
+.long 0xBF8CC07F
+.long 0xBE8C0036
+.long 0xBE8D0037
+.long 0xBE8F00FF, 0x00020000
+.long 0xBE8E00FF, 0x80000000
+.long 0x9254FF32, 0x00000080
+.long 0x92545403
+.long 0x925532A0
+.long 0x9255554E
+.long 0x81545554
+.long 0x2004CA84
+.long 0x2606CA8F
+.long 0x24060681
+.long 0xD2850004, 0x00020432
+.long 0x32AC0704
+.long 0x68ACAC54
+.long 0x24ACAC81
+.long 0x8E4A8332
+.long 0x80CAFF4A, 0x00000108
+.long 0x68AEAC4A
+.long 0x68B0AE4A
+.long 0x68B2B04A
+.long 0x68B4B24A
+.long 0x68B6B44A
+.long 0x68B8B64A
+.long 0x68BAB84A
+.long 0xBEDA00FF, 0x00000840
+.long 0x925A5A4E
+.long 0x815AFF5A, 0x00002100
+.long 0xBEFC005A
+.long 0x815BFF5A, 0x00002100
+.long 0xE0511000, 0x80034456
+.long 0xE0511108, 0x80034557
+.long 0xE0511210, 0x80034658
+.long 0xE0511318, 0x80034759
+.long 0xE0511420, 0x8003485A
+.long 0xE0511528, 0x8003495B
+.long 0xE0511630, 0x80034A5C
+.long 0xE0511738, 0x80034B5D
+.long 0xC0020800, 0x00000018
+.long 0xC0020840, 0x0000001C
+.long 0xC0020880, 0x00000020
+.long 0xC00208C0, 0x00000024
+.long 0xC0020600, 0x00000000
+.long 0xC0020640, 0x00000004
+.long 0xC0020A00, 0x00000038
+.long 0xC0020900, 0x00000040
+.long 0xC0020940, 0x00000044
+.long 0xC0020980, 0x00000048
+.long 0xC00209C0, 0x0000004C
+.long 0xC0020A80, 0x00000060
+.long 0xC0020AC0, 0x00000064
+.long 0xC0020B00, 0x00000068
+.long 0xC0020B40, 0x0000006C
+.long 0xD1130001, 0x00013F65
+.long 0xD285005E, 0x00020290
+.long 0x20020282
+.long 0xD2850001, 0x00020282
+.long 0x68BCBD01
+.long 0x2002CA85
+.long 0x68BCBD01
+.long 0x24BCBC82
+.long 0x68BCBC80
+.long 0x68BEBCFF, 0x00001080
+.long 0xD1130001, 0x00013F65
+.long 0xD2850060, 0x00020290
+.long 0x20020282
+.long 0xD2850001, 0x00020282
+.long 0x68C0C101
+.long 0x2002CA85
+.long 0x68C0C101
+.long 0x24C0C082
+.long 0x9254FF4E, 0x00000840
+.long 0x68C0C054
+.long 0x68C0C0FF, 0x00002100
+.long 0x68C2C0FF, 0x00002100
+.long 0x925488FF, 0x00000108
+.long 0x815C545A
+.long 0x815D545B
+.long 0x68A4A4C0
+.long 0x68A6A6C0
+.long 0x68A8A8C0
+.long 0x68AAAAC0
+.long 0xBE900022
+.long 0xBE910023
+.long 0xBE9200FF, 0x80000000
+.long 0xBE9300FF, 0x00020000
+.long 0xBE940020
+.long 0xBE950021
+.long 0xBE9600FF, 0x80000000
+.long 0xBE9700FF, 0x00020000
+.long 0x925603FF, 0x00000080
+.long 0x96552656
+.long 0x92542656
+.long 0x8ED48154
+.long 0x80105410
+.long 0x82115511
+.long 0x80145414
+.long 0x82155515
+.long 0x96552704
+.long 0x92542704
+.long 0x8ED48154
+.long 0x80105410
+.long 0x82115511
+.long 0x80145414
+.long 0x82155515
+.long 0x2008C886
+.long 0xD2850004, 0x000208A0
+.long 0xD2850003, 0x00004D04
+.long 0x2608C89F
+.long 0xD2850005, 0x00004D04
+.long 0x2608C8BF
+.long 0x200C0885
+.long 0x240C0C82
+.long 0x68440B03
+.long 0x925402C0
+.long 0x32400C54
+.long 0xD1FE0068, 0x02064520
+.long 0xBEFC0059
+.long 0xD3D94000, 0x18000080
+.long 0xD3D94001, 0x18000080
+.long 0xD3D94002, 0x18000080
+.long 0xD3D94003, 0x18000080
+.long 0xD3D94004, 0x18000080
+.long 0xD3D94005, 0x18000080
+.long 0xD3D94006, 0x18000080
+.long 0xD3D94007, 0x18000080
+.long 0xD3D94008, 0x18000080
+.long 0xD3D94009, 0x18000080
+.long 0xD3D9400A, 0x18000080
+.long 0xD3D9400B, 0x18000080
+.long 0xD3D9400C, 0x18000080
+.long 0xD3D9400D, 0x18000080
+.long 0xD3D9400E, 0x18000080
+.long 0xD3D9400F, 0x18000080
+.long 0xE0511000, 0x80023052
+.long 0xE0511108, 0x80023153
+.long 0xE0511210, 0x80023254
+.long 0xE0511318, 0x80023355
+.long 0xBEFC005B
+.long 0x68ACACC0
+.long 0x68AEAEC0
+.long 0x68B0B0C0
+.long 0x68B2B2C0
+.long 0x68B4B4C0
+.long 0x68B6B6C0
+.long 0x68B8B8C0
+.long 0x68BABAC0
+.long 0xE0511000, 0x80034456
+.long 0xE0511108, 0x80034557
+.long 0xE0511210, 0x80034658
+.long 0xE0511318, 0x80034759
+.long 0xD3D94010, 0x18000080
+.long 0xD3D94011, 0x18000080
+.long 0xD3D94012, 0x18000080
+.long 0xD3D94013, 0x18000080
+.long 0xD3D94014, 0x18000080
+.long 0xD3D94015, 0x18000080
+.long 0xD3D94016, 0x18000080
+.long 0xD3D94017, 0x18000080
+.long 0xD3D94018, 0x18000080
+.long 0xD3D94019, 0x18000080
+.long 0xD3D9401A, 0x18000080
+.long 0xD3D9401B, 0x18000080
+.long 0xD3D9401C, 0x18000080
+.long 0xD3D9401D, 0x18000080
+.long 0xD3D9401E, 0x18000080
+.long 0xD3D9401F, 0x18000080
+.long 0xE0511420, 0x8003485A
+.long 0xE0511528, 0x8003495B
+.long 0xE0511630, 0x80034A5C
+.long 0xE0511738, 0x80034B5D
+.long 0xBF8CC07F
+.long 0xBF8C4F74
+.long 0xBF8C0070
+.long 0xBF8A0000
+.long 0xD86C0000, 0x2000005E
+.long 0xD86C0840, 0x2100005E
+.long 0xD86C0008, 0x2200005E
+.long 0xD86C0848, 0x2300005E
+.long 0xBF8C0F7C
+.long 0xD86C0000, 0x34000060
+.long 0xD86C0008, 0x35000060
+.long 0xD86C0010, 0x36000060
+.long 0xD86C0018, 0x37000060
+.long 0x8F2E852D
+.long 0x80AE2E80
+.long 0xBF06802E
+.long 0xBF850234
+.long 0xBF8CC27F
+.long 0xD3EC0000, 0x04026920
+.long 0xD86C0010, 0x2400005E
+.long 0xD86C0850, 0x2500005E
+.long 0xD86C0018, 0x2600005E
+.long 0xD86C0858, 0x2700005E
+.long 0xD3EC0010, 0x04426921
+.long 0xD86C0020, 0x2800005E
+.long 0xD86C0860, 0x2900005E
+.long 0xD86C0020, 0x38000060
+.long 0xD86C0028, 0x39000060
+.long 0xBEFC0058
+.long 0xD3EC0000, 0x04026B22
+.long 0xD86C0028, 0x2A00005E
+.long 0xD86C0868, 0x2B00005E
+.long 0xD86C0030, 0x3A000060
+.long 0xD86C0038, 0x3B000060
+.long 0xD3EC0010, 0x04426B23
+.long 0xD86C0038, 0x2E00005E
+.long 0xD86C0878, 0x2F00005E
+.long 0xD86C0030, 0x2C00005E
+.long 0xD86C0870, 0x2D00005E
+.long 0xBF8CCE7F
+.long 0xD3EC0000, 0x04026D24
+.long 0x68A4A4C0
+.long 0x68A6A6C0
+.long 0x68A8A8C0
+.long 0x68AAAAC0
+.long 0xD3EC0010, 0x04426D25
+.long 0x68ACACC0
+.long 0x68AEAEC0
+.long 0x68B0B0C0
+.long 0x68B2B2C0
+.long 0xBF8CCC7F
+.long 0xD3EC0000, 0x04026F26
+.long 0x68B4B4C0
+.long 0x68B6B6C0
+.long 0x68B8B8C0
+.long 0x68BABAC0
+.long 0xD3EC0010, 0x04426F27
+.long 0xBF8CC87F
+.long 0xD3EC0000, 0x04027128
+.long 0xE0511000, 0x80023052
+.long 0xE0511108, 0x80023153
+.long 0xD3EC0010, 0x04427129
+.long 0xE0511210, 0x80023254
+.long 0xE0511318, 0x80023355
+.long 0xBEFC005A
+.long 0xBF8CC47F
+.long 0xD3EC0000, 0x0402732A
+.long 0xE0511000, 0x80034456
+.long 0xE0511108, 0x80034557
+.long 0xE0511210, 0x80034658
+.long 0xD3EC0010, 0x0442732B
+.long 0xE0511318, 0x80034759
+.long 0xE0511420, 0x8003485A
+.long 0xE0511528, 0x8003495B
+.long 0xBF8CC07F
+.long 0xD3EC0000, 0x0402752C
+.long 0xE0511630, 0x80034A5C
+.long 0xE0511738, 0x80034B5D
+.long 0xD3EC0010, 0x0442752D
+.long 0xBF8C4F74
+.long 0xBF8C0070
+.long 0xBF8A0000
+.long 0xD3EC0000, 0x0402772E
+.long 0xD86C0000, 0x2000005F
+.long 0xD86C0840, 0x2100005F
+.long 0xD86C0008, 0x2200005F
+.long 0xD86C0848, 0x2300005F
+.long 0xD3EC0010, 0x0442772F
+.long 0xBF8C0F7C
+.long 0xD86C0000, 0x3C000061
+.long 0xD86C0008, 0x3D000061
+.long 0xD86C0010, 0x3E000061
+.long 0xD86C0018, 0x3F000061
+.long 0x802E812E
+.long 0xBF8CC27F
+.long 0xD3EC0000, 0x04027920
+.long 0xD86C0010, 0x2400005F
+.long 0xD86C0850, 0x2500005F
+.long 0xD86C0018, 0x2600005F
+.long 0xD86C0858, 0x2700005F
+.long 0xD3EC0010, 0x04427921
+.long 0xD86C0020, 0x2800005F
+.long 0xD86C0860, 0x2900005F
+.long 0xD86C0020, 0x40000061
+.long 0xD86C0028, 0x41000061
+.long 0xBEFC0059
+.long 0xD3EC0000, 0x04027B22
+.long 0xD86C0028, 0x2A00005F
+.long 0xD86C0868, 0x2B00005F
+.long 0xD86C0030, 0x42000061
+.long 0xD86C0038, 0x43000061
+.long 0xD3EC0010, 0x04427B23
+.long 0xD86C0038, 0x2E00005F
+.long 0xD86C0878, 0x2F00005F
+.long 0xD86C0030, 0x2C00005F
+.long 0xD86C0870, 0x2D00005F
+.long 0xBF8CCE7F
+.long 0xD3EC0000, 0x04027D24
+.long 0x68A4A4C0
+.long 0x68A6A6C0
+.long 0x68A8A8C0
+.long 0x68AAAAC0
+.long 0xD3EC0010, 0x04427D25
+.long 0x68ACACC0
+.long 0x68AEAEC0
+.long 0x68B0B0C0
+.long 0x68B2B2C0
+.long 0xBF8CCC7F
+.long 0xD3EC0000, 0x04027F26
+.long 0x68B4B4C0
+.long 0x68B6B6C0
+.long 0x68B8B8C0
+.long 0x68BABAC0
+.long 0xD3EC0010, 0x04427F27
+.long 0xBF8CC87F
+.long 0xD3EC0000, 0x04028128
+.long 0xE0511000, 0x80023052
+.long 0xE0511108, 0x80023153
+.long 0xD3EC0010, 0x04428129
+.long 0xE0511210, 0x80023254
+.long 0xE0511318, 0x80023355
+.long 0xBEFC005B
+.long 0xBF8CC47F
+.long 0xD3EC0000, 0x0402832A
+.long 0xE0511000, 0x80034456
+.long 0xE0511108, 0x80034557
+.long 0xE0511210, 0x80034658
+.long 0xD3EC0010, 0x0442832B
+.long 0xE0511318, 0x80034759
+.long 0xE0511420, 0x8003485A
+.long 0xE0511528, 0x8003495B
+.long 0xBF8CC07F
+.long 0xD3EC0000, 0x0402852C
+.long 0xE0511630, 0x80034A5C
+.long 0xE0511738, 0x80034B5D
+.long 0xD3EC0010, 0x0442852D
+.long 0xBF8C4F74
+.long 0xBF8C0070
+.long 0xBF8A0000
+.long 0xD3EC0000, 0x0402872E
+.long 0xD86C0000, 0x2000005E
+.long 0xD86C0840, 0x2100005E
+.long 0xD86C0008, 0x2200005E
+.long 0xD86C0848, 0x2300005E
+.long 0xD3EC0010, 0x0442872F
+.long 0xBF8C0F7C
+.long 0xD86C0000, 0x34000060
+.long 0xD86C0008, 0x35000060
+.long 0xD86C0010, 0x36000060
+.long 0xD86C0018, 0x37000060
+.long 0x802E812E
+.long 0xBF00C22E
+.long 0xBF84FEFC
+.long 0xBF8CC27F
+.long 0xD3EC0000, 0x04026920
+.long 0xD86C0010, 0x2400005E
+.long 0xD86C0850, 0x2500005E
+.long 0xD86C0018, 0x2600005E
+.long 0xD86C0858, 0x2700005E
+.long 0xD3EC0010, 0x04426921
+.long 0xD86C0020, 0x2800005E
+.long 0xD86C0860, 0x2900005E
+.long 0xD86C0020, 0x38000060
+.long 0xD86C0028, 0x39000060
+.long 0xD3EC0000, 0x04026B22
+.long 0xD86C0028, 0x2A00005E
+.long 0xD86C0868, 0x2B00005E
+.long 0xD86C0030, 0x3A000060
+.long 0xD86C0038, 0x3B000060
+.long 0xD3EC0010, 0x04426B23
+.long 0xD86C0030, 0x2C00005E
+.long 0xD86C0870, 0x2D00005E
+.long 0xD86C0038, 0x2E00005E
+.long 0xD86C0878, 0x2F00005E
+.long 0xBF8CCE7F
+.long 0xD3EC0000, 0x04026D24
+.long 0xD3EC0010, 0x04426D25
+.long 0xBF8CCC7F
+.long 0xD3EC0000, 0x04026F26
+.long 0xD3EC0010, 0x04426F27
+.long 0xBF8CC87F
+.long 0xD3EC0000, 0x04027128
+.long 0xD3EC0010, 0x04427129
+.long 0xBF8CC47F
+.long 0xD3EC0000, 0x0402732A
+.long 0xD3EC0010, 0x0442732B
+.long 0xBF8CC07F
+.long 0xD3EC0000, 0x0402752C
+.long 0xD3EC0010, 0x0442752D
+.long 0xBF8C0F78
+.long 0xBF8C0070
+.long 0xBF8A0000
+.long 0xD3EC0000, 0x0402772E
+.long 0xD86C0000, 0x2000005F
+.long 0xD86C0840, 0x2100005F
+.long 0xD86C0008, 0x2200005F
+.long 0xD86C0848, 0x2300005F
+.long 0xD3EC0010, 0x0442772F
+.long 0xBF8C0F70
+.long 0xD86C0000, 0x3C000061
+.long 0xD86C0008, 0x3D000061
+.long 0xD86C0010, 0x3E000061
+.long 0xD86C0018, 0x3F000061
+.long 0xBF8CC27F
+.long 0xD3EC0000, 0x04027920
+.long 0xD86C0010, 0x2400005F
+.long 0xD86C0850, 0x2500005F
+.long 0xD86C0018, 0x2600005F
+.long 0xD86C0858, 0x2700005F
+.long 0xD3EC0010, 0x04427921
+.long 0xD86C0020, 0x2800005F
+.long 0xD86C0860, 0x2900005F
+.long 0xD86C0020, 0x40000061
+.long 0xD86C0028, 0x41000061
+.long 0xD3EC0000, 0x04027B22
+.long 0xD86C0028, 0x2A00005F
+.long 0xD86C0868, 0x2B00005F
+.long 0xD86C0030, 0x42000061
+.long 0xD86C0038, 0x43000061
+.long 0xD3EC0010, 0x04427B23
+.long 0xD86C0030, 0x2C00005F
+.long 0xD86C0870, 0x2D00005F
+.long 0xD86C0038, 0x2E00005F
+.long 0xD86C0878, 0x2F00005F
+.long 0xBF8CCE7F
+.long 0xD3EC0000, 0x04027D24
+.long 0xD3EC0010, 0x04427D25
+.long 0xBF8CCC7F
+.long 0xD3EC0000, 0x04027F26
+.long 0xD3EC0010, 0x04427F27
+.long 0xBF8CC87F
+.long 0xD3EC0000, 0x04028128
+.long 0xD3EC0010, 0x04428129
+.long 0xBF8CC47F
+.long 0xD3EC0000, 0x0402832A
+.long 0xD3EC0010, 0x0442832B
+.long 0xBF8CC07F
+.long 0xD3EC0000, 0x0402852C
+.long 0xD3EC0010, 0x0442852D
+.long 0xD3EC0000, 0x0402872E
+.long 0xD3EC0010, 0x0442872F
+.long 0xD3D84000, 0x18000100
+.long 0xD3D84001, 0x18000101
+.long 0xD3D84002, 0x18000102
+.long 0xD3D84003, 0x18000103
+.long 0xD3D84004, 0x18000104
+.long 0xD3D84005, 0x18000105
+.long 0xD3D84006, 0x18000106
+.long 0xD3D84007, 0x18000107
+.long 0xD3D84008, 0x18000108
+.long 0xD3D84009, 0x18000109
+.long 0xD3D8400A, 0x1800010A
+.long 0xD3D8400B, 0x1800010B
+.long 0xD3D8400C, 0x1800010C
+.long 0xD3D8400D, 0x1800010D
+.long 0xD3D8400E, 0x1800010E
+.long 0xD3D8400F, 0x1800010F
+.long 0x20000090
+.long 0x20020290
+.long 0x24020290
+.long 0x28000300
+.long 0x20040490
+.long 0x20060690
+.long 0x24060690
+.long 0x28020702
+.long 0x20080890
+.long 0x200A0A90
+.long 0x240A0A90
+.long 0x28040B04
+.long 0x200C0C90
+.long 0x200E0E90
+.long 0x240E0E90
+.long 0x28060F06
+.long 0x20101090
+.long 0x20121290
+.long 0x24121290
+.long 0x28081308
+.long 0x20141490
+.long 0x20161690
+.long 0x24161690
+.long 0x280A170A
+.long 0x20181890
+.long 0x201A1A90
+.long 0x241A1A90
+.long 0x280C1B0C
+.long 0x201C1C90
+.long 0x201E1E90
+.long 0x241E1E90
+.long 0x280E1F0E
+.long 0xE0741000, 0x80050068
+.long 0xE0741010, 0x80050268
+.long 0xE0741020, 0x80050468
+.long 0xE0741030, 0x80050668
+.long 0xD3D84000, 0x18000110
+.long 0xD3D84001, 0x18000111
+.long 0xD3D84002, 0x18000112
+.long 0xD3D84003, 0x18000113
+.long 0xD3D84004, 0x18000114
+.long 0xD3D84005, 0x18000115
+.long 0xD3D84006, 0x18000116
+.long 0xD3D84007, 0x18000117
+.long 0xD3D84008, 0x18000118
+.long 0xD3D84009, 0x18000119
+.long 0xD3D8400A, 0x1800011A
+.long 0xD3D8400B, 0x1800011B
+.long 0xD3D8400C, 0x1800011C
+.long 0xD3D8400D, 0x1800011D
+.long 0xD3D8400E, 0x1800011E
+.long 0xD3D8400F, 0x1800011F
+.long 0x20000090
+.long 0x20020290
+.long 0x24020290
+.long 0x28000300
+.long 0x20040490
+.long 0x20060690
+.long 0x24060690
+.long 0x28020702
+.long 0x20080890
+.long 0x200A0A90
+.long 0x240A0A90
+.long 0x28040B04
+.long 0x200C0C90
+.long 0x200E0E90
+.long 0x240E0E90
+.long 0x28060F06
+.long 0x20101090
+.long 0x20121290
+.long 0x24121290
+.long 0x28081308
+.long 0x20141490
+.long 0x20161690
+.long 0x24161690
+.long 0x280A170A
+.long 0x20181890
+.long 0x201A1A90
+.long 0x241A1A90
+.long 0x280C1B0C
+.long 0x201C1C90
+.long 0x201E1E90
+.long 0x241E1E90
+.long 0x280E1F0E
+.long 0xE0741040, 0x80050068
+.long 0xE0741050, 0x80050268
+.long 0xE0741060, 0x80050468
+.long 0xE0741070, 0x80050668
+.long 0xBF8C0000
+.long 0xBF810000

--- a/Tensile/ReplacementKernels/Cijk_Alik_Bljk_BBH_MT64x128x64_AF0EM8_ASEM8_FL0_GRVW4_ISA908_MDA2_PGR1_PLR1_SU32_TT4_4_VAW1_VW4_WG16_32_1_WGM8.s.txt
+++ b/Tensile/ReplacementKernels/Cijk_Alik_Bljk_BBH_MT64x128x64_AF0EM8_ASEM8_FL0_GRVW4_ISA908_MDA2_PGR1_PLR1_SU32_TT4_4_VAW1_VW4_WG16_32_1_WGM8.s.txt
@@ -1,0 +1,1724 @@
+
+
+/******************************************/
+/* Function Prefix                        */
+/******************************************/
+
+
+
+/******************************************/
+/* Begin Kernel                           */
+/******************************************/
+
+.hsa_code_object_version 2,0
+.hsa_code_object_isa 9, 0, 8, "AMD", "AMDGPU"
+.text
+.p2align 8
+.amdgpu_hsa_kernel Cijk_Alik_Bljk_BBH_MT64x128x64_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT4_4_TLDS0_USFGROn1_VAW1_VSn1_VW4_WSGRA0_WSGRB0_WG16_32_1_WGM8
+Cijk_Alik_Bljk_BBH_MT64x128x64_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT4_4_TLDS0_USFGROn1_VAW1_VSn1_VW4_WSGRA0_WSGRB0_WG16_32_1_WGM8:
+.amd_kernel_code_t
+  is_ptr64 = 1
+  enable_sgpr_kernarg_segment_ptr = 1
+  kernarg_segment_byte_size = 148 // bytes of kern args
+  workitem_vgpr_count = 108 // vgprs
+  wavefront_sgpr_count = 98 // sgprs
+  compute_pgm_rsrc1_vgprs = 26 // floor((108-1)/4)
+  compute_pgm_rsrc1_sgprs = 12 // floor((98-1)/8)
+  compute_pgm_rsrc2_tidig_comp_cnt = 0 // 1D wg
+  compute_pgm_rsrc2_tgid_x_en = 1 // wg.x
+  compute_pgm_rsrc2_tgid_y_en = 1 // wg.y
+  compute_pgm_rsrc2_tgid_z_en = 1 // wg.z
+  workgroup_group_segment_byte_size = 30000// lds bytes
+  compute_pgm_rsrc2_user_sgpr = 2 // vcc
+  kernarg_segment_alignment = 4
+  group_segment_alignment = 4
+  private_segment_alignment = 4
+.end_amd_kernel_code_t
+
+/******************************************/
+/* Optimizations and Config:              */
+/******************************************/
+/* ThreadTile= 4 x 4 */
+/* SubGroup= 32 x 16 */
+/* VectorWidth=4 */
+/* GlobalLoadVectorWidthA=4, GlobalLoadVectorWidthB=4 */
+/* DirectToLdsA=False */
+/* DirectToLdsB=False */
+/* UseSgprForGRO=False */
+.amd_amdgpu_hsa_metadata
+Version: [ 1, 0 ]
+Kernels:
+  - Name: Cijk_Alik_Bljk_BBH_MT64x128x64_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT4_4_TLDS0_USFGROn1_VAW1_VSn1_VW4_WSGRA0_WSGRB0_WG16_32_1_WGM8
+    SymbolName: 'Cijk_Alik_Bljk_BBH_MT64x128x64_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT4_4_TLDS0_USFGROn1_VAW1_VSn1_VW4_WSGRA0_WSGRB0_WG16_32_1_WGM8@kd'
+    Language: OpenCL C
+    LanguageVersion: [ 2, 0 ]
+    Args:
+      - Name:            sizeC
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            sizeA
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            sizeB
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            D
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       Struct
+        AddrSpaceQual:   Generic
+      - Name:            C
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       Struct
+        AddrSpaceQual:   Generic
+      - Name:            A
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       Struct
+        AddrSpaceQual:   Generic
+      - Name:            B
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       Struct
+        AddrSpaceQual:   Generic
+      - Name:            alpha
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       F32
+      - Name:            beta
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       F32
+      - Name:            strideD0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideD1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideC0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideC1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideA0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideA1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideB0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideB1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree2
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesSum0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            OrigStaggerUIter
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       I32
+      - Name:            NumWorkGroups0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            NumWorkGroups1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            NumFullBlocks
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            WgmRemainder1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            MagicNumberWgmRemainder1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+    CodeProps:
+      KernargSegmentSize: 148
+      GroupSegmentFixedSize: 28672
+      PrivateSegmentFixedSize: 0
+      KernargSegmentAlign:  8
+      WavefrontSize:        64
+      NumSGPRs:             98
+      NumVGPRs:             108
+      MaxFlatWorkGroupSize: 256
+.end_amd_amdgpu_hsa_metadata
+
+.set BufferOOB, 0x80000000
+
+///////////////implementation description///////////////////////
+/////1. 2wave/simd solution.  8 waves/wg split into 2 groups of 4waves
+/////   one group (called fetch group) dedeicated fetching elements for A&B for macro-tile
+/////   other group does math for macro-tile
+/////2. each thread group generate a 64X128. by multiply block A(64XK) and block B (KX128).
+/////3. each thread group's input block A addressed by thread gourp idy,  block B addressed by thread gourp idx.
+/////4. each thread group has 4 waves.
+/////5. each wave generate a 64X32,  by multiply block A(64XK) and block B (KX32)
+/////6. in each loop, each wave multiply block A(64X32) and block B (32X32),  wave mem data load as belowing:
+///           Matrix A (K)                       Matrix B (N)
+///           ---------32              --------4-------8------12-------16---------32---------- 64------------128----------
+///           0   w0Ab0                -       |       |       |       |          |            |              |             |            |
+///           4   w0Ab1                -       |       |       |       |          |            |              |             |            |
+///           8   w0Ab2                -       |       |       |       |          |            |              |             |            |
+///          12   w0Ab3                -       |       |       |       |          |            |              |             |            |
+///      (M) 16   w1Ab0           (K)  - w0Bb0 | w0Bb1 | w0Bb2 | w0Bb3 | w0Bb[4-7]| w1Bb[0-7] |  w2Bb[0-7]  | w3Bb[0-7]
+///           -                        -       |       |       |       |          |            |              |             |            |
+///          ...                       -       |       |       |       |          |            |              |             |            |
+///          32   w2Ab0                -       |       |       |       |          |            |              |             |            |
+///          ...                      32       |       |       |       |          |            |              |             |            |
+///          48   w3Ab0
+///          ..
+///          60   w3Ab3
+///      5.1  Ab means Matrix A block M(4)*K(32),  Bb means Matrix B block K(32)*N(4).
+///      5.2  w0Ab0 means wave 0 Matrix A first loading block.
+/////6. all of the data in step 5 are loaded into LDS directly with buffer_load lds:1.
+/////   in lds, the data stored location followed the order:  w0 -> w1 -> w2-> w3.
+
+//////sreg def/////////////
+
+.set sgprKernArgAddress ,0
+.set sgprWorkGroup0 ,2
+.set sgprWorkGroup1 ,3
+.set sgprWorkGroup2 ,4
+.set sgprNumWorkGroups0,5
+.set sgprNumWorkGroups1,6
+.set sgprSrdA,8
+.set sgprSrdB,12
+.set sgprSrdC,16
+.set sgprSrdD,20
+.set sgprTensor2dSizeC,24
+.set sgprTensor2dSizeA,26
+.set sgprTensor2dSizeB,28
+.set sgprSaveExecMask,30
+.set sgprAddressD,32
+.set sgprAddressC,34
+.set sgprStridesD,36
+.set sgprStridesC,38
+.set sgprAlpha,40
+.set sgprBeta,41
+.set sgprSizesFree ,42
+.set sgprSizesSum  ,45
+.set sgprLoopCounters,46
+.set sgprOrigLoopCounter,47
+.set sgprStridesA,48
+.set sgprStridesB,50
+.set sgprAddressA,52
+.set sgprAddressB,54
+.set sgprShadowLimitA,56
+.set sgprShadowLimitB,58
+.set sgprOrigStaggerUIter,60
+.set sgprStaggerUIter,61
+.set sgprWrapUA,62
+.set sgprWrapUB,64
+.set sgprNumFullBlocks,66
+.set sgprWgmRemainder1,67
+.set sgprMagicNumberWgmRemainder1,68
+.set sgprGlobalReadIncsA,69
+.set sgprGlobalReadIncsB,70
+.set sgprScalarGlobalReadOffsetA,71
+.set sgprScalarGlobalReadOffsetB,74
+.set sgprLocalWriteAddrA,88
+.set sgprLocalWriteAddrB,90
+.set sgprLoopIdx ,94
+.set hw_id ,95
+
+
+/////vreg def////////////////
+
+.set vgprValuC,0
+.set vgprAcc,0
+.set vgprValuA_X0_I0,32
+.set vgprG2LA,48
+.set vgprValuB_X0_I0,52
+.set vgprG2LB,68
+.set vgprLocalWriteAddrA,76
+.set vgprLocalWriteAddrB,78
+.set vgprGlobalReadOfvarA,82
+.set vgprGlobalReadOfvarB,86
+.set vgprLocalReadAddrA,94
+.set vgprLocalReadAddrB,96
+.set vgprSerial,100
+.set vgprGlobalWriteOfvarC,104
+.set vgprTmp,106
+
+////constant def/////////////
+.set varlds_pad            , 8
+.set varlds_pad_qw         , varlds_pad >> 2
+.set varlds_Asize_per_wr   , 256+varlds_pad                  //each load inst load one 32X4 block.    need contiunous 32X4X2=256    bytes in LDS
+.set varlds_Asize_per_wave , varlds_Asize_per_wr * 4   //each wave load 4 32X4 block one time.  need contiunous 32X4X4X2=1024 bytes in LDS
+.set varlds_Asize_per_wg   , varlds_Asize_per_wave * 4 //WG load 16 32X4 block(64X32) Matrix A to lds for pingpong.
+.set M_row_per_WG          , 64       //each WG process 64 row
+.set varlds_Bsize_per_wr   , 256+varlds_pad             //each load inst load one 32X4  block.    need contiunous 32X4X2=256     bytes in LDS
+.set varlds_Bsize_per_wave , varlds_Bsize_per_wr * 8   //each wave load seperate 32X64 block.    need contiunous 32X4X8X2=2048 bytes in LDS
+.set varlds_Bsize_per_wg   , varlds_Bsize_per_wave * 4  //WG load 64 32X4 block(32X256) Matrix B to lds for pingpong.
+.set varA_lds_base_addr    , 0
+.set varB_lds_base_addr    , varA_lds_base_addr+varlds_Asize_per_wg * 2  //in bytes
+
+/******************************************/
+/* 2GB limit - set offsets to -1 to exceed this and clamp */
+/******************************************/
+.set BufferLimit,0x80000000
+
+/******************************************/
+/* Bits 127:96 of SRD.  Set DataFormat = 32 bit */
+/******************************************/
+.set Srd127_96,0x0020000
+
+.long 0xC00A0D00, 0x00000028
+.long 0xC00A0C00, 0x00000050
+.long 0xC00A0600, 0x00000008
+.long 0xC0020B40, 0x0000006C
+.long 0xBEFC00FF, 0x00003000
+.long 0x7EC80300
+.long 0x26CA00BF
+.long 0x2004C886
+.long 0xB8D0F804
+.long 0xD1130004, 0x0000A0B0
+.long 0x20CC0884
+.long 0x7EA40566
+.long 0xD1130067, 0x0000A08F
+.long 0x7EA20567
+.long 0xBF068151
+.long 0xBF840118
+.long 0xBF8CC07F
+.long 0xBE880034
+.long 0xBE890035
+.long 0xBE8B00FF, 0x00020000
+.long 0x80B85418
+.long 0x80B95518
+.long 0x8EB88138
+.long 0x80388438
+.long 0x82398039
+.long 0xBF068039
+.long 0x850AFF38, 0x80000000
+.long 0xBE8A00FF, 0x80000000
+.long 0x9254C030
+.long 0x92545402
+.long 0x8E558452
+.long 0x92533055
+.long 0x92553104
+.long 0x81545354
+.long 0x81545554
+.long 0x2000CA84
+.long 0xD2850004, 0x00020030
+.long 0x2602CA8F
+.long 0x24020281
+.long 0x32A40304
+.long 0x68A4A454
+.long 0x24A4A481
+.long 0x8E478330
+.long 0x80C7FF47, 0x00000108
+.long 0x68A6A447
+.long 0x68A8A647
+.long 0x68AAA847
+.long 0xBECC00FF, 0x00000420
+.long 0x924C4C52
+.long 0xBE8C0036
+.long 0xBE8D0037
+.long 0xBE8F00FF, 0x00020000
+.long 0x80BA541A
+.long 0x80BB551A
+.long 0x8EBA813A
+.long 0x803A843A
+.long 0x823B803B
+.long 0xBF06803B
+.long 0x850EFF3A, 0x80000000
+.long 0xBE8E00FF, 0x80000000
+.long 0x9254FF32, 0x00000080
+.long 0x92545403
+.long 0x925532A0
+.long 0x92555552
+.long 0x81545554
+.long 0x92553304
+.long 0x81545554
+.long 0x2004CA84
+.long 0x2606CA8F
+.long 0x24060681
+.long 0xD2850004, 0x00020432
+.long 0x32AC0704
+.long 0x68ACAC54
+.long 0x24ACAC81
+.long 0x8E4A8332
+.long 0x80CAFF4A, 0x00000108
+.long 0x68AEAC4A
+.long 0x68B0AE4A
+.long 0x68B2B04A
+.long 0x68B4B24A
+.long 0x68B6B44A
+.long 0x68B8B64A
+.long 0x68BAB84A
+.long 0xBECE00FF, 0x00000840
+.long 0x924E4E52
+.long 0x814EFF4E, 0x00002100
+.long 0xBF8A0000
+.long 0xBEFC004C
+.long 0x814DFF4C, 0x00001080
+.long 0xE0511000, 0x80023052
+.long 0xE0511108, 0x80023153
+.long 0xE0511210, 0x80023254
+.long 0xE0511318, 0x80023355
+.long 0xBEFC004E
+.long 0x814FFF4E, 0x00002100
+.long 0xE0511000, 0x80034456
+.long 0xE0511108, 0x80034557
+.long 0xE0511210, 0x80034658
+.long 0xE0511318, 0x80034759
+.long 0xE0511420, 0x8003485A
+.long 0xE0511528, 0x8003495B
+.long 0xE0511630, 0x80034A5C
+.long 0xE0511738, 0x80034B5D
+.long 0xBEFC004D
+.long 0x68A4A4C0
+.long 0x68A6A6C0
+.long 0x68A8A8C0
+.long 0x68AAAAC0
+.long 0x68ACACC0
+.long 0x68AEAEC0
+.long 0x68B0B0C0
+.long 0x68B2B2C0
+.long 0x68B4B4C0
+.long 0x68B6B6C0
+.long 0x68B8B8C0
+.long 0x68BABAC0
+.long 0xE0511000, 0x80023052
+.long 0xE0511108, 0x80023153
+.long 0xE0511210, 0x80023254
+.long 0xE0511318, 0x80023355
+.long 0xBEFC004F
+.long 0xBF800000
+.long 0xE0511000, 0x80034456
+.long 0xE0511108, 0x80034557
+.long 0xE0511210, 0x80034658
+.long 0xE0511318, 0x80034759
+.long 0xE0511420, 0x8003485A
+.long 0xE0511528, 0x8003495B
+.long 0xE0511630, 0x80034A5C
+.long 0xE0511738, 0x80034B5D
+.long 0x68A4A4C0
+.long 0x68A6A6C0
+.long 0x68A8A8C0
+.long 0x68AAAAC0
+.long 0x68ACACC0
+.long 0x68AEAEC0
+.long 0x68B0B0C0
+.long 0x68B2B2C0
+.long 0x68B4B4C0
+.long 0x68B6B6C0
+.long 0x68B8B8C0
+.long 0x68BABAC0
+.long 0xBEFC004C
+.long 0xBF8C4F74
+.long 0xBF8A0000
+.long 0xBF8C0F7C
+.long 0xBF8A0000
+.long 0x8F2E852D
+.long 0x80AE2E80
+.long 0xBF06802E
+.long 0xBF850064
+.long 0xBF8A0000
+.long 0xE0511000, 0x80023052
+.long 0xE0511108, 0x80023153
+.long 0xE0511210, 0x80023254
+.long 0xE0511318, 0x80023355
+.long 0xBEFC004E
+.long 0xBF800000
+.long 0xE0511000, 0x80034456
+.long 0xE0511108, 0x80034557
+.long 0xE0511210, 0x80034658
+.long 0xE0511318, 0x80034759
+.long 0xE0511420, 0x8003485A
+.long 0xE0511528, 0x8003495B
+.long 0xE0511630, 0x80034A5C
+.long 0xE0511738, 0x80034B5D
+.long 0xBF8C4F74
+.long 0xBF8F0001
+.long 0xBF8A0000
+.long 0x68A4A4C0
+.long 0x68A6A6C0
+.long 0x68A8A8C0
+.long 0x68AAAAC0
+.long 0x68ACACC0
+.long 0x68AEAEC0
+.long 0x68B0B0C0
+.long 0x68B2B2C0
+.long 0xBF8F0000
+.long 0xBF8C0F7C
+.long 0xBF8F0001
+.long 0xBF8A0000
+.long 0x68B4B4C0
+.long 0x68B6B6C0
+.long 0x68B8B8C0
+.long 0x68BABAC0
+.long 0xBF8F0000
+.long 0xBEFC004D
+.long 0x802E812E
+.long 0xBF8A0000
+.long 0xE0511000, 0x80023052
+.long 0xE0511108, 0x80023153
+.long 0xE0511210, 0x80023254
+.long 0xE0511318, 0x80023355
+.long 0xBEFC004F
+.long 0xBF800000
+.long 0xE0511000, 0x80034456
+.long 0xE0511108, 0x80034557
+.long 0xE0511210, 0x80034658
+.long 0xE0511318, 0x80034759
+.long 0xE0511420, 0x8003485A
+.long 0xE0511528, 0x8003495B
+.long 0xE0511630, 0x80034A5C
+.long 0xE0511738, 0x80034B5D
+.long 0xBF8C4F74
+.long 0xBF8A0000
+.long 0xBF8F0001
+.long 0x68A4A4C0
+.long 0x68A6A6C0
+.long 0x68A8A8C0
+.long 0x68AAAAC0
+.long 0x68ACACC0
+.long 0x68AEAEC0
+.long 0x68B0B0C0
+.long 0x68B2B2C0
+.long 0xBF8F0000
+.long 0xBF8C0F7C
+.long 0xBF8A0000
+.long 0xBF8F0001
+.long 0x68B4B4C0
+.long 0x68B6B6C0
+.long 0x68B8B8C0
+.long 0x68BABAC0
+.long 0xBF8F0000
+.long 0xBEFC004C
+.long 0x802E812E
+.long 0xBF00C22E
+.long 0xBF84FF9C
+.long 0xBF8C0F78
+.long 0xBF8A0000
+.long 0xBF8C0F70
+.long 0xBF8A0000
+.long 0xBF810000
+.long 0xD3D94000, 0x18000080
+.long 0xD3D94001, 0x18000080
+.long 0xD3D94002, 0x18000080
+.long 0xD3D94003, 0x18000080
+.long 0xD3D94004, 0x18000080
+.long 0xD3D94005, 0x18000080
+.long 0xD3D94006, 0x18000080
+.long 0xD3D94007, 0x18000080
+.long 0xD3D94008, 0x18000080
+.long 0xD3D94009, 0x18000080
+.long 0xD3D9400A, 0x18000080
+.long 0xD3D9400B, 0x18000080
+.long 0xD3D9400C, 0x18000080
+.long 0xD3D9400D, 0x18000080
+.long 0xD3D9400E, 0x18000080
+.long 0xD3D9400F, 0x18000080
+.long 0xD3D94010, 0x18000080
+.long 0xD3D94011, 0x18000080
+.long 0xD3D94012, 0x18000080
+.long 0xD3D94013, 0x18000080
+.long 0xD3D94014, 0x18000080
+.long 0xD3D94015, 0x18000080
+.long 0xD3D94016, 0x18000080
+.long 0xD3D94017, 0x18000080
+.long 0xD3D94018, 0x18000080
+.long 0xD3D94019, 0x18000080
+.long 0xD3D9401A, 0x18000080
+.long 0xD3D9401B, 0x18000080
+.long 0xD3D9401C, 0x18000080
+.long 0xD3D9401D, 0x18000080
+.long 0xD3D9401E, 0x18000080
+.long 0xD3D9401F, 0x18000080
+.long 0xC0060700, 0x00000000
+.long 0xC00A0900, 0x00000040
+.long 0xC0020A00, 0x00000038
+.long 0xC0020A40, 0x0000003C
+.long 0xC00A0800, 0x00000018
+.long 0xD1130001, 0x00013F65
+.long 0xD285005E, 0x00020290
+.long 0x20020282
+.long 0xD2850001, 0x00020282
+.long 0x68BCBD01
+.long 0x2002CA85
+.long 0x68BCBD01
+.long 0x24BCBC82
+.long 0x68BCBC80
+.long 0x68BEBCFF, 0x00001080
+.long 0xBF8A0000
+.long 0xD1130001, 0x00013F65
+.long 0xD2850060, 0x00020290
+.long 0x20020282
+.long 0xD2850001, 0x00020282
+.long 0x68C0C101
+.long 0x2002CA85
+.long 0x68C0C101
+.long 0x24C0C082
+.long 0x9254FF52, 0x00000840
+.long 0x68C0C054
+.long 0x68C0C0FF, 0x00002100
+.long 0x68C2C0FF, 0x00002100
+.long 0xBF8CC07F
+.long 0xBE900022
+.long 0xBE910023
+.long 0xBE9200FF, 0x80000000
+.long 0xBE9300FF, 0x00020000
+.long 0xBE940020
+.long 0xBE950021
+.long 0xBE9600FF, 0x80000000
+.long 0xBE9700FF, 0x00020000
+.long 0x925603FF, 0x00000080
+.long 0x96552656
+.long 0x92542656
+.long 0x8ED48154
+.long 0x80105410
+.long 0x82115511
+.long 0x80145414
+.long 0x82155515
+.long 0x96552704
+.long 0x92542704
+.long 0x8ED48154
+.long 0x80105410
+.long 0x82115511
+.long 0x80145414
+.long 0x82155515
+.long 0x24C8CC86
+.long 0x68C8C965
+.long 0xD2850004, 0x0002CCA0
+.long 0xD2850003, 0x00004D04
+.long 0x2608C89F
+.long 0xD2850005, 0x00004D04
+.long 0x2608C8BF
+.long 0x200C0885
+.long 0x240C0C82
+.long 0x68D60B03
+.long 0x925402C0
+.long 0x32D40C54
+.long 0xD1FE0068, 0x0206D76A
+.long 0xBF8A0000
+.long 0xD86C0000, 0x2000005E
+.long 0xD86C0840, 0x2100005E
+.long 0xD86C0008, 0x2200005E
+.long 0xD86C0848, 0x2300005E
+.long 0xD86C0010, 0x2400005E
+.long 0xD86C0850, 0x2500005E
+.long 0xD86C0018, 0x2600005E
+.long 0xD86C0858, 0x2700005E
+.long 0xD86C0020, 0x2800005E
+.long 0xD86C0860, 0x2900005E
+.long 0xD86C0028, 0x2A00005E
+.long 0xD86C0868, 0x2B00005E
+.long 0xD86C0030, 0x2C00005E
+.long 0xD86C0870, 0x2D00005E
+.long 0xD86C0038, 0x2E00005E
+.long 0xD86C0878, 0x2F00005E
+.long 0xBF8A0000
+.long 0xD86C0000, 0x44000060
+.long 0xD86C0008, 0x45000060
+.long 0xD86C0010, 0x46000060
+.long 0xD86C0018, 0x47000060
+.long 0x8F2E852D
+.long 0x80AE2E80
+.long 0xBF06802E
+.long 0xBF850714
+.long 0xBF8CC37F
+.long 0xD3EC0000, 0x04028920
+.long 0xD86C0020, 0x48000060
+.long 0xD86C0028, 0x49000060
+.long 0xD86C0030, 0x4A000060
+.long 0xD86C0038, 0x4B000060
+.long 0xD3EC0010, 0x04428921
+.long 0xBF8A0000
+.long 0xBF8CC67F
+.long 0xD3EC0000, 0x04028B22
+.long 0xD3EC0010, 0x04428B23
+.long 0xBF8CC57F
+.long 0xD3EC0000, 0x04028D24
+.long 0xD3EC0010, 0x04428D25
+.long 0xBF8CC47F
+.long 0xD3EC0000, 0x04028F26
+.long 0xD3EC0010, 0x04428F27
+.long 0xBF8CC07F
+.long 0xD3EC0000, 0x04029128
+.long 0xD3EC0010, 0x04429129
+.long 0xBF8F0000
+.long 0xD3EC0000, 0x0402932A
+.long 0xBF8A0000
+.long 0xD86C0000, 0x3000005F
+.long 0xD86C0840, 0x3100005F
+.long 0xD3EC0010, 0x0442932B
+.long 0xD86C0008, 0x3200005F
+.long 0xD86C0848, 0x3300005F
+.long 0xD86C0010, 0x3400005F
+.long 0xD86C0850, 0x3500005F
+.long 0xD3EC0000, 0x0402952C
+.long 0xD86C0018, 0x3600005F
+.long 0xD86C0858, 0x3700005F
+.long 0xD86C0020, 0x3800005F
+.long 0xD86C0860, 0x3900005F
+.long 0xD86C0028, 0x3A00005F
+.long 0xD3EC0010, 0x0442952D
+.long 0xD86C0868, 0x3B00005F
+.long 0xD86C0030, 0x3C00005F
+.long 0xD86C0870, 0x3D00005F
+.long 0xD86C0038, 0x3E00005F
+.long 0xD86C0878, 0x3F00005F
+.long 0xD3EC0000, 0x0402972E
+.long 0xBF8A0000
+.long 0xD86C0000, 0x4C000061
+.long 0xD86C0008, 0x4D000061
+.long 0xD3EC0010, 0x0442972F
+.long 0xD86C0010, 0x4E000061
+.long 0xD86C0018, 0x4F000061
+.long 0xD86C0020, 0x50000061
+.long 0xD86C0028, 0x51000061
+.long 0xBF8F0001
+.long 0x802E812E
+.long 0xBF8CC57F
+.long 0xD3EC0000, 0x04029930
+.long 0xD86C0030, 0x52000061
+.long 0xD86C0038, 0x53000061
+.long 0xD3EC0010, 0x04429931
+.long 0xBF8A0000
+.long 0xBF8CC67F
+.long 0xD3EC0000, 0x04029B32
+.long 0xD3EC0010, 0x04429B33
+.long 0xBF8CC57F
+.long 0xD3EC0000, 0x04029D34
+.long 0xD3EC0010, 0x04429D35
+.long 0xBF8CC47F
+.long 0xD3EC0000, 0x04029F36
+.long 0xD3EC0010, 0x04429F37
+.long 0xBF8CC07F
+.long 0xD3EC0000, 0x0402A138
+.long 0xD3EC0010, 0x0442A139
+.long 0xBF8F0000
+.long 0xD3EC0000, 0x0402A33A
+.long 0xBF8A0000
+.long 0xD86C0000, 0x2000005E
+.long 0xD86C0840, 0x2100005E
+.long 0xD3EC0010, 0x0442A33B
+.long 0xD86C0008, 0x2200005E
+.long 0xD86C0848, 0x2300005E
+.long 0xD86C0010, 0x2400005E
+.long 0xD86C0850, 0x2500005E
+.long 0xD86C0018, 0x2600005E
+.long 0xD3EC0000, 0x0402A53C
+.long 0xD86C0858, 0x2700005E
+.long 0xD86C0020, 0x2800005E
+.long 0xD86C0860, 0x2900005E
+.long 0xD86C0028, 0x2A00005E
+.long 0xD3EC0010, 0x0442A53D
+.long 0xD86C0868, 0x2B00005E
+.long 0xD86C0030, 0x2C00005E
+.long 0xD86C0870, 0x2D00005E
+.long 0xD86C0038, 0x2E00005E
+.long 0xD86C0878, 0x2F00005E
+.long 0xD3EC0000, 0x0402A73E
+.long 0xBF8A0000
+.long 0xD86C0000, 0x44000060
+.long 0xD86C0008, 0x45000060
+.long 0xD3EC0010, 0x0442A73F
+.long 0xD86C0018, 0x47000060
+.long 0xD86C0020, 0x48000060
+.long 0xD86C0028, 0x49000060
+.long 0xD86C0010, 0x46000060
+.long 0xBF8F0001
+.long 0x802E812E
+.long 0xBF8CC57F
+.long 0xD3EC0000, 0x04028920
+.long 0xD86C0030, 0x4A000060
+.long 0xD86C0038, 0x4B000060
+.long 0xD3EC0010, 0x04428921
+.long 0xBF8A0000
+.long 0xBF8CC67F
+.long 0xD3EC0000, 0x04028B22
+.long 0xD3EC0010, 0x04428B23
+.long 0xBF8CC57F
+.long 0xD3EC0000, 0x04028D24
+.long 0xD3EC0010, 0x04428D25
+.long 0xBF8CC47F
+.long 0xD3EC0000, 0x04028F26
+.long 0xD3EC0010, 0x04428F27
+.long 0xBF8CC07F
+.long 0xD3EC0000, 0x04029128
+.long 0xD3EC0010, 0x04429129
+.long 0xBF8F0000
+.long 0xD3EC0000, 0x0402932A
+.long 0xBF8A0000
+.long 0xD86C0000, 0x3000005F
+.long 0xD86C0840, 0x3100005F
+.long 0xD3EC0010, 0x0442932B
+.long 0xD86C0008, 0x3200005F
+.long 0xD86C0848, 0x3300005F
+.long 0xD86C0010, 0x3400005F
+.long 0xD86C0850, 0x3500005F
+.long 0xD3EC0000, 0x0402952C
+.long 0xD86C0018, 0x3600005F
+.long 0xD86C0858, 0x3700005F
+.long 0xD86C0020, 0x3800005F
+.long 0xD86C0860, 0x3900005F
+.long 0xD86C0028, 0x3A00005F
+.long 0xD3EC0010, 0x0442952D
+.long 0xD86C0868, 0x3B00005F
+.long 0xD86C0030, 0x3C00005F
+.long 0xD86C0870, 0x3D00005F
+.long 0xD86C0038, 0x3E00005F
+.long 0xD86C0878, 0x3F00005F
+.long 0xD3EC0000, 0x0402972E
+.long 0xBF8A0000
+.long 0xD86C0000, 0x4C000061
+.long 0xD86C0008, 0x4D000061
+.long 0xD3EC0010, 0x0442972F
+.long 0xD86C0010, 0x4E000061
+.long 0xD86C0018, 0x4F000061
+.long 0xD86C0020, 0x50000061
+.long 0xD86C0028, 0x51000061
+.long 0xBF8F0001
+.long 0x802E812E
+.long 0xBF8CC57F
+.long 0xD3EC0000, 0x04029930
+.long 0xD86C0030, 0x52000061
+.long 0xD86C0038, 0x53000061
+.long 0xD3EC0010, 0x04429931
+.long 0xBF8A0000
+.long 0xBF8CC67F
+.long 0xD3EC0000, 0x04029B32
+.long 0xD3EC0010, 0x04429B33
+.long 0xBF8CC57F
+.long 0xD3EC0000, 0x04029D34
+.long 0xD3EC0010, 0x04429D35
+.long 0xBF8CC47F
+.long 0xD3EC0000, 0x04029F36
+.long 0xD3EC0010, 0x04429F37
+.long 0xBF8CC07F
+.long 0xD3EC0000, 0x0402A138
+.long 0xD3EC0010, 0x0442A139
+.long 0xBF8F0000
+.long 0xD3EC0000, 0x0402A33A
+.long 0xBF8A0000
+.long 0xD86C0000, 0x2000005E
+.long 0xD86C0840, 0x2100005E
+.long 0xD3EC0010, 0x0442A33B
+.long 0xD86C0008, 0x2200005E
+.long 0xD86C0848, 0x2300005E
+.long 0xD86C0010, 0x2400005E
+.long 0xD86C0850, 0x2500005E
+.long 0xD3EC0000, 0x0402A53C
+.long 0xD86C0018, 0x2600005E
+.long 0xD86C0858, 0x2700005E
+.long 0xD86C0020, 0x2800005E
+.long 0xD86C0860, 0x2900005E
+.long 0xD86C0028, 0x2A00005E
+.long 0xD3EC0010, 0x0442A53D
+.long 0xD86C0868, 0x2B00005E
+.long 0xD86C0030, 0x2C00005E
+.long 0xD86C0870, 0x2D00005E
+.long 0xD86C0038, 0x2E00005E
+.long 0xD86C0878, 0x2F00005E
+.long 0xD3EC0000, 0x0402A73E
+.long 0xBF8A0000
+.long 0xD86C0000, 0x44000060
+.long 0xD86C0008, 0x45000060
+.long 0xD3EC0010, 0x0442A73F
+.long 0xD86C0010, 0x46000060
+.long 0xD86C0018, 0x47000060
+.long 0xD86C0020, 0x48000060
+.long 0xD86C0028, 0x49000060
+.long 0xBF8F0001
+.long 0x802E812E
+.long 0xBF00C22E
+.long 0xBF84FF48
+.long 0xBF8CC57F
+.long 0xD3EC0000, 0x04028920
+.long 0xD86C0030, 0x4A000060
+.long 0xD86C0038, 0x4B000060
+.long 0xB4290000
+.long 0xBF840326
+.long 0xD3EC0010, 0x04428921
+.long 0xB4280001
+.long 0xBF8400FD
+.long 0xBF8CC67F
+.long 0xD3EC0000, 0x04028B22
+.long 0xD3EC0010, 0x04428B23
+.long 0xBF8CC57F
+.long 0xD3EC0000, 0x04028D24
+.long 0xD3EC0010, 0x04428D25
+.long 0xBF8CC47F
+.long 0xD3EC0000, 0x04028F26
+.long 0xD3EC0010, 0x04428F27
+.long 0xBF8CC07F
+.long 0xD3EC0000, 0x04029128
+.long 0xD3EC0010, 0x04429129
+.long 0xD3EC0000, 0x0402932A
+.long 0xBF8A0000
+.long 0xD86C0000, 0x3000005F
+.long 0xD86C0840, 0x3100005F
+.long 0xD3EC0010, 0x0442932B
+.long 0xD86C0008, 0x3200005F
+.long 0xD86C0848, 0x3300005F
+.long 0xD86C0010, 0x3400005F
+.long 0xD86C0850, 0x3500005F
+.long 0xD3EC0000, 0x0402952C
+.long 0xD86C0018, 0x3600005F
+.long 0xD86C0858, 0x3700005F
+.long 0xD86C0020, 0x3800005F
+.long 0xD86C0860, 0x3900005F
+.long 0xD86C0028, 0x3A00005F
+.long 0xD3EC0010, 0x0442952D
+.long 0xD86C0868, 0x3B00005F
+.long 0xD86C0030, 0x3C00005F
+.long 0xD86C0870, 0x3D00005F
+.long 0xD86C0038, 0x3E00005F
+.long 0xD86C0878, 0x3F00005F
+.long 0xD3EC0000, 0x0402972E
+.long 0xBF8A0000
+.long 0xD86C0000, 0x4C000061
+.long 0xD86C0008, 0x4D000061
+.long 0xD3EC0010, 0x0442972F
+.long 0xD86C0010, 0x4E000061
+.long 0xD86C0018, 0x4F000061
+.long 0xD86C0020, 0x50000061
+.long 0xD86C0028, 0x51000061
+.long 0xBF8CC57F
+.long 0xD3EC0000, 0x04029930
+.long 0xD86C0030, 0x52000061
+.long 0xD86C0038, 0x53000061
+.long 0xD3EC0010, 0x04429931
+.long 0xBF8CC67F
+.long 0xD3EC0000, 0x04029B32
+.long 0xD3EC0010, 0x04429B33
+.long 0xBF8CC57F
+.long 0xD3EC0000, 0x04029D34
+.long 0xD3EC0010, 0x04429D35
+.long 0xBF8CC47F
+.long 0xD3EC0000, 0x04029F36
+.long 0xD3EC0010, 0x04429F37
+.long 0xBF8CC07F
+.long 0xD3EC0000, 0x0402A138
+.long 0xD3EC0000, 0x0402A33A
+.long 0xD3EC0000, 0x0402A53C
+.long 0xD3EC0000, 0x0402A73E
+.long 0xBED400FF, 0xFFFF0000
+.long 0x2AD6D56A
+.long 0x28D6D654
+.long 0xD3EC0010, 0x0442A139
+.long 0xD3D84000, 0x18000100
+.long 0xD3D84001, 0x18000101
+.long 0xD3D84002, 0x18000102
+.long 0xD3D84003, 0x18000103
+.long 0xD3D84004, 0x18000104
+.long 0xD3D84005, 0x18000105
+.long 0xD3D84006, 0x18000106
+.long 0xD3D84007, 0x18000107
+.long 0x20000090
+.long 0xD2010000, 0x0402D701
+.long 0x20040490
+.long 0xD2010001, 0x040AD703
+.long 0x20080890
+.long 0xD2010002, 0x0412D705
+.long 0xD3EC0010, 0x0442A33B
+.long 0xE0741000, 0x80050068
+.long 0x200C0C90
+.long 0xD2010003, 0x041AD707
+.long 0xD3EC0010, 0x0442A53D
+.long 0xE0741010, 0x80050268
+.long 0xD3D84008, 0x18000108
+.long 0xD3D84009, 0x18000109
+.long 0xD3D8400A, 0x1800010A
+.long 0xD3D8400B, 0x1800010B
+.long 0xD3EC0010, 0x0442A73F
+.long 0x20101090
+.long 0xD2010004, 0x0422D709
+.long 0x20141490
+.long 0xD2010005, 0x042AD70B
+.long 0xE0741020, 0x80050468
+.long 0xD3D8400C, 0x1800010C
+.long 0xD3D8400D, 0x1800010D
+.long 0xD3D8400E, 0x1800010E
+.long 0xD3D8400F, 0x1800010F
+.long 0x20181890
+.long 0xD2010006, 0x0432D70D
+.long 0x201C1C90
+.long 0xD2010007, 0x043AD70F
+.long 0xE0741030, 0x80050668
+.long 0xD3D84000, 0x18000110
+.long 0xD3D84001, 0x18000111
+.long 0xD3D84002, 0x18000112
+.long 0xD3D84003, 0x18000113
+.long 0xD3D84004, 0x18000114
+.long 0xD3D84005, 0x18000115
+.long 0xD3D84006, 0x18000116
+.long 0xD3D84007, 0x18000117
+.long 0x20000090
+.long 0xD2010000, 0x0402D701
+.long 0x20040490
+.long 0xD2010001, 0x040AD703
+.long 0x20080890
+.long 0xD2010002, 0x0412D705
+.long 0xE0741040, 0x80050068
+.long 0x200C0C90
+.long 0xD2010003, 0x041AD707
+.long 0xD3D84008, 0x18000118
+.long 0xD3D84009, 0x18000119
+.long 0xD3D8400A, 0x1800011A
+.long 0xD3D8400B, 0x1800011B
+.long 0xE0741050, 0x80050268
+.long 0x20101090
+.long 0xD2010004, 0x0422D709
+.long 0x20141490
+.long 0xD2010005, 0x042AD70B
+.long 0xD3D8400C, 0x1800011C
+.long 0xD3D8400D, 0x1800011D
+.long 0xD3D8400E, 0x1800011E
+.long 0xD3D8400F, 0x1800011F
+.long 0xE0741060, 0x80050468
+.long 0x20181890
+.long 0xD2010006, 0x0432D70D
+.long 0x201C1C90
+.long 0xD2010007, 0x043AD70F
+.long 0xE0741070, 0x80050668
+.long 0xBF8C0000
+.long 0xBF810000
+.long 0xBF8CC67F
+.long 0xD3EC0000, 0x04028B22
+.long 0xB4290000
+.long 0xBF840220
+.long 0xD3EC0010, 0x04428B23
+.long 0xD3EC0000, 0x04028D24
+.long 0xD3EC0010, 0x04428D25
+.long 0xBF8CC47F
+.long 0xD3EC0000, 0x04028F26
+.long 0xD3EC0010, 0x04428F27
+.long 0xBF8CC07F
+.long 0xD3EC0000, 0x04029128
+.long 0xD3EC0010, 0x04429129
+.long 0xD3EC0000, 0x0402932A
+.long 0xBF8A0000
+.long 0xD86C0000, 0x3000005F
+.long 0xD86C0840, 0x3100005F
+.long 0xD3EC0010, 0x0442932B
+.long 0xD86C0008, 0x3200005F
+.long 0xD86C0848, 0x3300005F
+.long 0xD86C0010, 0x3400005F
+.long 0xD86C0850, 0x3500005F
+.long 0xD3EC0000, 0x0402952C
+.long 0xD86C0018, 0x3600005F
+.long 0xD86C0858, 0x3700005F
+.long 0xD86C0020, 0x3800005F
+.long 0xD86C0860, 0x3900005F
+.long 0xD86C0028, 0x3A00005F
+.long 0xD3EC0010, 0x0442952D
+.long 0xD86C0868, 0x3B00005F
+.long 0xD86C0030, 0x3C00005F
+.long 0xD86C0870, 0x3D00005F
+.long 0xD86C0038, 0x3E00005F
+.long 0xD86C0878, 0x3F00005F
+.long 0xD3EC0000, 0x0402972E
+.long 0xBF8A0000
+.long 0xD86C0000, 0x4C000061
+.long 0xD86C0008, 0x4D000061
+.long 0xD3EC0010, 0x0442972F
+.long 0xD86C0010, 0x4E000061
+.long 0xD86C0018, 0x4F000061
+.long 0xD86C0020, 0x50000061
+.long 0xD86C0028, 0x51000061
+.long 0xBF8CC57F
+.long 0xD3EC0000, 0x04029930
+.long 0xD86C0030, 0x52000061
+.long 0xD86C0038, 0x53000061
+.long 0xD3EC0010, 0x04429931
+.long 0xBF8CC67F
+.long 0xD3EC0000, 0x04029B32
+.long 0xD3EC0010, 0x04429B33
+.long 0xBF8CC57F
+.long 0xD3EC0000, 0x04029D34
+.long 0xD3EC0010, 0x04429D35
+.long 0xBF8CC47F
+.long 0xD3EC0000, 0x04029F36
+.long 0xD3EC0010, 0x04429F37
+.long 0xBF8CC07F
+.long 0xD3EC0000, 0x0402A138
+.long 0xD3EC0000, 0x0402A33A
+.long 0xD3EC0000, 0x0402A53C
+.long 0xD3EC0000, 0x0402A73E
+.long 0xD3EC0010, 0x0442A139
+.long 0xD3EC0010, 0x0442A33B
+.long 0xD3EC0010, 0x0442A53D
+.long 0xD3EC0010, 0x0442A73F
+.long 0xBED400FF, 0xFFFF0000
+.long 0x2AD6D56A
+.long 0x28D6D654
+.long 0x7E7602FF, 0xFFFF0000
+.long 0x7E7802FF, 0x7FFF0000
+.long 0x7E7A02FF, 0x00007FFF
+.long 0xBF8C0F70
+.long 0xD3D84000, 0x18000100
+.long 0xD3D84001, 0x18000101
+.long 0xD3D84002, 0x18000102
+.long 0xD3D84003, 0x18000103
+.long 0xD3D84004, 0x18000104
+.long 0xD3D84005, 0x18000105
+.long 0xD3D84006, 0x18000106
+.long 0xD3D84007, 0x18000107
+.long 0x0A000028
+.long 0x0A020228
+.long 0x0A040428
+.long 0x0A060628
+.long 0x0A080828
+.long 0x0A0A0A28
+.long 0xD0480036, 0x00020100
+.long 0xD1C8003A, 0x02052100
+.long 0xD1FF003A, 0x04F67500
+.long 0xD1000000, 0x00DA793A
+.long 0x20000090
+.long 0xD0480036, 0x00020301
+.long 0xD1C8003A, 0x02052101
+.long 0xD1FF003A, 0x04F67501
+.long 0xD1000001, 0x00DA793A
+.long 0xD2010000, 0x04027701
+.long 0xD0480036, 0x00020502
+.long 0xD1C8003A, 0x02052102
+.long 0xD1FF003A, 0x04F67502
+.long 0xD1000002, 0x00DA793A
+.long 0xD0480036, 0x00020703
+.long 0xD1C8003A, 0x02052103
+.long 0xD1FF003A, 0x04F67503
+.long 0xD1000003, 0x00DA793A
+.long 0x20040490
+.long 0xD2010001, 0x040A7703
+.long 0xD0480036, 0x00020904
+.long 0xD1C8003A, 0x02052104
+.long 0xD1FF003A, 0x04F67504
+.long 0xD1000004, 0x00DA793A
+.long 0xD0480036, 0x00020B05
+.long 0xD1C8003A, 0x02052105
+.long 0xD1FF003A, 0x04F67505
+.long 0xD1000005, 0x00DA793A
+.long 0x20080890
+.long 0xD2010002, 0x04127705
+.long 0xE0741000, 0x80050068
+.long 0x0A0C0C28
+.long 0x0A0E0E28
+.long 0xD0480036, 0x00020D06
+.long 0xD1C8003A, 0x02052106
+.long 0xD1FF003A, 0x04F67506
+.long 0xD1000006, 0x00DA793A
+.long 0xD0480036, 0x00020F07
+.long 0xD1C8003A, 0x02052107
+.long 0xD1FF003A, 0x04F67507
+.long 0xD1000007, 0x00DA793A
+.long 0x200C0C90
+.long 0xD2010003, 0x041A7707
+.long 0xE0741010, 0x80050268
+.long 0xD3D84008, 0x18000108
+.long 0xD3D84009, 0x18000109
+.long 0xD3D8400A, 0x1800010A
+.long 0xD3D8400B, 0x1800010B
+.long 0x0A101028
+.long 0x0A121228
+.long 0x0A141428
+.long 0x0A161628
+.long 0xD0480036, 0x00021108
+.long 0xD1C8003A, 0x02052108
+.long 0xD1FF003A, 0x04F67508
+.long 0xD1000008, 0x00DA793A
+.long 0xD0480036, 0x00021309
+.long 0xD1C8003A, 0x02052109
+.long 0xD1FF003A, 0x04F67509
+.long 0xD1000009, 0x00DA793A
+.long 0x20101090
+.long 0xD2010004, 0x04227709
+.long 0xD0480036, 0x0002150A
+.long 0xD1C8003A, 0x0205210A
+.long 0xD1FF003A, 0x04F6750A
+.long 0xD100000A, 0x00DA793A
+.long 0xD0480036, 0x0002170B
+.long 0xD1C8003A, 0x0205210B
+.long 0xD1FF003A, 0x04F6750B
+.long 0xD100000B, 0x00DA793A
+.long 0x20141490
+.long 0xD2010005, 0x042A770B
+.long 0xE0741020, 0x80050468
+.long 0xD3D8400C, 0x1800010C
+.long 0xD3D8400D, 0x1800010D
+.long 0xD3D8400E, 0x1800010E
+.long 0xD3D8400F, 0x1800010F
+.long 0x0A181828
+.long 0x0A1A1A28
+.long 0x0A1C1C28
+.long 0x0A1E1E28
+.long 0xD0480036, 0x0002190C
+.long 0xD1C8003A, 0x0205210C
+.long 0xD1FF003A, 0x04F6750C
+.long 0xD100000C, 0x00DA793A
+.long 0xD0480036, 0x00021B0D
+.long 0xD1C8003A, 0x0205210D
+.long 0xD1FF003A, 0x04F6750D
+.long 0xD100000D, 0x00DA793A
+.long 0x20181890
+.long 0xD2010006, 0x0432770D
+.long 0xD0480036, 0x00021D0E
+.long 0xD1C8003A, 0x0205210E
+.long 0xD1FF003A, 0x04F6750E
+.long 0xD100000E, 0x00DA793A
+.long 0xD0480036, 0x00021F0F
+.long 0xD1C8003A, 0x0205210F
+.long 0xD1FF003A, 0x04F6750F
+.long 0xD100000F, 0x00DA793A
+.long 0x201C1C90
+.long 0xD2010007, 0x043A770F
+.long 0xE0741030, 0x80050668
+.long 0xD3D84000, 0x18000110
+.long 0xD3D84001, 0x18000111
+.long 0xD3D84002, 0x18000112
+.long 0xD3D84003, 0x18000113
+.long 0xD3D84004, 0x18000114
+.long 0xD3D84005, 0x18000115
+.long 0xD3D84006, 0x18000116
+.long 0xD3D84007, 0x18000117
+.long 0x0A000028
+.long 0x0A020228
+.long 0x0A040428
+.long 0x0A060628
+.long 0x0A080828
+.long 0x0A0A0A28
+.long 0xD0480036, 0x00020100
+.long 0xD1C8003A, 0x02052100
+.long 0xD1FF003A, 0x04F67500
+.long 0xD1000000, 0x00DA793A
+.long 0x20000090
+.long 0xD0480036, 0x00020301
+.long 0xD1C8003A, 0x02052101
+.long 0xD1FF003A, 0x04F67501
+.long 0xD1000001, 0x00DA793A
+.long 0xD2010000, 0x04027701
+.long 0xD0480036, 0x00020502
+.long 0xD1C8003A, 0x02052102
+.long 0xD1FF003A, 0x04F67502
+.long 0xD1000002, 0x00DA793A
+.long 0xD0480036, 0x00020703
+.long 0xD1C8003A, 0x02052103
+.long 0xD1FF003A, 0x04F67503
+.long 0xD1000003, 0x00DA793A
+.long 0x20040490
+.long 0xD2010001, 0x040A7703
+.long 0xD0480036, 0x00020904
+.long 0xD1C8003A, 0x02052104
+.long 0xD1FF003A, 0x04F67504
+.long 0xD1000004, 0x00DA793A
+.long 0xD0480036, 0x00020B05
+.long 0xD1C8003A, 0x02052105
+.long 0xD1FF003A, 0x04F67505
+.long 0xD1000005, 0x00DA793A
+.long 0x20080890
+.long 0xD2010002, 0x04127705
+.long 0xE0741040, 0x80050068
+.long 0x0A0C0C28
+.long 0x0A0E0E28
+.long 0xD0480036, 0x00020D06
+.long 0xD1C8003A, 0x02052106
+.long 0xD1FF003A, 0x04F67506
+.long 0xD1000006, 0x00DA793A
+.long 0xD0480036, 0x00020F07
+.long 0xD1C8003A, 0x02052107
+.long 0xD1FF003A, 0x04F67507
+.long 0xD1000007, 0x00DA793A
+.long 0x200C0C90
+.long 0xD2010003, 0x041A7707
+.long 0xE0741050, 0x80050268
+.long 0xD3D84008, 0x18000118
+.long 0xD3D84009, 0x18000119
+.long 0xD3D8400A, 0x1800011A
+.long 0xD3D8400B, 0x1800011B
+.long 0x0A101028
+.long 0x0A121228
+.long 0x0A141428
+.long 0x0A161628
+.long 0xD0480036, 0x00021108
+.long 0xD1C8003A, 0x02052108
+.long 0xD1FF003A, 0x04F67508
+.long 0xD1000008, 0x00DA793A
+.long 0xD0480036, 0x00021309
+.long 0xD1C8003A, 0x02052109
+.long 0xD1FF003A, 0x04F67509
+.long 0xD1000009, 0x00DA793A
+.long 0x20101090
+.long 0xD2010004, 0x04227709
+.long 0xD0480036, 0x0002150A
+.long 0xD1C8003A, 0x0205210A
+.long 0xD1FF003A, 0x04F6750A
+.long 0xD100000A, 0x00DA793A
+.long 0xD0480036, 0x0002170B
+.long 0xD1C8003A, 0x0205210B
+.long 0xD1FF003A, 0x04F6750B
+.long 0xD100000B, 0x00DA793A
+.long 0x20141490
+.long 0xD2010005, 0x042A770B
+.long 0xE0741060, 0x80050468
+.long 0xD3D8400C, 0x1800011C
+.long 0xD3D8400D, 0x1800011D
+.long 0xD3D8400E, 0x1800011E
+.long 0xD3D8400F, 0x1800011F
+.long 0x0A181828
+.long 0x0A1A1A28
+.long 0x0A1C1C28
+.long 0x0A1E1E28
+.long 0xD0480036, 0x0002190C
+.long 0xD1C8003A, 0x0205210C
+.long 0xD1FF003A, 0x04F6750C
+.long 0xD100000C, 0x00DA793A
+.long 0xD0480036, 0x00021B0D
+.long 0xD1C8003A, 0x0205210D
+.long 0xD1FF003A, 0x04F6750D
+.long 0xD100000D, 0x00DA793A
+.long 0x20181890
+.long 0xD2010006, 0x0432770D
+.long 0xD0480036, 0x00021D0E
+.long 0xD1C8003A, 0x0205210E
+.long 0xD1FF003A, 0x04F6750E
+.long 0xD100000E, 0x00DA793A
+.long 0xD0480036, 0x00021F0F
+.long 0xD1C8003A, 0x0205210F
+.long 0xD1FF003A, 0x04F6750F
+.long 0xD100000F, 0x00DA793A
+.long 0x201C1C90
+.long 0xD2010007, 0x043A770F
+.long 0xE0741070, 0x80050668
+.long 0xBF8C0000
+.long 0xBF810000
+.long 0xD3EC0010, 0x04428921
+.long 0xE0541000, 0x80041068
+.long 0xE0541010, 0x80041268
+.long 0xE0541020, 0x80041468
+.long 0xBF8CC67F
+.long 0xD3EC0000, 0x04028B22
+.long 0xE0541030, 0x80041668
+.long 0xE0541040, 0x80041868
+.long 0xE0541050, 0x80041A68
+.long 0xD3EC0010, 0x04428B23
+.long 0xE0541060, 0x80041C68
+.long 0xE0541070, 0x80041E68
+.long 0xD3EC0000, 0x04028D24
+.long 0xD3EC0010, 0x04428D25
+.long 0xBF8CC47F
+.long 0xD3EC0000, 0x04028F26
+.long 0xD3EC0010, 0x04428F27
+.long 0xBF8CC07F
+.long 0xD3EC0000, 0x04029128
+.long 0xD3EC0010, 0x04429129
+.long 0xD3EC0000, 0x0402932A
+.long 0xBF8A0000
+.long 0xD86C0000, 0x3000005F
+.long 0xD86C0840, 0x3100005F
+.long 0xD3EC0010, 0x0442932B
+.long 0xD86C0008, 0x3200005F
+.long 0xD86C0848, 0x3300005F
+.long 0xD86C0010, 0x3400005F
+.long 0xD86C0850, 0x3500005F
+.long 0xD3EC0000, 0x0402952C
+.long 0xD86C0018, 0x3600005F
+.long 0xD86C0858, 0x3700005F
+.long 0xD86C0020, 0x3800005F
+.long 0xD86C0860, 0x3900005F
+.long 0xD86C0028, 0x3A00005F
+.long 0xD3EC0010, 0x0442952D
+.long 0xD86C0868, 0x3B00005F
+.long 0xD86C0030, 0x3C00005F
+.long 0xD86C0870, 0x3D00005F
+.long 0xD86C0038, 0x3E00005F
+.long 0xD86C0878, 0x3F00005F
+.long 0xD3EC0000, 0x0402972E
+.long 0xBF8A0000
+.long 0xD86C0000, 0x4C000061
+.long 0xD86C0008, 0x4D000061
+.long 0xD3EC0010, 0x0442972F
+.long 0xD86C0010, 0x4E000061
+.long 0xD86C0018, 0x4F000061
+.long 0xD86C0020, 0x50000061
+.long 0xD86C0028, 0x51000061
+.long 0xBF8CC57F
+.long 0xD3EC0000, 0x04029930
+.long 0xD86C0030, 0x52000061
+.long 0xD86C0038, 0x53000061
+.long 0xD3EC0010, 0x04429931
+.long 0xBF8CC67F
+.long 0xD3EC0000, 0x04029B32
+.long 0xD3EC0010, 0x04429B33
+.long 0xBF8CC57F
+.long 0xD3EC0000, 0x04029D34
+.long 0xD3EC0010, 0x04429D35
+.long 0xBF8CC47F
+.long 0xD3EC0000, 0x04029F36
+.long 0xD3EC0010, 0x04429F37
+.long 0xBF8CC07F
+.long 0xD3EC0000, 0x0402A138
+.long 0xD3EC0000, 0x0402A33A
+.long 0xD3EC0000, 0x0402A53C
+.long 0xD3EC0000, 0x0402A73E
+.long 0xD3EC0010, 0x0442A139
+.long 0xD3EC0010, 0x0442A33B
+.long 0xD3EC0010, 0x0442A53D
+.long 0xD3EC0010, 0x0442A73F
+.long 0xBED400FF, 0xFFFF0000
+.long 0x2AD6D56A
+.long 0x28D6D654
+.long 0x7E7602FF, 0xFFFF0000
+.long 0x7E7802FF, 0x7FFF0000
+.long 0x7E7A02FF, 0x00007FFF
+.long 0xBF8C0F70
+.long 0xD3D84000, 0x18000100
+.long 0xD3D84001, 0x18000101
+.long 0xD3D84002, 0x18000102
+.long 0xD3D84003, 0x18000103
+.long 0xD3D84004, 0x18000104
+.long 0xD3D84005, 0x18000105
+.long 0xD3D84006, 0x18000106
+.long 0xD3D84007, 0x18000107
+.long 0x0A000028
+.long 0x0A020228
+.long 0x24402090
+.long 0x2642216B
+.long 0x2C004029
+.long 0x2C024229
+.long 0x0A040428
+.long 0x0A060628
+.long 0x24402290
+.long 0x2642236B
+.long 0x2C044029
+.long 0x2C064229
+.long 0x0A080828
+.long 0x0A0A0A28
+.long 0x24402490
+.long 0x2642256B
+.long 0x2C084029
+.long 0x2C0A4229
+.long 0xD0480036, 0x00020100
+.long 0xD1C8003A, 0x02052100
+.long 0xD1FF003A, 0x04F67500
+.long 0xD1000000, 0x00DA793A
+.long 0x20000090
+.long 0xD0480036, 0x00020301
+.long 0xD1C8003A, 0x02052101
+.long 0xD1FF003A, 0x04F67501
+.long 0xD1000001, 0x00DA793A
+.long 0xD2010000, 0x04027701
+.long 0xD0480036, 0x00020502
+.long 0xD1C8003A, 0x02052102
+.long 0xD1FF003A, 0x04F67502
+.long 0xD1000002, 0x00DA793A
+.long 0xD0480036, 0x00020703
+.long 0xD1C8003A, 0x02052103
+.long 0xD1FF003A, 0x04F67503
+.long 0xD1000003, 0x00DA793A
+.long 0x20040490
+.long 0xD2010001, 0x040A7703
+.long 0xD0480036, 0x00020904
+.long 0xD1C8003A, 0x02052104
+.long 0xD1FF003A, 0x04F67504
+.long 0xD1000004, 0x00DA793A
+.long 0xD0480036, 0x00020B05
+.long 0xD1C8003A, 0x02052105
+.long 0xD1FF003A, 0x04F67505
+.long 0xD1000005, 0x00DA793A
+.long 0x20080890
+.long 0xD2010002, 0x04127705
+.long 0xE0741000, 0x80050068
+.long 0x0A0C0C28
+.long 0x0A0E0E28
+.long 0x24402690
+.long 0x2642276B
+.long 0x2C0C4029
+.long 0x2C0E4229
+.long 0xD0480036, 0x00020D06
+.long 0xD1C8003A, 0x02052106
+.long 0xD1FF003A, 0x04F67506
+.long 0xD1000006, 0x00DA793A
+.long 0xD0480036, 0x00020F07
+.long 0xD1C8003A, 0x02052107
+.long 0xD1FF003A, 0x04F67507
+.long 0xD1000007, 0x00DA793A
+.long 0x200C0C90
+.long 0xD2010003, 0x041A7707
+.long 0xE0741010, 0x80050268
+.long 0xD3D84008, 0x18000108
+.long 0xD3D84009, 0x18000109
+.long 0xD3D8400A, 0x1800010A
+.long 0xD3D8400B, 0x1800010B
+.long 0x0A101028
+.long 0x0A121228
+.long 0x24402890
+.long 0x2642296B
+.long 0x2C104029
+.long 0x2C124229
+.long 0x0A141428
+.long 0x0A161628
+.long 0x24402A90
+.long 0x26422B6B
+.long 0x2C144029
+.long 0x2C164229
+.long 0xD0480036, 0x00021108
+.long 0xD1C8003A, 0x02052108
+.long 0xD1FF003A, 0x04F67508
+.long 0xD1000008, 0x00DA793A
+.long 0xD0480036, 0x00021309
+.long 0xD1C8003A, 0x02052109
+.long 0xD1FF003A, 0x04F67509
+.long 0xD1000009, 0x00DA793A
+.long 0x20101090
+.long 0xD2010004, 0x04227709
+.long 0xD0480036, 0x0002150A
+.long 0xD1C8003A, 0x0205210A
+.long 0xD1FF003A, 0x04F6750A
+.long 0xD100000A, 0x00DA793A
+.long 0xD0480036, 0x0002170B
+.long 0xD1C8003A, 0x0205210B
+.long 0xD1FF003A, 0x04F6750B
+.long 0xD100000B, 0x00DA793A
+.long 0x20141490
+.long 0xD2010005, 0x042A770B
+.long 0xE0741020, 0x80050468
+.long 0xD3D8400C, 0x1800010C
+.long 0xD3D8400D, 0x1800010D
+.long 0xD3D8400E, 0x1800010E
+.long 0xD3D8400F, 0x1800010F
+.long 0x0A181828
+.long 0x0A1A1A28
+.long 0x24402C90
+.long 0x26422D6B
+.long 0x2C184029
+.long 0x2C1A4229
+.long 0x0A1C1C28
+.long 0x0A1E1E28
+.long 0x24402E90
+.long 0x26422F6B
+.long 0x2C1C4029
+.long 0x2C1E4229
+.long 0xD0480036, 0x0002190C
+.long 0xD1C8003A, 0x0205210C
+.long 0xD1FF003A, 0x04F6750C
+.long 0xD100000C, 0x00DA793A
+.long 0xD0480036, 0x00021B0D
+.long 0xD1C8003A, 0x0205210D
+.long 0xD1FF003A, 0x04F6750D
+.long 0xD100000D, 0x00DA793A
+.long 0x20181890
+.long 0xD2010006, 0x0432770D
+.long 0xD0480036, 0x00021D0E
+.long 0xD1C8003A, 0x0205210E
+.long 0xD1FF003A, 0x04F6750E
+.long 0xD100000E, 0x00DA793A
+.long 0xD0480036, 0x00021F0F
+.long 0xD1C8003A, 0x0205210F
+.long 0xD1FF003A, 0x04F6750F
+.long 0xD100000F, 0x00DA793A
+.long 0x201C1C90
+.long 0xD2010007, 0x043A770F
+.long 0xE0741030, 0x80050668
+.long 0xD3D84000, 0x18000110
+.long 0xD3D84001, 0x18000111
+.long 0xD3D84002, 0x18000112
+.long 0xD3D84003, 0x18000113
+.long 0xD3D84004, 0x18000114
+.long 0xD3D84005, 0x18000115
+.long 0xD3D84006, 0x18000116
+.long 0xD3D84007, 0x18000117
+.long 0x0A000028
+.long 0x0A020228
+.long 0x24403090
+.long 0x2642316B
+.long 0x2C004029
+.long 0x2C024229
+.long 0x0A040428
+.long 0x0A060628
+.long 0x24403290
+.long 0x2642336B
+.long 0x2C044029
+.long 0x2C064229
+.long 0x0A080828
+.long 0x0A0A0A28
+.long 0x24403490
+.long 0x2642356B
+.long 0x2C084029
+.long 0x2C0A4229
+.long 0xD0480036, 0x00020100
+.long 0xD1C8003A, 0x02052100
+.long 0xD1FF003A, 0x04F67500
+.long 0xD1000000, 0x00DA793A
+.long 0x20000090
+.long 0xD0480036, 0x00020301
+.long 0xD1C8003A, 0x02052101
+.long 0xD1FF003A, 0x04F67501
+.long 0xD1000001, 0x00DA793A
+.long 0xD2010000, 0x04027701
+.long 0xD0480036, 0x00020502
+.long 0xD1C8003A, 0x02052102
+.long 0xD1FF003A, 0x04F67502
+.long 0xD1000002, 0x00DA793A
+.long 0xD0480036, 0x00020703
+.long 0xD1C8003A, 0x02052103
+.long 0xD1FF003A, 0x04F67503
+.long 0xD1000003, 0x00DA793A
+.long 0x20040490
+.long 0xD2010001, 0x040A7703
+.long 0xD0480036, 0x00020904
+.long 0xD1C8003A, 0x02052104
+.long 0xD1FF003A, 0x04F67504
+.long 0xD1000004, 0x00DA793A
+.long 0xD0480036, 0x00020B05
+.long 0xD1C8003A, 0x02052105
+.long 0xD1FF003A, 0x04F67505
+.long 0xD1000005, 0x00DA793A
+.long 0x20080890
+.long 0xD2010002, 0x04127705
+.long 0xE0741040, 0x80050068
+.long 0x0A0C0C28
+.long 0x0A0E0E28
+.long 0x24403690
+.long 0x2642376B
+.long 0x2C0C4029
+.long 0x2C0E4229
+.long 0xD0480036, 0x00020D06
+.long 0xD1C8003A, 0x02052106
+.long 0xD1FF003A, 0x04F67506
+.long 0xD1000006, 0x00DA793A
+.long 0xD0480036, 0x00020F07
+.long 0xD1C8003A, 0x02052107
+.long 0xD1FF003A, 0x04F67507
+.long 0xD1000007, 0x00DA793A
+.long 0x200C0C90
+.long 0xD2010003, 0x041A7707
+.long 0xE0741050, 0x80050268
+.long 0xD3D84008, 0x18000118
+.long 0xD3D84009, 0x18000119
+.long 0xD3D8400A, 0x1800011A
+.long 0xD3D8400B, 0x1800011B
+.long 0x0A101028
+.long 0x0A121228
+.long 0x24403890
+.long 0x2642396B
+.long 0x2C104029
+.long 0x2C124229
+.long 0x0A141428
+.long 0x0A161628
+.long 0x24403A90
+.long 0x26423B6B
+.long 0x2C144029
+.long 0x2C164229
+.long 0xD0480036, 0x00021108
+.long 0xD1C8003A, 0x02052108
+.long 0xD1FF003A, 0x04F67508
+.long 0xD1000008, 0x00DA793A
+.long 0xD0480036, 0x00021309
+.long 0xD1C8003A, 0x02052109
+.long 0xD1FF003A, 0x04F67509
+.long 0xD1000009, 0x00DA793A
+.long 0x20101090
+.long 0xD2010004, 0x04227709
+.long 0xD0480036, 0x0002150A
+.long 0xD1C8003A, 0x0205210A
+.long 0xD1FF003A, 0x04F6750A
+.long 0xD100000A, 0x00DA793A
+.long 0xD0480036, 0x0002170B
+.long 0xD1C8003A, 0x0205210B
+.long 0xD1FF003A, 0x04F6750B
+.long 0xD100000B, 0x00DA793A
+.long 0x20141490
+.long 0xD2010005, 0x042A770B
+.long 0xE0741060, 0x80050468
+.long 0xD3D8400C, 0x1800011C
+.long 0xD3D8400D, 0x1800011D
+.long 0xD3D8400E, 0x1800011E
+.long 0xD3D8400F, 0x1800011F
+.long 0x0A181828
+.long 0x0A1A1A28
+.long 0x24403C90
+.long 0x26423D6B
+.long 0x2C184029
+.long 0x2C1A4229
+.long 0x0A1C1C28
+.long 0x0A1E1E28
+.long 0x24403E90
+.long 0x26423F6B
+.long 0x2C1C4029
+.long 0x2C1E4229
+.long 0xD0480036, 0x0002190C
+.long 0xD1C8003A, 0x0205210C
+.long 0xD1FF003A, 0x04F6750C
+.long 0xD100000C, 0x00DA793A
+.long 0xD0480036, 0x00021B0D
+.long 0xD1C8003A, 0x0205210D
+.long 0xD1FF003A, 0x04F6750D
+.long 0xD100000D, 0x00DA793A
+.long 0x20181890
+.long 0xD2010006, 0x0432770D
+.long 0xD0480036, 0x00021D0E
+.long 0xD1C8003A, 0x0205210E
+.long 0xD1FF003A, 0x04F6750E
+.long 0xD100000E, 0x00DA793A
+.long 0xD0480036, 0x00021F0F
+.long 0xD1C8003A, 0x0205210F
+.long 0xD1FF003A, 0x04F6750F
+.long 0xD100000F, 0x00DA793A
+.long 0x201C1C90
+.long 0xD2010007, 0x043A770F
+.long 0xE0741070, 0x80050668
+.long 0xBF8C0000
+.long 0xBF810000

--- a/Tensile/ReplacementKernels/Cijk_Alik_Bljk_BBH_MT64x32x64_AF0EM8_ASEM8_FL0_GRVW2_ISA908_MDA2_PGR1_PLR1_SU32_TT2_2_VAW1_VW2_WG32_16_1_WGM8.s.txt
+++ b/Tensile/ReplacementKernels/Cijk_Alik_Bljk_BBH_MT64x32x64_AF0EM8_ASEM8_FL0_GRVW2_ISA908_MDA2_PGR1_PLR1_SU32_TT2_2_VAW1_VW2_WG32_16_1_WGM8.s.txt
@@ -1,0 +1,915 @@
+
+
+/******************************************/
+/* Function Prefix                        */
+/******************************************/
+
+
+
+/******************************************/
+/* Begin Kernel                           */
+/******************************************/
+
+.hsa_code_object_version 2,0
+.hsa_code_object_isa 9, 0, 8, "AMD", "AMDGPU"
+.text
+.protected Cijk_Alik_Bljk_BBH_MT64x32x64_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG32_16_1_WGM8
+.globl Cijk_Alik_Bljk_BBH_MT64x32x64_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG32_16_1_WGM8
+.p2align 8
+.type Cijk_Alik_Bljk_BBH_MT64x32x64_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG32_16_1_WGM8,@function
+.amdgpu_hsa_kernel Cijk_Alik_Bljk_BBH_MT64x32x64_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG32_16_1_WGM8
+Cijk_Alik_Bljk_BBH_MT64x32x64_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG32_16_1_WGM8:
+.amd_kernel_code_t
+  is_ptr64 = 1
+  enable_sgpr_kernarg_segment_ptr = 1
+  kernarg_segment_byte_size = 148 // bytes of kern args
+  workitem_vgpr_count = 108 // vgprs
+  wavefront_sgpr_count = 98 // sgprs
+  compute_pgm_rsrc1_vgprs = 26 // floor((108-1)/4)
+  compute_pgm_rsrc1_sgprs = 12 // floor((98-1)/8)
+  compute_pgm_rsrc2_tidig_comp_cnt = 0 // 1D wg
+  compute_pgm_rsrc2_tgid_x_en = 1 // wg.x
+  compute_pgm_rsrc2_tgid_y_en = 1 // wg.y
+  compute_pgm_rsrc2_tgid_z_en = 1 // wg.z
+  workgroup_group_segment_byte_size = 30000// lds bytes
+  compute_pgm_rsrc2_user_sgpr = 2 // vcc
+  kernarg_segment_alignment = 4
+  group_segment_alignment = 4
+  private_segment_alignment = 4
+.end_amd_kernel_code_t
+
+/******************************************/
+/* Optimizations and Config:              */
+/******************************************/
+/* ThreadTile= 4 x 4 */
+/* SubGroup= 16 x 32 */
+/* VectorWidth=4 */
+/* GlobalLoadVectorWidthA=4, GlobalLoadVectorWidthB=4 */
+/* DirectToLdsA=False */
+/* DirectToLdsB=False */
+/* UseSgprForGRO=1 */
+.amd_amdgpu_hsa_metadata
+Version: [ 1, 0 ]
+Kernels:
+  - Name: Cijk_Alik_Bljk_BBH_MT64x32x64_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG32_16_1_WGM8
+    SymbolName: 'Cijk_Alik_Bljk_BBH_MT64x32x64_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG32_16_1_WGM8@kd'
+    Language: OpenCL C
+    LanguageVersion: [ 2, 0 ]
+    Args:
+      - Name:            sizeC
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            sizeA
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            sizeB
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            D
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       Struct
+        AddrSpaceQual:   Generic
+      - Name:            C
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       Struct
+        AddrSpaceQual:   Generic
+      - Name:            A
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       Struct
+        AddrSpaceQual:   Generic
+      - Name:            B
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       Struct
+        AddrSpaceQual:   Generic
+      - Name:            alpha
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       F32
+      - Name:            beta
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       F32
+      - Name:            strideD0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideD1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideC0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideC1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideA0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideA1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideB0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideB1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree2
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesSum0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            OrigStaggerUIter
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       I32
+      - Name:            NumWorkGroups0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            NumWorkGroups1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            NumFullBlocks
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            WgmRemainder1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            MagicNumberWgmRemainder1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+    CodeProps:
+      KernargSegmentSize: 148
+      GroupSegmentFixedSize: 28672
+      PrivateSegmentFixedSize: 0
+      KernargSegmentAlign:  8
+      WavefrontSize:        64
+      NumSGPRs:             98
+      NumVGPRs:             108
+      MaxFlatWorkGroupSize: 512
+.end_amd_amdgpu_hsa_metadata
+
+/******************************************/
+/* Asm syntax workarounds                 */
+/******************************************/
+.macro _v_add_co_u32 dst, cc, src0, src1, dpp=
+   v_add_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+
+.macro _v_add_u32 dst, src0, src1, dpp=
+   v_add_u32 \dst, \src0, \src1 \dpp
+.endm
+
+.macro _v_sub_co_u32 dst, cc, src0, src1, dpp=
+   v_sub_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+
+.macro _v_sub_u32 dst, src0, src1, dpp=
+   v_sub_u32 \dst, \src0, \src1 \dpp
+.endm
+
+.macro _v_addc_co_u32 dst, ccOut, src0, ccIn, src1, dpp=
+   v_addc_co_u32 \dst, \ccOut, \src0, \ccIn, \src1 \dpp
+.endm
+
+.macro _v_add_lshl_u32 dst, src0, src1, shiftCnt
+    v_add_lshl_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+.macro _v_lshl_add_u32 dst, src0, src1, shiftCnt
+    v_lshl_add_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+/******************************************/
+/* Magic div and mod functions            */
+/******************************************/
+.macro V_MAGIC_DIV dstIdx, dividend, magicNumber, magicShift
+    v_mul_hi_u32 v[\dstIdx+1], \dividend, \magicNumber
+    v_mul_lo_u32 v[\dstIdx+0], \dividend, \magicNumber
+    v_lshrrev_b64 v[\dstIdx:\dstIdx+1], \magicShift, v[\dstIdx:\dstIdx+1]
+.endm
+
+/******************************************/
+/* VGPR Assignments                       */
+/******************************************/
+.set vgprValuC, 0
+/* ValuA/B   Xn=PLR buffer idx,  In=InnerUnroll idx */
+.set vgprValuA_X0_I0, 32
+.set vgprValuA_X1_I0, 34
+.set vgprG2LA, 36
+.set vgprValuB_X0_I0, 40
+.set vgprValuB_X1_I0, 44
+.set vgprG2LB, 48
+.set vgprLocalWriteAddrA, 56
+.set vgprLocalWriteAddrB, 57
+.set vgprGlobalReadOffsetA, 58
+.set vgprGlobalReadOffsetB, 59
+.set vgprLocalReadAddrA, 60
+.set vgprLocalReadAddrB, 61
+.set vgprSerial, 62
+/* Num VGPR=63 */
+
+/******************************************/
+/* SGPR Assignments                       */
+/******************************************/
+.set sgprKernArgAddress, 0
+.set sgprWorkGroup0, 2
+.set sgprWorkGroup1, 3
+.set sgprWorkGroup2, 4
+.set sgprNumWorkGroups0, 5
+.set sgprNumWorkGroups1, 6
+.set sgprSrdA, 8
+.set sgprSrdB, 12
+.set sgprSrdD, 16
+.set sgprSrdC, 20
+.set sgprTensor2dSizeC, 24
+.set sgprTensor2dSizeA, 26
+.set sgprTensor2dSizeB, 28
+.set sgprSaveExecMask, 30
+.set sgprAddressD, 32
+.set sgprAddressC, 34
+.set sgprStridesD, 36
+.set sgprStridesC, 38
+.set sgprAlpha, 40
+.set sgprBeta, 41
+.set sgprSizesFree, 42
+.set sgprSizesSum, 45
+.set sgprLoopCounters, 46
+.set sgprOrigLoopCounter, 47
+.set sgprStridesA, 48
+.set sgprStridesB, 50
+.set sgprAddressA, 52
+.set sgprAddressB, 54
+.set sgprShadowLimitA, 56
+.set sgprShadowLimitB, 58
+.set sgprOrigStaggerUIter, 60
+.set sgprStaggerUIter, 61
+.set sgprWrapUA, 62
+.set sgprWrapUB, 64
+.set sgprNumFullBlocks, 66
+.set sgprWgmRemainder1, 67
+.set sgprMagicNumberWgmRemainder1, 68
+.set sgprGlobalReadIncsA, 69
+.set sgprGlobalReadIncsB, 70
+.set sgprScalarGlobalReadOffsetA, 71
+.set sgprScalarGlobalReadOffsetB, 72
+/* max SGPR=98 */
+
+/* Size Assignments */
+.set sgprSizeD0I, sgprSizesFree+0
+.set sgprSizeD1J, sgprSizesFree+1
+.set sgprSizeDK, sgprSizesFree+2
+.set sgprSizeC0I, sgprSizesFree+0
+.set sgprSizeC1J, sgprSizesFree+1
+.set sgprSizeCK, sgprSizesFree+2
+.set sgprSizeAL, sgprSizesSum+0
+.set sgprSizeA0I, sgprSizesFree+0
+.set sgprSizeAK, sgprSizesFree+2
+.set sgprSizeBL, sgprSizesSum+0
+.set sgprSizeB1J, sgprSizesFree+1
+.set sgprSizeBK, sgprSizesFree+2
+
+/* Stride Assignments */
+.set constStrideD0I, 1
+.set sgprStrideD1J, sgprStridesD+0
+.set sgprStrideDK, sgprStridesD+1
+.set constStrideC0I, 1
+.set sgprStrideC1J, sgprStridesC+0
+.set sgprStrideCK, sgprStridesC+1
+.set constStrideAL, 1
+.set sgprStrideA0I, sgprStridesA+0
+.set sgprStrideAK, sgprStridesA+1
+.set constStrideBL, 1
+.set sgprStrideB1J, sgprStridesB+0
+.set sgprStrideBK, sgprStridesB+1
+
+.set DepthU, 32
+/* Number of elements to shift-left SRD */
+.set SrdShiftLeftA, 4
+.set SrdShiftLeftB, 4
+/* 2GB limit - set offsets to -1 to exceed this and clamp */
+.set BufferLimit, 0x80000000
+/* Bits 127:96 of SRD.  Set DataFormat = 32 bit */
+.set Srd127_96, 0x0020000
+.set BufferOOB, 0x80000000
+
+/* Global Offset A */
+.macro GLOBAL_OFFSET_A vgprAddr vgprOffsetL vgprOffset0I vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStrideA0I], v[\vgprOffset0I] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprOffsetL], v[\vgprTmp+0] // accumulate d1 lower
+_v_add_u32 v[\vgprAddr+0], 0x4, v[\vgprAddr+0]     // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/* Global Offset B */
+.macro GLOBAL_OFFSET_B vgprAddr vgprOffsetL vgprOffset1J vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStrideB1J], v[\vgprOffset1J] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprOffsetL], v[\vgprTmp+0] // accumulate d1 lower
+_v_add_u32 v[\vgprAddr+0], 0x4, v[\vgprAddr+0]     // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/******************************************/
+/* Dynamic Scalar Divide: vQuotient=vDividend/vDivisor; vRemainder=vDividend%vDivisor; */
+/******************************************/
+.macro DYNAMIC_VECTOR_DIVIDE vQuotient vRemainder vDividend vDivisor vTmp0 vTmp1 sTmp
+v_cvt_f32_u32 v[\vQuotient], v[\vDivisor]          //
+v_rcp_f32 v[\vQuotient], v[\vQuotient]             //
+v_mul_f32 v[\vQuotient], 0x4f800000, v[\vQuotient] //
+v_cvt_u32_f32 v[\vQuotient], v[\vQuotient]         //
+v_mul_lo_u32 v[\vRemainder], v[\vDivisor], v[\vQuotient] //
+v_mul_hi_u32 v[\vTmp0], v[\vDivisor], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp1], vcc, 0x0, v[\vRemainder]  //
+v_cmp_ne_i32 s[\sTmp:\sTmp+1], 0x0, v[\vTmp0]      //
+v_cndmask_b32 v[\vRemainder], v[\vTmp1], v[\vRemainder], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vRemainder], v[\vRemainder], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vQuotient], v[\vRemainder] //
+_v_add_co_u32 v[\vQuotient], vcc, v[\vQuotient], v[\vRemainder] //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vTmp0], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vQuotient], v[\vQuotient], v[\vDividend] //
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vDividend], v[\vRemainder] //
+v_cmp_ge_u32 s[\sTmp:\sTmp+1], v[\vDividend], v[\vRemainder] //
+_v_add_co_u32 v[\vRemainder], vcc, 0x1, v[\vQuotient] //
+_v_add_co_u32 v[\vTmp1], vcc, -1, v[\vQuotient]    //
+v_cmp_le_u32 vcc, v[\vDivisor], v[\vTmp0]          //
+s_and_b64 vcc, s[\sTmp:\sTmp+1], vcc               //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vRemainder], vcc //
+v_cndmask_b32 v[\vQuotient], v[\vTmp1], v[\vQuotient], s[\sTmp:\sTmp+1] //
+v_cmp_ne_i32 vcc, 0x0, v[\vDivisor]                //
+v_cndmask_b32 v[\vQuotient], -1, v[\vQuotient], vcc // final result
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vRemainder], vcc, v[\vDividend], v[\vRemainder] // final result
+.endm
+
+/******************************************/
+/* 4x8 thread-tile                        */
+/******************************************/
+.macro MAC_4x8_X0
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[0] iui=0
+s_setprio 1 // Raise priority while processing macs
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[1]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[4]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[5]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[2] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[3]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[6]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[7]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[8] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[9]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[12]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[13]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[10] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[11]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[14]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[15]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[16] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[17]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[20]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[21]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[18] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[19]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[22]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[23]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[24] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[25]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[28]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[29]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[26] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[27]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[30]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[31]
+s_setprio 0 // Reset priority after macs
+.endm
+.macro MAC_4x8_X1
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[0] iui=0
+s_setprio 1 // Raise priority while processing macs
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[1]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[4]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[5]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[2] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[3]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[6]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[7]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[8] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[9]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[12]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[13]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[10] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[11]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[14]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[15]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[16] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[17]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[20]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[21]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[18] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[19]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[22]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[23]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[24] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[25]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[28]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[29]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[26] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[27]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[30]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[31]
+s_setprio 0 // Reset priority after macs
+.endm
+
+
+
+
+/***** program start from here *****/
+
+.long 0xC00A0600, 0x00000008
+.long 0xC00A0D00, 0x00000028
+.long 0xC00A0C00, 0x00000050
+.long 0xC0020B40, 0x0000006C
+.long 0x7ECC0300
+.long 0x26CE00BF
+.long 0xB8D0F804
+.long 0xD1130004, 0x0000A0B0
+.long 0x20D00884
+.long 0x7EA40568
+.long 0xD1130069, 0x0000A08F
+.long 0x7EA20569
+.long 0xBF068151
+.long 0xBF8400EC
+.long 0xBF8CC07F
+.long 0xBE880034
+.long 0xBE890035
+.long 0xBE8A00FF, 0x80000000
+.long 0xBE8B00FF, 0x00020000
+.long 0x96553104
+.long 0x92543104
+.long 0x8ED48154
+.long 0x80085408
+.long 0x82095509
+.long 0x9254C030
+.long 0x92545402
+.long 0x92559030
+.long 0x92555552
+.long 0x81545554
+.long 0x2000CE85
+.long 0xD2850004, 0x00020030
+.long 0x2602CE9F
+.long 0x24020281
+.long 0x32180304
+.long 0x68181854
+.long 0x24181881
+.long 0x8E478230
+.long 0x80C7FF47, 0x00000120
+.long 0x681A1847
+.long 0x681C1A47
+.long 0x681E1C47
+.long 0x68201E47
+.long 0x68222047
+.long 0x68242247
+.long 0x68262447
+.long 0xBECC00FF, 0x00000900
+.long 0x924C4C52
+.long 0xBE8C0036
+.long 0xBE8D0037
+.long 0xBE8E00FF, 0x80000000
+.long 0xBE8F00FF, 0x00020000
+.long 0x96553304
+.long 0x92543304
+.long 0x8ED48154
+.long 0x800C540C
+.long 0x820D550D
+.long 0x9254A032
+.long 0x92545403
+.long 0x92558832
+.long 0x92555552
+.long 0x81545554
+.long 0x2004CE85
+.long 0xD2850004, 0x00020432
+.long 0x2606CE9F
+.long 0x24060681
+.long 0x32280704
+.long 0x68282854
+.long 0x24282881
+.long 0x8E4A8232
+.long 0x80CAFF4A, 0x00000120
+.long 0x682A284A
+.long 0x682C2A4A
+.long 0x682E2C4A
+.long 0xBECE00FF, 0x00000480
+.long 0x924E4E52
+.long 0x814EFF4E, 0x00004800
+.long 0xBF8A0000
+.long 0xBEFC004E
+.long 0x814FFF4E, 0x00001200
+.long 0xE0511000, 0x80030814
+.long 0xE0511120, 0x80030915
+.long 0xE0511240, 0x80030A16
+.long 0xE0511360, 0x80030B17
+.long 0xBEFC004C
+.long 0x814DFF4C, 0x00002400
+.long 0xE0511000, 0x8002000C
+.long 0xE0511120, 0x8002010D
+.long 0xE0511240, 0x8002020E
+.long 0xE0511360, 0x8002030F
+.long 0xE0511480, 0x80020410
+.long 0xE05115A0, 0x80020511
+.long 0xE05116C0, 0x80020612
+.long 0xE05117E0, 0x80020713
+.long 0xBEFC004F
+.long 0x800CFF0C, 0x00000080
+.long 0x820D800D
+.long 0x8008FF08, 0x00000080
+.long 0x82098009
+.long 0xE0511000, 0x80030814
+.long 0xE0511120, 0x80030915
+.long 0xE0511240, 0x80030A16
+.long 0xE0511360, 0x80030B17
+.long 0xBEFC004D
+.long 0xBF800000
+.long 0xE0511000, 0x8002000C
+.long 0xE0511120, 0x8002010D
+.long 0xE0511240, 0x8002020E
+.long 0xE0511360, 0x8002030F
+.long 0xE0511480, 0x80020410
+.long 0xE05115A0, 0x80020511
+.long 0xE05116C0, 0x80020612
+.long 0xE05117E0, 0x80020713
+.long 0x800CFF0C, 0x00000080
+.long 0x820D800D
+.long 0x8008FF08, 0x00000080
+.long 0x82098009
+.long 0xBEFC004E
+.long 0xBF8C4F74
+.long 0xBF8A0000
+.long 0xBF8C0F7C
+.long 0xBF8A0000
+.long 0x8F2E862D
+.long 0x80AE2E80
+.long 0xBF03C22E
+.long 0xBF85004F
+.long 0xBF8A0000
+.long 0xE0511000, 0x80030814
+.long 0xE0511120, 0x80030915
+.long 0xE0511240, 0x80030A16
+.long 0xE0511360, 0x80030B17
+.long 0xBEFC004C
+.long 0xBF800000
+.long 0xE0511000, 0x8002000C
+.long 0xE0511120, 0x8002010D
+.long 0xE0511240, 0x8002020E
+.long 0xE0511360, 0x8002030F
+.long 0xE0511480, 0x80020410
+.long 0xE05115A0, 0x80020511
+.long 0xE05116C0, 0x80020612
+.long 0xE05117E0, 0x80020713
+.long 0xBF8C4F74
+.long 0xBF8A0000
+.long 0x800CFF0C, 0x00000080
+.long 0x820D800D
+.long 0xBF8C0F7C
+.long 0xBF8A0000
+.long 0x8008FF08, 0x00000080
+.long 0x82098009
+.long 0xBEFC004F
+.long 0xBF8A0000
+.long 0xE0511000, 0x80030814
+.long 0xE0511120, 0x80030915
+.long 0xE0511240, 0x80030A16
+.long 0xE0511360, 0x80030B17
+.long 0xBEFC004D
+.long 0xBF800000
+.long 0xE0511000, 0x8002000C
+.long 0xE0511120, 0x8002010D
+.long 0xE0511240, 0x8002020E
+.long 0xE0511360, 0x8002030F
+.long 0xE0511480, 0x80020410
+.long 0xE05115A0, 0x80020511
+.long 0xE05116C0, 0x80020612
+.long 0xE05117E0, 0x80020713
+.long 0xBF8C4F74
+.long 0xBF8A0000
+.long 0x800CFF0C, 0x00000080
+.long 0x820D800D
+.long 0xBF8C0F7C
+.long 0xBF8A0000
+.long 0x8008FF08, 0x00000080
+.long 0x82098009
+.long 0xBEFC004E
+.long 0x802E822E
+.long 0xBF03C22E
+.long 0xBF84FFB1
+.long 0xBF8C0F78
+.long 0xBF8A0000
+.long 0xBF8C0F70
+.long 0xBF8A0000
+.long 0xBF810000
+.long 0xC0060700, 0x00000000
+.long 0xC00A0800, 0x00000018
+.long 0xC00A0A00, 0x00000038
+.long 0xC00A0900, 0x00000040
+.long 0xD3D94000, 0x18000080
+.long 0xD3D94001, 0x18000080
+.long 0xD3D94002, 0x18000080
+.long 0xD3D94003, 0x18000080
+.long 0xD3D94004, 0x18000080
+.long 0xD3D94005, 0x18000080
+.long 0xD3D94006, 0x18000080
+.long 0xD3D94007, 0x18000080
+.long 0xD1130001, 0x00011F67
+.long 0xD2850040, 0x000202C0
+.long 0x20040281
+.long 0xD2850002, 0x000204A0
+.long 0x2002CE84
+.long 0x24020283
+.long 0x68808101
+.long 0x24808081
+.long 0x68808102
+.long 0x9254FF52, 0x00000900
+.long 0x68808054
+.long 0x68808080
+.long 0x688280FF, 0x00002400
+.long 0xBF8A0000
+.long 0xD1130001, 0x00011F67
+.long 0xD2850042, 0x000202C0
+.long 0x20040281
+.long 0xD2850002, 0x000204A0
+.long 0x2002CE84
+.long 0x24020283
+.long 0x68848501
+.long 0x24848481
+.long 0x68848502
+.long 0x688484FF, 0x00004800
+.long 0x688684FF, 0x00001200
+.long 0xBF8CC07F
+.long 0xBE900022
+.long 0xBE910023
+.long 0xBE9200FF, 0x80000000
+.long 0xBE9300FF, 0x00020000
+.long 0x925603A0
+.long 0x96552656
+.long 0x92542656
+.long 0x8ED48154
+.long 0x80105410
+.long 0x82115511
+.long 0x96552704
+.long 0x92542704
+.long 0x8ED48154
+.long 0x80105410
+.long 0x82115511
+.long 0xD2850003, 0x0002D090
+.long 0x2608CE8F
+.long 0xD2850005, 0x00004D04
+.long 0x200CCE84
+.long 0x240C0C82
+.long 0x68D60B03
+.long 0x925402C0
+.long 0x32D40C54
+.long 0xD1FE0044, 0x0206D76A
+.long 0x925426A0
+.long 0x688A8854
+.long 0xBE940020
+.long 0xBE950021
+.long 0xBE9600FF, 0x80000000
+.long 0xBE9700FF, 0x00020000
+.long 0x925603A0
+.long 0x96552456
+.long 0x92542456
+.long 0x8ED48154
+.long 0x80145414
+.long 0x82155515
+.long 0x96552504
+.long 0x92542504
+.long 0x8ED48154
+.long 0x80145414
+.long 0x82155515
+.long 0xD2850003, 0x0002D090
+.long 0x2608CE8F
+.long 0xD2850005, 0x00004904
+.long 0x200CCE84
+.long 0x240C0C82
+.long 0x68D60B03
+.long 0x925402C0
+.long 0x32D40C54
+.long 0xD1FE0046, 0x0206D76A
+.long 0x925426A0
+.long 0x688E8C54
+.long 0xBF8A0000
+.long 0xD9FE0000, 0x20000042
+.long 0xD9FE0900, 0x28000042
+.long 0xD9FE0040, 0x24000042
+.long 0xD9FE0940, 0x2C000042
+.long 0xBF8A0000
+.long 0xD9FE0000, 0x10000040
+.long 0xD9FE0040, 0x14000040
+.long 0x8F2E862D
+.long 0x80AE2E80
+.long 0xBF03C22E
+.long 0xBF850065
+.long 0xBF8A0000
+.long 0xBF8CC17F
+.long 0xD3ED0000, 0x04024110
+.long 0xD3ED0004, 0x04125110
+.long 0xD3ED0000, 0x04024311
+.long 0xD3ED0004, 0x04125311
+.long 0xD3ED0000, 0x04024512
+.long 0xBF8A0000
+.long 0xD3ED0004, 0x04125512
+.long 0xD9FE0000, 0x30000043
+.long 0xD3ED0000, 0x04024713
+.long 0xD9FE0900, 0x38000043
+.long 0xD3ED0004, 0x04125713
+.long 0xD9FE0040, 0x34000043
+.long 0xBF8CC37F
+.long 0xD3ED0000, 0x04024914
+.long 0xD9FE0940, 0x3C000043
+.long 0xD3ED0004, 0x04125914
+.long 0xD3ED0000, 0x04024B15
+.long 0xD3ED0004, 0x04125B15
+.long 0xD3ED0000, 0x04024D16
+.long 0xD3ED0004, 0x04125D16
+.long 0xBF8A0000
+.long 0xD9FE0000, 0x18000041
+.long 0xD3ED0000, 0x04024F17
+.long 0xD9FE0040, 0x1C000041
+.long 0xD3ED0004, 0x04125F17
+.long 0xBF8A0000
+.long 0xBF8CC17F
+.long 0xD3ED0000, 0x04026118
+.long 0xD3ED0004, 0x04127118
+.long 0xD3ED0000, 0x04026319
+.long 0xD3ED0004, 0x04127319
+.long 0xD3ED0000, 0x0402651A
+.long 0xBF8A0000
+.long 0xD3ED0004, 0x0412751A
+.long 0xD9FE0000, 0x20000042
+.long 0xD3ED0000, 0x0402671B
+.long 0xD9FE0900, 0x28000042
+.long 0xD3ED0004, 0x0412771B
+.long 0xD9FE0040, 0x24000042
+.long 0xBF8CC37F
+.long 0xD3ED0000, 0x0402691C
+.long 0xD9FE0940, 0x2C000042
+.long 0xD3ED0004, 0x0412791C
+.long 0xD3ED0000, 0x04026B1D
+.long 0xD3ED0004, 0x04127B1D
+.long 0xD3ED0000, 0x04026D1E
+.long 0xD3ED0004, 0x04127D1E
+.long 0xBF8A0000
+.long 0xD9FE0000, 0x10000040
+.long 0xD3ED0000, 0x04026F1F
+.long 0xD9FE0040, 0x14000040
+.long 0xD3ED0004, 0x04127F1F
+.long 0x802E822E
+.long 0xBF03C22E
+.long 0xBF84FF9B
+.long 0xBF8CC17F
+.long 0xD3ED0000, 0x04024110
+.long 0xE0541000, 0x80040844
+.long 0xE0541000, 0x80040A45
+.long 0xD3ED0004, 0x04125110
+.long 0xD3ED0000, 0x04024311
+.long 0xBF8A0000
+.long 0xD3ED0004, 0x04125311
+.long 0xD9FE0000, 0x30000043
+.long 0xD3ED0000, 0x04024512
+.long 0xD9FE0900, 0x38000043
+.long 0xD3ED0004, 0x04125512
+.long 0xD9FE0040, 0x34000043
+.long 0xD3ED0000, 0x04024713
+.long 0xD9FE0940, 0x3C000043
+.long 0xD3ED0004, 0x04125713
+.long 0xBF8CC37F
+.long 0xD3ED0000, 0x04024914
+.long 0xD3ED0004, 0x04125914
+.long 0xD3ED0000, 0x04024B15
+.long 0xD3ED0004, 0x04125B15
+.long 0xD3ED0000, 0x04024D16
+.long 0xBF8A0000
+.long 0xD9FE0000, 0x18000041
+.long 0xD3ED0004, 0x04125D16
+.long 0xD9FE0040, 0x1C000041
+.long 0xD3ED0000, 0x04024F17
+.long 0xD3ED0004, 0x04125F17
+.long 0xBF8CC17F
+.long 0xD3ED0000, 0x04026118
+.long 0xD3ED0004, 0x04127118
+.long 0xD3ED0000, 0x04026319
+.long 0xD3ED0004, 0x04127319
+.long 0xD3ED0000, 0x0402651A
+.long 0xD3ED0004, 0x0412751A
+.long 0xD3ED0000, 0x0402671B
+.long 0xD3ED0004, 0x0412771B
+.long 0xBF8CC07F
+.long 0xD3ED0000, 0x0402691C
+.long 0xD3ED0000, 0x04026B1D
+.long 0xD3ED0000, 0x04026D1E
+.long 0xD3ED0000, 0x04026F1F
+.long 0xD3ED0004, 0x0412791C
+.long 0xD3ED0004, 0x04127B1D
+.long 0xD3ED0004, 0x04127D1E
+.long 0xD3ED0004, 0x04127F1F
+.long 0x7ED602FF, 0xFFFF0000
+.long 0xD3D84000, 0x18000100
+.long 0x0A000028
+.long 0xD3D84001, 0x18000101
+.long 0x0A020228
+.long 0xD3D84002, 0x18000102
+.long 0x0A040428
+.long 0xD3D84003, 0x18000103
+.long 0x0A060628
+.long 0xBF8C0F71
+.long 0x24D41090
+.long 0xD1CB0000, 0x0400536A
+.long 0x26D410FF, 0xFFFF0000
+.long 0xD1CB0001, 0x0404536A
+.long 0x20000090
+.long 0xD2010000, 0x0402D701
+.long 0x24D41290
+.long 0xD1CB0002, 0x0408536A
+.long 0x26D412FF, 0xFFFF0000
+.long 0xD1CB0003, 0x040C536A
+.long 0x20040490
+.long 0xD2010001, 0x040AD703
+.long 0xE0741000, 0x80050046
+.long 0xD3D84004, 0x18000104
+.long 0x0A080828
+.long 0xD3D84005, 0x18000105
+.long 0x0A0A0A28
+.long 0xD3D84006, 0x18000106
+.long 0x0A0C0C28
+.long 0xD3D84007, 0x18000107
+.long 0x0A0E0E28
+.long 0xBF8C0F71
+.long 0x24D41490
+.long 0xD1CB0004, 0x0410536A
+.long 0x26D414FF, 0xFFFF0000
+.long 0xD1CB0005, 0x0414536A
+.long 0x20080890
+.long 0xD2010002, 0x0412D705
+.long 0x24D41690
+.long 0xD1CB0006, 0x0418536A
+.long 0x26D416FF, 0xFFFF0000
+.long 0xD1CB0007, 0x041C536A
+.long 0x200C0C90
+.long 0xD2010003, 0x041AD707
+.long 0xE0741000, 0x80050247
+.long 0xBF8C0000
+.long 0xBF810000

--- a/Tensile/ReplacementKernels/Cijk_Alik_Bljk_HBH_MT128x256x32_AF0EM8_ASEM8_FL0_GRVW8_ISA908_MDA2_PGR1_PLR1_SU32_TT8_8_VAW2_VW8_WG16_32_1_WGM8.s.txt
+++ b/Tensile/ReplacementKernels/Cijk_Alik_Bljk_HBH_MT128x256x32_AF0EM8_ASEM8_FL0_GRVW8_ISA908_MDA2_PGR1_PLR1_SU32_TT8_8_VAW2_VW8_WG16_32_1_WGM8.s.txt
@@ -1,0 +1,1853 @@
+
+
+/******************************************/
+/* Function Prefix                        */
+/******************************************/
+
+
+
+/******************************************/
+/* Begin Kernel                           */
+/******************************************/
+
+.hsa_code_object_version 2,0
+.hsa_code_object_isa 9, 0, 8, "AMD", "AMDGPU"
+.text
+.protected Cijk_Alik_Bljk_HBH_MT128x256x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW8_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT8_8_TLDS0_USFGROn1_VAW2_VS1_VW8_WSGRA0_WSGRB0_WG16_32_1_WGM8
+.globl Cijk_Alik_Bljk_HBH_MT128x256x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW8_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT8_8_TLDS0_USFGROn1_VAW2_VS1_VW8_WSGRA0_WSGRB0_WG16_32_1_WGM8
+.p2align 8
+.type Cijk_Alik_Bljk_HBH_MT128x256x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW8_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT8_8_TLDS0_USFGROn1_VAW2_VS1_VW8_WSGRA0_WSGRB0_WG16_32_1_WGM8,@function
+.amdgpu_hsa_kernel Cijk_Alik_Bljk_HBH_MT128x256x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW8_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT8_8_TLDS0_USFGROn1_VAW2_VS1_VW8_WSGRA0_WSGRB0_WG16_32_1_WGM8
+Cijk_Alik_Bljk_HBH_MT128x256x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW8_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT8_8_TLDS0_USFGROn1_VAW2_VS1_VW8_WSGRA0_WSGRB0_WG16_32_1_WGM8:
+.amd_kernel_code_t
+  is_ptr64 = 1
+  enable_sgpr_kernarg_segment_ptr = 1
+  kernarg_segment_byte_size = 148 // bytes of kern args
+  workitem_vgpr_count = 128 // vgprs
+  wavefront_sgpr_count = 98 // sgprs
+  compute_pgm_rsrc1_vgprs = 31 // floor((128-1)/4)
+  compute_pgm_rsrc1_sgprs = 13 // floor((98-1)/8)
+  compute_pgm_rsrc2_tidig_comp_cnt = 0 // 1D wg
+  compute_pgm_rsrc2_tgid_x_en = 1 // wg.x
+  compute_pgm_rsrc2_tgid_y_en = 1 // wg.y
+  compute_pgm_rsrc2_tgid_z_en = 1 // wg.z
+  workgroup_group_segment_byte_size = 57344 // lds bytes
+  compute_pgm_rsrc2_user_sgpr = 2 // vcc
+  kernarg_segment_alignment = 4
+  group_segment_alignment = 4
+  private_segment_alignment = 4
+.end_amd_kernel_code_t
+
+/******************************************/
+/* Optimizations and Config:              */
+/******************************************/
+/* ThreadTile= 8 x 8 */
+/* SubGroup= 16 x 32 */
+/* VectorWidth=8 */
+/* GlobalLoadVectorWidthA=8, GlobalLoadVectorWidthB=8 */
+/* DirectToLdsA=False */
+/* DirectToLdsB=False */
+/* UseSgprForGRO=1 */
+.amd_amdgpu_hsa_metadata
+Version: [ 1, 0 ]
+Kernels:
+  - Name: Cijk_Alik_Bljk_HBH_MT128x256x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW8_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT8_8_TLDS0_USFGROn1_VAW2_VS1_VW8_WSGRA0_WSGRB0_WG16_32_1_WGM8
+    SymbolName: 'Cijk_Alik_Bljk_HBH_MT128x256x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW8_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT8_8_TLDS0_USFGROn1_VAW2_VS1_VW8_WSGRA0_WSGRB0_WG16_32_1_WGM8@kd'
+    Language: OpenCL C
+    LanguageVersion: [ 2, 0 ]
+    Args:
+      - Name:            sizeC
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            sizeA
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            sizeB
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            D
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       Struct
+        AddrSpaceQual:   Generic
+      - Name:            C
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       Struct
+        AddrSpaceQual:   Generic
+      - Name:            A
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       Struct
+        AddrSpaceQual:   Generic
+      - Name:            B
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       Struct
+        AddrSpaceQual:   Generic
+      - Name:            alpha
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       F16
+      - Name:            beta
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       F16
+      - Name:            strideD0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideD1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideC0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideC1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideA0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideA1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideB0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideB1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree2
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesSum0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            OrigStaggerUIter
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       I32
+      - Name:            NumWorkGroups0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            NumWorkGroups1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            MagicNumberProblemNumGroupTiles0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            GridNumWorkGroups0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            NumFullBlocks
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            WgmRemainder1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            MagicNumberWgmRemainder1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            padding
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+    CodeProps:
+      KernargSegmentSize: 148
+      GroupSegmentFixedSize: 57344
+      PrivateSegmentFixedSize: 0
+      KernargSegmentAlign:  8
+      WavefrontSize:        64
+      NumSGPRs:             98
+      NumVGPRs:             128
+      MaxFlatWorkGroupSize: 512
+.end_amd_amdgpu_hsa_metadata
+
+/******************************************/
+/* Asm syntax workarounds                 */
+/******************************************/
+.macro _v_add_co_u32 dst, cc, src0, src1, dpp=
+   v_add_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+
+.macro _v_add_u32 dst, src0, src1, dpp=
+   v_add_u32 \dst, \src0, \src1 \dpp
+.endm
+
+.macro _v_sub_co_u32 dst, cc, src0, src1, dpp=
+   v_sub_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+
+.macro _v_sub_u32 dst, src0, src1, dpp=
+   v_sub_u32 \dst, \src0, \src1 \dpp
+.endm
+
+.macro _v_addc_co_u32 dst, ccOut, src0, ccIn, src1, dpp=
+   v_addc_co_u32 \dst, \ccOut, \src0, \ccIn, \src1 \dpp
+.endm
+
+.macro _v_add_lshl_u32 dst, src0, src1, shiftCnt
+    v_add_lshl_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+.macro _v_lshl_add_u32 dst, src0, src1, shiftCnt
+    v_lshl_add_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+/******************************************/
+/* Magic div and mod functions            */
+/******************************************/
+.macro V_MAGIC_DIV dstIdx, dividend, magicNumber, magicShift
+    v_mul_hi_u32 v[\dstIdx+1], \dividend, \magicNumber
+    v_mul_lo_u32 v[\dstIdx+0], \dividend, \magicNumber
+    v_lshrrev_b64 v[\dstIdx:\dstIdx+1], \magicShift, v[\dstIdx:\dstIdx+1]
+.endm
+
+/******************************************/
+/* VGPR Assignments                       */
+/******************************************/
+.set vgprValuC, 0
+/* ValuA/B   Xn=PLR buffer idx,  In=InnerUnroll idx */
+.set vgprValuA_X0_I0, 32
+.set vgprValuA_X1_I0, 34
+.set vgprG2LA, 36
+.set vgprValuB_X0_I0, 40
+.set vgprValuB_X1_I0, 44
+.set vgprG2LB, 48
+.set vgprLocalWriteAddrA, 56
+.set vgprLocalWriteAddrB, 57
+.set vgprGlobalReadOffsetA, 58
+.set vgprGlobalReadOffsetB, 59
+.set vgprLocalReadAddrA, 60
+.set vgprLocalReadAddrB, 61
+.set vgprSerial, 62
+/* Num VGPR=63 */
+
+/******************************************/
+/* SGPR Assignments                       */
+/******************************************/
+.set sgprKernArgAddress, 0
+.set sgprWorkGroup0, 2
+.set sgprWorkGroup1, 3
+.set sgprWorkGroup2, 4
+.set sgprNumWorkGroups0, 5
+.set sgprNumWorkGroups1, 6
+.set sgprSrdA, 8
+.set sgprSrdB, 12
+.set sgprSrdD, 16
+.set sgprSrdC, 20
+.set sgprTensor2dSizeC, 24
+.set sgprTensor2dSizeA, 26
+.set sgprTensor2dSizeB, 28
+.set sgprSaveExecMask, 30
+.set sgprAddressD, 32
+.set sgprAddressC, 34
+.set sgprStridesD, 36
+.set sgprStridesC, 38
+.set sgprAlpha, 40
+.set sgprBeta, 41
+.set sgprSizesFree, 42
+.set sgprSizesSum, 45
+.set sgprLoopCounters, 46
+.set sgprOrigLoopCounter, 47
+.set sgprStridesA, 48
+.set sgprStridesB, 50
+.set sgprAddressA, 52
+.set sgprAddressB, 54
+.set sgprShadowLimitA, 56
+.set sgprShadowLimitB, 58
+.set sgprOrigStaggerUIter, 60
+.set sgprStaggerUIter, 61
+.set sgprWrapUA, 62
+.set sgprWrapUB, 64
+.set sgprNumFullBlocks, 66
+.set sgprWgmRemainder1, 67
+.set sgprMagicNumberWgmRemainder1, 68
+.set sgprGlobalReadIncsA, 69
+.set sgprGlobalReadIncsB, 70
+.set sgprScalarGlobalReadOffsetA, 71
+.set sgprScalarGlobalReadOffsetB, 72
+/* max SGPR=98 */
+
+/* Size Assignments */
+.set sgprSizeD0I, sgprSizesFree+0
+.set sgprSizeD1J, sgprSizesFree+1
+.set sgprSizeDK, sgprSizesFree+2
+.set sgprSizeC0I, sgprSizesFree+0
+.set sgprSizeC1J, sgprSizesFree+1
+.set sgprSizeCK, sgprSizesFree+2
+.set sgprSizeAL, sgprSizesSum+0
+.set sgprSizeA0I, sgprSizesFree+0
+.set sgprSizeAK, sgprSizesFree+2
+.set sgprSizeBL, sgprSizesSum+0
+.set sgprSizeB1J, sgprSizesFree+1
+.set sgprSizeBK, sgprSizesFree+2
+
+/* Stride Assignments */
+.set constStrideD0I, 1
+.set sgprStrideD1J, sgprStridesD+0
+.set sgprStrideDK, sgprStridesD+1
+.set constStrideC0I, 1
+.set sgprStrideC1J, sgprStridesC+0
+.set sgprStrideCK, sgprStridesC+1
+.set constStrideAL, 1
+.set sgprStrideA0I, sgprStridesA+0
+.set sgprStrideAK, sgprStridesA+1
+.set constStrideBL, 1
+.set sgprStrideB1J, sgprStridesB+0
+.set sgprStrideBK, sgprStridesB+1
+
+.set DepthU, 32
+/* Number of elements to shift-left SRD */
+.set SrdShiftLeftA, 4
+.set SrdShiftLeftB, 4
+/* 2GB limit - set offsets to -1 to exceed this and clamp */
+.set BufferLimit, 0x80000000
+/* Bits 127:96 of SRD.  Set DataFormat = 32 bit */
+.set Srd127_96, 0x0020000
+.set BufferOOB, 0x80000000
+
+/* Global Offset A */
+.macro GLOBAL_OFFSET_A vgprAddr vgprOffsetL vgprOffset0I vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStrideA0I], v[\vgprOffset0I] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprOffsetL], v[\vgprTmp+0] // accumulate d1 lower
+_v_add_u32 v[\vgprAddr+0], 0x4, v[\vgprAddr+0]     // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/* Global Offset B */
+.macro GLOBAL_OFFSET_B vgprAddr vgprOffsetL vgprOffset1J vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStrideB1J], v[\vgprOffset1J] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprOffsetL], v[\vgprTmp+0] // accumulate d1 lower
+_v_add_u32 v[\vgprAddr+0], 0x4, v[\vgprAddr+0]     // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/******************************************/
+/* Dynamic Scalar Divide: vQuotient=vDividend/vDivisor; vRemainder=vDividend%vDivisor; */
+/******************************************/
+.macro DYNAMIC_VECTOR_DIVIDE vQuotient vRemainder vDividend vDivisor vTmp0 vTmp1 sTmp
+v_cvt_f32_u32 v[\vQuotient], v[\vDivisor]          //
+v_rcp_f32 v[\vQuotient], v[\vQuotient]             //
+v_mul_f32 v[\vQuotient], 0x4f800000, v[\vQuotient] //
+v_cvt_u32_f32 v[\vQuotient], v[\vQuotient]         //
+v_mul_lo_u32 v[\vRemainder], v[\vDivisor], v[\vQuotient] //
+v_mul_hi_u32 v[\vTmp0], v[\vDivisor], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp1], vcc, 0x0, v[\vRemainder]  //
+v_cmp_ne_i32 s[\sTmp:\sTmp+1], 0x0, v[\vTmp0]      //
+v_cndmask_b32 v[\vRemainder], v[\vTmp1], v[\vRemainder], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vRemainder], v[\vRemainder], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vQuotient], v[\vRemainder] //
+_v_add_co_u32 v[\vQuotient], vcc, v[\vQuotient], v[\vRemainder] //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vTmp0], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vQuotient], v[\vQuotient], v[\vDividend] //
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vDividend], v[\vRemainder] //
+v_cmp_ge_u32 s[\sTmp:\sTmp+1], v[\vDividend], v[\vRemainder] //
+_v_add_co_u32 v[\vRemainder], vcc, 0x1, v[\vQuotient] //
+_v_add_co_u32 v[\vTmp1], vcc, -1, v[\vQuotient]    //
+v_cmp_le_u32 vcc, v[\vDivisor], v[\vTmp0]          //
+s_and_b64 vcc, s[\sTmp:\sTmp+1], vcc               //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vRemainder], vcc //
+v_cndmask_b32 v[\vQuotient], v[\vTmp1], v[\vQuotient], s[\sTmp:\sTmp+1] //
+v_cmp_ne_i32 vcc, 0x0, v[\vDivisor]                //
+v_cndmask_b32 v[\vQuotient], -1, v[\vQuotient], vcc // final result
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vRemainder], vcc, v[\vDividend], v[\vRemainder] // final result
+.endm
+
+/******************************************/
+/* 4x8 thread-tile                        */
+/******************************************/
+.macro MAC_4x8_X0
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[0] iui=0
+s_setprio 1 // Raise priority while processing macs
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[1]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[4]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[5]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[2] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[3]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[6]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[7]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[8] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[9]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[12]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[13]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[10] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[11]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[14]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[15]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[16] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[17]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[20]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[21]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[18] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[19]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[22]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[23]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[24] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[25]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[28]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[29]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[26] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[27]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[30]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[31]
+s_setprio 0 // Reset priority after macs
+.endm
+.macro MAC_4x8_X1
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[0] iui=0
+s_setprio 1 // Raise priority while processing macs
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[1]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[4]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[5]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[2] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[3]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[6]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[7]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[8] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[9]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[12]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[13]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[10] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[11]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[14]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[15]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[16] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[17]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[20]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[21]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[18] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[19]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[22]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[23]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[24] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[25]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[28]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[29]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[26] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[27]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[30]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[31]
+s_setprio 0 // Reset priority after macs
+.endm
+
+
+
+
+/***** program start from here *****/
+
+.long 0xC00A0D00, 0x00000028
+.long 0xC00A0C00, 0x00000050
+.long 0xC00A0600, 0x00000008
+.long 0xC0020B40, 0x0000006C
+.long 0xC0020140, 0x00000074
+.long 0xBEFC00FF, 0x0000FFFF
+.long 0x7ECA0300
+.long 0x26CC00BF
+.long 0x2004CA86
+.long 0xB8D0F804
+.long 0xD1130004, 0x0000A0B0
+.long 0x20CE0884
+.long 0x7EA40567
+.long 0xD1130068, 0x0000A08F
+.long 0x7EA20568
+.long 0xBF068151
+.long 0xBF8400F3
+.long 0xBF8CC07F
+.long 0xBE880034
+.long 0xBE890035
+.long 0xBE8B00FF, 0x00020000
+.long 0xBE8A00FF, 0x80000000
+.long 0x9254FF30, 0x00000080
+.long 0x92545402
+.long 0x9255A052
+.long 0x92533055
+.long 0x92553104
+.long 0x81545354
+.long 0x80545554
+.long 0x2000CC82
+.long 0xD2850004, 0x00020030
+.long 0x2602CC83
+.long 0x24020283
+.long 0x32AC0304
+.long 0x68ACAC54
+.long 0x24ACAC81
+.long 0x8E478530
+.long 0x68AEAC47
+.long 0xBECC00FF, 0x00000880
+.long 0x924C4C52
+.long 0xBE8C0036
+.long 0xBE8D0037
+.long 0xBE8F00FF, 0x00020000
+.long 0xBE8E00FF, 0x80000000
+.long 0x9254FF32, 0x00000100
+.long 0x92545403
+.long 0x9255C052
+.long 0x92533255
+.long 0x92553304
+.long 0x81545354
+.long 0x80545554
+.long 0x2004CC82
+.long 0xD2850004, 0x00020432
+.long 0x2606CC83
+.long 0x24060683
+.long 0x32B40704
+.long 0x68B4B454
+.long 0x24B4B481
+.long 0x8E4A8532
+.long 0x68B6B44A
+.long 0x68B8B64A
+.long 0x68BAB84A
+.long 0xBECE00FF, 0x00001100
+.long 0x924E4E52
+.long 0x814EFF4E, 0x00004400
+.long 0xBF8A0000
+.long 0x814DFF4C, 0x00002200
+.long 0x24A0CC84
+.long 0x68A0A04C
+.long 0x24A2CC84
+.long 0x68A2A24D
+.long 0x814FFF4E, 0x00004400
+.long 0x24A4CC84
+.long 0x68A4A44E
+.long 0x24A6CC84
+.long 0x68A6A64F
+.long 0x2002CC83
+.long 0xD2850001, 0x00020288
+.long 0x68A0A101
+.long 0x68A2A301
+.long 0x68A4A501
+.long 0x68A6A701
+.long 0xD1340058, 0x00018156
+.long 0xD1340059, 0x00018157
+.long 0xD134005E, 0x0001815A
+.long 0xD134005F, 0x0001815B
+.long 0xD1340060, 0x0001815C
+.long 0xD1340061, 0x0001815D
+.long 0xE05E1000, 0x80022056
+.long 0xE05E1000, 0x80022457
+.long 0xE05E1000, 0x8003305A
+.long 0xE05E1000, 0x8003345B
+.long 0xE05E1000, 0x8003385C
+.long 0xE05E1000, 0x80033C5D
+.long 0xE05E1000, 0x80022858
+.long 0xE05E1000, 0x80022C59
+.long 0xE05E1000, 0x8003405E
+.long 0xE05E1000, 0x8003445F
+.long 0xE05E1000, 0x80034860
+.long 0xE05E1000, 0x80034C61
+.long 0x68ACACFF, 0x00000080
+.long 0x68AEAEFF, 0x00000080
+.long 0x8F2E852D
+.long 0x80AE2E80
+.long 0xBF06802E
+.long 0xBF850059
+.long 0xBF8C0F7A
+.long 0xD9BE0000, 0x00002050
+.long 0xD9BE0440, 0x00002450
+.long 0xBF8CC07F
+.long 0xE05E1000, 0x80022056
+.long 0xE05E1000, 0x80022457
+.long 0xBF8C0F78
+.long 0xD9BE0000, 0x00003052
+.long 0xD9BE0440, 0x00003452
+.long 0xD9BE0880, 0x00003852
+.long 0xD9BE0CC0, 0x00003C52
+.long 0x68ACACFF, 0x00000080
+.long 0x68AEAEFF, 0x00000080
+.long 0x68B4B4FF, 0x00000080
+.long 0x68B6B6FF, 0x00000080
+.long 0x68B8B8FF, 0x00000080
+.long 0x68BABAFF, 0x00000080
+.long 0x68B0B0FF, 0x00000080
+.long 0x68B2B2FF, 0x00000080
+.long 0x68BCBCFF, 0x00000080
+.long 0x68BEBEFF, 0x00000080
+.long 0x68C0C0FF, 0x00000080
+.long 0x68C2C2FF, 0x00000080
+.long 0xBF8CC07F
+.long 0xE05E1000, 0x8003305A
+.long 0xE05E1000, 0x8003345B
+.long 0xE05E1000, 0x8003385C
+.long 0xE05E1000, 0x80033C5D
+.long 0xBF8C0F7A
+.long 0xD9BE0000, 0x00002851
+.long 0xD9BE0440, 0x00002C51
+.long 0xBF8CC07F
+.long 0xE05E1000, 0x80022858
+.long 0xE05E1000, 0x80022C59
+.long 0xBF8C0F78
+.long 0xD9BE0000, 0x00004053
+.long 0xD9BE0440, 0x00004453
+.long 0xD9BE0880, 0x00004853
+.long 0xD9BE0CC0, 0x00004C53
+.long 0xBF8CC07F
+.long 0xBF8A0000
+.long 0xBF800018
+.long 0xE05E1000, 0x8003405E
+.long 0xBF80000B
+.long 0xE05E1000, 0x8003445F
+.long 0xBF80000B
+.long 0xE05E1000, 0x80034860
+.long 0xBF80000B
+.long 0xE05E1000, 0x80034C61
+.long 0xBF8A0000
+.long 0x802E822E
+.long 0xBF00C22E
+.long 0xBF84FFA7
+.long 0xBF8C0F7A
+.long 0xD9BE0000, 0x00002050
+.long 0xD9BE0440, 0x00002450
+.long 0xBF8C0F76
+.long 0xD9BE0000, 0x00003052
+.long 0xD9BE0440, 0x00003452
+.long 0xD9BE0880, 0x00003852
+.long 0xD9BE0CC0, 0x00003C52
+.long 0xBF8C0F74
+.long 0xD9BE0000, 0x00002851
+.long 0xD9BE0440, 0x00002C51
+.long 0xBF8C0F70
+.long 0xD9BE0000, 0x00004053
+.long 0xD9BE0440, 0x00004453
+.long 0xD9BE0880, 0x00004853
+.long 0xD9BE0CC0, 0x00004C53
+.long 0xBF8CC07F
+.long 0xBF8A0000
+.long 0xBF810000
+.long 0xD3D94000, 0x18000080
+.long 0xD3D94001, 0x18000080
+.long 0xD3D94002, 0x18000080
+.long 0xD3D94003, 0x18000080
+.long 0xD3D94004, 0x18000080
+.long 0xD3D94005, 0x18000080
+.long 0xD3D94006, 0x18000080
+.long 0xD3D94007, 0x18000080
+.long 0xD3D94008, 0x18000080
+.long 0xD3D94009, 0x18000080
+.long 0xD3D9400A, 0x18000080
+.long 0xD3D9400B, 0x18000080
+.long 0xD3D9400C, 0x18000080
+.long 0xD3D9400D, 0x18000080
+.long 0xD3D9400E, 0x18000080
+.long 0xD3D9400F, 0x18000080
+.long 0xD3D94010, 0x18000080
+.long 0xD3D94011, 0x18000080
+.long 0xD3D94012, 0x18000080
+.long 0xD3D94013, 0x18000080
+.long 0xD3D94014, 0x18000080
+.long 0xD3D94015, 0x18000080
+.long 0xD3D94016, 0x18000080
+.long 0xD3D94017, 0x18000080
+.long 0xD3D94018, 0x18000080
+.long 0xD3D94019, 0x18000080
+.long 0xD3D9401A, 0x18000080
+.long 0xD3D9401B, 0x18000080
+.long 0xD3D9401C, 0x18000080
+.long 0xD3D9401D, 0x18000080
+.long 0xD3D9401E, 0x18000080
+.long 0xD3D9401F, 0x18000080
+.long 0xD3D94020, 0x18000080
+.long 0xD3D94021, 0x18000080
+.long 0xD3D94022, 0x18000080
+.long 0xD3D94023, 0x18000080
+.long 0xD3D94024, 0x18000080
+.long 0xD3D94025, 0x18000080
+.long 0xD3D94026, 0x18000080
+.long 0xD3D94027, 0x18000080
+.long 0xD3D94028, 0x18000080
+.long 0xD3D94029, 0x18000080
+.long 0xD3D9402A, 0x18000080
+.long 0xD3D9402B, 0x18000080
+.long 0xD3D9402C, 0x18000080
+.long 0xD3D9402D, 0x18000080
+.long 0xD3D9402E, 0x18000080
+.long 0xD3D9402F, 0x18000080
+.long 0xD3D94030, 0x18000080
+.long 0xD3D94031, 0x18000080
+.long 0xD3D94032, 0x18000080
+.long 0xD3D94033, 0x18000080
+.long 0xD3D94034, 0x18000080
+.long 0xD3D94035, 0x18000080
+.long 0xD3D94036, 0x18000080
+.long 0xD3D94037, 0x18000080
+.long 0xD3D94038, 0x18000080
+.long 0xD3D94039, 0x18000080
+.long 0xD3D9403A, 0x18000080
+.long 0xD3D9403B, 0x18000080
+.long 0xD3D9403C, 0x18000080
+.long 0xD3D9403D, 0x18000080
+.long 0xD3D9403E, 0x18000080
+.long 0xD3D9403F, 0x18000080
+.long 0xD3D94040, 0x18000080
+.long 0xD3D94041, 0x18000080
+.long 0xD3D94042, 0x18000080
+.long 0xD3D94043, 0x18000080
+.long 0xD3D94044, 0x18000080
+.long 0xD3D94045, 0x18000080
+.long 0xD3D94046, 0x18000080
+.long 0xD3D94047, 0x18000080
+.long 0xD3D94048, 0x18000080
+.long 0xD3D94049, 0x18000080
+.long 0xD3D9404A, 0x18000080
+.long 0xD3D9404B, 0x18000080
+.long 0xD3D9404C, 0x18000080
+.long 0xD3D9404D, 0x18000080
+.long 0xD3D9404E, 0x18000080
+.long 0xD3D9404F, 0x18000080
+.long 0xD3D94050, 0x18000080
+.long 0xD3D94051, 0x18000080
+.long 0xD3D94052, 0x18000080
+.long 0xD3D94053, 0x18000080
+.long 0xD3D94054, 0x18000080
+.long 0xD3D94055, 0x18000080
+.long 0xD3D94056, 0x18000080
+.long 0xD3D94057, 0x18000080
+.long 0xD3D94058, 0x18000080
+.long 0xD3D94059, 0x18000080
+.long 0xD3D9405A, 0x18000080
+.long 0xD3D9405B, 0x18000080
+.long 0xD3D9405C, 0x18000080
+.long 0xD3D9405D, 0x18000080
+.long 0xD3D9405E, 0x18000080
+.long 0xD3D9405F, 0x18000080
+.long 0xD3D94060, 0x18000080
+.long 0xD3D94061, 0x18000080
+.long 0xD3D94062, 0x18000080
+.long 0xD3D94063, 0x18000080
+.long 0xD3D94064, 0x18000080
+.long 0xD3D94065, 0x18000080
+.long 0xD3D94066, 0x18000080
+.long 0xD3D94067, 0x18000080
+.long 0xD3D94068, 0x18000080
+.long 0xD3D94069, 0x18000080
+.long 0xD3D9406A, 0x18000080
+.long 0xD3D9406B, 0x18000080
+.long 0xD3D9406C, 0x18000080
+.long 0xD3D9406D, 0x18000080
+.long 0xD3D9406E, 0x18000080
+.long 0xD3D9406F, 0x18000080
+.long 0xD3D94070, 0x18000080
+.long 0xD3D94071, 0x18000080
+.long 0xD3D94072, 0x18000080
+.long 0xD3D94073, 0x18000080
+.long 0xD3D94074, 0x18000080
+.long 0xD3D94075, 0x18000080
+.long 0xD3D94076, 0x18000080
+.long 0xD3D94077, 0x18000080
+.long 0xD3D94078, 0x18000080
+.long 0xD3D94079, 0x18000080
+.long 0xD3D9407A, 0x18000080
+.long 0xD3D9407B, 0x18000080
+.long 0xD3D9407C, 0x18000080
+.long 0xD3D9407D, 0x18000080
+.long 0xD3D9407E, 0x18000080
+.long 0xD3D9407F, 0x18000080
+.long 0xC0060700, 0x00000000
+.long 0xC00A0A00, 0x00000038
+.long 0xC00A0900, 0x00000040
+.long 0xC00A0800, 0x00000018
+.long 0xC00A0A00, 0x00000038
+.long 0xD1130001, 0x00013F66
+.long 0xD2850061, 0x000202A0
+.long 0x20040281
+.long 0xD2850002, 0x00020488
+.long 0x2002CC85
+.long 0x24020282
+.long 0x68C2C301
+.long 0x24C2C281
+.long 0x68C2C302
+.long 0x86548152
+.long 0x9254FF54, 0x00001100
+.long 0x68C2C254
+.long 0x68C2C280
+.long 0x68C4C2FF, 0x00002200
+.long 0xBF8A0000
+.long 0xD1130001, 0x00013F66
+.long 0xD2850063, 0x000202A0
+.long 0x20040281
+.long 0xD2850002, 0x00020488
+.long 0x2002CC85
+.long 0x24020282
+.long 0x68C6C701
+.long 0x24C6C681
+.long 0x68C6C702
+.long 0x86548252
+.long 0x8F548154
+.long 0x9254FF54, 0x00002200
+.long 0x68C6C654
+.long 0x68C6C6FF, 0x00004400
+.long 0x68C8C6FF, 0x00004400
+.long 0xBF8CC07F
+.long 0xBE900022
+.long 0xBE910023
+.long 0xBE9200FF, 0x80000000
+.long 0xBE9300FF, 0x00020000
+.long 0xBE940020
+.long 0xBE950021
+.long 0xBE9600FF, 0x80000000
+.long 0xBE9700FF, 0x00020000
+.long 0x925603FF, 0x00000100
+.long 0x96552656
+.long 0x92542656
+.long 0x8ED48154
+.long 0x80105410
+.long 0x82115511
+.long 0x80145414
+.long 0x82155515
+.long 0x96552704
+.long 0x92542704
+.long 0x8ED48154
+.long 0x80105410
+.long 0x82115511
+.long 0x80145414
+.long 0x82155515
+.long 0x24CACE86
+.long 0x68CACB66
+.long 0x2608CE82
+.long 0x20080881
+.long 0x24080887
+.long 0xD2850003, 0x00004D04
+.long 0x2608CE81
+.long 0xD2850004, 0x000208C0
+.long 0x68060903
+.long 0x2608CA9F
+.long 0xD2850005, 0x00004D04
+.long 0x68D40B03
+.long 0x2608CABF
+.long 0x200C0885
+.long 0x240C0C82
+.long 0x925402FF, 0x00000080
+.long 0x32D20C54
+.long 0xD1FE0060, 0x0206D569
+.long 0x7ED20228
+.long 0x7ED21769
+.long 0x7E500569
+.long 0x7ED20229
+.long 0x7ED21769
+.long 0x7E520569
+.long 0xBF8A0000
+.long 0xD8EC0000, 0x00000061
+.long 0xD8EC0000, 0x20000063
+.long 0xD8EC0010, 0x02000061
+.long 0xD8EC0010, 0x22000063
+.long 0xBF8CC27F
+.long 0xD3CC0000, 0x04024100
+.long 0xD8EC0020, 0x04000061
+.long 0xD8EC0020, 0x24000063
+.long 0xD8EC0030, 0x06000061
+.long 0xD8EC0030, 0x26000063
+.long 0xBF8CC47F
+.long 0xD3CC0000, 0x04024502
+.long 0xD8EC0000, 0x10000062
+.long 0xD8EC0000, 0x40000064
+.long 0xD8EC0010, 0x12000062
+.long 0xD8EC0010, 0x42000064
+.long 0xD3CC0000, 0x04024904
+.long 0xD8EC0020, 0x14000062
+.long 0xD8EC0020, 0x44000064
+.long 0xD8EC0030, 0x16000062
+.long 0xD8EC0030, 0x46000064
+.long 0xD3CC0000, 0x04024D06
+.long 0xD8EC0880, 0x08000061
+.long 0xD8EC0880, 0x28000063
+.long 0xD8EC0890, 0x0A000061
+.long 0xD8EC0890, 0x2A000063
+.long 0xD3CC0000, 0x04028110
+.long 0xD8EC08A0, 0x0C000061
+.long 0xD8EC08A0, 0x2C000063
+.long 0xD8EC08B0, 0x0E000061
+.long 0xD8EC08B0, 0x2E000063
+.long 0xD3CC0000, 0x04028512
+.long 0xD8EC0880, 0x18000062
+.long 0xD8EC0890, 0x1A000062
+.long 0xD8EC08A0, 0x1C000062
+.long 0xD8EC08B0, 0x1E000062
+.long 0xD3CC0000, 0x04028914
+.long 0xD8EC0880, 0x48000064
+.long 0xD8EC0890, 0x4A000064
+.long 0xD8EC08A0, 0x4C000064
+.long 0xD8EC08B0, 0x4E000064
+.long 0xD3CC0000, 0x04028D16
+.long 0xD8EC1100, 0x30000063
+.long 0xD8EC1110, 0x32000063
+.long 0xD8EC1120, 0x34000063
+.long 0xD8EC1130, 0x36000063
+.long 0xD3CC0010, 0x04424108
+.long 0xD8EC1980, 0x38000063
+.long 0xD8EC1990, 0x3A000063
+.long 0xD8EC19A0, 0x3C000063
+.long 0xD8EC19B0, 0x3E000063
+.long 0xD3CC0010, 0x0442450A
+.long 0xD8EC1100, 0x50000064
+.long 0xD8EC1110, 0x52000064
+.long 0xD8EC1120, 0x54000064
+.long 0xD8EC1130, 0x56000064
+.long 0xD3CC0010, 0x0442490C
+.long 0xD8EC1980, 0x58000064
+.long 0xD8EC1990, 0x5A000064
+.long 0xD8EC19A0, 0x5C000064
+.long 0xD8EC19B0, 0x5E000064
+.long 0x8F2E852D
+.long 0x80AE2E80
+.long 0xBF06802E
+.long 0xBF850119
+.long 0xD3CC0010, 0x04424D0E
+.long 0xBF8CC07F
+.long 0xBF8A0000
+.long 0xD3CC0010, 0x04428118
+.long 0xBF80000C
+.long 0xD3CC0010, 0x0442851A
+.long 0xBF80000C
+.long 0xD3CC0010, 0x0442891C
+.long 0xBF80000C
+.long 0xD3CC0010, 0x04428D1E
+.long 0xBF80000C
+.long 0xD3CC0020, 0x04825100
+.long 0xBF80000C
+.long 0xD3CC0020, 0x04825502
+.long 0xBF80000C
+.long 0xD3CC0020, 0x04825904
+.long 0xBF80000C
+.long 0xD3CC0020, 0x04825D06
+.long 0xBF80000C
+.long 0xD3CC0020, 0x04829110
+.long 0xBF80000C
+.long 0xD3CC0020, 0x04829512
+.long 0xBF80000C
+.long 0xD3CC0020, 0x04829914
+.long 0xBF80000C
+.long 0xD3CC0020, 0x04829D16
+.long 0xBF80000C
+.long 0xD3CC0030, 0x04C25108
+.long 0xBF80000C
+.long 0xD3CC0030, 0x04C2550A
+.long 0xBF80000C
+.long 0xD3CC0030, 0x04C2590C
+.long 0xBF80000C
+.long 0xD3CC0030, 0x04C25D0E
+.long 0xBF80000C
+.long 0xD3CC0030, 0x04C29118
+.long 0xBF80000C
+.long 0xD3CC0030, 0x04C2951A
+.long 0xBF80000C
+.long 0xD3CC0030, 0x04C2991C
+.long 0xBF80000C
+.long 0xD3CC0030, 0x04C29D1E
+.long 0xBF80000C
+.long 0xD3CC0040, 0x05026100
+.long 0xBF80000C
+.long 0xD3CC0040, 0x05026502
+.long 0xBF80000C
+.long 0xD3CC0040, 0x05026904
+.long 0xBF80000C
+.long 0xD3CC0040, 0x05026D06
+.long 0xBF80000C
+.long 0xD3CC0040, 0x0502A110
+.long 0xBF80000C
+.long 0xD3CC0040, 0x0502A512
+.long 0xBF80000C
+.long 0xD3CC0040, 0x0502A914
+.long 0xBF80000C
+.long 0xD3CC0040, 0x0502AD16
+.long 0xBF80000C
+.long 0xD3CC0050, 0x05426108
+.long 0xBF80000C
+.long 0xD3CC0050, 0x0542650A
+.long 0xBF80000C
+.long 0xD3CC0050, 0x0542690C
+.long 0xBF80000C
+.long 0xD3CC0050, 0x05426D0E
+.long 0xBF80000C
+.long 0xD3CC0050, 0x0542A118
+.long 0xBF80000C
+.long 0xD3CC0050, 0x0542A51A
+.long 0xBF80000C
+.long 0xD3CC0050, 0x0542A91C
+.long 0xBF80000C
+.long 0xD3CC0050, 0x0542AD1E
+.long 0xBF80000C
+.long 0xD3CC0060, 0x05827100
+.long 0xBF80000C
+.long 0xD3CC0060, 0x05827502
+.long 0xBF80000C
+.long 0xD3CC0060, 0x05827904
+.long 0xBF80000C
+.long 0xD3CC0060, 0x05827D06
+.long 0xBF80000C
+.long 0xD3CC0060, 0x0582B110
+.long 0xBF80000C
+.long 0xD3CC0060, 0x0582B512
+.long 0xBF80000C
+.long 0xD3CC0060, 0x0582B914
+.long 0xBF80000C
+.long 0xD3CC0060, 0x0582BD16
+.long 0xBF80000C
+.long 0xD3CC0070, 0x05C27108
+.long 0xBF80000C
+.long 0xD3CC0070, 0x05C2750A
+.long 0xBF80000C
+.long 0xD3CC0070, 0x05C2790C
+.long 0xBF80000C
+.long 0xD3CC0070, 0x05C27D0E
+.long 0xBF80000C
+.long 0xD3CC0070, 0x05C2B118
+.long 0xBF80000C
+.long 0xD3CC0070, 0x05C2B51A
+.long 0xBF80000C
+.long 0xD3CC0070, 0x05C2B91C
+.long 0xBF8A0000
+.long 0xD8EC0000, 0x00000061
+.long 0xD8EC0000, 0x20000063
+.long 0xD8EC0010, 0x02000061
+.long 0xD8EC0010, 0x22000063
+.long 0xD3CC0070, 0x05C2BD1E
+.long 0xD8EC0020, 0x04000061
+.long 0xD8EC0020, 0x24000063
+.long 0xD8EC0030, 0x06000061
+.long 0xD8EC0030, 0x26000063
+.long 0xBF8CC67F
+.long 0xD3CC0000, 0x04024100
+.long 0xD8EC0000, 0x10000062
+.long 0xD8EC0000, 0x40000064
+.long 0xD8EC0010, 0x12000062
+.long 0xD8EC0010, 0x42000064
+.long 0xD3CC0000, 0x04024502
+.long 0xD8EC0020, 0x14000062
+.long 0xD8EC0020, 0x44000064
+.long 0xD8EC0030, 0x16000062
+.long 0xD8EC0030, 0x46000064
+.long 0xD3CC0000, 0x04024904
+.long 0xD8EC0880, 0x08000061
+.long 0xD8EC0880, 0x28000063
+.long 0xD8EC0890, 0x0A000061
+.long 0xD8EC0890, 0x2A000063
+.long 0xD3CC0000, 0x04024D06
+.long 0xD8EC08A0, 0x0C000061
+.long 0xD8EC08A0, 0x2C000063
+.long 0xD8EC08B0, 0x0E000061
+.long 0xD8EC08B0, 0x2E000063
+.long 0xD3CC0000, 0x04028110
+.long 0xD8EC0880, 0x18000062
+.long 0xD8EC0890, 0x1A000062
+.long 0xD8EC08A0, 0x1C000062
+.long 0xD8EC08B0, 0x1E000062
+.long 0xD3CC0000, 0x04028512
+.long 0xD8EC0880, 0x48000064
+.long 0xD8EC0890, 0x4A000064
+.long 0xD8EC08A0, 0x4C000064
+.long 0xD8EC08B0, 0x4E000064
+.long 0xD3CC0000, 0x04028914
+.long 0xD8EC1100, 0x30000063
+.long 0xD8EC1110, 0x32000063
+.long 0xD8EC1120, 0x34000063
+.long 0xD8EC1130, 0x36000063
+.long 0xD3CC0000, 0x04028D16
+.long 0xD8EC1980, 0x38000063
+.long 0xD8EC1990, 0x3A000063
+.long 0xD8EC19A0, 0x3C000063
+.long 0xD8EC19B0, 0x3E000063
+.long 0xD3CC0010, 0x04424108
+.long 0xD8EC1100, 0x50000064
+.long 0xD8EC1110, 0x52000064
+.long 0xD8EC1120, 0x54000064
+.long 0xD8EC1130, 0x56000064
+.long 0xD3CC0010, 0x0442450A
+.long 0xD8EC1980, 0x58000064
+.long 0xD8EC1990, 0x5A000064
+.long 0xD8EC19A0, 0x5C000064
+.long 0xD8EC19B0, 0x5E000064
+.long 0xD3CC0010, 0x0442490C
+.long 0x802E822E
+.long 0xBF00C22E
+.long 0xBF84FEE7
+.long 0x9254C026
+.long 0xD3CC0010, 0x04424D0E
+.long 0xE0541000, 0x80046160
+.long 0xE0541010, 0x80046360
+.long 0xE0541020, 0x80046560
+.long 0xE0541030, 0x80046760
+.long 0xD3D84069, 0x18000100
+.long 0xD3D8406A, 0x18000101
+.long 0xD3D8406B, 0x18000102
+.long 0xD3D8406C, 0x18000103
+.long 0xD3D8406D, 0x18000104
+.long 0xD3D8406E, 0x18000105
+.long 0xD3D8406F, 0x18000106
+.long 0xD3D84070, 0x18000107
+.long 0xD3CC0010, 0x04428118
+.long 0xBF8C0F73
+.long 0x0AD2D228
+.long 0x0AD4D428
+.long 0xD3A00069, 0x15A6C229
+.long 0xD3A0106A, 0x15AAC229
+.long 0x7ED21569
+.long 0x7ED4156A
+.long 0xD2000069, 0x05A5216A
+.long 0x0AD6D628
+.long 0x0AD8D828
+.long 0xD3A0006B, 0x15AEC429
+.long 0xD3A0106C, 0x15B2C429
+.long 0x7ED6156B
+.long 0x7ED8156C
+.long 0xD200006A, 0x05AD216C
+.long 0xD3CC0010, 0x0442851A
+.long 0xE0741000, 0x80056960
+.long 0xBF8C0F73
+.long 0x0ADADA28
+.long 0x0ADCDC28
+.long 0xD3A0006D, 0x15B6C629
+.long 0xD3A0106E, 0x15BAC629
+.long 0x7EDA156D
+.long 0x7EDC156E
+.long 0xD200006B, 0x05B5216E
+.long 0x0ADEDE28
+.long 0x0AE0E028
+.long 0xD3A0006F, 0x15BEC829
+.long 0xD3A01070, 0x15C2C829
+.long 0x7EDE156F
+.long 0x7EE01570
+.long 0xD200006C, 0x05BD2170
+.long 0xD3CC0010, 0x0442891C
+.long 0xD3D84071, 0x18000108
+.long 0xD3D84072, 0x18000109
+.long 0xD3D84073, 0x1800010A
+.long 0xD3D84074, 0x1800010B
+.long 0xD3CC0010, 0x04428D1E
+.long 0xE0741010, 0x80056B60
+.long 0xBF8C0F73
+.long 0x0AE2E228
+.long 0x0AE4E428
+.long 0xD3A00071, 0x15C6CA29
+.long 0xD3A01072, 0x15CACA29
+.long 0x7EE21571
+.long 0x7EE41572
+.long 0xD200006D, 0x05C52172
+.long 0x0AE6E628
+.long 0x0AE8E828
+.long 0xD3A00073, 0x15CECC29
+.long 0xD3A01074, 0x15D2CC29
+.long 0x7EE61573
+.long 0x7EE81574
+.long 0xD200006E, 0x05CD2174
+.long 0xD3CC0020, 0x04825100
+.long 0xD3D84075, 0x1800010C
+.long 0xD3D84076, 0x1800010D
+.long 0xD3D84077, 0x1800010E
+.long 0xD3D84078, 0x1800010F
+.long 0xE0741020, 0x80056D60
+.long 0xBF8C0F73
+.long 0x0AEAEA28
+.long 0x0AECEC28
+.long 0xD3A00075, 0x15D6CE29
+.long 0xD3A01076, 0x15DACE29
+.long 0x7EEA1575
+.long 0x7EEC1576
+.long 0xD200006F, 0x05D52176
+.long 0x0AEEEE28
+.long 0x0AF0F028
+.long 0xD3A00077, 0x15DED029
+.long 0xD3A01078, 0x15E2D029
+.long 0x7EEE1577
+.long 0x7EF01578
+.long 0xD2000070, 0x05DD2178
+.long 0xD3CC0020, 0x04825502
+.long 0xE0741030, 0x80056F60
+.long 0xE0541040, 0x80046160
+.long 0xE0541050, 0x80046360
+.long 0xE0541060, 0x80046560
+.long 0xE0541070, 0x80046760
+.long 0xD3D84069, 0x18000110
+.long 0xD3D8406A, 0x18000111
+.long 0xD3D8406B, 0x18000112
+.long 0xD3D8406C, 0x18000113
+.long 0xD3D8406D, 0x18000114
+.long 0xD3D8406E, 0x18000115
+.long 0xD3D8406F, 0x18000116
+.long 0xD3D84070, 0x18000117
+.long 0xD3CC0020, 0x04825904
+.long 0xBF8C0F73
+.long 0x0AD2D228
+.long 0x0AD4D428
+.long 0xD3A00069, 0x15A6C229
+.long 0xD3A0106A, 0x15AAC229
+.long 0x7ED21569
+.long 0x7ED4156A
+.long 0xD2000069, 0x05A5216A
+.long 0x0AD6D628
+.long 0x0AD8D828
+.long 0xD3A0006B, 0x15AEC429
+.long 0xD3A0106C, 0x15B2C429
+.long 0x7ED6156B
+.long 0x7ED8156C
+.long 0xD200006A, 0x05AD216C
+.long 0xD3CC0020, 0x04825D06
+.long 0xE0741040, 0x80056960
+.long 0xBF8C0F73
+.long 0x0ADADA28
+.long 0x0ADCDC28
+.long 0xD3A0006D, 0x15B6C629
+.long 0xD3A0106E, 0x15BAC629
+.long 0x7EDA156D
+.long 0x7EDC156E
+.long 0xD200006B, 0x05B5216E
+.long 0x0ADEDE28
+.long 0x0AE0E028
+.long 0xD3A0006F, 0x15BEC829
+.long 0xD3A01070, 0x15C2C829
+.long 0x7EDE156F
+.long 0x7EE01570
+.long 0xD200006C, 0x05BD2170
+.long 0xD3CC0020, 0x04829110
+.long 0xD3D84071, 0x18000118
+.long 0xD3D84072, 0x18000119
+.long 0xD3D84073, 0x1800011A
+.long 0xD3D84074, 0x1800011B
+.long 0xE0741050, 0x80056B60
+.long 0xD3CC0020, 0x04829512
+.long 0xBF8C0F73
+.long 0x0AE2E228
+.long 0x0AE4E428
+.long 0xD3A00071, 0x15C6CA29
+.long 0xD3A01072, 0x15CACA29
+.long 0x7EE21571
+.long 0x7EE41572
+.long 0xD200006D, 0x05C52172
+.long 0x0AE6E628
+.long 0x0AE8E828
+.long 0xD3A00073, 0x15CECC29
+.long 0xD3A01074, 0x15D2CC29
+.long 0x7EE61573
+.long 0x7EE81574
+.long 0xD200006E, 0x05CD2174
+.long 0xD3CC0020, 0x04829914
+.long 0xD3D84075, 0x1800011C
+.long 0xD3D84076, 0x1800011D
+.long 0xD3D84077, 0x1800011E
+.long 0xD3D84078, 0x1800011F
+.long 0xE0741060, 0x80056D60
+.long 0xD3CC0020, 0x04829D16
+.long 0xBF8C0F73
+.long 0x0AEAEA28
+.long 0x0AECEC28
+.long 0xD3A00075, 0x15D6CE29
+.long 0xD3A01076, 0x15DACE29
+.long 0x7EEA1575
+.long 0x7EEC1576
+.long 0xD200006F, 0x05D52176
+.long 0x0AEEEE28
+.long 0x0AF0F028
+.long 0xD3A00077, 0x15DED029
+.long 0xD3A01078, 0x15E2D029
+.long 0x7EEE1577
+.long 0x7EF01578
+.long 0xD2000070, 0x05DD2178
+.long 0xD3CC0030, 0x04C25108
+.long 0xE0741070, 0x80056F60
+.long 0xD3CC0030, 0x04C2550A
+.long 0xD1340060, 0x0000A960
+.long 0xE0541000, 0x80046160
+.long 0xE0541010, 0x80046360
+.long 0xE0541020, 0x80046560
+.long 0xE0541030, 0x80046760
+.long 0xD3D84069, 0x18000120
+.long 0xD3D8406A, 0x18000121
+.long 0xD3D8406B, 0x18000122
+.long 0xD3D8406C, 0x18000123
+.long 0xD3D8406D, 0x18000124
+.long 0xD3D8406E, 0x18000125
+.long 0xD3D8406F, 0x18000126
+.long 0xD3D84070, 0x18000127
+.long 0xBF8C0F73
+.long 0x0AD2D228
+.long 0x0AD4D428
+.long 0xD3A00069, 0x15A6C229
+.long 0xD3A0106A, 0x15AAC229
+.long 0x7ED21569
+.long 0x7ED4156A
+.long 0xD2000069, 0x05A5216A
+.long 0x0AD6D628
+.long 0x0AD8D828
+.long 0xD3A0006B, 0x15AEC429
+.long 0xD3A0106C, 0x15B2C429
+.long 0x7ED6156B
+.long 0x7ED8156C
+.long 0xD200006A, 0x05AD216C
+.long 0xD3CC0030, 0x04C2590C
+.long 0xE0741000, 0x80056960
+.long 0xD3CC0030, 0x04C25D0E
+.long 0xBF8C0F73
+.long 0x0ADADA28
+.long 0x0ADCDC28
+.long 0xD3A0006D, 0x15B6C629
+.long 0xD3A0106E, 0x15BAC629
+.long 0x7EDA156D
+.long 0x7EDC156E
+.long 0xD200006B, 0x05B5216E
+.long 0x0ADEDE28
+.long 0x0AE0E028
+.long 0xD3A0006F, 0x15BEC829
+.long 0xD3A01070, 0x15C2C829
+.long 0x7EDE156F
+.long 0x7EE01570
+.long 0xD200006C, 0x05BD2170
+.long 0xD3CC0030, 0x04C29118
+.long 0xD3D84071, 0x18000128
+.long 0xD3D84072, 0x18000129
+.long 0xD3D84073, 0x1800012A
+.long 0xD3D84074, 0x1800012B
+.long 0xE0741010, 0x80056B60
+.long 0xD3CC0030, 0x04C2951A
+.long 0xBF8C0F73
+.long 0x0AE2E228
+.long 0x0AE4E428
+.long 0xD3A00071, 0x15C6CA29
+.long 0xD3A01072, 0x15CACA29
+.long 0x7EE21571
+.long 0x7EE41572
+.long 0xD200006D, 0x05C52172
+.long 0x0AE6E628
+.long 0x0AE8E828
+.long 0xD3A00073, 0x15CECC29
+.long 0xD3A01074, 0x15D2CC29
+.long 0x7EE61573
+.long 0x7EE81574
+.long 0xD200006E, 0x05CD2174
+.long 0xD3CC0030, 0x04C2991C
+.long 0xD3D84075, 0x1800012C
+.long 0xD3D84076, 0x1800012D
+.long 0xD3D84077, 0x1800012E
+.long 0xD3D84078, 0x1800012F
+.long 0xE0741020, 0x80056D60
+.long 0xD3CC0030, 0x04C29D1E
+.long 0xBF8C0F73
+.long 0x0AEAEA28
+.long 0x0AECEC28
+.long 0xD3A00075, 0x15D6CE29
+.long 0xD3A01076, 0x15DACE29
+.long 0x7EEA1575
+.long 0x7EEC1576
+.long 0xD200006F, 0x05D52176
+.long 0x0AEEEE28
+.long 0x0AF0F028
+.long 0xD3A00077, 0x15DED029
+.long 0xD3A01078, 0x15E2D029
+.long 0x7EEE1577
+.long 0x7EF01578
+.long 0xD2000070, 0x05DD2178
+.long 0xD3CC0040, 0x05026100
+.long 0xE0741030, 0x80056F60
+.long 0xD3CC0040, 0x05026502
+.long 0xE0541040, 0x80046160
+.long 0xE0541050, 0x80046360
+.long 0xE0541060, 0x80046560
+.long 0xE0541070, 0x80046760
+.long 0xD3D84069, 0x18000130
+.long 0xD3D8406A, 0x18000131
+.long 0xD3D8406B, 0x18000132
+.long 0xD3D8406C, 0x18000133
+.long 0xD3D8406D, 0x18000134
+.long 0xD3D8406E, 0x18000135
+.long 0xD3D8406F, 0x18000136
+.long 0xD3D84070, 0x18000137
+.long 0xBF8C0F73
+.long 0x0AD2D228
+.long 0x0AD4D428
+.long 0xD3A00069, 0x15A6C229
+.long 0xD3A0106A, 0x15AAC229
+.long 0x7ED21569
+.long 0x7ED4156A
+.long 0xD2000069, 0x05A5216A
+.long 0x0AD6D628
+.long 0x0AD8D828
+.long 0xD3A0006B, 0x15AEC429
+.long 0xD3A0106C, 0x15B2C429
+.long 0x7ED6156B
+.long 0x7ED8156C
+.long 0xD200006A, 0x05AD216C
+.long 0xD3CC0040, 0x05026904
+.long 0xE0741040, 0x80056960
+.long 0xD3CC0040, 0x05026D06
+.long 0xBF8C0F73
+.long 0x0ADADA28
+.long 0x0ADCDC28
+.long 0xD3A0006D, 0x15B6C629
+.long 0xD3A0106E, 0x15BAC629
+.long 0x7EDA156D
+.long 0x7EDC156E
+.long 0xD200006B, 0x05B5216E
+.long 0x0ADEDE28
+.long 0x0AE0E028
+.long 0xD3A0006F, 0x15BEC829
+.long 0xD3A01070, 0x15C2C829
+.long 0x7EDE156F
+.long 0x7EE01570
+.long 0xD200006C, 0x05BD2170
+.long 0xD3CC0040, 0x0502A110
+.long 0xD3D84071, 0x18000138
+.long 0xD3D84072, 0x18000139
+.long 0xD3D84073, 0x1800013A
+.long 0xD3D84074, 0x1800013B
+.long 0xE0741050, 0x80056B60
+.long 0xD3CC0040, 0x0502A512
+.long 0xBF8C0F73
+.long 0x0AE2E228
+.long 0x0AE4E428
+.long 0xD3A00071, 0x15C6CA29
+.long 0xD3A01072, 0x15CACA29
+.long 0x7EE21571
+.long 0x7EE41572
+.long 0xD200006D, 0x05C52172
+.long 0x0AE6E628
+.long 0x0AE8E828
+.long 0xD3A00073, 0x15CECC29
+.long 0xD3A01074, 0x15D2CC29
+.long 0x7EE61573
+.long 0x7EE81574
+.long 0xD200006E, 0x05CD2174
+.long 0xD3CC0040, 0x0502A914
+.long 0xD3D84075, 0x1800013C
+.long 0xD3D84076, 0x1800013D
+.long 0xD3D84077, 0x1800013E
+.long 0xD3D84078, 0x1800013F
+.long 0xE0741060, 0x80056D60
+.long 0xD3CC0040, 0x0502AD16
+.long 0xBF8C0F73
+.long 0x0AEAEA28
+.long 0x0AECEC28
+.long 0xD3A00075, 0x15D6CE29
+.long 0xD3A01076, 0x15DACE29
+.long 0x7EEA1575
+.long 0x7EEC1576
+.long 0xD200006F, 0x05D52176
+.long 0x0AEEEE28
+.long 0x0AF0F028
+.long 0xD3A00077, 0x15DED029
+.long 0xD3A01078, 0x15E2D029
+.long 0x7EEE1577
+.long 0x7EF01578
+.long 0xD2000070, 0x05DD2178
+.long 0xD3CC0050, 0x05426108
+.long 0xE0741070, 0x80056F60
+.long 0xD3CC0050, 0x0542650A
+.long 0xD1340060, 0x0000A960
+.long 0xE0541000, 0x80046160
+.long 0xE0541010, 0x80046360
+.long 0xE0541020, 0x80046560
+.long 0xE0541030, 0x80046760
+.long 0xD3D84069, 0x18000140
+.long 0xD3D8406A, 0x18000141
+.long 0xD3D8406B, 0x18000142
+.long 0xD3D8406C, 0x18000143
+.long 0xD3D8406D, 0x18000144
+.long 0xD3D8406E, 0x18000145
+.long 0xD3D8406F, 0x18000146
+.long 0xD3D84070, 0x18000147
+.long 0xBF8C0F73
+.long 0x0AD2D228
+.long 0x0AD4D428
+.long 0xD3A00069, 0x15A6C229
+.long 0xD3A0106A, 0x15AAC229
+.long 0x7ED21569
+.long 0x7ED4156A
+.long 0xD2000069, 0x05A5216A
+.long 0x0AD6D628
+.long 0x0AD8D828
+.long 0xD3A0006B, 0x15AEC429
+.long 0xD3A0106C, 0x15B2C429
+.long 0x7ED6156B
+.long 0x7ED8156C
+.long 0xD200006A, 0x05AD216C
+.long 0xD3CC0050, 0x0542690C
+.long 0xE0741000, 0x80056960
+.long 0xD3CC0050, 0x05426D0E
+.long 0xBF8C0F73
+.long 0x0ADADA28
+.long 0x0ADCDC28
+.long 0xD3A0006D, 0x15B6C629
+.long 0xD3A0106E, 0x15BAC629
+.long 0x7EDA156D
+.long 0x7EDC156E
+.long 0xD200006B, 0x05B5216E
+.long 0x0ADEDE28
+.long 0x0AE0E028
+.long 0xD3A0006F, 0x15BEC829
+.long 0xD3A01070, 0x15C2C829
+.long 0x7EDE156F
+.long 0x7EE01570
+.long 0xD200006C, 0x05BD2170
+.long 0xD3CC0050, 0x0542A118
+.long 0xD3D84071, 0x18000148
+.long 0xD3D84072, 0x18000149
+.long 0xD3D84073, 0x1800014A
+.long 0xD3D84074, 0x1800014B
+.long 0xE0741010, 0x80056B60
+.long 0xD3CC0050, 0x0542A51A
+.long 0xBF8C0F73
+.long 0x0AE2E228
+.long 0x0AE4E428
+.long 0xD3A00071, 0x15C6CA29
+.long 0xD3A01072, 0x15CACA29
+.long 0x7EE21571
+.long 0x7EE41572
+.long 0xD200006D, 0x05C52172
+.long 0x0AE6E628
+.long 0x0AE8E828
+.long 0xD3A00073, 0x15CECC29
+.long 0xD3A01074, 0x15D2CC29
+.long 0x7EE61573
+.long 0x7EE81574
+.long 0xD200006E, 0x05CD2174
+.long 0xD3CC0050, 0x0542A91C
+.long 0xD3D84075, 0x1800014C
+.long 0xD3D84076, 0x1800014D
+.long 0xD3D84077, 0x1800014E
+.long 0xD3D84078, 0x1800014F
+.long 0xE0741020, 0x80056D60
+.long 0xD3CC0050, 0x0542AD1E
+.long 0xBF8C0F73
+.long 0x0AEAEA28
+.long 0x0AECEC28
+.long 0xD3A00075, 0x15D6CE29
+.long 0xD3A01076, 0x15DACE29
+.long 0x7EEA1575
+.long 0x7EEC1576
+.long 0xD200006F, 0x05D52176
+.long 0x0AEEEE28
+.long 0x0AF0F028
+.long 0xD3A00077, 0x15DED029
+.long 0xD3A01078, 0x15E2D029
+.long 0x7EEE1577
+.long 0x7EF01578
+.long 0xD2000070, 0x05DD2178
+.long 0xD3CC0060, 0x05827100
+.long 0xE0741030, 0x80056F60
+.long 0xD3CC0060, 0x05827502
+.long 0xE0541040, 0x80046160
+.long 0xE0541050, 0x80046360
+.long 0xE0541060, 0x80046560
+.long 0xE0541070, 0x80046760
+.long 0xD3D84069, 0x18000150
+.long 0xD3D8406A, 0x18000151
+.long 0xD3D8406B, 0x18000152
+.long 0xD3D8406C, 0x18000153
+.long 0xD3D8406D, 0x18000154
+.long 0xD3D8406E, 0x18000155
+.long 0xD3D8406F, 0x18000156
+.long 0xD3D84070, 0x18000157
+.long 0xBF8C0F73
+.long 0x0AD2D228
+.long 0x0AD4D428
+.long 0xD3A00069, 0x15A6C229
+.long 0xD3A0106A, 0x15AAC229
+.long 0x7ED21569
+.long 0x7ED4156A
+.long 0xD2000069, 0x05A5216A
+.long 0x0AD6D628
+.long 0x0AD8D828
+.long 0xD3A0006B, 0x15AEC429
+.long 0xD3A0106C, 0x15B2C429
+.long 0x7ED6156B
+.long 0x7ED8156C
+.long 0xD200006A, 0x05AD216C
+.long 0xD3CC0060, 0x05827904
+.long 0xE0741040, 0x80056960
+.long 0xD3CC0060, 0x05827D06
+.long 0xBF8C0F73
+.long 0x0ADADA28
+.long 0x0ADCDC28
+.long 0xD3A0006D, 0x15B6C629
+.long 0xD3A0106E, 0x15BAC629
+.long 0x7EDA156D
+.long 0x7EDC156E
+.long 0xD200006B, 0x05B5216E
+.long 0x0ADEDE28
+.long 0x0AE0E028
+.long 0xD3A0006F, 0x15BEC829
+.long 0xD3A01070, 0x15C2C829
+.long 0x7EDE156F
+.long 0x7EE01570
+.long 0xD200006C, 0x05BD2170
+.long 0xD3CC0060, 0x0582B110
+.long 0xD3D84071, 0x18000158
+.long 0xD3D84072, 0x18000159
+.long 0xD3D84073, 0x1800015A
+.long 0xD3D84074, 0x1800015B
+.long 0xE0741050, 0x80056B60
+.long 0xD3CC0060, 0x0582B512
+.long 0xBF8C0F73
+.long 0x0AE2E228
+.long 0x0AE4E428
+.long 0xD3A00071, 0x15C6CA29
+.long 0xD3A01072, 0x15CACA29
+.long 0x7EE21571
+.long 0x7EE41572
+.long 0xD200006D, 0x05C52172
+.long 0x0AE6E628
+.long 0x0AE8E828
+.long 0xD3A00073, 0x15CECC29
+.long 0xD3A01074, 0x15D2CC29
+.long 0x7EE61573
+.long 0x7EE81574
+.long 0xD200006E, 0x05CD2174
+.long 0xD3CC0060, 0x0582B914
+.long 0xD3D84075, 0x1800015C
+.long 0xD3D84076, 0x1800015D
+.long 0xD3D84077, 0x1800015E
+.long 0xD3D84078, 0x1800015F
+.long 0xE0741060, 0x80056D60
+.long 0xD3CC0060, 0x0582BD16
+.long 0xBF8C0F73
+.long 0x0AEAEA28
+.long 0x0AECEC28
+.long 0xD3A00075, 0x15D6CE29
+.long 0xD3A01076, 0x15DACE29
+.long 0x7EEA1575
+.long 0x7EEC1576
+.long 0xD200006F, 0x05D52176
+.long 0x0AEEEE28
+.long 0x0AF0F028
+.long 0xD3A00077, 0x15DED029
+.long 0xD3A01078, 0x15E2D029
+.long 0x7EEE1577
+.long 0x7EF01578
+.long 0xD2000070, 0x05DD2178
+.long 0xD3CC0070, 0x05C27108
+.long 0xE0741070, 0x80056F60
+.long 0xD3CC0070, 0x05C2750A
+.long 0xD1340060, 0x0000A960
+.long 0xE0541000, 0x80046160
+.long 0xE0541010, 0x80046360
+.long 0xE0541020, 0x80046560
+.long 0xE0541030, 0x80046760
+.long 0xD3D84069, 0x18000160
+.long 0xD3D8406A, 0x18000161
+.long 0xD3D8406B, 0x18000162
+.long 0xD3D8406C, 0x18000163
+.long 0xD3D8406D, 0x18000164
+.long 0xD3D8406E, 0x18000165
+.long 0xD3D8406F, 0x18000166
+.long 0xD3D84070, 0x18000167
+.long 0xBF8C0F73
+.long 0x0AD2D228
+.long 0x0AD4D428
+.long 0xD3A00069, 0x15A6C229
+.long 0xD3A0106A, 0x15AAC229
+.long 0x7ED21569
+.long 0x7ED4156A
+.long 0xD2000069, 0x05A5216A
+.long 0x0AD6D628
+.long 0x0AD8D828
+.long 0xD3A0006B, 0x15AEC429
+.long 0xD3A0106C, 0x15B2C429
+.long 0x7ED6156B
+.long 0x7ED8156C
+.long 0xD200006A, 0x05AD216C
+.long 0xD3CC0070, 0x05C2790C
+.long 0xE0741000, 0x80056960
+.long 0xD3CC0070, 0x05C27D0E
+.long 0xBF8C0F73
+.long 0x0ADADA28
+.long 0x0ADCDC28
+.long 0xD3A0006D, 0x15B6C629
+.long 0xD3A0106E, 0x15BAC629
+.long 0x7EDA156D
+.long 0x7EDC156E
+.long 0xD200006B, 0x05B5216E
+.long 0x0ADEDE28
+.long 0x0AE0E028
+.long 0xD3A0006F, 0x15BEC829
+.long 0xD3A01070, 0x15C2C829
+.long 0x7EDE156F
+.long 0x7EE01570
+.long 0xD200006C, 0x05BD2170
+.long 0xD3CC0070, 0x05C2B118
+.long 0xD3D84071, 0x18000168
+.long 0xD3D84072, 0x18000169
+.long 0xD3D84073, 0x1800016A
+.long 0xD3D84074, 0x1800016B
+.long 0xE0741010, 0x80056B60
+.long 0xD3CC0070, 0x05C2B51A
+.long 0xBF8C0F73
+.long 0x0AE2E228
+.long 0x0AE4E428
+.long 0xD3A00071, 0x15C6CA29
+.long 0xD3A01072, 0x15CACA29
+.long 0x7EE21571
+.long 0x7EE41572
+.long 0xD200006D, 0x05C52172
+.long 0x0AE6E628
+.long 0x0AE8E828
+.long 0xD3A00073, 0x15CECC29
+.long 0xD3A01074, 0x15D2CC29
+.long 0x7EE61573
+.long 0x7EE81574
+.long 0xD200006E, 0x05CD2174
+.long 0xD3CC0070, 0x05C2B91C
+.long 0xD3D84075, 0x1800016C
+.long 0xD3D84076, 0x1800016D
+.long 0xD3D84077, 0x1800016E
+.long 0xD3D84078, 0x1800016F
+.long 0xE0741020, 0x80056D60
+.long 0xD3CC0070, 0x05C2BD1E
+.long 0xBF800007
+.long 0xBF8C0F73
+.long 0x0AEAEA28
+.long 0x0AECEC28
+.long 0xD3A00075, 0x15D6CE29
+.long 0xD3A01076, 0x15DACE29
+.long 0x7EEA1575
+.long 0x7EEC1576
+.long 0xD200006F, 0x05D52176
+.long 0x0AEEEE28
+.long 0x0AF0F028
+.long 0xD3A00077, 0x15DED029
+.long 0xD3A01078, 0x15E2D029
+.long 0x7EEE1577
+.long 0x7EF01578
+.long 0xD2000070, 0x05DD2178
+.long 0xE0741030, 0x80056F60
+.long 0xE0541040, 0x80046160
+.long 0xE0541050, 0x80046360
+.long 0xE0541060, 0x80046560
+.long 0xE0541070, 0x80046760
+.long 0xD3D84069, 0x18000170
+.long 0xD3D8406A, 0x18000171
+.long 0xD3D8406B, 0x18000172
+.long 0xD3D8406C, 0x18000173
+.long 0xD3D8406D, 0x18000174
+.long 0xD3D8406E, 0x18000175
+.long 0xD3D8406F, 0x18000176
+.long 0xD3D84070, 0x18000177
+.long 0xBF8C0F73
+.long 0x0AD2D228
+.long 0x0AD4D428
+.long 0xD3A00069, 0x15A6C229
+.long 0xD3A0106A, 0x15AAC229
+.long 0x7ED21569
+.long 0x7ED4156A
+.long 0xD2000069, 0x05A5216A
+.long 0x0AD6D628
+.long 0x0AD8D828
+.long 0xD3A0006B, 0x15AEC429
+.long 0xD3A0106C, 0x15B2C429
+.long 0x7ED6156B
+.long 0x7ED8156C
+.long 0xD200006A, 0x05AD216C
+.long 0xE0741040, 0x80056960
+.long 0xBF8C0F73
+.long 0x0ADADA28
+.long 0x0ADCDC28
+.long 0xD3A0006D, 0x15B6C629
+.long 0xD3A0106E, 0x15BAC629
+.long 0x7EDA156D
+.long 0x7EDC156E
+.long 0xD200006B, 0x05B5216E
+.long 0x0ADEDE28
+.long 0x0AE0E028
+.long 0xD3A0006F, 0x15BEC829
+.long 0xD3A01070, 0x15C2C829
+.long 0x7EDE156F
+.long 0x7EE01570
+.long 0xD200006C, 0x05BD2170
+.long 0xD3D84071, 0x18000178
+.long 0xD3D84072, 0x18000179
+.long 0xD3D84073, 0x1800017A
+.long 0xD3D84074, 0x1800017B
+.long 0xE0741050, 0x80056B60
+.long 0xBF8C0F73
+.long 0x0AE2E228
+.long 0x0AE4E428
+.long 0xD3A00071, 0x15C6CA29
+.long 0xD3A01072, 0x15CACA29
+.long 0x7EE21571
+.long 0x7EE41572
+.long 0xD200006D, 0x05C52172
+.long 0x0AE6E628
+.long 0x0AE8E828
+.long 0xD3A00073, 0x15CECC29
+.long 0xD3A01074, 0x15D2CC29
+.long 0x7EE61573
+.long 0x7EE81574
+.long 0xD200006E, 0x05CD2174
+.long 0xD3D84075, 0x1800017C
+.long 0xD3D84076, 0x1800017D
+.long 0xD3D84077, 0x1800017E
+.long 0xD3D84078, 0x1800017F
+.long 0xE0741060, 0x80056D60
+.long 0xBF8C0F73
+.long 0x0AEAEA28
+.long 0x0AECEC28
+.long 0xD3A00075, 0x15D6CE29
+.long 0xD3A01076, 0x15DACE29
+.long 0x7EEA1575
+.long 0x7EEC1576
+.long 0xD200006F, 0x05D52176
+.long 0x0AEEEE28
+.long 0x0AF0F028
+.long 0xD3A00077, 0x15DED029
+.long 0xD3A01078, 0x15E2D029
+.long 0x7EEE1577
+.long 0x7EF01578
+.long 0xD2000070, 0x05DD2178
+.long 0xE0741070, 0x80056F60
+.long 0xBF8C0000
+.long 0xBF810000

--- a/Tensile/ReplacementKernels/Cijk_Alik_Bljk_HBH_MT64x128x32_AF0EM8_ASEM8_FL0_GRVW4_ISA908_MDA2_PGR1_PLR1_SU32_TT4_4_VAW2_VW4_WG16_32_1_WGM8.s.txt
+++ b/Tensile/ReplacementKernels/Cijk_Alik_Bljk_HBH_MT64x128x32_AF0EM8_ASEM8_FL0_GRVW4_ISA908_MDA2_PGR1_PLR1_SU32_TT4_4_VAW2_VW4_WG16_32_1_WGM8.s.txt
@@ -1,0 +1,1026 @@
+
+
+/******************************************/
+/* Function Prefix                        */
+/******************************************/
+
+
+
+/******************************************/
+/* Begin Kernel                           */
+/******************************************/
+
+.hsa_code_object_version 2,0
+.hsa_code_object_isa 9, 0, 8, "AMD", "AMDGPU"
+.text
+.protected Cijk_Alik_Bljk_HBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT4_4_TLDS0_USFGROn1_VAW2_VS1_VW4_WSGRA0_WSGRB0_WG16_32_1_WGM8
+.globl Cijk_Alik_Bljk_HBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT4_4_TLDS0_USFGROn1_VAW2_VS1_VW4_WSGRA0_WSGRB0_WG16_32_1_WGM8
+.p2align 8
+.type Cijk_Alik_Bljk_HBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT4_4_TLDS0_USFGROn1_VAW2_VS1_VW4_WSGRA0_WSGRB0_WG16_32_1_WGM8,@function
+.amdgpu_hsa_kernel Cijk_Alik_Bljk_HBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT4_4_TLDS0_USFGROn1_VAW2_VS1_VW4_WSGRA0_WSGRB0_WG16_32_1_WGM8
+Cijk_Alik_Bljk_HBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT4_4_TLDS0_USFGROn1_VAW2_VS1_VW4_WSGRA0_WSGRB0_WG16_32_1_WGM8:
+.amd_kernel_code_t
+  is_ptr64 = 1
+  enable_sgpr_kernarg_segment_ptr = 1
+  kernarg_segment_byte_size = 148 // bytes of kern args
+  workitem_vgpr_count = 108 // vgprs
+  wavefront_sgpr_count = 98 // sgprs
+  compute_pgm_rsrc1_vgprs = 26 // floor((108-1)/4)
+  compute_pgm_rsrc1_sgprs = 12 // floor((98-1)/8)
+  compute_pgm_rsrc2_tidig_comp_cnt = 0 // 1D wg
+  compute_pgm_rsrc2_tgid_x_en = 1 // wg.x
+  compute_pgm_rsrc2_tgid_y_en = 1 // wg.y
+  compute_pgm_rsrc2_tgid_z_en = 1 // wg.z
+  workgroup_group_segment_byte_size = 30000// lds bytes
+  compute_pgm_rsrc2_user_sgpr = 2 // vcc
+  kernarg_segment_alignment = 4
+  group_segment_alignment = 4
+  private_segment_alignment = 4
+.end_amd_kernel_code_t
+
+/******************************************/
+/* Optimizations and Config:              */
+/******************************************/
+/* ThreadTile= 4 x 4 */
+/* SubGroup= 16 x 32 */
+/* VectorWidth=4 */
+/* GlobalLoadVectorWidthA=4, GlobalLoadVectorWidthB=4 */
+/* DirectToLdsA=False */
+/* DirectToLdsB=False */
+/* UseSgprForGRO=1 */
+.amd_amdgpu_hsa_metadata
+Version: [ 1, 0 ]
+Kernels:
+  - Name: Cijk_Alik_Bljk_HBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT4_4_TLDS0_USFGROn1_VAW2_VS1_VW4_WSGRA0_WSGRB0_WG16_32_1_WGM8
+    SymbolName: 'Cijk_Alik_Bljk_HBH_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT4_4_TLDS0_USFGROn1_VAW2_VS1_VW4_WSGRA0_WSGRB0_WG16_32_1_WGM8@kd'
+    Language: OpenCL C
+    LanguageVersion: [ 2, 0 ]
+    Args:
+      - Name:            sizeC
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            sizeA
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            sizeB
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            D
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       Struct
+        AddrSpaceQual:   Generic
+      - Name:            C
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       Struct
+        AddrSpaceQual:   Generic
+      - Name:            A
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       Struct
+        AddrSpaceQual:   Generic
+      - Name:            B
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       Struct
+        AddrSpaceQual:   Generic
+      - Name:            alpha
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       F16
+      - Name:            beta
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       F16
+      - Name:            strideD0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideD1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideC0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideC1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideA0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideA1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideB0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideB1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree2
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesSum0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            OrigStaggerUIter
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       I32
+      - Name:            NumWorkGroups0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            NumWorkGroups1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            MagicNumberProblemNumGroupTiles0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            GridNumWorkGroups0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            NumFullBlocks
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            WgmRemainder1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            MagicNumberWgmRemainder1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            padding
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+    CodeProps:
+      KernargSegmentSize: 148
+      GroupSegmentFixedSize: 28672
+      PrivateSegmentFixedSize: 0
+      KernargSegmentAlign:  8
+      WavefrontSize:        64
+      NumSGPRs:             98
+      NumVGPRs:             108
+      MaxFlatWorkGroupSize: 512
+.end_amd_amdgpu_hsa_metadata
+
+/******************************************/
+/* Asm syntax workarounds                 */
+/******************************************/
+.macro _v_add_co_u32 dst, cc, src0, src1, dpp=
+   v_add_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+
+.macro _v_add_u32 dst, src0, src1, dpp=
+   v_add_u32 \dst, \src0, \src1 \dpp
+.endm
+
+.macro _v_sub_co_u32 dst, cc, src0, src1, dpp=
+   v_sub_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+
+.macro _v_sub_u32 dst, src0, src1, dpp=
+   v_sub_u32 \dst, \src0, \src1 \dpp
+.endm
+
+.macro _v_addc_co_u32 dst, ccOut, src0, ccIn, src1, dpp=
+   v_addc_co_u32 \dst, \ccOut, \src0, \ccIn, \src1 \dpp
+.endm
+
+.macro _v_add_lshl_u32 dst, src0, src1, shiftCnt
+    v_add_lshl_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+.macro _v_lshl_add_u32 dst, src0, src1, shiftCnt
+    v_lshl_add_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+/******************************************/
+/* Magic div and mod functions            */
+/******************************************/
+.macro V_MAGIC_DIV dstIdx, dividend, magicNumber, magicShift
+    v_mul_hi_u32 v[\dstIdx+1], \dividend, \magicNumber
+    v_mul_lo_u32 v[\dstIdx+0], \dividend, \magicNumber
+    v_lshrrev_b64 v[\dstIdx:\dstIdx+1], \magicShift, v[\dstIdx:\dstIdx+1]
+.endm
+
+/******************************************/
+/* VGPR Assignments                       */
+/******************************************/
+.set vgprValuC, 0
+/* ValuA/B   Xn=PLR buffer idx,  In=InnerUnroll idx */
+.set vgprValuA_X0_I0, 32
+.set vgprValuA_X1_I0, 34
+.set vgprG2LA, 36
+.set vgprValuB_X0_I0, 40
+.set vgprValuB_X1_I0, 44
+.set vgprG2LB, 48
+.set vgprLocalWriteAddrA, 56
+.set vgprLocalWriteAddrB, 57
+.set vgprGlobalReadOffsetA, 58
+.set vgprGlobalReadOffsetB, 59
+.set vgprLocalReadAddrA, 60
+.set vgprLocalReadAddrB, 61
+.set vgprSerial, 62
+/* Num VGPR=63 */
+
+/******************************************/
+/* SGPR Assignments                       */
+/******************************************/
+.set sgprKernArgAddress, 0
+.set sgprWorkGroup0, 2
+.set sgprWorkGroup1, 3
+.set sgprWorkGroup2, 4
+.set sgprNumWorkGroups0, 5
+.set sgprNumWorkGroups1, 6
+.set sgprSrdA, 8
+.set sgprSrdB, 12
+.set sgprSrdD, 16
+.set sgprSrdC, 20
+.set sgprTensor2dSizeC, 24
+.set sgprTensor2dSizeA, 26
+.set sgprTensor2dSizeB, 28
+.set sgprSaveExecMask, 30
+.set sgprAddressD, 32
+.set sgprAddressC, 34
+.set sgprStridesD, 36
+.set sgprStridesC, 38
+.set sgprAlpha, 40
+.set sgprBeta, 41
+.set sgprSizesFree, 42
+.set sgprSizesSum, 45
+.set sgprLoopCounters, 46
+.set sgprOrigLoopCounter, 47
+.set sgprStridesA, 48
+.set sgprStridesB, 50
+.set sgprAddressA, 52
+.set sgprAddressB, 54
+.set sgprShadowLimitA, 56
+.set sgprShadowLimitB, 58
+.set sgprOrigStaggerUIter, 60
+.set sgprStaggerUIter, 61
+.set sgprWrapUA, 62
+.set sgprWrapUB, 64
+.set sgprNumFullBlocks, 66
+.set sgprWgmRemainder1, 67
+.set sgprMagicNumberWgmRemainder1, 68
+.set sgprGlobalReadIncsA, 69
+.set sgprGlobalReadIncsB, 70
+.set sgprScalarGlobalReadOffsetA, 71
+.set sgprScalarGlobalReadOffsetB, 72
+/* max SGPR=98 */
+
+/* Size Assignments */
+.set sgprSizeD0I, sgprSizesFree+0
+.set sgprSizeD1J, sgprSizesFree+1
+.set sgprSizeDK, sgprSizesFree+2
+.set sgprSizeC0I, sgprSizesFree+0
+.set sgprSizeC1J, sgprSizesFree+1
+.set sgprSizeCK, sgprSizesFree+2
+.set sgprSizeAL, sgprSizesSum+0
+.set sgprSizeA0I, sgprSizesFree+0
+.set sgprSizeAK, sgprSizesFree+2
+.set sgprSizeBL, sgprSizesSum+0
+.set sgprSizeB1J, sgprSizesFree+1
+.set sgprSizeBK, sgprSizesFree+2
+
+/* Stride Assignments */
+.set constStrideD0I, 1
+.set sgprStrideD1J, sgprStridesD+0
+.set sgprStrideDK, sgprStridesD+1
+.set constStrideC0I, 1
+.set sgprStrideC1J, sgprStridesC+0
+.set sgprStrideCK, sgprStridesC+1
+.set constStrideAL, 1
+.set sgprStrideA0I, sgprStridesA+0
+.set sgprStrideAK, sgprStridesA+1
+.set constStrideBL, 1
+.set sgprStrideB1J, sgprStridesB+0
+.set sgprStrideBK, sgprStridesB+1
+
+.set DepthU, 32
+/* Number of elements to shift-left SRD */
+.set SrdShiftLeftA, 4
+.set SrdShiftLeftB, 4
+/* 2GB limit - set offsets to -1 to exceed this and clamp */
+.set BufferLimit, 0x80000000
+/* Bits 127:96 of SRD.  Set DataFormat = 32 bit */
+.set Srd127_96, 0x0020000
+.set BufferOOB, 0x80000000
+
+/* Global Offset A */
+.macro GLOBAL_OFFSET_A vgprAddr vgprOffsetL vgprOffset0I vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStrideA0I], v[\vgprOffset0I] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprOffsetL], v[\vgprTmp+0] // accumulate d1 lower
+_v_add_u32 v[\vgprAddr+0], 0x4, v[\vgprAddr+0]     // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/* Global Offset B */
+.macro GLOBAL_OFFSET_B vgprAddr vgprOffsetL vgprOffset1J vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStrideB1J], v[\vgprOffset1J] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprOffsetL], v[\vgprTmp+0] // accumulate d1 lower
+_v_add_u32 v[\vgprAddr+0], 0x4, v[\vgprAddr+0]     // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/******************************************/
+/* Dynamic Scalar Divide: vQuotient=vDividend/vDivisor; vRemainder=vDividend%vDivisor; */
+/******************************************/
+.macro DYNAMIC_VECTOR_DIVIDE vQuotient vRemainder vDividend vDivisor vTmp0 vTmp1 sTmp
+v_cvt_f32_u32 v[\vQuotient], v[\vDivisor]          //
+v_rcp_f32 v[\vQuotient], v[\vQuotient]             //
+v_mul_f32 v[\vQuotient], 0x4f800000, v[\vQuotient] //
+v_cvt_u32_f32 v[\vQuotient], v[\vQuotient]         //
+v_mul_lo_u32 v[\vRemainder], v[\vDivisor], v[\vQuotient] //
+v_mul_hi_u32 v[\vTmp0], v[\vDivisor], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp1], vcc, 0x0, v[\vRemainder]  //
+v_cmp_ne_i32 s[\sTmp:\sTmp+1], 0x0, v[\vTmp0]      //
+v_cndmask_b32 v[\vRemainder], v[\vTmp1], v[\vRemainder], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vRemainder], v[\vRemainder], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vQuotient], v[\vRemainder] //
+_v_add_co_u32 v[\vQuotient], vcc, v[\vQuotient], v[\vRemainder] //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vTmp0], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vQuotient], v[\vQuotient], v[\vDividend] //
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vDividend], v[\vRemainder] //
+v_cmp_ge_u32 s[\sTmp:\sTmp+1], v[\vDividend], v[\vRemainder] //
+_v_add_co_u32 v[\vRemainder], vcc, 0x1, v[\vQuotient] //
+_v_add_co_u32 v[\vTmp1], vcc, -1, v[\vQuotient]    //
+v_cmp_le_u32 vcc, v[\vDivisor], v[\vTmp0]          //
+s_and_b64 vcc, s[\sTmp:\sTmp+1], vcc               //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vRemainder], vcc //
+v_cndmask_b32 v[\vQuotient], v[\vTmp1], v[\vQuotient], s[\sTmp:\sTmp+1] //
+v_cmp_ne_i32 vcc, 0x0, v[\vDivisor]                //
+v_cndmask_b32 v[\vQuotient], -1, v[\vQuotient], vcc // final result
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vRemainder], vcc, v[\vDividend], v[\vRemainder] // final result
+.endm
+
+/******************************************/
+/* 4x8 thread-tile                        */
+/******************************************/
+.macro MAC_4x8_X0
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[0] iui=0
+s_setprio 1 // Raise priority while processing macs
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[1]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[4]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[5]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[2] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[3]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[6]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[7]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[8] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[9]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[12]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[13]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[10] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[11]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[14]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[15]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[16] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[17]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[20]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[21]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[18] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[19]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[22]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[23]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[24] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[25]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[28]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[29]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[26] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[27]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[30]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[31]
+s_setprio 0 // Reset priority after macs
+.endm
+.macro MAC_4x8_X1
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[0] iui=0
+s_setprio 1 // Raise priority while processing macs
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[1]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[4]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[5]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[2] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[3]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[6]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[7]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[8] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[9]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[12]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[13]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[10] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[11]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[14]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[15]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[16] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[17]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[20]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[21]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[18] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[19]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[22]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[23]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[24] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[25]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[28]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[29]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[26] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[27]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[30]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[31]
+s_setprio 0 // Reset priority after macs
+.endm
+
+
+
+
+/***** program start from here *****/
+
+.long 0xC00A0D00, 0x00000028
+.long 0xC00A0C00, 0x00000050
+.long 0xC00A0600, 0x00000008
+.long 0xC0020B40, 0x0000006C
+.long 0xBEFC00FF, 0x00006600
+.long 0x7EC80300
+.long 0x26CA00BF
+.long 0x2004C886
+.long 0xB8D0F804
+.long 0xD1130004, 0x0000A0B0
+.long 0x20CC0884
+.long 0x7EA40566
+.long 0xD1130067, 0x0000A08F
+.long 0x7EA20567
+.long 0xBF068151
+.long 0xBF8400AD
+.long 0xBF8CC07F
+.long 0xBE880034
+.long 0xBE890035
+.long 0xBE8B00FF, 0x00020000
+.long 0xBE8A00FF, 0x80000000
+.long 0x9254C030
+.long 0x92545402
+.long 0x92559052
+.long 0x92533055
+.long 0x92553104
+.long 0x81545354
+.long 0x80545554
+.long 0x2000CA82
+.long 0xD2850004, 0x00020030
+.long 0x2602CA83
+.long 0x24020283
+.long 0x32A40304
+.long 0x68A4A454
+.long 0x24A4A481
+.long 0xBECC00FF, 0x00000440
+.long 0x924C4C52
+.long 0xBE8C0036
+.long 0xBE8D0037
+.long 0xBE8F00FF, 0x00020000
+.long 0xBE8E00FF, 0x80000000
+.long 0x9254FF32, 0x00000080
+.long 0x92545403
+.long 0x9255A052
+.long 0x92533255
+.long 0x92553304
+.long 0x81545354
+.long 0x80545554
+.long 0x2004CA82
+.long 0xD2850004, 0x00020432
+.long 0x2606CA83
+.long 0x24060683
+.long 0x32AC0704
+.long 0x68ACAC54
+.long 0x24ACAC81
+.long 0x8E4A8532
+.long 0x68AEAC4A
+.long 0xBECE00FF, 0x00000880
+.long 0x924E4E52
+.long 0x814EFF4E, 0x00002200
+.long 0x814DFF4C, 0x00001100
+.long 0x2498CA84
+.long 0x6898984C
+.long 0x249ACA84
+.long 0x689A9A4D
+.long 0x814FFF4E, 0x00002200
+.long 0x249CCA84
+.long 0x689C9C4E
+.long 0x249ECA84
+.long 0x689E9E4F
+.long 0x2002CA83
+.long 0xD2850001, 0x00020288
+.long 0x68989901
+.long 0x689A9B01
+.long 0x689C9D01
+.long 0x689E9F01
+.long 0xD1340054, 0x00018152
+.long 0xD1340058, 0x00018156
+.long 0xD1340059, 0x00018157
+.long 0xBF8A0000
+.long 0xE05C1000, 0x80022052
+.long 0xE05C1000, 0x80033056
+.long 0xE05C1000, 0x80033457
+.long 0xE05C1000, 0x80022854
+.long 0xE05C1000, 0x80033858
+.long 0xE05C1000, 0x80033C59
+.long 0x68A4A4FF, 0x00000080
+.long 0x68ACACFF, 0x00000080
+.long 0x68AEAEFF, 0x00000080
+.long 0x8F2E852D
+.long 0x80AE2E80
+.long 0xBF06C22E
+.long 0xBF850034
+.long 0xBF8C0F75
+.long 0xD9BE0000, 0x0000204C
+.long 0xBF8C0F73
+.long 0xD9BE0000, 0x0000304E
+.long 0xD9BE0440, 0x0000344E
+.long 0xBF8CC27F
+.long 0xE05C1000, 0x80022052
+.long 0xBF8CC17F
+.long 0xE05C1000, 0x80033056
+.long 0xBF8CC07F
+.long 0xE05C1000, 0x80033457
+.long 0xBF8F0001
+.long 0x68A4A4FF, 0x00000080
+.long 0x68ACACFF, 0x00000080
+.long 0x68AEAEFF, 0x00000080
+.long 0x68A8A8FF, 0x00000080
+.long 0x68B0B0FF, 0x00000080
+.long 0x68B2B2FF, 0x00000080
+.long 0xBF8F0000
+.long 0xBF8C0F75
+.long 0xD9BE0000, 0x0000284D
+.long 0xBF8C0F73
+.long 0xD9BE0000, 0x0000384F
+.long 0xD9BE0440, 0x00003C4F
+.long 0xBF8CC27F
+.long 0xE05C1000, 0x80022854
+.long 0xBF8CC07F
+.long 0xBF8A0000
+.long 0xE05C1000, 0x80033858
+.long 0xE05C1000, 0x80033C59
+.long 0xBF8A0000
+.long 0x802E822E
+.long 0xBF00C22E
+.long 0xBF84FFCC
+.long 0xBF8C0F75
+.long 0xD9BE0000, 0x0000204C
+.long 0xBF8C0F73
+.long 0xD9BE0000, 0x0000304E
+.long 0xD9BE0440, 0x0000344E
+.long 0xBF8C0F72
+.long 0xD9BE0000, 0x0000284D
+.long 0xBF8C0F70
+.long 0xD9BE0000, 0x0000384F
+.long 0xD9BE0440, 0x00003C4F
+.long 0xBF8CC07F
+.long 0xBF8A0000
+.long 0xBF810000
+.long 0xD3D94000, 0x18000080
+.long 0xD3D94001, 0x18000080
+.long 0xD3D94002, 0x18000080
+.long 0xD3D94003, 0x18000080
+.long 0xD3D94004, 0x18000080
+.long 0xD3D94005, 0x18000080
+.long 0xD3D94006, 0x18000080
+.long 0xD3D94007, 0x18000080
+.long 0xD3D94008, 0x18000080
+.long 0xD3D94009, 0x18000080
+.long 0xD3D9400A, 0x18000080
+.long 0xD3D9400B, 0x18000080
+.long 0xD3D9400C, 0x18000080
+.long 0xD3D9400D, 0x18000080
+.long 0xD3D9400E, 0x18000080
+.long 0xD3D9400F, 0x18000080
+.long 0xD3D94010, 0x18000080
+.long 0xD3D94011, 0x18000080
+.long 0xD3D94012, 0x18000080
+.long 0xD3D94013, 0x18000080
+.long 0xD3D94014, 0x18000080
+.long 0xD3D94015, 0x18000080
+.long 0xD3D94016, 0x18000080
+.long 0xD3D94017, 0x18000080
+.long 0xD3D94018, 0x18000080
+.long 0xD3D94019, 0x18000080
+.long 0xD3D9401A, 0x18000080
+.long 0xD3D9401B, 0x18000080
+.long 0xD3D9401C, 0x18000080
+.long 0xD3D9401D, 0x18000080
+.long 0xD3D9401E, 0x18000080
+.long 0xD3D9401F, 0x18000080
+.long 0xC0060700, 0x00000000
+.long 0xC00A0A00, 0x00000038
+.long 0xC00A0900, 0x00000040
+.long 0xC00A0800, 0x00000018
+.long 0xD1130001, 0x00013F65
+.long 0xD2850060, 0x000202A0
+.long 0x20040281
+.long 0xD2850002, 0x00020488
+.long 0x2002CA85
+.long 0x24020282
+.long 0x68C0C101
+.long 0x24C0C081
+.long 0x68C0C102
+.long 0x68C0C080
+.long 0x68C2C0FF, 0x00001100
+.long 0xBF8A0000
+.long 0xD1130001, 0x00013F65
+.long 0xD2850062, 0x000202A0
+.long 0x20040281
+.long 0xD2850002, 0x00020488
+.long 0x2002CA85
+.long 0x24020282
+.long 0x68C4C501
+.long 0x24C4C481
+.long 0x68C4C502
+.long 0x9254FF52, 0x00000880
+.long 0x68C4C454
+.long 0x68C4C4FF, 0x00002200
+.long 0x68C6C4FF, 0x00002200
+.long 0xBF8CC07F
+.long 0xBE900022
+.long 0xBE910023
+.long 0xBE9200FF, 0x80000000
+.long 0xBE9300FF, 0x00020000
+.long 0xBE940020
+.long 0xBE950021
+.long 0xBE9600FF, 0x80000000
+.long 0xBE9700FF, 0x00020000
+.long 0x925603FF, 0x00000080
+.long 0x96552656
+.long 0x92542656
+.long 0x8ED48154
+.long 0x80105410
+.long 0x82115511
+.long 0x80145414
+.long 0x82155515
+.long 0x96552704
+.long 0x92542704
+.long 0x8ED48154
+.long 0x80105410
+.long 0x82115511
+.long 0x80145414
+.long 0x82155515
+.long 0x24C8CC86
+.long 0x68C8C965
+.long 0xD2850004, 0x0002CCA0
+.long 0xD2850003, 0x00004D04
+.long 0x2608C89F
+.long 0xD2850005, 0x00004D04
+.long 0x2608C8BF
+.long 0x200C0885
+.long 0x240C0C82
+.long 0x68D60B03
+.long 0x925402C0
+.long 0x32D40C54
+.long 0xD1FE0068, 0x0206D76A
+.long 0x7ED40228
+.long 0x7ED4176A
+.long 0x7E50056A
+.long 0x7ED40229
+.long 0x7ED4176A
+.long 0x7E52056A
+.long 0xBF8A0000
+.long 0xD8EC0000, 0x20000060
+.long 0xD8EC0000, 0x40000062
+.long 0xD8EC0000, 0x30000061
+.long 0xD8EC0000, 0x48000063
+.long 0xBF8CC27F
+.long 0xD3CC0000, 0x04028120
+.long 0xD8EC0010, 0x22000060
+.long 0xD8EC0010, 0x42000062
+.long 0xD8EC0010, 0x32000061
+.long 0xD8EC0010, 0x4A000063
+.long 0xBF8CC47F
+.long 0xD3CC0000, 0x04029130
+.long 0xD8EC0020, 0x24000060
+.long 0xD8EC0020, 0x44000062
+.long 0xD8EC0020, 0x34000061
+.long 0xD8EC0020, 0x4C000063
+.long 0xE0541000, 0x80041068
+.long 0xE0541010, 0x80041268
+.long 0xBF8CC67F
+.long 0xD3CC0000, 0x04028522
+.long 0xD8EC0030, 0x26000060
+.long 0xD8EC0030, 0x46000062
+.long 0xD8EC0030, 0x36000061
+.long 0xD8EC0030, 0x4E000063
+.long 0xE0541020, 0x80041468
+.long 0xE0541030, 0x80041668
+.long 0xBF8CC87F
+.long 0xD3CC0000, 0x04029532
+.long 0xD8EC0880, 0x28000060
+.long 0xD8EC0880, 0x38000061
+.long 0xD8EC0890, 0x2A000060
+.long 0xD8EC0890, 0x3A000061
+.long 0xBF8CCA7F
+.long 0xD3CC0000, 0x04028924
+.long 0xD8EC08A0, 0x2C000060
+.long 0xD8EC08A0, 0x3C000061
+.long 0xD8EC08B0, 0x2E000060
+.long 0xD8EC08B0, 0x3E000061
+.long 0xBF8CCC7F
+.long 0xD3CC0000, 0x04029934
+.long 0xBF8CCE7F
+.long 0xD3CC0000, 0x04028D26
+.long 0xBF8CC07F
+.long 0xBF8A0000
+.long 0x8F2E852D
+.long 0x80AE2E80
+.long 0xBF06C22E
+.long 0xBF850064
+.long 0xD3CC0000, 0x04029D36
+.long 0xBF80000C
+.long 0xD3CC0010, 0x04428128
+.long 0xBF80000C
+.long 0xD3CC0010, 0x04429138
+.long 0xBF80000C
+.long 0xD3CC0010, 0x0442852A
+.long 0xBF80000C
+.long 0xD3CC0010, 0x0442953A
+.long 0xBF80000C
+.long 0xD3CC0010, 0x0442892C
+.long 0xBF80000C
+.long 0xD3CC0010, 0x0442993C
+.long 0xBF80000C
+.long 0xD3CC0010, 0x04428D2E
+.long 0xBF8A0000
+.long 0xD8EC0000, 0x20000060
+.long 0xD8EC0000, 0x40000062
+.long 0xD8EC0000, 0x30000061
+.long 0xD8EC0000, 0x48000063
+.long 0xD3CC0010, 0x04429D3E
+.long 0xD8EC0010, 0x22000060
+.long 0xD8EC0010, 0x42000062
+.long 0xD8EC0010, 0x32000061
+.long 0xD8EC0010, 0x4A000063
+.long 0xBF8CC67F
+.long 0xD3CC0000, 0x04028120
+.long 0xD8EC0020, 0x24000060
+.long 0xD8EC0020, 0x44000062
+.long 0xD8EC0020, 0x34000061
+.long 0xD8EC0020, 0x4C000063
+.long 0xBF8CC87F
+.long 0xD3CC0000, 0x04029130
+.long 0xD8EC0030, 0x26000060
+.long 0xD8EC0030, 0x46000062
+.long 0xD8EC0030, 0x36000061
+.long 0xD8EC0030, 0x4E000063
+.long 0xBF8CCA7F
+.long 0xD3CC0000, 0x04028522
+.long 0xD8EC0880, 0x28000060
+.long 0xD8EC0880, 0x38000061
+.long 0xD8EC0890, 0x2A000060
+.long 0xD8EC0890, 0x3A000061
+.long 0xBF8CCC7F
+.long 0xD3CC0000, 0x04029532
+.long 0xD8EC08A0, 0x2C000060
+.long 0xD8EC08A0, 0x3C000061
+.long 0xD8EC08B0, 0x2E000060
+.long 0xD8EC08B0, 0x3E000061
+.long 0xBF8CCE7F
+.long 0xD3CC0000, 0x04028924
+.long 0xBF80000C
+.long 0xBF8CCC7F
+.long 0xD3CC0000, 0x04029934
+.long 0xBF8CC07F
+.long 0xBF8A0000
+.long 0xD3CC0000, 0x04028D26
+.long 0x802E822E
+.long 0xBF00C22E
+.long 0xBF84FF9C
+.long 0xE0541040, 0x80041868
+.long 0xE0541050, 0x80041A68
+.long 0xD3CC0000, 0x04029D36
+.long 0xE0541060, 0x80041C68
+.long 0xE0541070, 0x80041E68
+.long 0xD3CC0010, 0x04428128
+.long 0xD3D84000, 0x18000100
+.long 0xD3D84001, 0x18000101
+.long 0xD3D84002, 0x18000102
+.long 0xD3D84003, 0x18000103
+.long 0xD3D84004, 0x18000104
+.long 0xD3D84005, 0x18000105
+.long 0xD3D84006, 0x18000106
+.long 0xD3D84007, 0x18000107
+.long 0xD3CC0010, 0x04429138
+.long 0xBF8C0F77
+.long 0x0A000028
+.long 0x0A020228
+.long 0xD3A00000, 0x14022029
+.long 0xD3A01001, 0x14062029
+.long 0x7E001500
+.long 0x7E021501
+.long 0xD2000000, 0x04012101
+.long 0x0A040428
+.long 0x0A060628
+.long 0xD3A00002, 0x140A2229
+.long 0xD3A01003, 0x140E2229
+.long 0x7E041502
+.long 0x7E061503
+.long 0xD2000001, 0x04092103
+.long 0xE0741000, 0x80050068
+.long 0xD3CC0010, 0x0442852A
+.long 0xBF8C0F77
+.long 0x0A080828
+.long 0x0A0A0A28
+.long 0xD3A00004, 0x14122429
+.long 0xD3A01005, 0x14162429
+.long 0x7E081504
+.long 0x7E0A1505
+.long 0xD2000002, 0x04112105
+.long 0x0A0C0C28
+.long 0x0A0E0E28
+.long 0xD3A00006, 0x141A2629
+.long 0xD3A01007, 0x141E2629
+.long 0x7E0C1506
+.long 0x7E0E1507
+.long 0xD2000003, 0x04192107
+.long 0xD3CC0010, 0x0442953A
+.long 0xE0741010, 0x80050268
+.long 0xD3CC0010, 0x0442892C
+.long 0xD3D84008, 0x18000108
+.long 0xD3D84009, 0x18000109
+.long 0xD3D8400A, 0x1800010A
+.long 0xD3D8400B, 0x1800010B
+.long 0xBF8C0F77
+.long 0x0A101028
+.long 0x0A121228
+.long 0xD3A00008, 0x14222829
+.long 0xD3A01009, 0x14262829
+.long 0x7E101508
+.long 0x7E121509
+.long 0xD2000004, 0x04212109
+.long 0x0A141428
+.long 0x0A161628
+.long 0xD3A0000A, 0x142A2A29
+.long 0xD3A0100B, 0x142E2A29
+.long 0x7E14150A
+.long 0x7E16150B
+.long 0xD2000005, 0x0429210B
+.long 0xD3CC0010, 0x0442993C
+.long 0xE0741020, 0x80050468
+.long 0xD3CC0010, 0x04428D2E
+.long 0xD3D8400C, 0x1800010C
+.long 0xD3D8400D, 0x1800010D
+.long 0xD3D8400E, 0x1800010E
+.long 0xD3D8400F, 0x1800010F
+.long 0xBF8C0F77
+.long 0x0A181828
+.long 0x0A1A1A28
+.long 0xD3A0000C, 0x14322C29
+.long 0xD3A0100D, 0x14362C29
+.long 0x7E18150C
+.long 0x7E1A150D
+.long 0xD2000006, 0x0431210D
+.long 0x0A1C1C28
+.long 0x0A1E1E28
+.long 0xD3A0000E, 0x143A2E29
+.long 0xD3A0100F, 0x143E2E29
+.long 0x7E1C150E
+.long 0x7E1E150F
+.long 0xD2000007, 0x0439210F
+.long 0xD3CC0010, 0x04429D3E
+.long 0xBF800008
+.long 0xE0741030, 0x80050668
+.long 0xD3D84000, 0x18000110
+.long 0xD3D84001, 0x18000111
+.long 0xD3D84002, 0x18000112
+.long 0xD3D84003, 0x18000113
+.long 0xD3D84004, 0x18000114
+.long 0xD3D84005, 0x18000115
+.long 0xD3D84006, 0x18000116
+.long 0xD3D84007, 0x18000117
+.long 0xBF8C0F77
+.long 0x0A000028
+.long 0x0A020228
+.long 0xD3A00000, 0x14023029
+.long 0xD3A01001, 0x14063029
+.long 0x7E001500
+.long 0x7E021501
+.long 0xD2000000, 0x04012101
+.long 0x0A040428
+.long 0x0A060628
+.long 0xD3A00002, 0x140A3229
+.long 0xD3A01003, 0x140E3229
+.long 0x7E041502
+.long 0x7E061503
+.long 0xD2000001, 0x04092103
+.long 0xE0741040, 0x80050068
+.long 0xBF8C0F77
+.long 0x0A080828
+.long 0x0A0A0A28
+.long 0xD3A00004, 0x14123429
+.long 0xD3A01005, 0x14163429
+.long 0x7E081504
+.long 0x7E0A1505
+.long 0xD2000002, 0x04112105
+.long 0x0A0C0C28
+.long 0x0A0E0E28
+.long 0xD3A00006, 0x141A3629
+.long 0xD3A01007, 0x141E3629
+.long 0x7E0C1506
+.long 0x7E0E1507
+.long 0xD2000003, 0x04192107
+.long 0xD3D84008, 0x18000118
+.long 0xD3D84009, 0x18000119
+.long 0xD3D8400A, 0x1800011A
+.long 0xD3D8400B, 0x1800011B
+.long 0xE0741050, 0x80050268
+.long 0xBF8C0F77
+.long 0x0A101028
+.long 0x0A121228
+.long 0xD3A00008, 0x14223829
+.long 0xD3A01009, 0x14263829
+.long 0x7E101508
+.long 0x7E121509
+.long 0xD2000004, 0x04212109
+.long 0x0A141428
+.long 0x0A161628
+.long 0xD3A0000A, 0x142A3A29
+.long 0xD3A0100B, 0x142E3A29
+.long 0x7E14150A
+.long 0x7E16150B
+.long 0xD2000005, 0x0429210B
+.long 0xD3D8400C, 0x1800011C
+.long 0xD3D8400D, 0x1800011D
+.long 0xD3D8400E, 0x1800011E
+.long 0xD3D8400F, 0x1800011F
+.long 0xE0741060, 0x80050468
+.long 0xBF8C0F77
+.long 0x0A181828
+.long 0x0A1A1A28
+.long 0xD3A0000C, 0x14323C29
+.long 0xD3A0100D, 0x14363C29
+.long 0x7E18150C
+.long 0x7E1A150D
+.long 0xD2000006, 0x0431210D
+.long 0x0A1C1C28
+.long 0x0A1E1E28
+.long 0xD3A0000E, 0x143A3E29
+.long 0xD3A0100F, 0x143E3E29
+.long 0x7E1C150E
+.long 0x7E1E150F
+.long 0xD2000007, 0x0439210F
+.long 0xE0741070, 0x80050668
+.long 0xBF8C0000
+.long 0xBF810000

--- a/Tensile/ReplacementKernels/Cijk_Alik_Bljk_SB_MT32x64x32_AF0EM8_ASEM8_FL0_GRVW2_ISA908_MDA2_PGR1_PLR1_SU32_TT2_2_VAW1_VW2_WG16_32_1_WGM8.s.txt
+++ b/Tensile/ReplacementKernels/Cijk_Alik_Bljk_SB_MT32x64x32_AF0EM8_ASEM8_FL0_GRVW2_ISA908_MDA2_PGR1_PLR1_SU32_TT2_2_VAW1_VW2_WG16_32_1_WGM8.s.txt
@@ -1,0 +1,909 @@
+
+
+/******************************************/
+/* Function Prefix                        */
+/******************************************/
+
+
+
+/******************************************/
+/* Begin Kernel                           */
+/******************************************/
+
+.hsa_code_object_version 2,0
+.hsa_code_object_isa 9, 0, 8, "AMD", "AMDGPU"
+.text
+.protected Cijk_Alik_Bljk_SB_MT32x64x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG16_32_1_WGM8
+.globl Cijk_Alik_Bljk_SB_MT32x64x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG16_32_1_WGM8
+.p2align 8
+.type Cijk_Alik_Bljk_SB_MT32x64x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG16_32_1_WGM8,@function
+.amdgpu_hsa_kernel Cijk_Alik_Bljk_SB_MT32x64x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG16_32_1_WGM8
+Cijk_Alik_Bljk_SB_MT32x64x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG16_32_1_WGM8:
+.amd_kernel_code_t
+  is_ptr64 = 1
+  enable_sgpr_kernarg_segment_ptr = 1
+  kernarg_segment_byte_size = 148 // bytes of kern args
+  workitem_vgpr_count = 108 // vgprs
+  wavefront_sgpr_count = 98 // sgprs
+  compute_pgm_rsrc1_vgprs = 26 // floor((108-1)/4)
+  compute_pgm_rsrc1_sgprs = 12 // floor((98-1)/8)
+  compute_pgm_rsrc2_tidig_comp_cnt = 0 // 1D wg
+  compute_pgm_rsrc2_tgid_x_en = 1 // wg.x
+  compute_pgm_rsrc2_tgid_y_en = 1 // wg.y
+  compute_pgm_rsrc2_tgid_z_en = 1 // wg.z
+  workgroup_group_segment_byte_size = 30000// lds bytes
+  compute_pgm_rsrc2_user_sgpr = 2 // vcc
+  kernarg_segment_alignment = 4
+  group_segment_alignment = 4
+  private_segment_alignment = 4
+.end_amd_kernel_code_t
+
+/******************************************/
+/* Optimizations and Config:              */
+/******************************************/
+/* ThreadTile= 4 x 4 */
+/* SubGroup= 16 x 32 */
+/* VectorWidth=4 */
+/* GlobalLoadVectorWidthA=4, GlobalLoadVectorWidthB=4 */
+/* DirectToLdsA=False */
+/* DirectToLdsB=False */
+/* UseSgprForGRO=1 */
+.amd_amdgpu_hsa_metadata
+Version: [ 1, 0 ]
+Kernels:
+  - Name: Cijk_Alik_Bljk_SB_MT32x64x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG16_32_1_WGM8
+    SymbolName: 'Cijk_Alik_Bljk_SB_MT32x64x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG16_32_1_WGM8@kd'
+    Language: OpenCL C
+    LanguageVersion: [ 2, 0 ]
+    Args:
+      - Name:            sizeC
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            sizeA
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            sizeB
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            D
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       F32
+        AddrSpaceQual:   Generic
+      - Name:            C
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       F32
+        AddrSpaceQual:   Generic
+      - Name:            A
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       F32
+        AddrSpaceQual:   Generic
+      - Name:            B
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       F32
+        AddrSpaceQual:   Generic
+      - Name:            alpha
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       F32
+      - Name:            beta
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       F32
+      - Name:            strideD0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideD1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideC0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideC1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideA0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideA1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideB0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideB1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree2
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesSum0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            OrigStaggerUIter
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       I32
+      - Name:            NumWorkGroups0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            NumWorkGroups1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            MagicNumberProblemNumGroupTiles0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            GridNumWorkGroups0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            NumFullBlocks
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            WgmRemainder1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            MagicNumberWgmRemainder1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            padding
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+    CodeProps:
+      KernargSegmentSize: 148
+      GroupSegmentFixedSize: 28672
+      PrivateSegmentFixedSize: 0
+      KernargSegmentAlign:  8
+      WavefrontSize:        64
+      NumSGPRs:             98
+      NumVGPRs:             108
+      MaxFlatWorkGroupSize: 512
+.end_amd_amdgpu_hsa_metadata
+
+/******************************************/
+/* Asm syntax workarounds                 */
+/******************************************/
+.macro _v_add_co_u32 dst, cc, src0, src1, dpp=
+   v_add_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+
+.macro _v_add_u32 dst, src0, src1, dpp=
+   v_add_u32 \dst, \src0, \src1 \dpp
+.endm
+
+.macro _v_sub_co_u32 dst, cc, src0, src1, dpp=
+   v_sub_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+
+.macro _v_sub_u32 dst, src0, src1, dpp=
+   v_sub_u32 \dst, \src0, \src1 \dpp
+.endm
+
+.macro _v_addc_co_u32 dst, ccOut, src0, ccIn, src1, dpp=
+   v_addc_co_u32 \dst, \ccOut, \src0, \ccIn, \src1 \dpp
+.endm
+
+.macro _v_add_lshl_u32 dst, src0, src1, shiftCnt
+    v_add_lshl_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+.macro _v_lshl_add_u32 dst, src0, src1, shiftCnt
+    v_lshl_add_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+/******************************************/
+/* Magic div and mod functions            */
+/******************************************/
+.macro V_MAGIC_DIV dstIdx, dividend, magicNumber, magicShift
+    v_mul_hi_u32 v[\dstIdx+1], \dividend, \magicNumber
+    v_mul_lo_u32 v[\dstIdx+0], \dividend, \magicNumber
+    v_lshrrev_b64 v[\dstIdx:\dstIdx+1], \magicShift, v[\dstIdx:\dstIdx+1]
+.endm
+
+/******************************************/
+/* VGPR Assignments                       */
+/******************************************/
+.set vgprValuC, 0
+/* ValuA/B   Xn=PLR buffer idx,  In=InnerUnroll idx */
+.set vgprValuA_X0_I0, 32
+.set vgprValuA_X1_I0, 34
+.set vgprG2LA, 36
+.set vgprValuB_X0_I0, 40
+.set vgprValuB_X1_I0, 44
+.set vgprG2LB, 48
+.set vgprLocalWriteAddrA, 56
+.set vgprLocalWriteAddrB, 57
+.set vgprGlobalReadOffsetA, 58
+.set vgprGlobalReadOffsetB, 59
+.set vgprLocalReadAddrA, 60
+.set vgprLocalReadAddrB, 61
+.set vgprSerial, 62
+/* Num VGPR=63 */
+
+/******************************************/
+/* SGPR Assignments                       */
+/******************************************/
+.set sgprKernArgAddress, 0
+.set sgprWorkGroup0, 2
+.set sgprWorkGroup1, 3
+.set sgprWorkGroup2, 4
+.set sgprNumWorkGroups0, 5
+.set sgprNumWorkGroups1, 6
+.set sgprSrdA, 8
+.set sgprSrdB, 12
+.set sgprSrdD, 16
+.set sgprSrdC, 20
+.set sgprTensor2dSizeC, 24
+.set sgprTensor2dSizeA, 26
+.set sgprTensor2dSizeB, 28
+.set sgprSaveExecMask, 30
+.set sgprAddressD, 32
+.set sgprAddressC, 34
+.set sgprStridesD, 36
+.set sgprStridesC, 38
+.set sgprAlpha, 40
+.set sgprBeta, 41
+.set sgprSizesFree, 42
+.set sgprSizesSum, 45
+.set sgprLoopCounters, 46
+.set sgprOrigLoopCounter, 47
+.set sgprStridesA, 48
+.set sgprStridesB, 50
+.set sgprAddressA, 52
+.set sgprAddressB, 54
+.set sgprShadowLimitA, 56
+.set sgprShadowLimitB, 58
+.set sgprOrigStaggerUIter, 60
+.set sgprStaggerUIter, 61
+.set sgprWrapUA, 62
+.set sgprWrapUB, 64
+.set sgprNumFullBlocks, 66
+.set sgprWgmRemainder1, 67
+.set sgprMagicNumberWgmRemainder1, 68
+.set sgprGlobalReadIncsA, 69
+.set sgprGlobalReadIncsB, 70
+.set sgprScalarGlobalReadOffsetA, 71
+.set sgprScalarGlobalReadOffsetB, 72
+/* max SGPR=98 */
+
+/* Size Assignments */
+.set sgprSizeD0I, sgprSizesFree+0
+.set sgprSizeD1J, sgprSizesFree+1
+.set sgprSizeDK, sgprSizesFree+2
+.set sgprSizeC0I, sgprSizesFree+0
+.set sgprSizeC1J, sgprSizesFree+1
+.set sgprSizeCK, sgprSizesFree+2
+.set sgprSizeAL, sgprSizesSum+0
+.set sgprSizeA0I, sgprSizesFree+0
+.set sgprSizeAK, sgprSizesFree+2
+.set sgprSizeBL, sgprSizesSum+0
+.set sgprSizeB1J, sgprSizesFree+1
+.set sgprSizeBK, sgprSizesFree+2
+
+/* Stride Assignments */
+.set constStrideD0I, 1
+.set sgprStrideD1J, sgprStridesD+0
+.set sgprStrideDK, sgprStridesD+1
+.set constStrideC0I, 1
+.set sgprStrideC1J, sgprStridesC+0
+.set sgprStrideCK, sgprStridesC+1
+.set constStrideAL, 1
+.set sgprStrideA0I, sgprStridesA+0
+.set sgprStrideAK, sgprStridesA+1
+.set constStrideBL, 1
+.set sgprStrideB1J, sgprStridesB+0
+.set sgprStrideBK, sgprStridesB+1
+
+.set DepthU, 32
+/* Number of elements to shift-left SRD */
+.set SrdShiftLeftA, 4
+.set SrdShiftLeftB, 4
+/* 2GB limit - set offsets to -1 to exceed this and clamp */
+.set BufferLimit, 0x80000000
+/* Bits 127:96 of SRD.  Set DataFormat = 32 bit */
+.set Srd127_96, 0x0020000
+.set BufferOOB, 0x80000000
+
+/* Global Offset A */
+.macro GLOBAL_OFFSET_A vgprAddr vgprOffsetL vgprOffset0I vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStrideA0I], v[\vgprOffset0I] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprOffsetL], v[\vgprTmp+0] // accumulate d1 lower
+_v_add_u32 v[\vgprAddr+0], 0x4, v[\vgprAddr+0]     // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/* Global Offset B */
+.macro GLOBAL_OFFSET_B vgprAddr vgprOffsetL vgprOffset1J vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStrideB1J], v[\vgprOffset1J] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprOffsetL], v[\vgprTmp+0] // accumulate d1 lower
+_v_add_u32 v[\vgprAddr+0], 0x4, v[\vgprAddr+0]     // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/******************************************/
+/* Dynamic Scalar Divide: vQuotient=vDividend/vDivisor; vRemainder=vDividend%vDivisor; */
+/******************************************/
+.macro DYNAMIC_VECTOR_DIVIDE vQuotient vRemainder vDividend vDivisor vTmp0 vTmp1 sTmp
+v_cvt_f32_u32 v[\vQuotient], v[\vDivisor]          //
+v_rcp_f32 v[\vQuotient], v[\vQuotient]             //
+v_mul_f32 v[\vQuotient], 0x4f800000, v[\vQuotient] //
+v_cvt_u32_f32 v[\vQuotient], v[\vQuotient]         //
+v_mul_lo_u32 v[\vRemainder], v[\vDivisor], v[\vQuotient] //
+v_mul_hi_u32 v[\vTmp0], v[\vDivisor], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp1], vcc, 0x0, v[\vRemainder]  //
+v_cmp_ne_i32 s[\sTmp:\sTmp+1], 0x0, v[\vTmp0]      //
+v_cndmask_b32 v[\vRemainder], v[\vTmp1], v[\vRemainder], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vRemainder], v[\vRemainder], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vQuotient], v[\vRemainder] //
+_v_add_co_u32 v[\vQuotient], vcc, v[\vQuotient], v[\vRemainder] //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vTmp0], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vQuotient], v[\vQuotient], v[\vDividend] //
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vDividend], v[\vRemainder] //
+v_cmp_ge_u32 s[\sTmp:\sTmp+1], v[\vDividend], v[\vRemainder] //
+_v_add_co_u32 v[\vRemainder], vcc, 0x1, v[\vQuotient] //
+_v_add_co_u32 v[\vTmp1], vcc, -1, v[\vQuotient]    //
+v_cmp_le_u32 vcc, v[\vDivisor], v[\vTmp0]          //
+s_and_b64 vcc, s[\sTmp:\sTmp+1], vcc               //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vRemainder], vcc //
+v_cndmask_b32 v[\vQuotient], v[\vTmp1], v[\vQuotient], s[\sTmp:\sTmp+1] //
+v_cmp_ne_i32 vcc, 0x0, v[\vDivisor]                //
+v_cndmask_b32 v[\vQuotient], -1, v[\vQuotient], vcc // final result
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vRemainder], vcc, v[\vDividend], v[\vRemainder] // final result
+.endm
+
+/******************************************/
+/* 4x8 thread-tile                        */
+/******************************************/
+.macro MAC_4x8_X0
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[0] iui=0
+s_setprio 1 // Raise priority while processing macs
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[1]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[4]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[5]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[2] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[3]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[6]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[7]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[8] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[9]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[12]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[13]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[10] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[11]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[14]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[15]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[16] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[17]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[20]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[21]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[18] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[19]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[22]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[23]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[24] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[25]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[28]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[29]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[26] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[27]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[30]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[31]
+s_setprio 0 // Reset priority after macs
+.endm
+.macro MAC_4x8_X1
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[0] iui=0
+s_setprio 1 // Raise priority while processing macs
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[1]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[4]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[5]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[2] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[3]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[6]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[7]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[8] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[9]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[12]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[13]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[10] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[11]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[14]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[15]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[16] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[17]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[20]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[21]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[18] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[19]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[22]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[23]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[24] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[25]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[28]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[29]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[26] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[27]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[30]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[31]
+s_setprio 0 // Reset priority after macs
+.endm
+
+
+
+
+/***** program start from here *****/
+
+.long 0xC00A0600, 0x00000008
+.long 0xC00A0D00, 0x00000028
+.long 0xC00A0C00, 0x00000050
+.long 0xC0020B40, 0x0000006C
+.long 0x7EC80300
+.long 0x26CA00BF
+.long 0xB8D0F804
+.long 0xD1130004, 0x0000A0B0
+.long 0x20CC0884
+.long 0x7EA40566
+.long 0xD1130067, 0x0000A08F
+.long 0x7EA20567
+.long 0xBF068151
+.long 0xBF8400EA
+.long 0xBF8CC07F
+.long 0xBE880034
+.long 0xBE890035
+.long 0xBE8A00FF, 0x80000000
+.long 0xBE8B00FF, 0x00020000
+.long 0x96553104
+.long 0x92543104
+.long 0x8ED48254
+.long 0x80085408
+.long 0x82095509
+.long 0x9254A030
+.long 0x92545402
+.long 0x92558830
+.long 0x92555552
+.long 0x81545554
+.long 0x2000CA85
+.long 0xD2850004, 0x00020030
+.long 0x2602CA9F
+.long 0x32A40304
+.long 0x68A4A454
+.long 0x24A4A482
+.long 0x8E478330
+.long 0x80C7FF47, 0x00000120
+.long 0x68A6A447
+.long 0x68A8A647
+.long 0x68AAA847
+.long 0xBECC00FF, 0x00000480
+.long 0x924C4C52
+.long 0xBE8C0036
+.long 0xBE8D0037
+.long 0xBE8E00FF, 0x80000000
+.long 0xBE8F00FF, 0x00020000
+.long 0x96553304
+.long 0x92543304
+.long 0x8ED48254
+.long 0x800C540C
+.long 0x820D550D
+.long 0x9254C032
+.long 0x92545403
+.long 0x92559032
+.long 0x92555552
+.long 0x81545554
+.long 0x2004CA85
+.long 0xD2850004, 0x00020432
+.long 0x2606CA9F
+.long 0x32AC0704
+.long 0x68ACAC54
+.long 0x24ACAC82
+.long 0x8E4A8332
+.long 0x80CAFF4A, 0x00000120
+.long 0x68AEAC4A
+.long 0x68B0AE4A
+.long 0x68B2B04A
+.long 0x68B4B24A
+.long 0x68B6B44A
+.long 0x68B8B64A
+.long 0x68BAB84A
+.long 0xBECE00FF, 0x00000900
+.long 0x924E4E52
+.long 0x814EFF4E, 0x00002400
+.long 0xBF8A0000
+.long 0xBEFC004C
+.long 0x814DFF4C, 0x00001200
+.long 0xE0511000, 0x80023052
+.long 0xE0511120, 0x80023153
+.long 0xE0511240, 0x80023254
+.long 0xE0511360, 0x80023355
+.long 0xBEFC004E
+.long 0x814FFF4E, 0x00002400
+.long 0xE0511000, 0x80034456
+.long 0xE0511120, 0x80034557
+.long 0xE0511240, 0x80034658
+.long 0xE0511360, 0x80034759
+.long 0xE0511480, 0x8003485A
+.long 0xE05115A0, 0x8003495B
+.long 0xE05116C0, 0x80034A5C
+.long 0xE05117E0, 0x80034B5D
+.long 0xBEFC004D
+.long 0x8008FF08, 0x00000080
+.long 0x82098009
+.long 0x800CFF0C, 0x00000080
+.long 0x820D800D
+.long 0xE0511000, 0x80023052
+.long 0xE0511120, 0x80023153
+.long 0xE0511240, 0x80023254
+.long 0xE0511360, 0x80023355
+.long 0xBEFC004F
+.long 0xBF800000
+.long 0xE0511000, 0x80034456
+.long 0xE0511120, 0x80034557
+.long 0xE0511240, 0x80034658
+.long 0xE0511360, 0x80034759
+.long 0xE0511480, 0x8003485A
+.long 0xE05115A0, 0x8003495B
+.long 0xE05116C0, 0x80034A5C
+.long 0xE05117E0, 0x80034B5D
+.long 0x8008FF08, 0x00000080
+.long 0x82098009
+.long 0x800CFF0C, 0x00000080
+.long 0x820D800D
+.long 0xBEFC004C
+.long 0xBF8C4F74
+.long 0xBF8A0000
+.long 0xBF8C0F7C
+.long 0xBF8A0000
+.long 0x8F2E852D
+.long 0x80AE2E80
+.long 0xBF03C22E
+.long 0xBF85004F
+.long 0xBF8A0000
+.long 0xE0511000, 0x80023052
+.long 0xE0511120, 0x80023153
+.long 0xE0511240, 0x80023254
+.long 0xE0511360, 0x80023355
+.long 0xBEFC004E
+.long 0xBF800000
+.long 0xE0511000, 0x80034456
+.long 0xE0511120, 0x80034557
+.long 0xE0511240, 0x80034658
+.long 0xE0511360, 0x80034759
+.long 0xE0511480, 0x8003485A
+.long 0xE05115A0, 0x8003495B
+.long 0xE05116C0, 0x80034A5C
+.long 0xE05117E0, 0x80034B5D
+.long 0xBF8C4F74
+.long 0xBF8A0000
+.long 0x8008FF08, 0x00000080
+.long 0x82098009
+.long 0xBF8C0F7C
+.long 0xBF8A0000
+.long 0x800CFF0C, 0x00000080
+.long 0x820D800D
+.long 0xBEFC004D
+.long 0xBF8A0000
+.long 0xE0511000, 0x80023052
+.long 0xE0511120, 0x80023153
+.long 0xE0511240, 0x80023254
+.long 0xE0511360, 0x80023355
+.long 0xBEFC004F
+.long 0xBF800000
+.long 0xE0511000, 0x80034456
+.long 0xE0511120, 0x80034557
+.long 0xE0511240, 0x80034658
+.long 0xE0511360, 0x80034759
+.long 0xE0511480, 0x8003485A
+.long 0xE05115A0, 0x8003495B
+.long 0xE05116C0, 0x80034A5C
+.long 0xE05117E0, 0x80034B5D
+.long 0xBF8C4F74
+.long 0xBF8A0000
+.long 0x8008FF08, 0x00000080
+.long 0x82098009
+.long 0xBF8C0F7C
+.long 0xBF8A0000
+.long 0x800CFF0C, 0x00000080
+.long 0x820D800D
+.long 0xBEFC004C
+.long 0x802E822E
+.long 0xBF03C22E
+.long 0xBF84FFB1
+.long 0xBF8C0F78
+.long 0xBF8A0000
+.long 0xBF8C0F70
+.long 0xBF8A0000
+.long 0xBF810000
+.long 0xC0060700, 0x00000000
+.long 0xC00A0800, 0x00000018
+.long 0xC00A0A00, 0x00000038
+.long 0xC00A0900, 0x00000040
+.long 0xD3D94000, 0x18000080
+.long 0xD3D94001, 0x18000080
+.long 0xD3D94002, 0x18000080
+.long 0xD3D94003, 0x18000080
+.long 0xD3D94004, 0x18000080
+.long 0xD3D94005, 0x18000080
+.long 0xD3D94006, 0x18000080
+.long 0xD3D94007, 0x18000080
+.long 0xD1130001, 0x00011F65
+.long 0xD285005E, 0x000202A0
+.long 0x20040281
+.long 0xD2850002, 0x000204A0
+.long 0x2002CA84
+.long 0x24020282
+.long 0x68BCBD01
+.long 0x24BCBC82
+.long 0x68BCBD02
+.long 0x68BCBC80
+.long 0x68BEBCFF, 0x00001200
+.long 0xBF8A0000
+.long 0xD1130001, 0x00011F65
+.long 0xD2850060, 0x000202A0
+.long 0x20040281
+.long 0xD2850002, 0x000204A0
+.long 0x2002CA84
+.long 0x24020282
+.long 0x68C0C101
+.long 0x24C0C082
+.long 0x68C0C102
+.long 0x9254FF52, 0x00000900
+.long 0x68C0C054
+.long 0x68C0C0FF, 0x00002400
+.long 0x68C2C0FF, 0x00002400
+.long 0xBF8CC07F
+.long 0xBE900022
+.long 0xBE910023
+.long 0xBE9200FF, 0x80000000
+.long 0xBE9300FF, 0x00020000
+.long 0x925603C0
+.long 0x96552656
+.long 0x92542656
+.long 0x8ED48254
+.long 0x80105410
+.long 0x82115511
+.long 0x96552704
+.long 0x92542704
+.long 0x8ED48254
+.long 0x80105410
+.long 0x82115511
+.long 0xD2850004, 0x0002CC90
+.long 0xD2850003, 0x00004D04
+.long 0x2608CA8F
+.long 0xD2850005, 0x00004D04
+.long 0x200CCA84
+.long 0x240C0C82
+.long 0x68D60B03
+.long 0x925402A0
+.long 0x32D40C54
+.long 0xD1FE0068, 0x020AD76A
+.long 0xBE940020
+.long 0xBE950021
+.long 0xBE9600FF, 0x80000000
+.long 0xBE9700FF, 0x00020000
+.long 0x925603C0
+.long 0x96552456
+.long 0x92542456
+.long 0x8ED48254
+.long 0x80145414
+.long 0x82155515
+.long 0x96552504
+.long 0x92542504
+.long 0x8ED48254
+.long 0x80145414
+.long 0x82155515
+.long 0xD2850004, 0x0002CC90
+.long 0xD2850003, 0x00004904
+.long 0x2608CA8F
+.long 0xD2850005, 0x00004904
+.long 0x200CCA84
+.long 0x240C0C82
+.long 0x68D60B03
+.long 0x925402A0
+.long 0x32D40C54
+.long 0xD1FE0069, 0x020AD76A
+.long 0xBF8A0000
+.long 0xD9FE0000, 0x2000005E
+.long 0xD9FE0900, 0x2800005E
+.long 0xD9FE0040, 0x2400005E
+.long 0xD9FE0940, 0x2C00005E
+.long 0xBF8A0000
+.long 0xD9FE0000, 0x44000060
+.long 0xD9FE0040, 0x48000060
+.long 0x8F2E852D
+.long 0x80AE2E80
+.long 0xBF03C22E
+.long 0xBF850065
+.long 0xBF8A0000
+.long 0xBF8CC17F
+.long 0xD3C50000, 0x04028920
+.long 0xD3C50004, 0x04128928
+.long 0xD3C50000, 0x04028B21
+.long 0xD3C50004, 0x04128B29
+.long 0xD3C50000, 0x04028D22
+.long 0xBF8A0000
+.long 0xD3C50004, 0x04128D2A
+.long 0xD9FE0000, 0x3000005F
+.long 0xD3C50000, 0x04028F23
+.long 0xD9FE0900, 0x3800005F
+.long 0xD3C50004, 0x04128F2B
+.long 0xD9FE0040, 0x3400005F
+.long 0xBF8CC37F
+.long 0xD3C50000, 0x04029124
+.long 0xD9FE0940, 0x3C00005F
+.long 0xD3C50004, 0x0412912C
+.long 0xD3C50000, 0x04029325
+.long 0xD3C50004, 0x0412932D
+.long 0xD3C50000, 0x04029526
+.long 0xD3C50004, 0x0412952E
+.long 0xBF8A0000
+.long 0xD9FE0000, 0x4C000061
+.long 0xD3C50000, 0x04029727
+.long 0xD9FE0040, 0x50000061
+.long 0xD3C50004, 0x0412972F
+.long 0xBF8A0000
+.long 0xBF8CC17F
+.long 0xD3C50000, 0x04029930
+.long 0xD3C50004, 0x04129938
+.long 0xD3C50000, 0x04029B31
+.long 0xD3C50004, 0x04129B39
+.long 0xD3C50000, 0x04029D32
+.long 0xBF8A0000
+.long 0xD3C50004, 0x04129D3A
+.long 0xD9FE0000, 0x2000005E
+.long 0xD3C50000, 0x04029F33
+.long 0xD9FE0900, 0x2800005E
+.long 0xD3C50004, 0x04129F3B
+.long 0xD9FE0040, 0x2400005E
+.long 0xBF8CC37F
+.long 0xD3C50000, 0x0402A134
+.long 0xD9FE0940, 0x2C00005E
+.long 0xD3C50004, 0x0412A13C
+.long 0xD3C50000, 0x0402A335
+.long 0xD3C50004, 0x0412A33D
+.long 0xD3C50000, 0x0402A536
+.long 0xD3C50004, 0x0412A53E
+.long 0xBF8A0000
+.long 0xD9FE0000, 0x44000060
+.long 0xD3C50000, 0x0402A737
+.long 0xD9FE0040, 0x48000060
+.long 0xD3C50004, 0x0412A73F
+.long 0x802E822E
+.long 0xBF03C22E
+.long 0xBF84FF9B
+.long 0xBF8CC17F
+.long 0xD3C50000, 0x04028920
+.long 0xE05C1000, 0x80041068
+.long 0xE05C1040, 0x80041468
+.long 0xD3C50004, 0x04128928
+.long 0xD3C50000, 0x04028B21
+.long 0xBF8A0000
+.long 0xD3C50004, 0x04128B29
+.long 0xD9FE0000, 0x3000005F
+.long 0xD3C50000, 0x04028D22
+.long 0xD9FE0900, 0x3800005F
+.long 0xD3C50004, 0x04128D2A
+.long 0xD9FE0040, 0x3400005F
+.long 0xD3C50000, 0x04028F23
+.long 0xD9FE0940, 0x3C00005F
+.long 0xD3C50004, 0x04128F2B
+.long 0xBF8CC37F
+.long 0xD3C50000, 0x04029124
+.long 0xD3C50004, 0x0412912C
+.long 0xD3C50000, 0x04029325
+.long 0xD3C50004, 0x0412932D
+.long 0xD3C50000, 0x04029526
+.long 0xBF8A0000
+.long 0xD9FE0000, 0x4C000061
+.long 0xD3C50004, 0x0412952E
+.long 0xD9FE0040, 0x50000061
+.long 0xD3C50000, 0x04029727
+.long 0xD3C50004, 0x0412972F
+.long 0xBF8CC17F
+.long 0xD3C50000, 0x04029930
+.long 0xD3C50004, 0x04129938
+.long 0xD3C50000, 0x04029B31
+.long 0xD3C50004, 0x04129B39
+.long 0xD3C50000, 0x04029D32
+.long 0xD3C50004, 0x04129D3A
+.long 0xD3C50000, 0x04029F33
+.long 0xD3C50004, 0x04129F3B
+.long 0xBF8CC07F
+.long 0xD3C50000, 0x0402A134
+.long 0xD3C50000, 0x0402A335
+.long 0xD3C50000, 0x0402A536
+.long 0xD3C50000, 0x0402A737
+.long 0xD3C50004, 0x0412A13C
+.long 0xD3C50004, 0x0412A33D
+.long 0xD3C50004, 0x0412A53E
+.long 0xD3C50004, 0x0412A73F
+.long 0xD3D84000, 0x18000100
+.long 0x0A000028
+.long 0xD3D84001, 0x18000101
+.long 0x0A020228
+.long 0xD3D84002, 0x18000102
+.long 0x0A040428
+.long 0xD3D84003, 0x18000103
+.long 0x0A060628
+.long 0xBF8C0F71
+.long 0xD1CB0000, 0x04005310
+.long 0xD1CB0001, 0x04045311
+.long 0xD1CB0002, 0x04085312
+.long 0xD1CB0003, 0x040C5313
+.long 0xE07C1000, 0x80050069
+.long 0xD3D84004, 0x18000104
+.long 0x0A080828
+.long 0xD3D84005, 0x18000105
+.long 0x0A0A0A28
+.long 0xD3D84006, 0x18000106
+.long 0x0A0C0C28
+.long 0xD3D84007, 0x18000107
+.long 0x0A0E0E28
+.long 0xBF8C0F71
+.long 0xD1CB0004, 0x04105314
+.long 0xD1CB0005, 0x04145315
+.long 0xD1CB0006, 0x04185316
+.long 0xD1CB0007, 0x041C5317
+.long 0xE07C1040, 0x80050469
+.long 0xBF8C0000
+.long 0xBF810000

--- a/Tensile/ReplacementKernels/Cijk_Alik_Bljk_SB_MT64x128x32_AF0EM8_ASEM8_FL0_GRVW4_ISA908_MDA2_PGR1_PLR1_SU32_TT4_4_VAW1_VW4_WG16_32_1_WGM8.s.txt
+++ b/Tensile/ReplacementKernels/Cijk_Alik_Bljk_SB_MT64x128x32_AF0EM8_ASEM8_FL0_GRVW4_ISA908_MDA2_PGR1_PLR1_SU32_TT4_4_VAW1_VW4_WG16_32_1_WGM8.s.txt
@@ -1,0 +1,1557 @@
+
+
+/******************************************/
+/* Function Prefix                        */
+/******************************************/
+
+
+
+/******************************************/
+/* Begin Kernel                           */
+/******************************************/
+
+.hsa_code_object_version 2,0
+.hsa_code_object_isa 9, 0, 8, "AMD", "AMDGPU"
+.text
+.protected Cijk_Alik_Bljk_SB_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT4_4_TLDS0_USFGRO1_VAW1_VS1_VW4_WSGRA0_WSGRB0_WG16_32_1_WGM8
+.globl Cijk_Alik_Bljk_SB_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT4_4_TLDS0_USFGRO1_VAW1_VS1_VW4_WSGRA0_WSGRB0_WG16_32_1_WGM8
+.p2align 8
+.type Cijk_Alik_Bljk_SB_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT4_4_TLDS0_USFGRO1_VAW1_VS1_VW4_WSGRA0_WSGRB0_WG16_32_1_WGM8,@function
+.amdgpu_hsa_kernel Cijk_Alik_Bljk_SB_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT4_4_TLDS0_USFGRO1_VAW1_VS1_VW4_WSGRA0_WSGRB0_WG16_32_1_WGM8
+Cijk_Alik_Bljk_SB_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT4_4_TLDS0_USFGRO1_VAW1_VS1_VW4_WSGRA0_WSGRB0_WG16_32_1_WGM8:
+.amd_kernel_code_t
+  is_ptr64 = 1
+  enable_sgpr_kernarg_segment_ptr = 1
+  kernarg_segment_byte_size = 148 // bytes of kern args
+  workitem_vgpr_count = 108 // vgprs
+  wavefront_sgpr_count = 98 // sgprs
+  compute_pgm_rsrc1_vgprs = 26 // floor((108-1)/4)
+  compute_pgm_rsrc1_sgprs = 12 // floor((98-1)/8)
+  compute_pgm_rsrc2_tidig_comp_cnt = 0 // 1D wg
+  compute_pgm_rsrc2_tgid_x_en = 1 // wg.x
+  compute_pgm_rsrc2_tgid_y_en = 1 // wg.y
+  compute_pgm_rsrc2_tgid_z_en = 1 // wg.z
+  workgroup_group_segment_byte_size = 60000// lds bytes
+  compute_pgm_rsrc2_user_sgpr = 2 // vcc
+  kernarg_segment_alignment = 4
+  group_segment_alignment = 4
+  private_segment_alignment = 4
+.end_amd_kernel_code_t
+
+/******************************************/
+/* Optimizations and Config:              */
+/******************************************/
+/* ThreadTile= 4 x 4 */
+/* SubGroup= 16 x 32 */
+/* VectorWidth=4 */
+/* GlobalLoadVectorWidthA=4, GlobalLoadVectorWidthB=4 */
+/* DirectToLdsA=False */
+/* DirectToLdsB=False */
+/* UseSgprForGRO=1 */
+.amd_amdgpu_hsa_metadata
+Version: [ 1, 0 ]
+Kernels:
+  - Name: Cijk_Alik_Bljk_SB_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT4_4_TLDS0_USFGRO1_VAW1_VS1_VW4_WSGRA0_WSGRB0_WG16_32_1_WGM8
+    SymbolName: 'Cijk_Alik_Bljk_SB_MT64x128x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW4_GSU1_ISA908_IU1_K1_KLA_LBSPP0_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT4_4_TLDS0_USFGRO1_VAW1_VS1_VW4_WSGRA0_WSGRB0_WG16_32_1_WGM8@kd'
+    Language: OpenCL C
+    LanguageVersion: [ 2, 0 ]
+    Args:
+      - Name:            sizeC
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            sizeA
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            sizeB
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            D
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       F32
+        AddrSpaceQual:   Generic
+      - Name:            C
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       F32
+        AddrSpaceQual:   Generic
+      - Name:            A
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       F32
+        AddrSpaceQual:   Generic
+      - Name:            B
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       F32
+        AddrSpaceQual:   Generic
+      - Name:            alpha
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       F32
+      - Name:            beta
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       F32
+      - Name:            strideD0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideD1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideC0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideC1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideA0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideA1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideB0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideB1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree2
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesSum0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            OrigStaggerUIter
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       I32
+      - Name:            NumWorkGroups0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            NumWorkGroups1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            MagicNumberProblemNumGroupTiles0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            GridNumWorkGroups0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            NumFullBlocks
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            WgmRemainder1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            MagicNumberWgmRemainder1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            padding
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+    CodeProps:
+      KernargSegmentSize: 148
+      GroupSegmentFixedSize: 60000
+      PrivateSegmentFixedSize: 0
+      KernargSegmentAlign:  8
+      WavefrontSize:        64
+      NumSGPRs:             98
+      NumVGPRs:             108
+      MaxFlatWorkGroupSize: 512
+.end_amd_amdgpu_hsa_metadata
+
+/******************************************/
+/* Asm syntax workarounds                 */
+/******************************************/
+.macro _v_add_co_u32 dst, cc, src0, src1, dpp=
+   v_add_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+
+.macro _v_add_u32 dst, src0, src1, dpp=
+   v_add_u32 \dst, \src0, \src1 \dpp
+.endm
+
+.macro _v_sub_co_u32 dst, cc, src0, src1, dpp=
+   v_sub_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+
+.macro _v_sub_u32 dst, src0, src1, dpp=
+   v_sub_u32 \dst, \src0, \src1 \dpp
+.endm
+
+.macro _v_addc_co_u32 dst, ccOut, src0, ccIn, src1, dpp=
+   v_addc_co_u32 \dst, \ccOut, \src0, \ccIn, \src1 \dpp
+.endm
+
+.macro _v_add_lshl_u32 dst, src0, src1, shiftCnt
+    v_add_lshl_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+.macro _v_lshl_add_u32 dst, src0, src1, shiftCnt
+    v_lshl_add_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+/******************************************/
+/* Magic div and mod functions            */
+/******************************************/
+.macro V_MAGIC_DIV dstIdx, dividend, magicNumber, magicShift
+    v_mul_hi_u32 v[\dstIdx+1], \dividend, \magicNumber
+    v_mul_lo_u32 v[\dstIdx+0], \dividend, \magicNumber
+    v_lshrrev_b64 v[\dstIdx:\dstIdx+1], \magicShift, v[\dstIdx:\dstIdx+1]
+.endm
+
+/******************************************/
+/* VGPR Assignments                       */
+/******************************************/
+.set vgprValuC, 0
+/* ValuA/B   Xn=PLR buffer idx,  In=InnerUnroll idx */
+.set vgprValuA_X0_I0, 32
+.set vgprValuA_X1_I0, 36
+.set vgprG2LA, 40
+.set vgprValuB_X0_I0, 48
+.set vgprValuB_X1_I0, 56
+.set vgprG2LB, 64
+.set vgprLocalWriteAddrA, 80
+.set vgprLocalWriteAddrB, 81
+.set vgprGlobalReadOffsetA, 82
+.set vgprGlobalReadOffsetB, 83
+.set vgprLocalReadAddrA, 84
+.set vgprLocalReadAddrB, 85
+.set vgprSerial, 86
+/* Num VGPR=87 */
+
+/******************************************/
+/* SGPR Assignments                       */
+/******************************************/
+.set sgprKernArgAddress, 0
+.set sgprWorkGroup0, 2
+.set sgprWorkGroup1, 3
+.set sgprWorkGroup2, 4
+.set sgprNumWorkGroups0, 5
+.set sgprNumWorkGroups1, 6
+.set sgprSrdA, 8
+.set sgprSrdB, 12
+.set sgprSrdD, 16
+.set sgprSrdC, 20
+.set sgprTensor2dSizeC, 24
+.set sgprTensor2dSizeA, 26
+.set sgprTensor2dSizeB, 28
+.set sgprSaveExecMask, 30
+.set sgprAddressD, 32
+.set sgprAddressC, 34
+.set sgprStridesD, 36
+.set sgprStridesC, 38
+.set sgprAlpha, 40
+.set sgprBeta, 41
+.set sgprSizesFree, 42
+.set sgprSizesSum, 45
+.set sgprLoopCounters, 46
+.set sgprOrigLoopCounter, 47
+.set sgprStridesA, 48
+.set sgprStridesB, 50
+.set sgprAddressA, 52
+.set sgprAddressB, 54
+.set sgprShadowLimitA, 56
+.set sgprShadowLimitB, 58
+.set sgprOrigStaggerUIter, 60
+.set sgprStaggerUIter, 61
+.set sgprWrapUA, 62
+.set sgprWrapUB, 64
+.set sgprNumFullBlocks, 66
+.set sgprWgmRemainder1, 67
+.set sgprMagicNumberWgmRemainder1, 68
+.set sgprGlobalReadIncsA, 69
+.set sgprGlobalReadIncsB, 70
+.set sgprScalarGlobalReadOffsetA, 71
+.set sgprScalarGlobalReadOffsetB, 72
+/* max SGPR=98 */
+
+/* Size Assignments */
+.set sgprSizeD0I, sgprSizesFree+0
+.set sgprSizeD1J, sgprSizesFree+1
+.set sgprSizeDK, sgprSizesFree+2
+.set sgprSizeC0I, sgprSizesFree+0
+.set sgprSizeC1J, sgprSizesFree+1
+.set sgprSizeCK, sgprSizesFree+2
+.set sgprSizeAL, sgprSizesSum+0
+.set sgprSizeA0I, sgprSizesFree+0
+.set sgprSizeAK, sgprSizesFree+2
+.set sgprSizeBL, sgprSizesSum+0
+.set sgprSizeB1J, sgprSizesFree+1
+.set sgprSizeBK, sgprSizesFree+2
+
+/* Stride Assignments */
+.set constStrideD0I, 1
+.set sgprStrideD1J, sgprStridesD+0
+.set sgprStrideDK, sgprStridesD+1
+.set constStrideC0I, 1
+.set sgprStrideC1J, sgprStridesC+0
+.set sgprStrideCK, sgprStridesC+1
+.set constStrideAL, 1
+.set sgprStrideA0I, sgprStridesA+0
+.set sgprStrideAK, sgprStridesA+1
+.set constStrideBL, 1
+.set sgprStrideB1J, sgprStridesB+0
+.set sgprStrideBK, sgprStridesB+1
+
+.set DepthU, 32
+/* Number of elements to shift-left SRD */
+.set SrdShiftLeftA, 4
+.set SrdShiftLeftB, 4
+/* 2GB limit - set offsets to -1 to exceed this and clamp */
+.set BufferLimit, 0x80000000
+/* Bits 127:96 of SRD.  Set DataFormat = 32 bit */
+.set Srd127_96, 0x0020000
+.set BufferOOB, 0x80000000
+
+
+
+
+
+.long 0xC00A0D00, 0x00000028
+.long 0xC00A0C00, 0x00000050
+.long 0xC00A0600, 0x00000008
+.long 0xC0020B40, 0x0000006C
+.long 0xBEFC00FF, 0x00006000
+.long 0x7EC80300
+.long 0x26CA00BF
+.long 0x2004C886
+.long 0xB8D0F804
+.long 0xD1130004, 0x0000A0B0
+.long 0x20CC0884
+.long 0x7EA40566
+.long 0xD1130067, 0x0000A08F
+.long 0x7EA20567
+.long 0xBF068151
+.long 0xBF840212
+.long 0xBF8CC07F
+.long 0xBE880034
+.long 0xBE890035
+.long 0xBE8B00FF, 0x00020000
+.long 0x80B85418
+.long 0x80B95518
+.long 0x8EB88238
+.long 0x80388438
+.long 0x82398039
+.long 0xBF068039
+.long 0x850AFF38, 0x80000000
+.long 0xBE8A00FF, 0x80000000
+.long 0x9254C030
+.long 0x92545402
+.long 0x8E558452
+.long 0x92533055
+.long 0x92553104
+.long 0x81545354
+.long 0x80545554
+.long 0x2000CA85
+.long 0xD2850004, 0x00020030
+.long 0x2602CA9F
+.long 0x32A40304
+.long 0x68A4A454
+.long 0x24A4A482
+.long 0x8E478330
+.long 0x80C7FF47, 0x00000108
+.long 0x68A6A447
+.long 0x68A8A647
+.long 0x68AAA847
+.long 0x68ACAA47
+.long 0x68AEAC47
+.long 0x68B0AE47
+.long 0x68B2B047
+.long 0xBECC00FF, 0x00000840
+.long 0x924C4C52
+.long 0xBE8C0036
+.long 0xBE8D0037
+.long 0xBE8F00FF, 0x00020000
+.long 0x80BA541A
+.long 0x80BB551A
+.long 0x8EBA823A
+.long 0x803A843A
+.long 0x823B803B
+.long 0xBF06803B
+.long 0x850EFF3A, 0x80000000
+.long 0xBE8E00FF, 0x80000000
+.long 0x9254FF32, 0x00000080
+.long 0x92545403
+.long 0x925532A0
+.long 0x92555552
+.long 0x81545554
+.long 0x92553304
+.long 0x80545554
+.long 0x2004CA85
+.long 0x2606CA9F
+.long 0xD2850004, 0x00020432
+.long 0x32400704
+.long 0x68404054
+.long 0x24404082
+.long 0x8E4A8332
+.long 0x80CAFF4A, 0x00000108
+.long 0x6842404A
+.long 0x6844424A
+.long 0x6846444A
+.long 0x6848464A
+.long 0x684A484A
+.long 0x684C4A4A
+.long 0x684E4C4A
+.long 0x68504E4A
+.long 0x6852504A
+.long 0x6854524A
+.long 0x6856544A
+.long 0x6858564A
+.long 0x685A584A
+.long 0x685C5A4A
+.long 0x685E5C4A
+.long 0xBECE00FF, 0x00001080
+.long 0x924E4E52
+.long 0x814EFF4E, 0x00004200
+.long 0xBF8A0000
+.long 0xBEFC004C
+.long 0x814DFF4C, 0x00002100
+.long 0xE0511000, 0x80023052
+.long 0xE0511108, 0x80023153
+.long 0xE0511210, 0x80023254
+.long 0xE0511318, 0x80023355
+.long 0xE0511420, 0x80023456
+.long 0xE0511528, 0x80023557
+.long 0xE0511630, 0x80023658
+.long 0xE0511738, 0x80023759
+.long 0xBEFC004E
+.long 0x814FFF4E, 0x00004200
+.long 0xE0511000, 0x80033020
+.long 0xE0511108, 0x80033121
+.long 0xE0511210, 0x80033222
+.long 0xE0511318, 0x80033323
+.long 0xE0511420, 0x80033424
+.long 0xE0511528, 0x80033525
+.long 0xE0511630, 0x80033626
+.long 0xE0511738, 0x80033727
+.long 0xE0511840, 0x80033828
+.long 0xE0511948, 0x80033929
+.long 0xE0511A50, 0x80033A2A
+.long 0xE0511B58, 0x80033B2B
+.long 0xE0511C60, 0x80033C2C
+.long 0xE0511D68, 0x80033D2D
+.long 0xE0511E70, 0x80033E2E
+.long 0xE0511F78, 0x80033F2F
+.long 0xBEFC004D
+.long 0x68A4A4FF, 0x00000080
+.long 0x68A6A6FF, 0x00000080
+.long 0x68A8A8FF, 0x00000080
+.long 0x68AAAAFF, 0x00000080
+.long 0x68ACACFF, 0x00000080
+.long 0x68AEAEFF, 0x00000080
+.long 0x68B0B0FF, 0x00000080
+.long 0x68B2B2FF, 0x00000080
+.long 0x684040FF, 0x00000080
+.long 0x684242FF, 0x00000080
+.long 0x684444FF, 0x00000080
+.long 0x684646FF, 0x00000080
+.long 0x684848FF, 0x00000080
+.long 0x684A4AFF, 0x00000080
+.long 0x684C4CFF, 0x00000080
+.long 0x684E4EFF, 0x00000080
+.long 0x685050FF, 0x00000080
+.long 0x685252FF, 0x00000080
+.long 0x685454FF, 0x00000080
+.long 0x685656FF, 0x00000080
+.long 0x685858FF, 0x00000080
+.long 0x685A5AFF, 0x00000080
+.long 0x685C5CFF, 0x00000080
+.long 0x685E5EFF, 0x00000080
+.long 0xE0511000, 0x80023052
+.long 0xE0511108, 0x80023153
+.long 0xE0511210, 0x80023254
+.long 0xE0511318, 0x80023355
+.long 0xE0511420, 0x80023456
+.long 0xE0511528, 0x80023557
+.long 0xE0511630, 0x80023658
+.long 0xE0511738, 0x80023759
+.long 0xBEFC004F
+.long 0xBF800000
+.long 0xE0511000, 0x80033020
+.long 0xE0511108, 0x80033121
+.long 0xE0511210, 0x80033222
+.long 0xE0511318, 0x80033323
+.long 0xE0511420, 0x80033424
+.long 0xE0511528, 0x80033525
+.long 0xE0511630, 0x80033626
+.long 0xE0511738, 0x80033727
+.long 0xE0511840, 0x80033828
+.long 0xE0511948, 0x80033929
+.long 0xE0511A50, 0x80033A2A
+.long 0xE0511B58, 0x80033B2B
+.long 0xE0511C60, 0x80033C2C
+.long 0xE0511D68, 0x80033D2D
+.long 0xE0511E70, 0x80033E2E
+.long 0xE0511F78, 0x80033F2F
+.long 0x68A4A4FF, 0x00000080
+.long 0x68A6A6FF, 0x00000080
+.long 0x68A8A8FF, 0x00000080
+.long 0x68AAAAFF, 0x00000080
+.long 0x68ACACFF, 0x00000080
+.long 0x68AEAEFF, 0x00000080
+.long 0x68B0B0FF, 0x00000080
+.long 0x68B2B2FF, 0x00000080
+.long 0x684040FF, 0x00000080
+.long 0x684242FF, 0x00000080
+.long 0x684444FF, 0x00000080
+.long 0x684646FF, 0x00000080
+.long 0x684848FF, 0x00000080
+.long 0x684A4AFF, 0x00000080
+.long 0x684C4CFF, 0x00000080
+.long 0x684E4EFF, 0x00000080
+.long 0x685050FF, 0x00000080
+.long 0x685252FF, 0x00000080
+.long 0x685454FF, 0x00000080
+.long 0x685656FF, 0x00000080
+.long 0x685858FF, 0x00000080
+.long 0x685A5AFF, 0x00000080
+.long 0x685C5CFF, 0x00000080
+.long 0x685E5EFF, 0x00000080
+.long 0xBEFC004C
+.long 0xBF8C8F78
+.long 0xBF8A0000
+.long 0xBF8C4F78
+.long 0xBF8A0000
+.long 0x8F2E852D
+.long 0x80AE2E80
+.long 0xBF06802E
+.long 0xBF8500DC
+.long 0xBF8A0000
+.long 0xE0511000, 0x80023052
+.long 0xE0511108, 0x80023153
+.long 0xE0511210, 0x80023254
+.long 0xE0511318, 0x80023355
+.long 0xE0511420, 0x80023456
+.long 0xE0511528, 0x80023557
+.long 0xE0511630, 0x80023658
+.long 0xE0511738, 0x80023759
+.long 0xBEFC004E
+.long 0xBF800000
+.long 0xE0511000, 0x80033020
+.long 0xE0511108, 0x80033121
+.long 0xE0511210, 0x80033222
+.long 0xE0511318, 0x80033323
+.long 0xE0511420, 0x80033424
+.long 0xE0511528, 0x80033525
+.long 0xE0511630, 0x80033626
+.long 0xE0511738, 0x80033727
+.long 0xE0511840, 0x80033828
+.long 0xE0511948, 0x80033929
+.long 0xE0511A50, 0x80033A2A
+.long 0xE0511B58, 0x80033B2B
+.long 0xE0511C60, 0x80033C2C
+.long 0xE0511D68, 0x80033D2D
+.long 0xE0511E70, 0x80033E2E
+.long 0xE0511F78, 0x80033F2F
+.long 0xBF8C8F78
+.long 0xBF8F0001
+.long 0xBF8A0000
+.long 0x68A4A4FF, 0x00000080
+.long 0x68A6A6FF, 0x00000080
+.long 0x68A8A8FF, 0x00000080
+.long 0x68AAAAFF, 0x00000080
+.long 0x68ACACFF, 0x00000080
+.long 0x68AEAEFF, 0x00000080
+.long 0x68B0B0FF, 0x00000080
+.long 0x68B2B2FF, 0x00000080
+.long 0x684040FF, 0x00000080
+.long 0x684242FF, 0x00000080
+.long 0x684444FF, 0x00000080
+.long 0x684646FF, 0x00000080
+.long 0x684848FF, 0x00000080
+.long 0x684A4AFF, 0x00000080
+.long 0x684C4CFF, 0x00000080
+.long 0x684E4EFF, 0x00000080
+.long 0xBF8F0000
+.long 0xBF8C4F78
+.long 0xBF8F0001
+.long 0xBF8A0000
+.long 0x685050FF, 0x00000080
+.long 0x685252FF, 0x00000080
+.long 0x685454FF, 0x00000080
+.long 0x685656FF, 0x00000080
+.long 0x685858FF, 0x00000080
+.long 0x685A5AFF, 0x00000080
+.long 0x685C5CFF, 0x00000080
+.long 0x685E5EFF, 0x00000080
+.long 0xBF8F0000
+.long 0xBEFC004D
+.long 0x802E812E
+.long 0xBF8A0000
+.long 0xE0511000, 0x80023052
+.long 0xE0511108, 0x80023153
+.long 0xE0511210, 0x80023254
+.long 0xE0511318, 0x80023355
+.long 0xE0511420, 0x80023456
+.long 0xE0511528, 0x80023557
+.long 0xE0511630, 0x80023658
+.long 0xE0511738, 0x80023759
+.long 0xBEFC004F
+.long 0xBF800000
+.long 0xE0511000, 0x80033020
+.long 0xE0511108, 0x80033121
+.long 0xE0511210, 0x80033222
+.long 0xE0511318, 0x80033323
+.long 0xE0511420, 0x80033424
+.long 0xE0511528, 0x80033525
+.long 0xE0511630, 0x80033626
+.long 0xE0511738, 0x80033727
+.long 0xE0511840, 0x80033828
+.long 0xE0511948, 0x80033929
+.long 0xE0511A50, 0x80033A2A
+.long 0xE0511B58, 0x80033B2B
+.long 0xE0511C60, 0x80033C2C
+.long 0xE0511D68, 0x80033D2D
+.long 0xE0511E70, 0x80033E2E
+.long 0xE0511F78, 0x80033F2F
+.long 0xBF8C8F78
+.long 0xBF8A0000
+.long 0xBF8F0001
+.long 0x68A4A4FF, 0x00000080
+.long 0x68A6A6FF, 0x00000080
+.long 0x68A8A8FF, 0x00000080
+.long 0x68AAAAFF, 0x00000080
+.long 0x68ACACFF, 0x00000080
+.long 0x68AEAEFF, 0x00000080
+.long 0x68B0B0FF, 0x00000080
+.long 0x68B2B2FF, 0x00000080
+.long 0x684040FF, 0x00000080
+.long 0x684242FF, 0x00000080
+.long 0x684444FF, 0x00000080
+.long 0x684646FF, 0x00000080
+.long 0x684848FF, 0x00000080
+.long 0x684A4AFF, 0x00000080
+.long 0x684C4CFF, 0x00000080
+.long 0x684E4EFF, 0x00000080
+.long 0xBF8F0000
+.long 0xBF8C4F78
+.long 0xBF8A0000
+.long 0xBF8F0001
+.long 0x685050FF, 0x00000080
+.long 0x685252FF, 0x00000080
+.long 0x685454FF, 0x00000080
+.long 0x685656FF, 0x00000080
+.long 0x685858FF, 0x00000080
+.long 0x685A5AFF, 0x00000080
+.long 0x685C5CFF, 0x00000080
+.long 0x685E5EFF, 0x00000080
+.long 0xBF8F0000
+.long 0xBEFC004C
+.long 0x802E812E
+.long 0xBF00C22E
+.long 0xBF84FF24
+.long 0xBF8C4F70
+.long 0xBF8A0000
+.long 0xBF8C0F70
+.long 0xBF8A0000
+.long 0xBF810000
+.long 0xD3D94000, 0x18000080
+.long 0xD3D94001, 0x18000080
+.long 0xD3D94002, 0x18000080
+.long 0xD3D94003, 0x18000080
+.long 0xD3D94004, 0x18000080
+.long 0xD3D94005, 0x18000080
+.long 0xD3D94006, 0x18000080
+.long 0xD3D94007, 0x18000080
+.long 0xD3D94008, 0x18000080
+.long 0xD3D94009, 0x18000080
+.long 0xD3D9400A, 0x18000080
+.long 0xD3D9400B, 0x18000080
+.long 0xD3D9400C, 0x18000080
+.long 0xD3D9400D, 0x18000080
+.long 0xD3D9400E, 0x18000080
+.long 0xD3D9400F, 0x18000080
+.long 0xD3D94010, 0x18000080
+.long 0xD3D94011, 0x18000080
+.long 0xD3D94012, 0x18000080
+.long 0xD3D94013, 0x18000080
+.long 0xD3D94014, 0x18000080
+.long 0xD3D94015, 0x18000080
+.long 0xD3D94016, 0x18000080
+.long 0xD3D94017, 0x18000080
+.long 0xD3D94018, 0x18000080
+.long 0xD3D94019, 0x18000080
+.long 0xD3D9401A, 0x18000080
+.long 0xD3D9401B, 0x18000080
+.long 0xD3D9401C, 0x18000080
+.long 0xD3D9401D, 0x18000080
+.long 0xD3D9401E, 0x18000080
+.long 0xD3D9401F, 0x18000080
+.long 0xC0060700, 0x00000000
+.long 0xC00A0A00, 0x00000038
+.long 0xC00A0900, 0x00000040
+.long 0xC00A0800, 0x00000018
+.long 0xD1130001, 0x00013F65
+.long 0xD2850060, 0x000202A0
+.long 0x20020281
+.long 0xD2850001, 0x00020282
+.long 0x68C0C101
+.long 0x2002CA85
+.long 0x68C0C101
+.long 0x24C0C082
+.long 0x68C0C080
+.long 0x68C2C0FF, 0x00002100
+.long 0xBF8A0000
+.long 0xD1130001, 0x00013F65
+.long 0xD2850062, 0x000202A0
+.long 0x20020281
+.long 0xD2850001, 0x00020282
+.long 0x68C4C501
+.long 0x2002CA85
+.long 0x68C4C501
+.long 0x24C4C482
+.long 0x9254FF52, 0x00001080
+.long 0x68C4C454
+.long 0x68C4C4FF, 0x00004200
+.long 0x68C6C4FF, 0x00004200
+.long 0xBF8CC07F
+.long 0xBE900022
+.long 0xBE910023
+.long 0xBE9200FF, 0x80000000
+.long 0xBE9300FF, 0x00020000
+.long 0xBE940020
+.long 0xBE950021
+.long 0xBE9600FF, 0x80000000
+.long 0xBE9700FF, 0x00020000
+.long 0x925603FF, 0x00000080
+.long 0x96552656
+.long 0x92542656
+.long 0x8ED48254
+.long 0x80105410
+.long 0x82115511
+.long 0x80145414
+.long 0x82155515
+.long 0x96552704
+.long 0x92542704
+.long 0x8ED48254
+.long 0x80105410
+.long 0x82115511
+.long 0x80145414
+.long 0x82155515
+.long 0x24C8CC86
+.long 0x68C8C965
+.long 0xD2850004, 0x0002CCA0
+.long 0xD2850003, 0x00004D04
+.long 0x2608C89F
+.long 0xD2850005, 0x00004D04
+.long 0x2608C8BF
+.long 0x200C0885
+.long 0x240C0C82
+.long 0x68D60B03
+.long 0x925402C0
+.long 0x32D40C54
+.long 0xD1FE0068, 0x020AD76A
+.long 0xBF8A0000
+.long 0xD86C0000, 0x20000060
+.long 0xD86C1080, 0x21000060
+.long 0xD86C0008, 0x22000060
+.long 0xD86C1088, 0x23000060
+.long 0xD86C0010, 0x24000060
+.long 0xD86C1090, 0x25000060
+.long 0xD86C0018, 0x26000060
+.long 0xD86C1098, 0x27000060
+.long 0xD86C0020, 0x28000060
+.long 0xD86C10A0, 0x29000060
+.long 0xD86C0028, 0x2A000060
+.long 0xD86C10A8, 0x2B000060
+.long 0xD86C0030, 0x2C000060
+.long 0xD86C10B0, 0x2D000060
+.long 0xD86C0038, 0x2E000060
+.long 0xD86C10B8, 0x2F000060
+.long 0xD86C0040, 0x30000060
+.long 0xD86C10C0, 0x31000060
+.long 0xD86C0048, 0x32000060
+.long 0xD86C10C8, 0x33000060
+.long 0xD86C0050, 0x34000060
+.long 0xD86C10D0, 0x35000060
+.long 0xD86C0058, 0x36000060
+.long 0xD86C10D8, 0x37000060
+.long 0xD86C0060, 0x38000060
+.long 0xD86C10E0, 0x39000060
+.long 0xD86C0068, 0x3A000060
+.long 0xD86C10E8, 0x3B000060
+.long 0xD86C0070, 0x3C000060
+.long 0xD86C10F0, 0x3D000060
+.long 0xD86C0078, 0x3E000060
+.long 0xD86C10F8, 0x3F000060
+.long 0xBF8A0000
+.long 0xD86C0000, 0x00000062
+.long 0xD86C0008, 0x01000062
+.long 0xD86C0010, 0x02000062
+.long 0xD86C0018, 0x03000062
+.long 0xD86C0020, 0x04000062
+.long 0xD86C0028, 0x05000062
+.long 0x8F2E852D
+.long 0x80AE2E80
+.long 0xBF06802E
+.long 0xBF85053B
+.long 0xBF8CC47F
+.long 0xD3C40000, 0x04020120
+.long 0xD86C0030, 0x06000062
+.long 0xD86C0038, 0x07000062
+.long 0xD3C40010, 0x04420121
+.long 0xD86C0040, 0x08000062
+.long 0xD86C0048, 0x09000062
+.long 0xD3C40000, 0x04020322
+.long 0xD86C0050, 0x0A000062
+.long 0xD86C0058, 0x0B000062
+.long 0xD86C0060, 0x0C000062
+.long 0xD3C40010, 0x04420323
+.long 0xD86C0068, 0x0D000062
+.long 0xD86C0070, 0x0E000062
+.long 0xD86C0078, 0x0F000062
+.long 0xBF8A0000
+.long 0xBF8CCD7F
+.long 0xD3C40000, 0x04020524
+.long 0xD3C40010, 0x04420525
+.long 0xBF8CCC7F
+.long 0xD3C40000, 0x04020726
+.long 0xD3C40010, 0x04420727
+.long 0xBF8CCB7F
+.long 0xD3C40000, 0x04020928
+.long 0xD3C40010, 0x04420929
+.long 0xBF8CCA7F
+.long 0xD3C40000, 0x04020B2A
+.long 0xD3C40010, 0x04420B2B
+.long 0xBF8CC97F
+.long 0xD3C40000, 0x04020D2C
+.long 0xD3C40010, 0x04420D2D
+.long 0xBF8CC87F
+.long 0xD3C40000, 0x04020F2E
+.long 0xD3C40010, 0x04420F2F
+.long 0xBF8CC07F
+.long 0xD3C40000, 0x04021130
+.long 0xD3C40010, 0x04421131
+.long 0xD3C40000, 0x04021332
+.long 0xD3C40010, 0x04421333
+.long 0xBF8F0000
+.long 0xD3C40000, 0x04021534
+.long 0xD3C40010, 0x04421535
+.long 0xBF8A0000
+.long 0xD3C40000, 0x04021736
+.long 0xD86C0000, 0x40000061
+.long 0xD86C1080, 0x41000061
+.long 0xD86C0008, 0x42000061
+.long 0xD86C1088, 0x43000061
+.long 0xD3C40010, 0x04421737
+.long 0xD86C0010, 0x44000061
+.long 0xD86C1090, 0x45000061
+.long 0xD86C0018, 0x46000061
+.long 0xD86C1098, 0x47000061
+.long 0xD3C40000, 0x04021938
+.long 0xD86C0020, 0x48000061
+.long 0xD86C10A0, 0x49000061
+.long 0xD86C0028, 0x4A000061
+.long 0xD86C10A8, 0x4B000061
+.long 0xD3C40010, 0x04421939
+.long 0xD86C0030, 0x4C000061
+.long 0xD86C10B0, 0x4D000061
+.long 0xD86C0038, 0x4E000061
+.long 0xD86C10B8, 0x4F000061
+.long 0xD3C40000, 0x04021B3A
+.long 0xD86C0040, 0x50000061
+.long 0xD86C10C0, 0x51000061
+.long 0xD86C0048, 0x52000061
+.long 0xD86C10C8, 0x53000061
+.long 0xD3C40010, 0x04421B3B
+.long 0xD86C0050, 0x54000061
+.long 0xD86C10D0, 0x55000061
+.long 0xD86C0058, 0x56000061
+.long 0xD86C10D8, 0x57000061
+.long 0xD3C40000, 0x04021D3C
+.long 0xD86C0060, 0x58000061
+.long 0xD86C10E0, 0x59000061
+.long 0xD86C0068, 0x5A000061
+.long 0xD86C10E8, 0x5B000061
+.long 0xD3C40010, 0x04421D3D
+.long 0xD86C0070, 0x5C000061
+.long 0xD86C10F0, 0x5D000061
+.long 0xD86C0078, 0x5E000061
+.long 0xD86C10F8, 0x5F000061
+.long 0xBF8A0000
+.long 0xD86C0000, 0x10000063
+.long 0xD86C0008, 0x11000063
+.long 0xD3C40000, 0x04021F3E
+.long 0xD86C0010, 0x12000063
+.long 0xD86C0018, 0x13000063
+.long 0xD86C0020, 0x14000063
+.long 0xD86C0028, 0x15000063
+.long 0xD86C0030, 0x16000063
+.long 0xD3C40010, 0x04421F3F
+.long 0xD86C0038, 0x17000063
+.long 0xD86C0040, 0x18000063
+.long 0xD86C0048, 0x19000063
+.long 0xD86C0050, 0x1A000063
+.long 0xD86C0058, 0x1B000063
+.long 0xBF8F0001
+.long 0x802E812E
+.long 0xBF8CCA7F
+.long 0xD3C40000, 0x04022140
+.long 0xD86C0060, 0x1C000063
+.long 0xD86C0068, 0x1D000063
+.long 0xD3C40010, 0x04422141
+.long 0xD86C0070, 0x1E000063
+.long 0xD86C0078, 0x1F000063
+.long 0xD3C40000, 0x04022342
+.long 0xD3C40010, 0x04422343
+.long 0xBF8A0000
+.long 0xBF8CCD7F
+.long 0xD3C40000, 0x04022544
+.long 0xD3C40010, 0x04422545
+.long 0xBF8CCC7F
+.long 0xD3C40000, 0x04022746
+.long 0xD3C40010, 0x04422747
+.long 0xBF8CCB7F
+.long 0xD3C40000, 0x04022948
+.long 0xD3C40010, 0x04422949
+.long 0xBF8CCA7F
+.long 0xD3C40000, 0x04022B4A
+.long 0xD3C40010, 0x04422B4B
+.long 0xBF8CC97F
+.long 0xD3C40000, 0x04022D4C
+.long 0xD3C40010, 0x04422D4D
+.long 0xBF8CC87F
+.long 0xD3C40000, 0x04022F4E
+.long 0xD3C40010, 0x04422F4F
+.long 0xBF8CC07F
+.long 0xD3C40000, 0x04023150
+.long 0xD3C40010, 0x04423151
+.long 0xD3C40000, 0x04023352
+.long 0xD3C40010, 0x04423353
+.long 0xBF8F0000
+.long 0xD3C40000, 0x04023554
+.long 0xD3C40010, 0x04423555
+.long 0xBF8A0000
+.long 0xD86C0000, 0x20000060
+.long 0xD86C1080, 0x21000060
+.long 0xD86C0008, 0x22000060
+.long 0xD86C1088, 0x23000060
+.long 0xD3C40000, 0x04023756
+.long 0xD86C0010, 0x24000060
+.long 0xD86C1090, 0x25000060
+.long 0xD86C0018, 0x26000060
+.long 0xD86C1098, 0x27000060
+.long 0xD3C40010, 0x04423757
+.long 0xD86C0020, 0x28000060
+.long 0xD86C10A0, 0x29000060
+.long 0xD86C0028, 0x2A000060
+.long 0xD86C10A8, 0x2B000060
+.long 0xD3C40000, 0x04023958
+.long 0xD86C0030, 0x2C000060
+.long 0xD86C10B0, 0x2D000060
+.long 0xD86C0038, 0x2E000060
+.long 0xD86C10B8, 0x2F000060
+.long 0xD3C40010, 0x04423959
+.long 0xD86C0040, 0x30000060
+.long 0xD86C10C0, 0x31000060
+.long 0xD86C0048, 0x32000060
+.long 0xD86C10C8, 0x33000060
+.long 0xD3C40000, 0x04023B5A
+.long 0xD86C0050, 0x34000060
+.long 0xD86C10D0, 0x35000060
+.long 0xD86C0058, 0x36000060
+.long 0xD86C10D8, 0x37000060
+.long 0xD3C40010, 0x04423B5B
+.long 0xD86C0060, 0x38000060
+.long 0xD86C10E0, 0x39000060
+.long 0xD86C0068, 0x3A000060
+.long 0xD86C10E8, 0x3B000060
+.long 0xD3C40000, 0x04023D5C
+.long 0xD86C0070, 0x3C000060
+.long 0xD86C10F0, 0x3D000060
+.long 0xD86C0078, 0x3E000060
+.long 0xD86C10F8, 0x3F000060
+.long 0xD3C40010, 0x04423D5D
+.long 0xBF8A0000
+.long 0xD86C0000, 0x00000062
+.long 0xD86C0008, 0x01000062
+.long 0xD86C0010, 0x02000062
+.long 0xD86C0018, 0x03000062
+.long 0xD3C40000, 0x04023F5E
+.long 0xD86C0020, 0x04000062
+.long 0xD86C0028, 0x05000062
+.long 0xD86C0030, 0x06000062
+.long 0xD86C0038, 0x07000062
+.long 0xD3C40010, 0x04423F5F
+.long 0xD86C0040, 0x08000062
+.long 0xD86C0048, 0x09000062
+.long 0xD86C0050, 0x0A000062
+.long 0xD86C0058, 0x0B000062
+.long 0xBF8F0001
+.long 0x802E812E
+.long 0xBF8CCA7F
+.long 0xD3C40000, 0x04020120
+.long 0xD86C0060, 0x0C000062
+.long 0xD86C0068, 0x0D000062
+.long 0xD3C40010, 0x04420121
+.long 0xD86C0070, 0x0E000062
+.long 0xD86C0078, 0x0F000062
+.long 0xD3C40000, 0x04020322
+.long 0xD3C40010, 0x04420323
+.long 0xBF8A0000
+.long 0xBF8CC87F
+.long 0xD3C40000, 0x04020524
+.long 0xD3C40010, 0x04420525
+.long 0xD3C40000, 0x04020726
+.long 0xD3C40010, 0x04420727
+.long 0xD3C40000, 0x04020928
+.long 0xD3C40010, 0x04420929
+.long 0xD3C40000, 0x04020B2A
+.long 0xD3C40010, 0x04420B2B
+.long 0xD3C40000, 0x04020D2C
+.long 0xD3C40010, 0x04420D2D
+.long 0xD3C40000, 0x04020F2E
+.long 0xD3C40010, 0x04420F2F
+.long 0xBF8CC07F
+.long 0xD3C40000, 0x04021130
+.long 0xD3C40010, 0x04421131
+.long 0xD3C40000, 0x04021332
+.long 0xD3C40010, 0x04421333
+.long 0xBF8F0000
+.long 0xD3C40000, 0x04021534
+.long 0xD3C40010, 0x04421535
+.long 0xBF8A0000
+.long 0xD86C0000, 0x40000061
+.long 0xD86C1080, 0x41000061
+.long 0xD86C0008, 0x42000061
+.long 0xD86C1088, 0x43000061
+.long 0xD3C40000, 0x04021736
+.long 0xD86C0010, 0x44000061
+.long 0xD86C1090, 0x45000061
+.long 0xD86C0018, 0x46000061
+.long 0xD86C1098, 0x47000061
+.long 0xD3C40010, 0x04421737
+.long 0xD86C0020, 0x48000061
+.long 0xD86C10A0, 0x49000061
+.long 0xD86C0028, 0x4A000061
+.long 0xD86C10A8, 0x4B000061
+.long 0xD3C40000, 0x04021938
+.long 0xD86C0030, 0x4C000061
+.long 0xD86C10B0, 0x4D000061
+.long 0xD86C0038, 0x4E000061
+.long 0xD86C10B8, 0x4F000061
+.long 0xD3C40010, 0x04421939
+.long 0xD86C0040, 0x50000061
+.long 0xD86C10C0, 0x51000061
+.long 0xD86C0048, 0x52000061
+.long 0xD86C10C8, 0x53000061
+.long 0xD3C40000, 0x04021B3A
+.long 0xD86C0050, 0x54000061
+.long 0xD86C10D0, 0x55000061
+.long 0xD86C0058, 0x56000061
+.long 0xD86C10D8, 0x57000061
+.long 0xD3C40010, 0x04421B3B
+.long 0xD86C0060, 0x58000061
+.long 0xD86C10E0, 0x59000061
+.long 0xD86C0068, 0x5A000061
+.long 0xD86C10E8, 0x5B000061
+.long 0xD3C40000, 0x04021D3C
+.long 0xD86C0070, 0x5C000061
+.long 0xD86C10F0, 0x5D000061
+.long 0xD86C0078, 0x5E000061
+.long 0xD86C10F8, 0x5F000061
+.long 0xD3C40010, 0x04421D3D
+.long 0xBF8A0000
+.long 0xD86C0000, 0x10000063
+.long 0xD86C0008, 0x11000063
+.long 0xD3C40000, 0x04021F3E
+.long 0xD86C0010, 0x12000063
+.long 0xD86C0018, 0x13000063
+.long 0xD86C0020, 0x14000063
+.long 0xD86C0028, 0x15000063
+.long 0xD86C0030, 0x16000063
+.long 0xD3C40010, 0x04421F3F
+.long 0xD86C0038, 0x17000063
+.long 0xD86C0040, 0x18000063
+.long 0xD86C0048, 0x19000063
+.long 0xD86C0050, 0x1A000063
+.long 0xD86C0058, 0x1B000063
+.long 0xBF8F0001
+.long 0x802E812E
+.long 0xBF8CCA7F
+.long 0xD3C40000, 0x04022140
+.long 0xD86C0060, 0x1C000063
+.long 0xD86C0068, 0x1D000063
+.long 0xD3C40010, 0x04422141
+.long 0xD86C0070, 0x1E000063
+.long 0xD86C0078, 0x1F000063
+.long 0xD3C40000, 0x04022342
+.long 0xD3C40010, 0x04422343
+.long 0xBF8A0000
+.long 0xBF8CC87F
+.long 0xD3C40000, 0x04022544
+.long 0xD3C40010, 0x04422545
+.long 0xD3C40000, 0x04022746
+.long 0xD3C40010, 0x04422747
+.long 0xD3C40000, 0x04022948
+.long 0xD3C40010, 0x04422949
+.long 0xD3C40000, 0x04022B4A
+.long 0xD3C40010, 0x04422B4B
+.long 0xD3C40000, 0x04022D4C
+.long 0xD3C40010, 0x04422D4D
+.long 0xD3C40000, 0x04022F4E
+.long 0xD3C40010, 0x04422F4F
+.long 0xBF8CC07F
+.long 0xD3C40000, 0x04023150
+.long 0xD3C40010, 0x04423151
+.long 0xD3C40000, 0x04023352
+.long 0xD3C40010, 0x04423353
+.long 0xBF8F0000
+.long 0xD3C40000, 0x04023554
+.long 0xD3C40010, 0x04423555
+.long 0xBF8A0000
+.long 0xD86C0000, 0x20000060
+.long 0xD86C1080, 0x21000060
+.long 0xD86C0008, 0x22000060
+.long 0xD86C1088, 0x23000060
+.long 0xD3C40000, 0x04023756
+.long 0xD86C0010, 0x24000060
+.long 0xD86C1090, 0x25000060
+.long 0xD86C0018, 0x26000060
+.long 0xD86C1098, 0x27000060
+.long 0xD3C40010, 0x04423757
+.long 0xD86C0020, 0x28000060
+.long 0xD86C10A0, 0x29000060
+.long 0xD86C0028, 0x2A000060
+.long 0xD86C10A8, 0x2B000060
+.long 0xD3C40000, 0x04023958
+.long 0xD86C0030, 0x2C000060
+.long 0xD86C10B0, 0x2D000060
+.long 0xD86C0038, 0x2E000060
+.long 0xD86C10B8, 0x2F000060
+.long 0xD3C40010, 0x04423959
+.long 0xD86C0040, 0x30000060
+.long 0xD86C10C0, 0x31000060
+.long 0xD86C0048, 0x32000060
+.long 0xD86C10C8, 0x33000060
+.long 0xD3C40000, 0x04023B5A
+.long 0xD86C0050, 0x34000060
+.long 0xD86C10D0, 0x35000060
+.long 0xD86C0058, 0x36000060
+.long 0xD86C10D8, 0x37000060
+.long 0xD3C40010, 0x04423B5B
+.long 0xD86C0060, 0x38000060
+.long 0xD86C10E0, 0x39000060
+.long 0xD86C0068, 0x3A000060
+.long 0xD86C10E8, 0x3B000060
+.long 0xD3C40000, 0x04023D5C
+.long 0xD86C0070, 0x3C000060
+.long 0xD86C10F0, 0x3D000060
+.long 0xD86C0078, 0x3E000060
+.long 0xD86C10F8, 0x3F000060
+.long 0xD3C40010, 0x04423D5D
+.long 0xBF8A0000
+.long 0xD86C0000, 0x00000062
+.long 0xD86C0008, 0x01000062
+.long 0xD3C40000, 0x04023F5E
+.long 0xD86C0010, 0x02000062
+.long 0xD86C0018, 0x03000062
+.long 0xD86C0020, 0x04000062
+.long 0xD86C0028, 0x05000062
+.long 0xD86C0030, 0x06000062
+.long 0xD3C40010, 0x04423F5F
+.long 0xD86C0038, 0x07000062
+.long 0xD86C0040, 0x08000062
+.long 0xD86C0048, 0x09000062
+.long 0xD86C0050, 0x0A000062
+.long 0xD86C0058, 0x0B000062
+.long 0xBF8F0001
+.long 0x802E812E
+.long 0xBF00C22E
+.long 0xBF84FEAC
+.long 0xBF8CCA7F
+.long 0xD3C40000, 0x04020120
+.long 0xD3C40010, 0x04420121
+.long 0xD86C0060, 0x0C000062
+.long 0xD86C0068, 0x0D000062
+.long 0xD86C0070, 0x0E000062
+.long 0xD86C0078, 0x0F000062
+.long 0xD3C40000, 0x04020322
+.long 0xD3C40010, 0x04420323
+.long 0xBF8CCC7F
+.long 0xD3C40000, 0x04020524
+.long 0xD3C40010, 0x04420525
+.long 0xD3C40000, 0x04020726
+.long 0xD3C40010, 0x04420727
+.long 0xBF8CCA7F
+.long 0xD3C40000, 0x04020928
+.long 0xD3C40010, 0x04420929
+.long 0xD3C40000, 0x04020B2A
+.long 0xD3C40010, 0x04420B2B
+.long 0xBF8CC87F
+.long 0xD3C40000, 0x04020D2C
+.long 0xD3C40010, 0x04420D2D
+.long 0xD3C40000, 0x04020F2E
+.long 0xD3C40010, 0x04420F2F
+.long 0xBF8CC07F
+.long 0xD3C40000, 0x04021130
+.long 0xBF068029
+.long 0xBF850008
+.long 0xE05C1000, 0x80042068
+.long 0xE05C1020, 0x80042468
+.long 0xE05C1040, 0x80042868
+.long 0xE05C1060, 0x80042C68
+.long 0xD3C40010, 0x04421131
+.long 0xD3C40000, 0x04021332
+.long 0xD3C40010, 0x04421333
+.long 0xD3C40000, 0x04021534
+.long 0xD3C40010, 0x04421535
+.long 0xBF8A0000
+.long 0xD86C0000, 0x40000061
+.long 0xD86C1080, 0x41000061
+.long 0xD86C0008, 0x42000061
+.long 0xD86C1088, 0x43000061
+.long 0xD3C40000, 0x04021736
+.long 0xD86C0010, 0x44000061
+.long 0xD86C1090, 0x45000061
+.long 0xD86C0018, 0x46000061
+.long 0xD86C1098, 0x47000061
+.long 0xD3C40010, 0x04421737
+.long 0xD86C0020, 0x48000061
+.long 0xD86C10A0, 0x49000061
+.long 0xD86C0028, 0x4A000061
+.long 0xD86C10A8, 0x4B000061
+.long 0xD3C40000, 0x04021938
+.long 0xD86C0030, 0x4C000061
+.long 0xD86C10B0, 0x4D000061
+.long 0xD86C0038, 0x4E000061
+.long 0xD86C10B8, 0x4F000061
+.long 0xD3C40010, 0x04421939
+.long 0xD86C0040, 0x50000061
+.long 0xD86C10C0, 0x51000061
+.long 0xD86C0048, 0x52000061
+.long 0xD86C10C8, 0x53000061
+.long 0xD3C40000, 0x04021B3A
+.long 0xD86C0050, 0x54000061
+.long 0xD86C10D0, 0x55000061
+.long 0xD86C0058, 0x56000061
+.long 0xD86C10D8, 0x57000061
+.long 0xD3C40010, 0x04421B3B
+.long 0xD86C0060, 0x58000061
+.long 0xD86C10E0, 0x59000061
+.long 0xD86C0068, 0x5A000061
+.long 0xD86C10E8, 0x5B000061
+.long 0xD3C40000, 0x04021D3C
+.long 0xD86C0070, 0x5C000061
+.long 0xD86C10F0, 0x5D000061
+.long 0xD86C0078, 0x5E000061
+.long 0xD86C10F8, 0x5F000061
+.long 0xD3C40010, 0x04421D3D
+.long 0xBF8A0000
+.long 0xD86C0000, 0x10000063
+.long 0xD86C0008, 0x11000063
+.long 0xD3C40000, 0x04021F3E
+.long 0xD86C0010, 0x12000063
+.long 0xD86C0018, 0x13000063
+.long 0xD86C0020, 0x14000063
+.long 0xD86C0028, 0x15000063
+.long 0xD86C0030, 0x16000063
+.long 0xD3C40010, 0x04421F3F
+.long 0xD86C0038, 0x17000063
+.long 0xD86C0040, 0x18000063
+.long 0xD86C0048, 0x19000063
+.long 0xD86C0050, 0x1A000063
+.long 0xD86C0058, 0x1B000063
+.long 0xBF8CCA7F
+.long 0xD3C40000, 0x04022140
+.long 0xBF068029
+.long 0xBF850008
+.long 0xE05C1080, 0x80043068
+.long 0xE05C10A0, 0x80043468
+.long 0xE05C10C0, 0x80043868
+.long 0xE05C10E0, 0x80043C68
+.long 0xD3C40010, 0x04422141
+.long 0xD86C0060, 0x1C000063
+.long 0xD86C0068, 0x1D000063
+.long 0xD86C0070, 0x1E000063
+.long 0xD86C0078, 0x1F000063
+.long 0xD3C40000, 0x04022342
+.long 0xD3C40010, 0x04422343
+.long 0xBF8CCC7F
+.long 0xD3C40000, 0x04022544
+.long 0xD3C40010, 0x04422545
+.long 0xD3C40000, 0x04022746
+.long 0xD3C40010, 0x04422747
+.long 0xBF8CCA7F
+.long 0xD3C40000, 0x04022948
+.long 0xD3C40010, 0x04422949
+.long 0xD3C40000, 0x04022B4A
+.long 0xD3C40010, 0x04422B4B
+.long 0xBF8CC87F
+.long 0xD3C40000, 0x04022D4C
+.long 0xD3C40010, 0x04422D4D
+.long 0xD3C40000, 0x04022F4E
+.long 0xD3C40010, 0x04422F4F
+.long 0xBF8CC07F
+.long 0xD3C40000, 0x04023150
+.long 0xD3C40000, 0x04023352
+.long 0xD3C40000, 0x04023554
+.long 0xD3C40000, 0x04023756
+.long 0xD3C40000, 0x04023958
+.long 0xD3C40000, 0x04023B5A
+.long 0xD3C40000, 0x04023D5C
+.long 0xD3C40000, 0x04023F5E
+.long 0xBF068029
+.long 0xBF8400A3
+.long 0xD3C40010, 0x04423151
+.long 0xD3D84000, 0x18000100
+.long 0xD3D84001, 0x18000101
+.long 0xD3D84002, 0x18000102
+.long 0xD3D84003, 0x18000103
+.long 0xD3C40010, 0x04423353
+.long 0xD3D84004, 0x18000104
+.long 0xD3D84005, 0x18000105
+.long 0xD3D84006, 0x18000106
+.long 0xD3D84007, 0x18000107
+.long 0xD1050000, 0x00005100
+.long 0xD1050001, 0x00005101
+.long 0xD1050002, 0x00005102
+.long 0xD1050003, 0x00005103
+.long 0xE07C1000, 0x80050068
+.long 0xD3C40010, 0x04423555
+.long 0xD3D84008, 0x18000108
+.long 0xD3D84009, 0x18000109
+.long 0xD3D8400A, 0x1800010A
+.long 0xD3D8400B, 0x1800010B
+.long 0xD1050004, 0x00005104
+.long 0xD1050005, 0x00005105
+.long 0xD1050006, 0x00005106
+.long 0xD1050007, 0x00005107
+.long 0xE07C1020, 0x80050468
+.long 0xD3C40010, 0x04423757
+.long 0xD3D8400C, 0x1800010C
+.long 0xD3D8400D, 0x1800010D
+.long 0xD3D8400E, 0x1800010E
+.long 0xD3D8400F, 0x1800010F
+.long 0xD1050008, 0x00005108
+.long 0xD1050009, 0x00005109
+.long 0xD105000A, 0x0000510A
+.long 0xD105000B, 0x0000510B
+.long 0xE07C1040, 0x80050868
+.long 0xD3C40010, 0x04423959
+.long 0xD105000C, 0x0000510C
+.long 0xD105000D, 0x0000510D
+.long 0xD105000E, 0x0000510E
+.long 0xD105000F, 0x0000510F
+.long 0xE07C1060, 0x80050C68
+.long 0xD3C40010, 0x04423B5B
+.long 0xD3C40010, 0x04423D5D
+.long 0xD3C40010, 0x04423F5F
+.long 0xBF800003
+.long 0xD3D84000, 0x18000110
+.long 0xD3D84001, 0x18000111
+.long 0xD3D84002, 0x18000112
+.long 0xD3D84003, 0x18000113
+.long 0xD3D84004, 0x18000114
+.long 0xD3D84005, 0x18000115
+.long 0xD3D84006, 0x18000116
+.long 0xD3D84007, 0x18000117
+.long 0xD1050000, 0x00005100
+.long 0xD1050001, 0x00005101
+.long 0xD1050002, 0x00005102
+.long 0xD1050003, 0x00005103
+.long 0xE07C1080, 0x80050068
+.long 0xD3D84008, 0x18000118
+.long 0xD3D84009, 0x18000119
+.long 0xD3D8400A, 0x1800011A
+.long 0xD3D8400B, 0x1800011B
+.long 0xD1050004, 0x00005104
+.long 0xD1050005, 0x00005105
+.long 0xD1050006, 0x00005106
+.long 0xD1050007, 0x00005107
+.long 0xE07C10A0, 0x80050468
+.long 0xD3D8400C, 0x1800011C
+.long 0xD3D8400D, 0x1800011D
+.long 0xD3D8400E, 0x1800011E
+.long 0xD3D8400F, 0x1800011F
+.long 0xD1050008, 0x00005108
+.long 0xD1050009, 0x00005109
+.long 0xD105000A, 0x0000510A
+.long 0xD105000B, 0x0000510B
+.long 0xE07C10C0, 0x80050868
+.long 0xD105000C, 0x0000510C
+.long 0xD105000D, 0x0000510D
+.long 0xD105000E, 0x0000510E
+.long 0xD105000F, 0x0000510F
+.long 0xE07C10E0, 0x80050C68
+.long 0xBF8C0000
+.long 0xBF810000
+.long 0xD3C40010, 0x04423151
+.long 0xD3C40010, 0x04423353
+.long 0xD3C40010, 0x04423555
+.long 0xD3C40010, 0x04423757
+.long 0xD3C40010, 0x04423959
+.long 0xD3C40010, 0x04423B5B
+.long 0xD3C40010, 0x04423D5D
+.long 0xD3C40010, 0x04423F5F
+.long 0xD3D84000, 0x18000100
+.long 0xD3D84001, 0x18000101
+.long 0xD3D84002, 0x18000102
+.long 0xD3D84003, 0x18000103
+.long 0xD3D84004, 0x18000104
+.long 0xD3D84005, 0x18000105
+.long 0xD3D84006, 0x18000106
+.long 0xD3D84007, 0x18000107
+.long 0xD3D84008, 0x18000108
+.long 0xD3D84009, 0x18000109
+.long 0xD3D8400A, 0x1800010A
+.long 0xD3D8400B, 0x1800010B
+.long 0xD3D8400C, 0x1800010C
+.long 0xD3D8400D, 0x1800010D
+.long 0xD3D8400E, 0x1800010E
+.long 0xD3D8400F, 0x1800010F
+.long 0xBF8C0F74
+.long 0xD1050000, 0x00005100
+.long 0xD1050001, 0x00005101
+.long 0xD1050002, 0x00005102
+.long 0xD1050003, 0x00005103
+.long 0xD1160000, 0x00005320
+.long 0xD1160001, 0x00005321
+.long 0xD1160002, 0x00005322
+.long 0xD1160003, 0x00005323
+.long 0xE07C1000, 0x80050068
+.long 0xD1050004, 0x00005104
+.long 0xD1050005, 0x00005105
+.long 0xD1050006, 0x00005106
+.long 0xD1050007, 0x00005107
+.long 0xD1160004, 0x00005324
+.long 0xD1160005, 0x00005325
+.long 0xD1160006, 0x00005326
+.long 0xD1160007, 0x00005327
+.long 0xE07C1020, 0x80050468
+.long 0xD1050008, 0x00005108
+.long 0xD1050009, 0x00005109
+.long 0xD105000A, 0x0000510A
+.long 0xD105000B, 0x0000510B
+.long 0xD1160008, 0x00005328
+.long 0xD1160009, 0x00005329
+.long 0xD116000A, 0x0000532A
+.long 0xD116000B, 0x0000532B
+.long 0xE07C1040, 0x80050868
+.long 0xD105000C, 0x0000510C
+.long 0xD105000D, 0x0000510D
+.long 0xD105000E, 0x0000510E
+.long 0xD105000F, 0x0000510F
+.long 0xD116000C, 0x0000532C
+.long 0xD116000D, 0x0000532D
+.long 0xD116000E, 0x0000532E
+.long 0xD116000F, 0x0000532F
+.long 0xE07C1060, 0x80050C68
+.long 0xD3D84000, 0x18000110
+.long 0xD3D84001, 0x18000111
+.long 0xD3D84002, 0x18000112
+.long 0xD3D84003, 0x18000113
+.long 0xD3D84004, 0x18000114
+.long 0xD3D84005, 0x18000115
+.long 0xD3D84006, 0x18000116
+.long 0xD3D84007, 0x18000117
+.long 0xD3D84008, 0x18000118
+.long 0xD3D84009, 0x18000119
+.long 0xD3D8400A, 0x1800011A
+.long 0xD3D8400B, 0x1800011B
+.long 0xD3D8400C, 0x1800011C
+.long 0xD3D8400D, 0x1800011D
+.long 0xD3D8400E, 0x1800011E
+.long 0xD3D8400F, 0x1800011F
+.long 0xBF8C0F70
+.long 0xD1050000, 0x00005100
+.long 0xD1050001, 0x00005101
+.long 0xD1050002, 0x00005102
+.long 0xD1050003, 0x00005103
+.long 0xD1160000, 0x00005330
+.long 0xD1160001, 0x00005331
+.long 0xD1160002, 0x00005332
+.long 0xD1160003, 0x00005333
+.long 0xE07C1080, 0x80050068
+.long 0xD1050004, 0x00005104
+.long 0xD1050005, 0x00005105
+.long 0xD1050006, 0x00005106
+.long 0xD1050007, 0x00005107
+.long 0xD1160004, 0x00005334
+.long 0xD1160005, 0x00005335
+.long 0xD1160006, 0x00005336
+.long 0xD1160007, 0x00005337
+.long 0xE07C10A0, 0x80050468
+.long 0xD1050008, 0x00005108
+.long 0xD1050009, 0x00005109
+.long 0xD105000A, 0x0000510A
+.long 0xD105000B, 0x0000510B
+.long 0xD1160008, 0x00005338
+.long 0xD1160009, 0x00005339
+.long 0xD116000A, 0x0000533A
+.long 0xD116000B, 0x0000533B
+.long 0xE07C10C0, 0x80050868
+.long 0xD105000C, 0x0000510C
+.long 0xD105000D, 0x0000510D
+.long 0xD105000E, 0x0000510E
+.long 0xD105000F, 0x0000510F
+.long 0xD116000C, 0x0000533C
+.long 0xD116000D, 0x0000533D
+.long 0xD116000E, 0x0000533E
+.long 0xD116000F, 0x0000533F
+.long 0xE07C10E0, 0x80050C68
+.long 0xBF8C0000
+.long 0xBF810000
+

--- a/Tensile/ReplacementKernels/Cijk_Alik_Bljk_SB_MT64x32x32_AF0EM8_ASEM8_FL0_GRVW2_ISA908_MDA2_PGR1_PLR1_SU32_TT2_2_VAW1_VW2_WG32_16_1_WGM8.s.txt
+++ b/Tensile/ReplacementKernels/Cijk_Alik_Bljk_SB_MT64x32x32_AF0EM8_ASEM8_FL0_GRVW2_ISA908_MDA2_PGR1_PLR1_SU32_TT2_2_VAW1_VW2_WG32_16_1_WGM8.s.txt
@@ -1,0 +1,911 @@
+
+
+/******************************************/
+/* Function Prefix                        */
+/******************************************/
+
+
+
+/******************************************/
+/* Begin Kernel                           */
+/******************************************/
+
+.hsa_code_object_version 2,0
+.hsa_code_object_isa 9, 0, 8, "AMD", "AMDGPU"
+.text
+.protected Cijk_Alik_Bljk_SB_MT64x32x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG32_16_1_WGM8
+.globl Cijk_Alik_Bljk_SB_MT64x32x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG32_16_1_WGM8
+.p2align 8
+.type Cijk_Alik_Bljk_SB_MT64x32x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG32_16_1_WGM8,@function
+.amdgpu_hsa_kernel Cijk_Alik_Bljk_SB_MT64x32x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG32_16_1_WGM8
+Cijk_Alik_Bljk_SB_MT64x32x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG32_16_1_WGM8:
+.amd_kernel_code_t
+  is_ptr64 = 1
+  enable_sgpr_kernarg_segment_ptr = 1
+  kernarg_segment_byte_size = 148 // bytes of kern args
+  workitem_vgpr_count = 108 // vgprs
+  wavefront_sgpr_count = 98 // sgprs
+  compute_pgm_rsrc1_vgprs = 26 // floor((108-1)/4)
+  compute_pgm_rsrc1_sgprs = 12 // floor((98-1)/8)
+  compute_pgm_rsrc2_tidig_comp_cnt = 0 // 1D wg
+  compute_pgm_rsrc2_tgid_x_en = 1 // wg.x
+  compute_pgm_rsrc2_tgid_y_en = 1 // wg.y
+  compute_pgm_rsrc2_tgid_z_en = 1 // wg.z
+  workgroup_group_segment_byte_size = 30000// lds bytes
+  compute_pgm_rsrc2_user_sgpr = 2 // vcc
+  kernarg_segment_alignment = 4
+  group_segment_alignment = 4
+  private_segment_alignment = 4
+.end_amd_kernel_code_t
+
+/******************************************/
+/* Optimizations and Config:              */
+/******************************************/
+/* ThreadTile= 4 x 4 */
+/* SubGroup= 16 x 32 */
+/* VectorWidth=4 */
+/* GlobalLoadVectorWidthA=4, GlobalLoadVectorWidthB=4 */
+/* DirectToLdsA=False */
+/* DirectToLdsB=False */
+/* UseSgprForGRO=1 */
+.amd_amdgpu_hsa_metadata
+Version: [ 1, 0 ]
+Kernels:
+  - Name: Cijk_Alik_Bljk_SB_MT64x32x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG32_16_1_WGM8
+    SymbolName: 'Cijk_Alik_Bljk_SB_MT64x32x32_SE_APM1_AF0EM8_AF1EM1_AMAS3_ASBE01_ASEM8_BL1_DTL0_EPS1_FL0_GRVW2_GSU1_ISA908_IU1_K1_KLA_LBSPPn1_LPA0_LPB0_LDL1_MDA2_NLCA1_NLCB1_ONLL1_PBD0_PK0_PGR1_PLR1_RK1_SIA1_SU32_SUM0_SUS256_SRVW0_SNLL0_TT2_2_TLDS0_USFGROn1_VAW1_VSn1_VW2_WSGRA0_WSGRB0_WG32_16_1_WGM8@kd'
+    Language: OpenCL C
+    LanguageVersion: [ 2, 0 ]
+    Args:
+      - Name:            sizeC
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            sizeA
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            sizeB
+        Size:            8
+        Align:           8
+        ValueKind:       ByValue
+        ValueType:       I64
+      - Name:            D
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       F32
+        AddrSpaceQual:   Generic
+      - Name:            C
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       F32
+        AddrSpaceQual:   Generic
+      - Name:            A
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       F32
+        AddrSpaceQual:   Generic
+      - Name:            B
+        Size:            8
+        Align:           8
+        ValueKind:       GlobalBuffer
+        ValueType:       F32
+        AddrSpaceQual:   Generic
+      - Name:            alpha
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       F32
+      - Name:            beta
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       F32
+      - Name:            strideD0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideD1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideC0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideC1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideA0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideA1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideB0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            strideB1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesFree2
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            SizesSum0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            OrigStaggerUIter
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       I32
+      - Name:            NumWorkGroups0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            NumWorkGroups1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            MagicNumberProblemNumGroupTiles0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            GridNumWorkGroups0
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            NumFullBlocks
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            WgmRemainder1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            MagicNumberWgmRemainder1
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+      - Name:            padding
+        Size:            4
+        Align:           4
+        ValueKind:       ByValue
+        ValueType:       U32
+    CodeProps:
+      KernargSegmentSize: 148
+      GroupSegmentFixedSize: 28672
+      PrivateSegmentFixedSize: 0
+      KernargSegmentAlign:  8
+      WavefrontSize:        64
+      NumSGPRs:             98
+      NumVGPRs:             108
+      MaxFlatWorkGroupSize: 512
+.end_amd_amdgpu_hsa_metadata
+
+/******************************************/
+/* Asm syntax workarounds                 */
+/******************************************/
+.macro _v_add_co_u32 dst, cc, src0, src1, dpp=
+   v_add_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+
+.macro _v_add_u32 dst, src0, src1, dpp=
+   v_add_u32 \dst, \src0, \src1 \dpp
+.endm
+
+.macro _v_sub_co_u32 dst, cc, src0, src1, dpp=
+   v_sub_co_u32 \dst, \cc, \src0, \src1 \dpp
+.endm
+
+.macro _v_sub_u32 dst, src0, src1, dpp=
+   v_sub_u32 \dst, \src0, \src1 \dpp
+.endm
+
+.macro _v_addc_co_u32 dst, ccOut, src0, ccIn, src1, dpp=
+   v_addc_co_u32 \dst, \ccOut, \src0, \ccIn, \src1 \dpp
+.endm
+
+.macro _v_add_lshl_u32 dst, src0, src1, shiftCnt
+    v_add_lshl_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+.macro _v_lshl_add_u32 dst, src0, src1, shiftCnt
+    v_lshl_add_u32 \dst, \src0, \src1, \shiftCnt
+.endm
+
+/******************************************/
+/* Magic div and mod functions            */
+/******************************************/
+.macro V_MAGIC_DIV dstIdx, dividend, magicNumber, magicShift
+    v_mul_hi_u32 v[\dstIdx+1], \dividend, \magicNumber
+    v_mul_lo_u32 v[\dstIdx+0], \dividend, \magicNumber
+    v_lshrrev_b64 v[\dstIdx:\dstIdx+1], \magicShift, v[\dstIdx:\dstIdx+1]
+.endm
+
+/******************************************/
+/* VGPR Assignments                       */
+/******************************************/
+.set vgprValuC, 0
+/* ValuA/B   Xn=PLR buffer idx,  In=InnerUnroll idx */
+.set vgprValuA_X0_I0, 32
+.set vgprValuA_X1_I0, 34
+.set vgprG2LA, 36
+.set vgprValuB_X0_I0, 40
+.set vgprValuB_X1_I0, 44
+.set vgprG2LB, 48
+.set vgprLocalWriteAddrA, 56
+.set vgprLocalWriteAddrB, 57
+.set vgprGlobalReadOffsetA, 58
+.set vgprGlobalReadOffsetB, 59
+.set vgprLocalReadAddrA, 60
+.set vgprLocalReadAddrB, 61
+.set vgprSerial, 62
+/* Num VGPR=63 */
+
+/******************************************/
+/* SGPR Assignments                       */
+/******************************************/
+.set sgprKernArgAddress, 0
+.set sgprWorkGroup0, 2
+.set sgprWorkGroup1, 3
+.set sgprWorkGroup2, 4
+.set sgprNumWorkGroups0, 5
+.set sgprNumWorkGroups1, 6
+.set sgprSrdA, 8
+.set sgprSrdB, 12
+.set sgprSrdD, 16
+.set sgprSrdC, 20
+.set sgprTensor2dSizeC, 24
+.set sgprTensor2dSizeA, 26
+.set sgprTensor2dSizeB, 28
+.set sgprSaveExecMask, 30
+.set sgprAddressD, 32
+.set sgprAddressC, 34
+.set sgprStridesD, 36
+.set sgprStridesC, 38
+.set sgprAlpha, 40
+.set sgprBeta, 41
+.set sgprSizesFree, 42
+.set sgprSizesSum, 45
+.set sgprLoopCounters, 46
+.set sgprOrigLoopCounter, 47
+.set sgprStridesA, 48
+.set sgprStridesB, 50
+.set sgprAddressA, 52
+.set sgprAddressB, 54
+.set sgprShadowLimitA, 56
+.set sgprShadowLimitB, 58
+.set sgprOrigStaggerUIter, 60
+.set sgprStaggerUIter, 61
+.set sgprWrapUA, 62
+.set sgprWrapUB, 64
+.set sgprNumFullBlocks, 66
+.set sgprWgmRemainder1, 67
+.set sgprMagicNumberWgmRemainder1, 68
+.set sgprGlobalReadIncsA, 69
+.set sgprGlobalReadIncsB, 70
+.set sgprScalarGlobalReadOffsetA, 71
+.set sgprScalarGlobalReadOffsetB, 72
+/* max SGPR=98 */
+
+/* Size Assignments */
+.set sgprSizeD0I, sgprSizesFree+0
+.set sgprSizeD1J, sgprSizesFree+1
+.set sgprSizeDK, sgprSizesFree+2
+.set sgprSizeC0I, sgprSizesFree+0
+.set sgprSizeC1J, sgprSizesFree+1
+.set sgprSizeCK, sgprSizesFree+2
+.set sgprSizeAL, sgprSizesSum+0
+.set sgprSizeA0I, sgprSizesFree+0
+.set sgprSizeAK, sgprSizesFree+2
+.set sgprSizeBL, sgprSizesSum+0
+.set sgprSizeB1J, sgprSizesFree+1
+.set sgprSizeBK, sgprSizesFree+2
+
+/* Stride Assignments */
+.set constStrideD0I, 1
+.set sgprStrideD1J, sgprStridesD+0
+.set sgprStrideDK, sgprStridesD+1
+.set constStrideC0I, 1
+.set sgprStrideC1J, sgprStridesC+0
+.set sgprStrideCK, sgprStridesC+1
+.set constStrideAL, 1
+.set sgprStrideA0I, sgprStridesA+0
+.set sgprStrideAK, sgprStridesA+1
+.set constStrideBL, 1
+.set sgprStrideB1J, sgprStridesB+0
+.set sgprStrideBK, sgprStridesB+1
+
+.set DepthU, 32
+/* Number of elements to shift-left SRD */
+.set SrdShiftLeftA, 4
+.set SrdShiftLeftB, 4
+/* 2GB limit - set offsets to -1 to exceed this and clamp */
+.set BufferLimit, 0x80000000
+/* Bits 127:96 of SRD.  Set DataFormat = 32 bit */
+.set Srd127_96, 0x0020000
+.set BufferOOB, 0x80000000
+
+/* Global Offset A */
+.macro GLOBAL_OFFSET_A vgprAddr vgprOffsetL vgprOffset0I vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStrideA0I], v[\vgprOffset0I] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprOffsetL], v[\vgprTmp+0] // accumulate d1 lower
+_v_add_u32 v[\vgprAddr+0], 0x4, v[\vgprAddr+0]     // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/* Global Offset B */
+.macro GLOBAL_OFFSET_B vgprAddr vgprOffsetL vgprOffset1J vgprTmp
+v_mul_lo_u32 v[\vgprTmp+0], s[sgprStrideB1J], v[\vgprOffset1J] // mul d1 lower
+_v_add_co_u32 v[\vgprAddr+0], vcc, v[\vgprOffsetL], v[\vgprTmp+0] // accumulate d1 lower
+_v_add_u32 v[\vgprAddr+0], 0x4, v[\vgprAddr+0]     // add prepad for pointer shift
+v_lshlrev_b32 v[\vgprAddr+0], 0x1, v[\vgprAddr+0]  // offset *= bytes/element
+.endm
+
+/******************************************/
+/* Dynamic Scalar Divide: vQuotient=vDividend/vDivisor; vRemainder=vDividend%vDivisor; */
+/******************************************/
+.macro DYNAMIC_VECTOR_DIVIDE vQuotient vRemainder vDividend vDivisor vTmp0 vTmp1 sTmp
+v_cvt_f32_u32 v[\vQuotient], v[\vDivisor]          //
+v_rcp_f32 v[\vQuotient], v[\vQuotient]             //
+v_mul_f32 v[\vQuotient], 0x4f800000, v[\vQuotient] //
+v_cvt_u32_f32 v[\vQuotient], v[\vQuotient]         //
+v_mul_lo_u32 v[\vRemainder], v[\vDivisor], v[\vQuotient] //
+v_mul_hi_u32 v[\vTmp0], v[\vDivisor], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp1], vcc, 0x0, v[\vRemainder]  //
+v_cmp_ne_i32 s[\sTmp:\sTmp+1], 0x0, v[\vTmp0]      //
+v_cndmask_b32 v[\vRemainder], v[\vTmp1], v[\vRemainder], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vRemainder], v[\vRemainder], v[\vQuotient] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vQuotient], v[\vRemainder] //
+_v_add_co_u32 v[\vQuotient], vcc, v[\vQuotient], v[\vRemainder] //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vTmp0], s[\sTmp:\sTmp+1] //
+v_mul_hi_u32 v[\vQuotient], v[\vQuotient], v[\vDividend] //
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vTmp0], vcc, v[\vDividend], v[\vRemainder] //
+v_cmp_ge_u32 s[\sTmp:\sTmp+1], v[\vDividend], v[\vRemainder] //
+_v_add_co_u32 v[\vRemainder], vcc, 0x1, v[\vQuotient] //
+_v_add_co_u32 v[\vTmp1], vcc, -1, v[\vQuotient]    //
+v_cmp_le_u32 vcc, v[\vDivisor], v[\vTmp0]          //
+s_and_b64 vcc, s[\sTmp:\sTmp+1], vcc               //
+v_cndmask_b32 v[\vQuotient], v[\vQuotient], v[\vRemainder], vcc //
+v_cndmask_b32 v[\vQuotient], v[\vTmp1], v[\vQuotient], s[\sTmp:\sTmp+1] //
+v_cmp_ne_i32 vcc, 0x0, v[\vDivisor]                //
+v_cndmask_b32 v[\vQuotient], -1, v[\vQuotient], vcc // final result
+v_mul_lo_u32 v[\vRemainder], v[\vQuotient], v[\vDivisor] //
+_v_sub_co_u32 v[\vRemainder], vcc, v[\vDividend], v[\vRemainder] // final result
+.endm
+
+/******************************************/
+/* 4x8 thread-tile                        */
+/******************************************/
+.macro MAC_4x8_X0
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[0] iui=0
+s_setprio 1 // Raise priority while processing macs
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[1]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[4]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+0], v[vgprValuC+0*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[5]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[2] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[3]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[6]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+0], v[vgprValuC+1*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[7]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[8] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[9]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[12]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+1], v[vgprValuC+0*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[13]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[10] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[11]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[14]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+1], v[vgprValuC+1*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[15]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[16] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[17]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[20]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+2], v[vgprValuC+0*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[21]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[18] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[19]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[22]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+2], v[vgprValuC+1*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[23]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[24] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[25]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+0], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[28]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+1], v[vgprValuA_X0_I0+0], v[vgprValuB_X0_I0+3], v[vgprValuC+0*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[29]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[26] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[27]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+0], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[30]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+1], v[vgprValuA_X0_I0+1], v[vgprValuB_X0_I0+3], v[vgprValuC+1*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[31]
+s_setprio 0 // Reset priority after macs
+.endm
+.macro MAC_4x8_X1
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[0] iui=0
+s_setprio 1 // Raise priority while processing macs
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[1]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[4]
+v_fma_mix_f32 v[vgprValuC+0*2+0*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+0], v[vgprValuC+0*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[5]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[2] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[3]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[6]
+v_fma_mix_f32 v[vgprValuC+1*2+0*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+0], v[vgprValuC+1*2+0*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[7]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[8] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[9]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[12]
+v_fma_mix_f32 v[vgprValuC+0*2+1*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+1], v[vgprValuC+0*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[13]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[10] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[11]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[14]
+v_fma_mix_f32 v[vgprValuC+1*2+1*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+1], v[vgprValuC+1*2+1*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[15]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[16] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[17]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[20]
+v_fma_mix_f32 v[vgprValuC+0*2+2*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+2], v[vgprValuC+0*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[21]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[18] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[19]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[22]
+v_fma_mix_f32 v[vgprValuC+1*2+2*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+2], v[vgprValuC+1*2+2*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[23]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[24] iui=0
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+0*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[25]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+0], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[28]
+v_fma_mix_f32 v[vgprValuC+0*2+3*4*2+2*2+1], v[vgprValuA_X1_I0+0], v[vgprValuB_X1_I0+3], v[vgprValuC+0*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[29]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+0*2+0] op_sel:[0,0,0] op_sel_hi:[1,1,0] //ValuC[26] iui=0
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+0*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+0*2+1] op_sel:[1,0,0] op_sel_hi:[1,1,0] //ValuC[27]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+0], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+2*2+0] op_sel:[0,1,0] op_sel_hi:[1,1,0] //ValuC[30]
+v_fma_mix_f32 v[vgprValuC+1*2+3*4*2+2*2+1], v[vgprValuA_X1_I0+1], v[vgprValuB_X1_I0+3], v[vgprValuC+1*2+3*4*2+2*2+1] op_sel:[1,1,0] op_sel_hi:[1,1,0] //valuC[31]
+s_setprio 0 // Reset priority after macs
+.endm
+
+
+
+
+/***** program start from here *****/
+
+.long 0xC00A0600, 0x00000008
+.long 0xC00A0D00, 0x00000028
+.long 0xC00A0C00, 0x00000050
+.long 0xC0020B40, 0x0000006C
+.long 0x7ECC0300
+.long 0x26CE00BF
+.long 0xB8D0F804
+.long 0xD1130004, 0x0000A0B0
+.long 0x20D00884
+.long 0x7EA40568
+.long 0xD1130069, 0x0000A08F
+.long 0x7EA20569
+.long 0xBF068151
+.long 0xBF8400EA
+.long 0xBF8CC07F
+.long 0xBE880034
+.long 0xBE890035
+.long 0xBE8A00FF, 0x80000000
+.long 0xBE8B00FF, 0x00020000
+.long 0x96553104
+.long 0x92543104
+.long 0x8ED48254
+.long 0x80085408
+.long 0x82095509
+.long 0x9254C030
+.long 0x92545402
+.long 0x92559030
+.long 0x92555552
+.long 0x81545554
+.long 0x2000CE85
+.long 0xD2850004, 0x00020030
+.long 0x2602CE9F
+.long 0x32180304
+.long 0x68181854
+.long 0x24181882
+.long 0x8E478330
+.long 0x80C7FF47, 0x00000120
+.long 0x681A1847
+.long 0x681C1A47
+.long 0x681E1C47
+.long 0x68201E47
+.long 0x68222047
+.long 0x68242247
+.long 0x68262447
+.long 0xBECC00FF, 0x00000900
+.long 0x924C4C52
+.long 0xBE8C0036
+.long 0xBE8D0037
+.long 0xBE8E00FF, 0x80000000
+.long 0xBE8F00FF, 0x00020000
+.long 0x96553304
+.long 0x92543304
+.long 0x8ED48254
+.long 0x800C540C
+.long 0x820D550D
+.long 0x9254A032
+.long 0x92545403
+.long 0x92558832
+.long 0x92555552
+.long 0x81545554
+.long 0x2004CE85
+.long 0xD2850004, 0x00020432
+.long 0x2606CE9F
+.long 0x32280704
+.long 0x68282854
+.long 0x24282882
+.long 0x8E4A8332
+.long 0x80CAFF4A, 0x00000120
+.long 0x682A284A
+.long 0x682C2A4A
+.long 0x682E2C4A
+.long 0xBECE00FF, 0x00000480
+.long 0x924E4E52
+.long 0x814EFF4E, 0x00004800
+.long 0xBF8A0000
+.long 0xBEFC004E
+.long 0x814FFF4E, 0x00001200
+.long 0xE0511000, 0x80030814
+.long 0xE0511120, 0x80030915
+.long 0xE0511240, 0x80030A16
+.long 0xE0511360, 0x80030B17
+.long 0xBEFC004C
+.long 0x814DFF4C, 0x00002400
+.long 0xE0511000, 0x8002000C
+.long 0xE0511120, 0x8002010D
+.long 0xE0511240, 0x8002020E
+.long 0xE0511360, 0x8002030F
+.long 0xE0511480, 0x80020410
+.long 0xE05115A0, 0x80020511
+.long 0xE05116C0, 0x80020612
+.long 0xE05117E0, 0x80020713
+.long 0xBEFC004F
+.long 0x800CFF0C, 0x00000080
+.long 0x820D800D
+.long 0x8008FF08, 0x00000080
+.long 0x82098009
+.long 0xE0511000, 0x80030814
+.long 0xE0511120, 0x80030915
+.long 0xE0511240, 0x80030A16
+.long 0xE0511360, 0x80030B17
+.long 0xBEFC004D
+.long 0xBF800000
+.long 0xE0511000, 0x8002000C
+.long 0xE0511120, 0x8002010D
+.long 0xE0511240, 0x8002020E
+.long 0xE0511360, 0x8002030F
+.long 0xE0511480, 0x80020410
+.long 0xE05115A0, 0x80020511
+.long 0xE05116C0, 0x80020612
+.long 0xE05117E0, 0x80020713
+.long 0x800CFF0C, 0x00000080
+.long 0x820D800D
+.long 0x8008FF08, 0x00000080
+.long 0x82098009
+.long 0xBEFC004E
+.long 0xBF8C4F74
+.long 0xBF8A0000
+.long 0xBF8C0F7C
+.long 0xBF8A0000
+.long 0x8F2E852D
+.long 0x80AE2E80
+.long 0xBF03C22E
+.long 0xBF85004F
+.long 0xBF8A0000
+.long 0xE0511000, 0x80030814
+.long 0xE0511120, 0x80030915
+.long 0xE0511240, 0x80030A16
+.long 0xE0511360, 0x80030B17
+.long 0xBEFC004C
+.long 0xBF800000
+.long 0xE0511000, 0x8002000C
+.long 0xE0511120, 0x8002010D
+.long 0xE0511240, 0x8002020E
+.long 0xE0511360, 0x8002030F
+.long 0xE0511480, 0x80020410
+.long 0xE05115A0, 0x80020511
+.long 0xE05116C0, 0x80020612
+.long 0xE05117E0, 0x80020713
+.long 0xBF8C4F74
+.long 0xBF8A0000
+.long 0x800CFF0C, 0x00000080
+.long 0x820D800D
+.long 0xBF8C0F7C
+.long 0xBF8A0000
+.long 0x8008FF08, 0x00000080
+.long 0x82098009
+.long 0xBEFC004F
+.long 0xBF8A0000
+.long 0xE0511000, 0x80030814
+.long 0xE0511120, 0x80030915
+.long 0xE0511240, 0x80030A16
+.long 0xE0511360, 0x80030B17
+.long 0xBEFC004D
+.long 0xBF800000
+.long 0xE0511000, 0x8002000C
+.long 0xE0511120, 0x8002010D
+.long 0xE0511240, 0x8002020E
+.long 0xE0511360, 0x8002030F
+.long 0xE0511480, 0x80020410
+.long 0xE05115A0, 0x80020511
+.long 0xE05116C0, 0x80020612
+.long 0xE05117E0, 0x80020713
+.long 0xBF8C4F74
+.long 0xBF8A0000
+.long 0x800CFF0C, 0x00000080
+.long 0x820D800D
+.long 0xBF8C0F7C
+.long 0xBF8A0000
+.long 0x8008FF08, 0x00000080
+.long 0x82098009
+.long 0xBEFC004E
+.long 0x802E822E
+.long 0xBF03C22E
+.long 0xBF84FFB1
+.long 0xBF8C0F78
+.long 0xBF8A0000
+.long 0xBF8C0F70
+.long 0xBF8A0000
+.long 0xBF810000
+.long 0xC0060700, 0x00000000
+.long 0xC00A0800, 0x00000018
+.long 0xC00A0A00, 0x00000038
+.long 0xC00A0900, 0x00000040
+.long 0xD3D94000, 0x18000080
+.long 0xD3D94001, 0x18000080
+.long 0xD3D94002, 0x18000080
+.long 0xD3D94003, 0x18000080
+.long 0xD3D94004, 0x18000080
+.long 0xD3D94005, 0x18000080
+.long 0xD3D94006, 0x18000080
+.long 0xD3D94007, 0x18000080
+.long 0xD1130001, 0x00011F67
+.long 0xD2850040, 0x000202A0
+.long 0x20040281
+.long 0xD2850002, 0x000204A0
+.long 0x2002CE84
+.long 0x24020282
+.long 0x68808101
+.long 0x24808082
+.long 0x68808102
+.long 0x9254FF52, 0x00000900
+.long 0x68808054
+.long 0x68808080
+.long 0x688280FF, 0x00002400
+.long 0xBF8A0000
+.long 0xD1130001, 0x00011F67
+.long 0xD2850042, 0x000202A0
+.long 0x20040281
+.long 0xD2850002, 0x000204A0
+.long 0x2002CE84
+.long 0x24020282
+.long 0x68848501
+.long 0x24848482
+.long 0x68848502
+.long 0x688484FF, 0x00004800
+.long 0x688684FF, 0x00001200
+.long 0xBF8CC07F
+.long 0xBE900022
+.long 0xBE910023
+.long 0xBE9200FF, 0x80000000
+.long 0xBE9300FF, 0x00020000
+.long 0x925603A0
+.long 0x96552656
+.long 0x92542656
+.long 0x8ED48254
+.long 0x80105410
+.long 0x82115511
+.long 0x96552704
+.long 0x92542704
+.long 0x8ED48254
+.long 0x80105410
+.long 0x82115511
+.long 0xD2850003, 0x0002D090
+.long 0x2608CE8F
+.long 0xD2850005, 0x00004D04
+.long 0x200CCE84
+.long 0x240C0C82
+.long 0x68D60B03
+.long 0x925402C0
+.long 0x32D40C54
+.long 0xD1FE0044, 0x020AD76A
+.long 0x925426C0
+.long 0x688A8854
+.long 0xBE940020
+.long 0xBE950021
+.long 0xBE9600FF, 0x80000000
+.long 0xBE9700FF, 0x00020000
+.long 0x925603A0
+.long 0x96552456
+.long 0x92542456
+.long 0x8ED48254
+.long 0x80145414
+.long 0x82155515
+.long 0x96552504
+.long 0x92542504
+.long 0x8ED48254
+.long 0x80145414
+.long 0x82155515
+.long 0xD2850003, 0x0002D090
+.long 0x2608CE8F
+.long 0xD2850005, 0x00004904
+.long 0x200CCE84
+.long 0x240C0C82
+.long 0x68D60B03
+.long 0x925402C0
+.long 0x32D40C54
+.long 0xD1FE0046, 0x020AD76A
+.long 0x925426C0
+.long 0x688E8C54
+.long 0xBF8A0000
+.long 0xD9FE0000, 0x20000042
+.long 0xD9FE0900, 0x28000042
+.long 0xD9FE0040, 0x24000042
+.long 0xD9FE0940, 0x2C000042
+.long 0xBF8A0000
+.long 0xD9FE0000, 0x10000040
+.long 0xD9FE0040, 0x14000040
+.long 0x8F2E852D
+.long 0x80AE2E80
+.long 0xBF03C22E
+.long 0xBF850065
+.long 0xBF8A0000
+.long 0xBF8CC17F
+.long 0xD3C50000, 0x04024110
+.long 0xD3C50004, 0x04125110
+.long 0xD3C50000, 0x04024311
+.long 0xD3C50004, 0x04125311
+.long 0xD3C50000, 0x04024512
+.long 0xBF8A0000
+.long 0xD3C50004, 0x04125512
+.long 0xD9FE0000, 0x30000043
+.long 0xD3C50000, 0x04024713
+.long 0xD9FE0900, 0x38000043
+.long 0xD3C50004, 0x04125713
+.long 0xD9FE0040, 0x34000043
+.long 0xBF8CC37F
+.long 0xD3C50000, 0x04024914
+.long 0xD9FE0940, 0x3C000043
+.long 0xD3C50004, 0x04125914
+.long 0xD3C50000, 0x04024B15
+.long 0xD3C50004, 0x04125B15
+.long 0xD3C50000, 0x04024D16
+.long 0xD3C50004, 0x04125D16
+.long 0xBF8A0000
+.long 0xD9FE0000, 0x18000041
+.long 0xD3C50000, 0x04024F17
+.long 0xD9FE0040, 0x1C000041
+.long 0xD3C50004, 0x04125F17
+.long 0xBF8A0000
+.long 0xBF8CC17F
+.long 0xD3C50000, 0x04026118
+.long 0xD3C50004, 0x04127118
+.long 0xD3C50000, 0x04026319
+.long 0xD3C50004, 0x04127319
+.long 0xD3C50000, 0x0402651A
+.long 0xBF8A0000
+.long 0xD3C50004, 0x0412751A
+.long 0xD9FE0000, 0x20000042
+.long 0xD3C50000, 0x0402671B
+.long 0xD9FE0900, 0x28000042
+.long 0xD3C50004, 0x0412771B
+.long 0xD9FE0040, 0x24000042
+.long 0xBF8CC37F
+.long 0xD3C50000, 0x0402691C
+.long 0xD9FE0940, 0x2C000042
+.long 0xD3C50004, 0x0412791C
+.long 0xD3C50000, 0x04026B1D
+.long 0xD3C50004, 0x04127B1D
+.long 0xD3C50000, 0x04026D1E
+.long 0xD3C50004, 0x04127D1E
+.long 0xBF8A0000
+.long 0xD9FE0000, 0x10000040
+.long 0xD3C50000, 0x04026F1F
+.long 0xD9FE0040, 0x14000040
+.long 0xD3C50004, 0x04127F1F
+.long 0x802E822E
+.long 0xBF03C22E
+.long 0xBF84FF9B
+.long 0xBF8CC17F
+.long 0xD3C50000, 0x04024110
+.long 0xE05C1000, 0x80040844
+.long 0xE05C1000, 0x80040C45
+.long 0xD3C50004, 0x04125110
+.long 0xD3C50000, 0x04024311
+.long 0xBF8A0000
+.long 0xD3C50004, 0x04125311
+.long 0xD9FE0000, 0x30000043
+.long 0xD3C50000, 0x04024512
+.long 0xD9FE0900, 0x38000043
+.long 0xD3C50004, 0x04125512
+.long 0xD9FE0040, 0x34000043
+.long 0xD3C50000, 0x04024713
+.long 0xD9FE0940, 0x3C000043
+.long 0xD3C50004, 0x04125713
+.long 0xBF8CC37F
+.long 0xD3C50000, 0x04024914
+.long 0xD3C50004, 0x04125914
+.long 0xD3C50000, 0x04024B15
+.long 0xD3C50004, 0x04125B15
+.long 0xD3C50000, 0x04024D16
+.long 0xBF8A0000
+.long 0xD9FE0000, 0x18000041
+.long 0xD3C50004, 0x04125D16
+.long 0xD9FE0040, 0x1C000041
+.long 0xD3C50000, 0x04024F17
+.long 0xD3C50004, 0x04125F17
+.long 0xBF8CC17F
+.long 0xD3C50000, 0x04026118
+.long 0xD3C50004, 0x04127118
+.long 0xD3C50000, 0x04026319
+.long 0xD3C50004, 0x04127319
+.long 0xD3C50000, 0x0402651A
+.long 0xD3C50004, 0x0412751A
+.long 0xD3C50000, 0x0402671B
+.long 0xD3C50004, 0x0412771B
+.long 0xBF8CC07F
+.long 0xD3C50000, 0x0402691C
+.long 0xD3C50000, 0x04026B1D
+.long 0xD3C50000, 0x04026D1E
+.long 0xD3C50000, 0x04026F1F
+.long 0xD3C50004, 0x0412791C
+.long 0xD3C50004, 0x04127B1D
+.long 0xD3C50004, 0x04127D1E
+.long 0xD3C50004, 0x04127F1F
+.long 0xD3D84000, 0x18000100
+.long 0x0A000028
+.long 0xD3D84001, 0x18000101
+.long 0x0A020228
+.long 0xD3D84002, 0x18000102
+.long 0x0A040428
+.long 0xD3D84003, 0x18000103
+.long 0x0A060628
+.long 0xBF8C0F71
+.long 0xD1CB0000, 0x04005308
+.long 0xD1CB0001, 0x04045309
+.long 0xD1CB0002, 0x0408530A
+.long 0xD1CB0003, 0x040C530B
+.long 0xE07C1000, 0x80050046
+.long 0xD3D84004, 0x18000104
+.long 0x0A080828
+.long 0xD3D84005, 0x18000105
+.long 0x0A0A0A28
+.long 0xD3D84006, 0x18000106
+.long 0x0A0C0C28
+.long 0xD3D84007, 0x18000107
+.long 0x0A0E0E28
+.long 0xBF8C0F71
+.long 0xD1CB0004, 0x0410530C
+.long 0xD1CB0005, 0x0414530D
+.long 0xD1CB0006, 0x0418530E
+.long 0xD1CB0007, 0x041C530F
+.long 0xE07C1000, 0x80050447
+.long 0xBF8C0000
+.long 0xBF810000


### PR DESCRIPTION
- Fix synchronization issue in one Arcturus DB_MT48x64x4_WGM4 replacement kernel causing 3 Arcturus rocblas-test nightly unit test failures in dtrmm and dtrsm
- Add replacement kernel support for NewClient:2; 14x2 replacement kernels with MDA2_ name segment are needed