### PR TITLE
storeRemap: support free 0 direction MIWaveGroup

### DIFF
--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -9201,6 +9201,11 @@ class KernelWriterAssembly(KernelWriter):
     kStr = ""
 
     kStr += inst("s_waitcnt", "lgkmcnt(0)", "wait for LDS write" )
+
+    #Data exchange between different waves
+    #Make sure LDS writes are finished of all waves
+    if kernel["MIWaveGroup"][0] > 1:
+      kStr += self.indent + self.syncStr + " //wait all lds write finished" + self.endLine
     kStr += "\n"
 
     gwvw = kernel["StoreRemapVectorWidth"]
@@ -9294,6 +9299,11 @@ class KernelWriterAssembly(KernelWriter):
     kStr += "\n"
     self.vgprPool.checkIn(vTmp)
 
+    #Data exchange between different waves
+    #Make sure LDS reads are finished of all waves
+    if kernel["MIWaveGroup"][0] > 1:
+      kStr += self.indent + self.syncStr + " //wait all lds read finished" + self.endLine
+
     return kStr
 
   ##############################################################################
@@ -9316,7 +9326,7 @@ class KernelWriterAssembly(KernelWriter):
     storeRemapLR = self.vgprPool.checkOut(1, "SR local read")
 
     tmpV0 = self.vgprPool.checkOut(5, "tmpV0")
-    tmpV1 = tmpV0+1
+    waveCoord0 = tmpV1 = tmpV0+1
     ldsStride = tmpV0+2
     coord0 = tmpV0+3
     waveCoord1 = tmpV0+4
@@ -9325,7 +9335,7 @@ class KernelWriterAssembly(KernelWriter):
     ldsPad = max(kernel["StoreRemapVectorWidth"],kernel["MIOutputVectorWidth"])
 
     #calculate local write Address: v[vgprLocalWriteAddrC]
-    kStr += vectorStaticDivideAndRemainder(tid1, tid0, "Serial", globalParameters["WavefrontWidth"], \
+    kStr += vectorStaticDivideAndRemainder(tid1, tid0, "Serial", globalParameters["WavefrontWidth"]*kernel["MIWaveGroup"][0], \
       tmpV0, tmpS0)
 
     kStr += inst("v_mul_lo_u32", vgpr(waveCoord1),
@@ -9337,11 +9347,17 @@ class KernelWriterAssembly(KernelWriter):
                     "lds stride = MT0 + PAD")
     kStr += inst("v_mul_lo_u32", vgpr(tmpV0), vgpr(tid1), vgpr(ldsStride), \
                   "lds coord1 offset = Col-id* lds stride")
+
+    kStr += vectorStaticDivideAndRemainder(waveCoord0, tid0, tid0, globalParameters["WavefrontWidth"],tmpV0, tmpS0)
     kStr += inst("v_lshrrev_b32", vgpr(coord0),
-                hex(log2(kernel["MatrixInstM"])), vgpr(tid0), \
-                "tid / matrixInstM")
+                hex(log2(kernel["MatrixInstN"])), vgpr(tid0), \
+                "tid / matrixInstN")
+
     kStr += inst("v_lshlrev_b32", vgpr(coord0), hex(log2(kernel["MIOutputVectorWidth"])), vgpr(coord0), \
                   "lds coord0 offset *= 4 (each thread hold 4 element)")
