### PR TITLE
wider local read and use 1 LDS buffer with prefetch global read

### DIFF
--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -281,7 +281,7 @@ validParameters = {
     "WaveSeparateGlobalReadB":    [ 0, 1 ],
 
     "PrefetchGlobalRead":         [ False, True ], # prefetch / double-buffer reads from global memory -> vgprs -> lds. Requires 2X LDS space, and VGPRs for buffering data on way into LDS
-    "PrefetchLocalRead":          [ 0,1,2,3], # prefetch / double-buffer reads from lds (or 2 for triple-buffer, 3 for quad-buffer).  Increases size of ValuA/ValuB registers.
+    "PrefetchLocalRead":          list(range(128+1)), # prefetch / double-buffer reads from lds (or 2 for triple-buffer, 3 for quad-buffer).  Increases size of ValuA/ValuB registers.
 
     # Split the unroll summation into multiple sections and combine the sections
     # GSU applies only to the unroll summation dimension

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -280,8 +280,33 @@ validParameters = {
     "WaveSeparateGlobalReadA":    [ 0, 1 ],
     "WaveSeparateGlobalReadB":    [ 0, 1 ],
 
-    "PrefetchGlobalRead":         [ False, True ], # prefetch / double-buffer reads from global memory -> vgprs -> lds. Requires 2X LDS space, and VGPRs for buffering data on way into LDS
-    "PrefetchLocalRead":          list(range(128+1)), # prefetch / double-buffer reads from lds (or 2 for triple-buffer, 3 for quad-buffer).  Increases size of ValuA/ValuB registers.
+    # prefetch / double-buffer reads from global memory -> vgprs -> lds. Requires 2X LDS space, and VGPRs for buffering data on way into LDS
+    "PrefetchGlobalRead":         [ False, True ],
+
+    # number of iteration prefetch local reads from lds to VGPRs buffer = PLR % LoopIter
+    # number of VGPRs buffer = min(PLR,LoopIters)
+    # LoopIters = DepthU / LocalSplitU
+    # (LoopIters /= MatrixInstruction_K)
+    # ex. MT64x128x16_MI32x32x4x2_PLR1, we'll have 4 LoopIters, prefetch read 1 iteration, with 2 VGPRs buffer
+    #     befor loop:       plr[0]
+    #           loop: iter0:plr[1] MAC_r[0], iter1:plr[0] MAC_r[1], iter2:plr[1] MAC_r[0], iter3:plr[0] MAC_r[1]
+    #   no load loop: iter0:plr[1] MAC_r[0], iter1:plr[0] MAC_r[1], iter2:plr[1] MAC_r[0], iter3:       MAC_r[1]
+    #
+    # ex. MT64x128x16_MI32x32x4x2_PLR3, we'll have 4 LoopIterss, prefetch read 3 iteration, with 4 VGPRs buffer
+    #     befor loop:       plr[0] plr[1] plr[2]
+    #           loop: iter0:plr[3] MAC_r[0], iter1:plr[0] MAC_r[1], iter2:plr[1] MAC_r[2], iter3:plr[2] MAC_r[3]
+    #   no load loop: iter0:plr[3] MAC_r[0], iter1:       MAC_r[1], iter2:       MAC_r[2], iter3:       MAC_r[3]
+    #
+    # ex. MT64x128x16_MI32x32x4x2_PLR5, we'll have 4 LoopIterss, prefetch read 5%4=1 iteration, with 4 VGPRs buffer
+    #     befor loop:       plr[0]
+    #           loop: iter0:plr[1] MAC_r[0], iter1:plr[2] MAC_r[1], iter2:plr[3] MAC_r[2], iter3:plr[0] MAC_r[3]
+    #   no load loop: iter0:plr[1] MAC_r[0], iter1:plr[2] MAC_r[1], iter2:plr[3] MAC_r[2], iter3:       MAC_r[3]
+    #
+    # ex. MT64x128x16_MI32x32x4x2_PLR5_LRVW8, we'll have 4 LoopIterss, prefetch read 5%4=1 iteration, with 4 VGPRs buffer, each read read 2 iterations
+    #     befor loop:       plr[0:1]
+    #           loop: iter0:plr[2:3] MAC_r[0], iter1: MAC_r[1], iter2: MAC_r[2], iter3:plr[0:1] MAC_r[3]
+    #   no load loop: iter0:plr[2:3] MAC_r[0], iter1: MAC_r[1], iter2: MAC_r[2], iter3:         MAC_r[3]
+    "PrefetchLocalRead":          list(range(128+1)),
 
     # We use double LDS buffer when PrefetchGlobalRead. 
     # While it reads data from LDS[0]/[1], it prefetch global data and writes to LDS[1]/[0]

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -2739,6 +2739,8 @@ class KernelWriterAssembly(KernelWriter):
         msg = "half store requires at lesat two elements per batch"
       elif self.overflowedResources == 4:
         msg = "Occupancy limit"
+      elif self.overflowedResources == 5:
+        msg = "reading and writing LDS at same time require 2 LDS buffer"
       else:
         msg = "unknown"
 
@@ -6659,6 +6661,8 @@ class KernelWriterAssembly(KernelWriter):
   def localWriteSwapOffsets(self, kernel, tP):
     if not self.do["LocalWrite"]: return ""
     kStr = ""
+    if kernel["1LDSBuffer"]:
+      return kStr
     tc = tP["tensorChar"]
 #fixme-iui  need to use wrapping increment for double or triple buffering:
     if kernel["ExpandPointerSwap"]:
@@ -6687,6 +6691,8 @@ class KernelWriterAssembly(KernelWriter):
   def localWriteResetOffsets(self, kernel, tP):
     if not self.do["LocalWrite"]: return ""
     kStr = ""
+    if kernel["1LDSBuffer"]:
+      return kStr
     resetMask = hex(kernel["LdsOffsetA_Blk"]*tP["bpe"]-1 | self.LdsOOB)
     tc = tP["tensorChar"]
     if kernel["ExpandPointerSwap"]:
@@ -7011,7 +7017,8 @@ class KernelWriterAssembly(KernelWriter):
     tc=tP["tensorChar"]
     if not self.do["LocalRead%s"%tc]: return ""
     kStr = ""
-
+    if kernel["1LDSBuffer"]:
+      return kStr
     if internalPointerSwap:
       tP["localReadSwapByteOffset"] = 0 if tP["localReadSwapByteOffset"] else kernel["LdsOffsetA_Blk"]*tP["bpe"]
       kStr += self.comment("local read swap internal offset -> %u" % tP["localReadSwapByteOffset"])

--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -2785,6 +2785,21 @@ class Solution:
     #print("ldsNumElementsAlignedB", ldsNumElementsAlignedB)
     #print("ldsNumElementsAB", ldsNumElementsAB)
 
+
+    if state["1LDSBuffer"] == -1:
+      if ldsNumElementsAB * state["ProblemType"]["DataType"].numBytes() > globalParameters["MaxLDS"]:
+        state["1LDSBuffer"] = 1
+      else:
+        state["1LDSBuffer"] = 0
+
+    if state["1LDSBuffer"]:
+      if not state["PrefetchGlobalRead"]:
+        reject(state, "PGR=0 already use 1 LDS buffer only")
+      if not state["LocalReadVectorWidth"] > state["ProblemType"]["DataType"].numMIInput():
+        reject(state, "(currently) require wider localread to avoid reading and writing same LDS buffer at same time")
+      state["LdsOffsetB"] = ldsNumElementsAlignedA
+      ldsNumElementsAB = ldsNumElementsAlignedA + ldsNumElementsB
+
     # lds size is the greater of the two
     ldsNumElements = max(ldsNumElementsAB, ldsNumElementsReduction, ldsNumElementsOccupancy)
 

--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -2697,12 +2697,12 @@ class Solution:
 
     # Default LocalReadVectorWidth
     if state["LocalReadVectorWidth"] == -1:
-      if state["MatrixInstruction"]:
+      if state["EnableMatrixInstruction"]:
         state["LocalReadVectorWidth"] = state["ProblemType"]["DataType"].numMIInput()
       else:
         state["LocalReadVectorWidth"] = state["VectorWidth"]
     else:
-      if not state["MatrixInstruction"]:
+      if not state["EnableMatrixInstruction"]:
         reject(state, "LocalReadVectorWidth requires MatrixInstruction")
       if not state["TransposeLDS"]:
         reject(state, "LocalReadVectorWidth requires TransposeLDS=1")
@@ -2715,7 +2715,7 @@ class Solution:
       if state["ProblemType"]["TLUA"]:
         state["LdsPadA"] = 0
       else:
-        if state["MatrixInstruction"] and state["TransposeLDS"]:
+        if state["EnableMatrixInstruction"] and state["TransposeLDS"]:
           state["LdsPadA"] = max(state["GlobalReadVectorWidth"],state["LocalReadVectorWidth"])
         else:
           state["LdsPadA"] = state["VectorWidth"]
@@ -2724,7 +2724,7 @@ class Solution:
       if state["ProblemType"]["TLUB"]:
         state["LdsPadB"] = 0
       else:
-        if state["MatrixInstruction"] and state["TransposeLDS"]:
+        if state["EnableMatrixInstruction"] and state["TransposeLDS"]:
           state["LdsPadB"] = max(state["GlobalReadVectorWidth"],state["LocalReadVectorWidth"])
         else:
           state["LdsPadB"] = state["VectorWidth"]
@@ -2903,11 +2903,11 @@ class Solution:
       reject(state, "ScheduleIterAlg 2 only work with EPS1_SGR1, LoopIter=1")
 
     if state["TransposeLDS"] == 1:
-      if not state["MatrixInstruction"]:
+      if not state["EnableMatrixInstruction"]:
         reject(state, "TransposeLds Supports only in MatrixInstruction=1")
       if state["ProblemType"]["TLUA"] and state["ProblemType"]["TLUB"]:
           reject(state, "TransposeLds requires TLUA=0 or TLUB=0")
-      if state["MatrixInstruction"]:
+      if state["EnableMatrixInstruction"]:
         # enable widerLocalRead
         if state["LocalReadVectorWidth"] > state["ProblemType"]["DataType"].numMIInput():
           # not support 1 block MI

--- a/Tensile/Tests/pre_checkin/mfma/1LDSB.yaml
+++ b/Tensile/Tests/pre_checkin/mfma/1LDSB.yaml
@@ -1,0 +1,153 @@
+GlobalParameters:
+  NumElementsToValidate: -1
+  BoundsCheck: True
+  KernelTime: True
+  NewClient: 2
+
+BenchmarkProblems:
+  ########################################
+  # TN - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: s
+      TransposeA: True
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [32, 32, 1, 2]
+          - [32, 32, 2, 1]
+          - [16, 16, 1, 4]
+          - [16, 16, 4, 1]
+        - ThreadTile:
+          - [ 1, 32 ]
+          - [ 2, 64 ]
+        - WorkGroup:
+          - [ 64, 4, 1 ]
+        - AssertSummationElementMultiple: [1]
+        - AssertFree0ElementMultiple: [1]
+        - AssertFree1ElementMultiple: [1]
+        - VectorWidth: [1]
+        - PrefetchGlobalRead: [1]
+        - PrefetchLocalRead: [1,5,9,17]
+        - DepthU: [16,32]
+        - GlobalReadVectorWidth: [1]
+        - LocalReadVectorWidth: [-1,1,2,4]
+        - ScheduleIterAlg: [3]
+        - InnerUnroll: [1,2,4]
+        - TransposeLDS: [0,1]
+        - LdsBlockSizePerPad: [-1]
+        - LdsPadA: [-1]
+        - LdsPadB: [-1]
+        - 1LDSBuffer: [1]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [128], [256], [1], [255,1,257] ]
+
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: b
+      DestDataType: B
+      ComputeDataType: s
+      HighPrecisionAccumulate: True
+      TransposeA: True
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [32, 32, 2, 2]
+          - [32, 32, 4, 1]
+          - [16, 16, 2, 4]
+          - [16, 16, 8, 1]
+        - ThreadTile:
+          - [ 1, 32 ]
+          - [ 2, 64 ]
+        - WorkGroup:
+          - [ 64, 4, 1 ]
+        - AssertSummationElementMultiple: [1]
+        - AssertFree0ElementMultiple: [1]
+        - AssertFree1ElementMultiple: [1]
+        - VectorWidth: [2]
+        - PrefetchGlobalRead: [1]
+        - PrefetchLocalRead: [1,5,9,17]
+        - DepthU: [32,64]
+        - GlobalReadVectorWidth: [2]
+        - LocalReadVectorWidth: [-1,2,4,8]
+        - ScheduleIterAlg: [3]
+        - InnerUnroll: [1,2,4]
+        - TransposeLDS: [0,1]
+        - LdsBlockSizePerPad: [-1]
+        - LdsPadA: [-1]
+        - LdsPadB: [-1]
+        - 1LDSBuffer: [1]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [128], [256], [1], [255,1,257] ]
+
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: h
+      HighPrecisionAccumulate: True
+      TransposeA: True
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [32, 32, 4, 2]
+          - [32, 32, 8, 1]
+          - [16, 16, 4, 4]
+          - [16, 16, 16, 1]
+        - ThreadTile:
+          - [ 1, 32 ]
+          - [ 2, 64 ]
+        - WorkGroup:
+          - [ 64, 4, 1 ]
+        - AssertSummationElementMultiple: [1]
+        - AssertFree0ElementMultiple: [1]
+        - AssertFree1ElementMultiple: [1]
+        - VectorWidth: [2]
+        - PrefetchGlobalRead: [1]
+        - PrefetchLocalRead: [1,3,5,9]
+        - DepthU: [32,64]
+        - GlobalReadVectorWidth: [2,4]
+        - LocalReadVectorWidth: [-1,2,4,8]
+        - ScheduleIterAlg: [3]
+        - InnerUnroll: [1,2]
+        - TransposeLDS: [0,1]
+        - LdsBlockSizePerPad: [-1]
+        - LdsPadA: [-1]
+        - LdsPadB: [-1]
+        - 1LDSBuffer: [1]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [128], [256], [1], [255,1,257] ]
+
+LibraryLogic:
+    ScheduleName: "arcturus"
+    DeviceNames: ["Device 7380", "Device 7388", "Device 738c", "Device 7390"]
+    ArchitectureName: "gfx908"

