### PR TITLE
Pass the pylint check by an error introduced in PR #1060

### DIFF
--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -583,7 +583,6 @@ class KernelWriterAssembly(KernelWriter):
     multiplier = int(ceil(max(kernel["NumThreads"], 256) / 256.0))
     # example: wg=512 multiplier=2, 1024=4
 
-    maxLds = 65536
     ldsSize = kernel["LdsNumElements"] * kernel["ProblemType"]["DataType"].numBytes()
     ldsSize = (ldsSize + 255) & 0x1ff00 # 256-byte granularity
     ldsLimitedOccupancy = self.getLdsLimitedOccupancy(ldsSize)


### PR DESCRIPTION
Forgot to run pylint check on test machine while CI is broken. Now:

```
$ python3 -m tox -v --workdir /tmp/.tensile-tox -e lint
...
  lint: commands succeeded
  congratulations :)
```