### PR TITLE
Fix passwordless sudo issue for Tensile in CI

### DIFF
--- a/docker/dockerfile-build-ubuntu-rock
+++ b/docker/dockerfile-build-ubuntu-rock
@@ -49,6 +49,6 @@ RUN pip3 install setuptools --upgrade && \
 # docker pipeline runs containers with particular uid
 # create a jenkins user with this specific uid so it can use sudo privileges
 # Grant any member of sudo group password-less sudo privileges
-RUN useradd --create-home -u ${user_uid} -o -G sudo --shell /bin/bash jenkins && \
-    mkdir -p /etc/sudoers.d/ && \
-    echo '%sudo   ALL=(ALL) NOPASSWD:ALL' | tee /etc/sudoers.d/sudo-nopasswd
+RUN useradd --create-home -u ${user_uid} -o -G video --shell /bin/bash jenkins && \
+    echo '%video   ALL=(ALL) NOPASSWD:ALL' | tee /etc/sudoers.d/sudo-nopasswd && \
+    chmod 400 /etc/sudoers.d/sudo-nopasswd


### PR DESCRIPTION
- The issue is due to the Jenkins user being added to the sudo group, which doesn't work to enable passwordless sudo. The Jenkins user needs to be added to the video group in the sudo-nopasswd file