--- a/Tensile/Tests/pre_checkin/mfma/1LDSB.yaml
+++ b/Tensile/Tests/pre_checkin/mfma/1LDSB.yaml
@@ -1,3 +1,6 @@
+TestParameters:
+  marks: [skip-gfx900, skip-gfx906, skip-gfx1010] # not supported by arch
+
 GlobalParameters:
   NumElementsToValidate: -1
   BoundsCheck: True

--- a/Tensile/Tests/pre_checkin/mfma/wider_local_read.yaml
+++ b/Tensile/Tests/pre_checkin/mfma/wider_local_read.yaml
@@ -1,0 +1,415 @@
+GlobalParameters:
+  NumElementsToValidate: -1
+  BoundsCheck: True
+  KernelTime: True
+  NewClient: 2
+
+BenchmarkProblems:
+  ########################################
+  # TN - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: s
+      TransposeA: True
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [32, 32, 1, 2]
+          - [32, 32, 2, 1]
+          - [16, 16, 1, 4]
+          - [16, 16, 4, 1]
+        - ThreadTile:
+          - [ 1, 32 ]
+          - [ 2, 64 ]
+        - WorkGroup:
+          - [ 64, 4, 1 ]
+        - AssertSummationElementMultiple: [1]
+        - AssertFree0ElementMultiple: [1]
+        - AssertFree1ElementMultiple: [1]
+        - VectorWidth: [1]
+        - PrefetchGlobalRead: [1]
+        - PrefetchLocalRead: [1,5,9,17]
+        - DepthU: [16]
+        - GlobalReadVectorWidth: [1]
+        - LocalReadVectorWidth: [-1,1,2,4]
+        - ScheduleIterAlg: [3]
+        - InnerUnroll: [1,2,4]
+        - TransposeLDS: [0,1]
+        - LdsBlockSizePerPad: [128]
+        - LdsPadA: [-1]
+        - LdsPadB: [-1]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [128], [256], [1], [255,1,257] ]
+
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: b
+      DestDataType: B
+      ComputeDataType: s
+      HighPrecisionAccumulate: True
+      TransposeA: True
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [32, 32, 2, 2]
+          - [32, 32, 4, 1]
+          - [16, 16, 2, 4]
+          - [16, 16, 8, 1]
+        - ThreadTile:
+          - [ 1, 32 ]
+          - [ 2, 64 ]
+        - WorkGroup:
+          - [ 64, 4, 1 ]
+        - AssertSummationElementMultiple: [1]
+        - AssertFree0ElementMultiple: [1]
+        - AssertFree1ElementMultiple: [1]
+        - VectorWidth: [2]
+        - PrefetchGlobalRead: [1]
+        - PrefetchLocalRead: [1,5,9,17]
+        - DepthU: [32]
+        - GlobalReadVectorWidth: [2]
+        - LocalReadVectorWidth: [-1,2,4,8]
+        - ScheduleIterAlg: [3]
+        - InnerUnroll: [1,2,4]
+        - TransposeLDS: [0,1]
+        - LdsBlockSizePerPad: [128]
+        - LdsPadA: [-1]
+        - LdsPadB: [-1]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [128], [256], [1], [255,1,257] ]
+
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: h
+      HighPrecisionAccumulate: True
+      TransposeA: True
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [32, 32, 4, 2]
+          - [32, 32, 8, 1]
+          - [16, 16, 4, 4]
+          - [16, 16, 16, 1]
+        - ThreadTile:
+          - [ 1, 32 ]
+          - [ 2, 64 ]
+        - WorkGroup:
+          - [ 64, 4, 1 ]
+        - AssertSummationElementMultiple: [1]
+        - AssertFree0ElementMultiple: [1]
+        - AssertFree1ElementMultiple: [1]
+        - VectorWidth: [2]
+        - PrefetchGlobalRead: [1]
+        - PrefetchLocalRead: [1,3,5,9]
+        - DepthU: [32]
+        - GlobalReadVectorWidth: [2]
+        - LocalReadVectorWidth: [-1,2,4,8]
+        - ScheduleIterAlg: [3]
+        - InnerUnroll: [1,2]
+        - TransposeLDS: [0,1]
+        - LdsBlockSizePerPad: [128]
+        - LdsPadA: [-1]
+        - LdsPadB: [-1]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [128], [256], [1], [255,1,257] ]
+
+  ########################################
+  # NT - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: s
+      TransposeA: False
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [32, 32, 1, 2]
+          - [32, 32, 2, 1]
+          - [16, 16, 1, 4]
+          - [16, 16, 4, 1]
+        - ThreadTile:
+          - [ 1, 32 ]
+          - [ 2, 64 ]
+        - WorkGroup:
+          - [ 64, 4, 1 ]
+        - AssertSummationElementMultiple: [1]
+        - AssertFree0ElementMultiple: [1]
+        - AssertFree1ElementMultiple: [1]
+        - VectorWidth: [1]
+        - PrefetchGlobalRead: [1]
+        - PrefetchLocalRead: [1,9,17]
+        - DepthU: [16]
+        - GlobalReadVectorWidth: [1]
+        - LocalReadVectorWidth: [-1,1,2,4] # not support LRVW != -1
+        - ScheduleIterAlg: [3]
+        - InnerUnroll: [1,2]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [128], [256], [1], [255,1,257] ]
+
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: b
+      DestDataType: B
+      ComputeDataType: s
+      HighPrecisionAccumulate: True
+      TransposeA: False
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [32, 32, 2, 2]
+          - [32, 32, 4, 1]
+          - [16, 16, 2, 4]
+          - [16, 16, 8, 1]
+        - ThreadTile:
+          - [ 1, 32 ]
+          - [ 2, 64 ]
+        - WorkGroup:
+          - [ 64, 4, 1 ]
+        - AssertSummationElementMultiple: [1]
+        - AssertFree0ElementMultiple: [1]
+        - AssertFree1ElementMultiple: [1]
+        - VectorWidth: [2]
+        - PrefetchGlobalRead: [1]
+        - PrefetchLocalRead: [1,9,17]
+        - DepthU: [32]
+        - GlobalReadVectorWidth: [2]
+        - LocalReadVectorWidth: [-1,2,4,8] # not support LRVW != -1
+        - ScheduleIterAlg: [3]
+        - InnerUnroll: [1,2]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [128], [256], [1], [255,1,257] ]
+
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: h
+      HighPrecisionAccumulate: True
+      TransposeA: False
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [32, 32, 4, 2]
+          - [32, 32, 8, 1]
+          - [16, 16, 4, 4]
+          - [16, 16, 16, 1]
+        - ThreadTile:
+          - [ 1, 32 ]
+          - [ 2, 64 ]
+        - WorkGroup:
+          - [ 64, 4, 1 ]
+        - AssertSummationElementMultiple: [1]
+        - AssertFree0ElementMultiple: [1]
+        - AssertFree1ElementMultiple: [1]
+        - VectorWidth: [2]
+        - PrefetchGlobalRead: [1]
+        - PrefetchLocalRead: [1,5,9]
+        - DepthU: [32]
+        - GlobalReadVectorWidth: [2]
+        - LocalReadVectorWidth: [-1,2,4,8] # not support LRVW != -1
+        - ScheduleIterAlg: [3]
+        - InnerUnroll: [1,2]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [128], [256], [1], [255,1,257] ]
+
+  ########################################
+  # NN - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: s
+      TransposeA: False
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [32, 32, 1, 2]
+          - [32, 32, 2, 1]
+          - [16, 16, 1, 4]
+          - [16, 16, 4, 1]
+        - ThreadTile:
+          - [ 1, 32 ]
+          - [ 2, 64 ]
+        - WorkGroup:
+          - [ 64, 4, 1 ]
+        - AssertSummationElementMultiple: [1]
+        - AssertFree0ElementMultiple: [1]
+        - AssertFree1ElementMultiple: [1]
+        - VectorWidth: [1]
+        - PrefetchGlobalRead: [1]
+        - PrefetchLocalRead: [1,9,17]
+        - DepthU: [16]
+        - GlobalReadVectorWidth: [1]
+        - LocalReadVectorWidth: [-1,1,2,4] # not support LRVW != -1
+        - ScheduleIterAlg: [3]
+        - InnerUnroll: [1,2]
+        - TransposeLDS: [0,1]
+        - LdsBlockSizePerPad: [128]
+        - LdsPadA: [-1]
+        - LdsPadB: [-1]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [128], [256], [1], [255,1,257] ]
+
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: b
+      DestDataType: B
+      ComputeDataType: s
+      HighPrecisionAccumulate: True
+      TransposeA: False
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [32, 32, 2, 2]
+          - [32, 32, 4, 1]
+          - [16, 16, 2, 4]
+          - [16, 16, 8, 1]
+        - ThreadTile:
+          - [ 1, 32 ]
+          - [ 2, 64 ]
+        - WorkGroup:
+          - [ 64, 4, 1 ]
+        - AssertSummationElementMultiple: [1]
+        - AssertFree0ElementMultiple: [1]
+        - AssertFree1ElementMultiple: [1]
+        - VectorWidth: [2]
+        - PrefetchGlobalRead: [1]
+        - PrefetchLocalRead: [1,9,17]
+        - DepthU: [32]
+        - GlobalReadVectorWidth: [2]
+        - LocalReadVectorWidth: [-1,2,4,8] # not support LRVW != -1
+        - ScheduleIterAlg: [3]
+        - InnerUnroll: [1,2]
+        - TransposeLDS: [0,1]
+        - LdsBlockSizePerPad: [128]
+        - LdsPadA: [-1]
+        - LdsPadB: [-1]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [128], [256], [1], [255,1,257] ]
+
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: h
+      HighPrecisionAccumulate: True
+      TransposeA: False
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [32, 32, 4, 2]
+          - [32, 32, 8, 1]
+          - [16, 16, 4, 4]
+          - [16, 16, 16, 1]
+        - ThreadTile:
+          - [ 1, 32 ]
+          - [ 2, 64 ]
+        - WorkGroup:
+          - [ 64, 4, 1 ]
+        - AssertSummationElementMultiple: [1]
+        - AssertFree0ElementMultiple: [1]
+        - AssertFree1ElementMultiple: [1]
+        - VectorWidth: [2]
+        - PrefetchGlobalRead: [1]
+        - PrefetchLocalRead: [1,5,9]
+        - DepthU: [32]
+        - GlobalReadVectorWidth: [2]
+        - LocalReadVectorWidth: [-1,2,4,8] # not support LRVW != -1
+        - ScheduleIterAlg: [3]
+        - InnerUnroll: [1,2]
+        - TransposeLDS: [0,1]
+        - LdsBlockSizePerPad: [128]
+        - LdsPadA: [-1]
+        - LdsPadB: [-1]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [128], [256], [1], [255,1,257] ]
+LibraryLogic:
+    ScheduleName: "arcturus"
+    DeviceNames: ["Device 7380", "Device 7388", "Device 738c", "Device 7390"]
+    ArchitectureName: "gfx908"

