### PR TITLE
only add dependency when on and links as private static

### DIFF
--- a/Tensile/Source/lib/CMakeLists.txt
+++ b/Tensile/Source/lib/CMakeLists.txt
@@ -77,8 +77,10 @@ add_library (TensileHost STATIC ${tensile_sources})
 
 target_include_directories(TensileHost INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
-find_package(msgpack)
-target_link_libraries(TensileHost PUBLIC msgpackc)
+if(Tensile_LIBRARY_FORMAT MATCHES "msgpack")
+    find_package(msgpack)
+    target_link_libraries(TensileHost PRIVATE msgpackc.a)
+endif()
 
 if(TENSILE_USE_LLVM)
     target_compile_definitions(TensileHost PUBLIC TENSILE_DEFAULT_SERIALIZATION)

--- a/Tensile/Source/lib/CMakeLists.txt
+++ b/Tensile/Source/lib/CMakeLists.txt
@@ -79,7 +79,11 @@ target_include_directories(TensileHost INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/in
 
 if(Tensile_LIBRARY_FORMAT MATCHES "msgpack")
     find_package(msgpack)
-    target_link_libraries(TensileHost PRIVATE msgpackc.a)
+    if(TARGET msgpackc-static)
+        target_link_libraries(TensileHost PRIVATE msgpackc-static)
+    else()
+        target_link_libraries(TensileHost PRIVATE msgpackc)
+    endif()
 endif()
 
 if(TENSILE_USE_LLVM)


### PR DESCRIPTION
This overlaps slightly with PR#1057 so maybe can be integrated into it, but seems to allow hiding the shared library dependency from propagating down the application chain by statically linking msgpackc into TensileHost.  Please comment