+
+    kStr += inst("v_mad_u32_u24", vgpr(coord0), kernel["MatrixInstM"]*kernel["MatrixInstBM"], vgpr(waveCoord0), vgpr(coord0), \
+                  "coord0 += waveCoord0 * wave M shape(blockM*MiM)")
 
     kStr += inst("_v_add_lshl_u32", \
       vgpr(storeRemapLW), \
@@ -9354,16 +9370,21 @@ class KernelWriterAssembly(KernelWriter):
     # calculate local read address : v[vgprLocalReadAddrC]
 
     kStr += self.comment1("Store Remap Local Read address")
+
+    kStr += vectorStaticDivideAndRemainder(tid1, tid0, "Serial", globalParameters["WavefrontWidth"], \
+      tmpV0, tmpS0)
+    kStr += inst("v_mul_lo_u32", vgpr(waveCoord1),
+                  hex(kernel["MatrixInstN"]//kernel["MIWaveGroup"][0]), vgpr(tid1), "coord1 offset of LDS for each Wave")
+
     nThreadPerCol = kernel["MacroTile0"] // gwvw
     nColPerLoad = globalParameters["WavefrontWidth"] // nThreadPerCol
     self.storeRemapLrOffset = (kernel["MacroTile0"]+ldsPad) * nColPerLoad
     self.storeRemapNCPL = nColPerLoad
-    kStr += inst("v_lshrrev_b32", vgpr(tid1),\
+
+    kStr += inst("v_lshrrev_b32", vgpr(tmpV1),\
                 hex(log2(nThreadPerCol)), vgpr(tid0), \
                 "tid / nThreadPerCol")
-    kStr += inst("v_add_u32", vgpr(coord1Offset), vgpr(waveCoord1),vgpr(tid1),"coord1 offset in MacroTile")
-    kStr += inst("v_mov_b32", vgpr(ldsStride), hex(kernel["MacroTile0"]+ldsPad), \
-                    "lds stride = MT0 + PAD")
+    kStr += inst("v_add_u32", vgpr(coord1Offset), vgpr(waveCoord1),vgpr(tmpV1),"coord1 offset in MacroTile")
     kStr += inst("v_mul_lo_u32", vgpr(tmpV0), vgpr(coord1Offset), vgpr(ldsStride), \
                   "lds coord1 offset = Col-id* lds stride")
 
@@ -9382,15 +9403,23 @@ class KernelWriterAssembly(KernelWriter):
 
     # calculate global write coord0 and coord1
     kStr += self.comment1("Store Remap global write coord0 and coord1")
-    kStr += vectorStaticDivideAndRemainder(waveCoord1, tmpV1, "Serial", globalParameters["WavefrontWidth"], \
+    kStr += vectorStaticDivideAndRemainder(tid1, tid0, "Serial", globalParameters["WavefrontWidth"]*kernel["MIWaveGroup"][0], \
       tmpV0, tmpS0)
 
-    ColsPerWave = kernel["MatrixInstN"] * kernel["MatrixInstBN"]
+    ColsPerBlockShape = kernel["MatrixInstN"] * kernel["MatrixInstBN"]
+
     kStr += inst("v_mul_lo_u32", vgpr(waveCoord1),
-                  hex(ColsPerWave), vgpr(waveCoord1), "coord1 offset of global memory for each Wave")
+                  hex(ColsPerBlockShape), vgpr(tid1), "coord1 offset of global memory for each Wave")
+
+    kStr += vectorStaticDivideAndRemainder(tid1, tid0, tid0, globalParameters["WavefrontWidth"], \
+      tmpV0, tmpS0)
+    kStr += inst("v_mad_u32_u24", vgpr(waveCoord1), kernel["MatrixInstN"]//kernel["MIWaveGroup"][0], vgpr(tid1), vgpr(waveCoord1), \
+                  "waveCoord1 += waveCoord0 * MiN / WaveGroupM")
+
     kStr += inst("v_lshrrev_b32", vgpr(tmpV1),\
-                hex(log2(nThreadPerCol)), vgpr(tmpV1), \
+                hex(log2(nThreadPerCol)), vgpr(tid0), \
                 "tid / nThreadPerCol")
+
     kStr += inst("v_add_u32", vgpr(coord1Offset), vgpr(waveCoord1),vgpr(tmpV1),"coord1 offset in MacroTile")
 
     kStr += inst("s_mul_i32", \

--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -2770,16 +2770,19 @@ class Solution:
     if state["StoreRemapVectorWidth"]:
       if not state["EnableMatrixInstruction"]:
         reject(state, "storeRemap only support MaxtrixInstruction kernel")
+        return
       if state["PersistentKernel"]:
         reject(state, "storeRemap doesn't support persist kernel yet")
+        return
       if state["GlobalSplitU"] > 1:
         reject(state, "storeRemap doesn't support GlobalSplitU yet")
+        return
       if packedC0 or packedC1:
         reject(state, "storeRemap doesn't support packedC0 and packedC1 yet")
-      if state["MIWaveGroup"][0] > 1:
-        reject(state, "storeRemap doesn't support MI wave group in M direction yet")
+        return
       if state["MatrixInstBN"] > 1 and state["MatrixInstN"] == 4:
         reject(state, "storeRemap doesn't support MI4x4 multi blocks in N direction yet")
+        return
 
       srMinVw = 1
       srMaxVw = 8
@@ -2789,13 +2792,18 @@ class Solution:
         srMinVw = 2
       if srMinVw > state["StoreRemapVectorWidth"] or srMaxVw < state["StoreRemapVectorWidth"]:
         reject(state, "StoreRemapVectorWidth %u is not allowed for this data type" % state["StoreRemapVectorWidth"])
+        return
 
-      if state["MacroTile0"]*state["MatrixInstN"] < state["StoreRemapVectorWidth"]*globalParameters["WavefrontWidth"]:
-        reject(state, "storeRemap: number of lds elements less than per wave local read elements. Please use smaller StoreRemapVectorWidth")
-      wavefronts = state["NumThreads"] // globalParameters["WavefrontWidth"]
+      if state["StoreRemapVectorWidth"] * globalParameters["WavefrontWidth"] < state["MacroTile0"]:
+        reject(state, "storeRemap: Per wave single global write instruction doesn't enough to write one M column." + \
+               " Please use larger StoreRemapVectorWidth.")
+        return
+      if (state["MacroTile0"]*state["MatrixInstN"])//state["MIWaveGroup"][0] < state["StoreRemapVectorWidth"]*globalParameters["WavefrontWidth"]:
+        reject(state, "storeRemap: number elements of lds less than per wave per local read elements." + \
+               " Please use smaller StoreRemapVectorWidth.")
+        return
       ldsRemapPad = max(state["StoreRemapVectorWidth"],state["MIOutputVectorWidth"])
-      ldsNumElementsPerWave = (state["MacroTile0"]+ldsRemapPad)* state["MatrixInstN"]
-      ldsNumElementsRemapC = ldsNumElementsPerWave * wavefronts
+      ldsNumElementsRemapC = (state["MacroTile0"]+ldsRemapPad)* state["MatrixInstN"] * state["MIWaveGroup"][1]
       #print("ldsNumElementsRemapC=%u" % ldsNumElementsRemapC)
       ldsNumElements = max(ldsNumElements, ldsNumElementsRemapC)
 


### PR DESCRIPTION
New Refactor MI instruction can support MIWaveGroup layout placed in free 0 dims.
Modify storeRemap to support this design.

Pros:
- Support almost all new refactor MI kernel
- Lower LDS consumption for same MT
Cons:
- Needs s_barrier between LDS write/read