--- a/Tensile/Tests/pre_checkin/mfma/wider_local_read.yaml
+++ b/Tensile/Tests/pre_checkin/mfma/wider_local_read.yaml
@@ -1,3 +1,6 @@
+TestParameters:
+  marks: [skip-gfx900, skip-gfx906, skip-gfx1010] # not supported by arch
+
 GlobalParameters:
   NumElementsToValidate: -1
   BoundsCheck: True


### PR DESCRIPTION
1. allow TN transposeLDS to use wider local read by setting "LocalReadVectorWidth"
2. prefetch global read without using double LDS buffer by prefetch all LDS to register by setting "1LDSB"


ex.  MI_32x32x4x2fp16 with DepthU_32, we will have 32/4=8 Iterations in loops, each localRead reads 4 elements.

To enable prefetch all LDS to register by setting PLR >= LoopIter:

- setting PLR to 8 means each iteration will use identical register (Valu_X0_I0 ~ Valu_X7_I0) with prefetch 0 iteration before loop start (PLR%LoopIter)
- setting PLR to 9 means each iteration will use identical register (Valu_X0_I0 ~ Valu_X7_I0) with prefetch 1 iteration before loop start (PLR%LoopIter)

To enable wider local read by setting LocalReadVectorWidth = 8, each localRead will read 8 elements.

- in this way, each localRead will read data for 2 iterations, and front read all lds to register.

To enable 1LDSB we need to make sure not reading and writing to LDS at same time.

- using wider local read front read all lds to register before prefetch global data writing to lds, we can save LDS memory to use larger DepthU

