### PR TITLE
Fix reading winnerIdx from csv (for conv and contraction)

### DIFF
--- a/Tensile/LibraryLogic.py
+++ b/Tensile/LibraryLogic.py
@@ -414,15 +414,17 @@ class LogicAnalyzer:
     # column indices
     csvFile = csv.reader(dataFile)
     problemSizeStartIdx = 1
+    # notice that for OperationType != GEMM, the numIndices = 0
     totalSizeIdx = problemSizeStartIdx + self.numIndices
-    solutionStartIdx = totalSizeIdx + 1
-    rowLength = solutionStartIdx + numSolutions
 
     # iterate over rows
     rowIdx = 0
     for row in csvFile:
       rowIdx+=1
       if rowIdx == 1:
+        # get the length of each row, and derive the first column of the solution instead of using wrong "solutionStartIdx = totalSizeIdx + 1"
+        rowLength = len(row)
+        solutionStartIdx = rowLength - numSolutions        
         continue
       else:
         #if len(row) < rowLength:


### PR DESCRIPTION
For OperationType != GEMM, the numIndices is set 0
But the csv file still output LDD/A/B/C. So in addFromCSV, using "solutionStartIdx = totalSizeIdx + 1" to determine the column ID of the first solution ID would be incorrect since the Logic Yaml will always choose the "TotalFlops" as the winner. (starts from LDD/A/B/C/TotalFlops...)

This can be seen in an existing logic "Tensile/Tensile/Configs/miopen/archives/resnet/2020-05-06/exact/vega20_Cijk_Ailk_Bjlk_HH.yaml", you may notice that all the winners at the end are wrong.