### PR TITLE
Restore SolutionIndex and SolutionNameMin to LibraryLogic file

### DIFF
--- a/Tensile/LibraryLogic.py
+++ b/Tensile/LibraryLogic.py
@@ -112,6 +112,12 @@ def analyzeProblemType( problemType, problemSizeGroups, inputParameters ):
       line += "\n"
     print(line)
 
+  for i in range(0, len(logicAnalyzer.solutions)):
+    s = logicAnalyzer.solutions[i]
+    s["SolutionIndex"] = i
+    s["SolutionNameMin"] = Solution.getNameMin(s, solutionMinNaming)
+    print1("(%2u) %s : %s" % (i, Solution.getNameMin(s, solutionMinNaming), Solution.getNameFull(s)))
+
   if enableTileSelection:
     if globalParameters["NewClient"] == 2:
       validSelectionSolutions = SolutionSelectionLibrary.analyzeSolutionSelection(problemType, selectionFileNameList, \


### PR DESCRIPTION
This is the section of code that handled adding SolutionIndex and SolutionNameMin to the LibraryLogic file. I need to do some experiments with tile aware enabled: SolutionIndex in a tile aware logic file are probably not sequential numbers. In the use case, should SolutionIndex be sequential in all solutions, or after tile aware is analyzed. Or, is SolutionIndex still important, I think SolutionNameMin is more commonly used.