### PR TITLE
Use LLVM 9.0 on CentOS

### DIFF
--- a/Tensile/Source/lib/CMakeLists.txt
+++ b/Tensile/Source/lib/CMakeLists.txt
@@ -50,7 +50,10 @@ set(tensile_sources  ${tensile_sources}
 if(TENSILE_USE_LLVM)
     find_package(LLVM 6.0 QUIET CONFIG)
     if(NOT LLVM_FOUND)
-        find_package(LLVM REQUIRED CONFIG)
+        find_package(LLVM 9.0 QUIET CONFIG)
+        if(NOT LLVM_FOUND)
+            find_package(LLVM REQUIRED CONFIG)
+        endif()
     endif()
     set(tensile_sources ${tensile_sources}
         source/llvm/YAML.cpp


### PR DESCRIPTION
Tell cmake to prefer using LLVM 9.0 over 11.0 on CentOS to avoid header incompatibilities. This fixes linker error when building rocBLAS.