### PR TITLE
Enhance csv exporter and speed up librarylogic analyzing 

### DIFF
--- a/Tensile/ClientWriter.py
+++ b/Tensile/ClientWriter.py
@@ -351,6 +351,7 @@ def writeRunScript(path, libraryLogicPath, forBenchmark, enableTileSelection):
       clp += " --use-gpu-timer %u" % globalParameters["KernelTime"]
       clp += " --sleep-percent %u" % globalParameters["SleepPercent"]
       clp += " --benchmark-solutions %u" % enableTileSelection
+      clp += " --csv-export-extra-cols %u" % globalParameters["CSVExportWinner"]
       if "ClientArgs" in globalParameters:
         clientParams = globalParameters["ClientArgs"]
         if clientParams:
@@ -639,6 +640,8 @@ def writeClientConfig(forBenchmark, solutions, problemSizes, stepName, stepBaseD
         param("perf-l2-write-hits",       globalParameters["PerfModelL2WriteHits"])
         param("perf-l2-read-bw-mul",      globalParameters["PerfModelL2ReadBwMul"])
         param("perf-read-efficiency",     globalParameters["PerfModelReadEfficiency"])
+        param("csv-export-extra-cols",    globalParameters["CSVExportWinner"])
+        param("csv-merge-same-problems",  globalParameters["CSVMergeSameProblemID"])
 
 
 

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -110,6 +110,17 @@ globalParameters["CMakeBuildType"] = "Release"            # whether benchmark cl
 globalParameters["PrintSolutionRejectionReason"] = False  # when a solution is marked as invalid, print why
 globalParameters["LibraryFormat"] = "yaml"                # set library backend (either yaml or msgpack)
 
+# True/False: CSV will/won't export WinnerGFlops, WinnerTimeUS, WinnerIdx, WinnerName.
+# TODO - if no side-effect, we can set default to True. This can make analyzing "LibraryLogic" (AddFromCSV) faster
+globalParameters["CSVExportWinner"] = False
+
+# (When NumBenchmarks > 1). True: CSV will merge the rows of same Problem-ID. False: Each problem will write out "NumBenchmarks" rows
+#   In old client - No effect, since in old client, CSV file only exports the last benchmark, somehow is not correct because the previous benchmarks are discarded
+#   In new client - csv file exports "NumBenchmarks" rows for every problem. This also make the later analyzing slower
+#                   Set this to "True" can merge the rows for same problem, hence can reduce the csv file size and speed up the later analyzing
+# TODO - if side-effect, we can set default to True. This can make "getResults()" / "AddFromCSV()" faster
+globalParameters["CSVMergeSameProblemID"] = False
+
 # how to initialize tensor data
 # serial-in-u will use a sequence that increments in the K dimension
 # This is a predictable patterns that can be checked as the kernel runs to detect

--- a/Tensile/LibraryLogic.py
+++ b/Tensile/LibraryLogic.py
@@ -424,6 +424,14 @@ class LogicAnalyzer:
     # notice that for OperationType != GEMM, the numIndices = 0
     totalSizeIdx = problemSizeStartIdx + self.numIndices
 
+    # need to take care if the loaded csv is the export-winner-version
+    csvHasWinner = "_CSVWinner" in dataFileName
+    if csvHasWinner:
+      # the column of the two are fixed (GFlops, SizeI/J/K/L, LDD/C/A/B, TotalFlops, WinnerGFlops, WinnerTimeUs, WinnerIdx, WinnerName)
+      # the order are implemented in ResultFileReporter.cpp (NewClient) and Client.h (OldClient)
+      columnOfWinnerGFlops = 10
+      columnOfWinnerIdx = 12
+
     # iterate over rows
     rowIdx = 0
     for row in csvFile:
@@ -447,16 +455,24 @@ class LogicAnalyzer:
 
         # Exact Problem Size
         if problemSize in self.exactProblemSizes:
-          # solution gflops
-          solutionIdx = 0
-          winnerIdx = -1
-          winnerGFlops = -1
-          for i in range(solutionStartIdx, rowLength):
-            gflops = float(row[i])
-            if gflops > winnerGFlops:
-              winnerIdx = solutionIdx
-              winnerGFlops = gflops
-            solutionIdx += 1
+
+          if csvHasWinner:
+            # Faster. Get the winner info from csv directly, avoid an extra loop
+            winnerGFlops = float(row[columnOfWinnerGFlops])
+            winnerIdx = int(row[columnOfWinnerIdx])
+          else:
+            # Old code. TODO - Can we get rid of this in the future?
+            # solution gflops
+            solutionIdx = 0
+            winnerIdx = -1
+            winnerGFlops = -1
+            for i in range(solutionStartIdx, rowLength):
+              gflops = float(row[i])
+              if gflops > winnerGFlops:
+                winnerIdx = solutionIdx
+                winnerGFlops = gflops
+              solutionIdx += 1
+
           if winnerIdx != -1:
             if problemSize in self.exactWinners:
               if winnerGFlops > self.exactWinners[problemSize][1]:

--- a/Tensile/Source/client/include/CSVStackFile.hpp
+++ b/Tensile/Source/client/include/CSVStackFile.hpp
@@ -62,6 +62,8 @@ namespace Tensile
             void pop();
 
             void writeCurrentRow();
+            void readCurrentRow(std::unordered_map<std::string, std::string>& outMap);
+            void clearCurrentRow();
 
         private:
             std::string escape(std::string const& value);

--- a/Tensile/Source/client/include/ResultFileReporter.hpp
+++ b/Tensile/Source/client/include/ResultFileReporter.hpp
@@ -44,7 +44,7 @@ namespace Tensile
         public:
             static std::shared_ptr<ResultFileReporter> Default(po::variables_map const& args);
 
-            ResultFileReporter(std::string const& filename);
+            ResultFileReporter(std::string const& filename, bool exportExtraCols, bool mergeSameProblems);
 
             virtual void reportValue_string(std::string const& key,
                                             std::string const& value) override;
@@ -62,10 +62,22 @@ namespace Tensile
         private:
             template <typename T>
             void reportValue(std::string const& key, T const& value);
+            void mergeRow(std::unordered_map<std::string,std::string>& newRow);
 
             CSVStackFile m_output;
             std::string  m_solutionName;
             bool         m_invalidSolution = false;
+            bool         m_extraCol;
+            bool         m_mergeSameProblems;
+            // for extra columns
+            std::string  m_winnerSolution;
+            int64_t      m_currSolutionIdx = -1;
+            int64_t      m_winnerSolutionIdx = -1;
+            int64_t      m_fastestGflops = -1;
+            double       m_fasterTimeUS = -1;
+            // for merge rows
+            int64_t      m_currProbID = -1;
+            std::map<int64_t, std::unordered_map<std::string,std::string>> m_probMap;
         };
     } // namespace Client
 } // namespace Tensile

--- a/Tensile/Source/client/include/ResultReporter.hpp
+++ b/Tensile/Source/client/include/ResultReporter.hpp
@@ -80,12 +80,15 @@ namespace Tensile
             const std::string SolutionName     = "solution";
             const std::string SolutionIndex    = "solution-index";
             const std::string SolutionProgress = "solution-progress";
+            const std::string SolutionWinnerIdx= "solution-winner-idx";
+            const std::string SolutionWinner   = "solution-winner";
 
             // Performance-related
-            const std::string Validation  = "validation";
-            const std::string TimeUS      = "time-us";
-            const std::string SpeedGFlops = "gflops";
-            const std::string EnqueueTime = "enqueue-time";
+            const std::string Validation   = "validation";
+            const std::string TimeUS       = "time-us";
+            const std::string SpeedGFlops  = "gflops";
+            const std::string EnqueueTime  = "enqueue-time";
+            const std::string FastestGFlops= "fastest-gflops";
 
             // Performance estimation and granularity
             const std::string Tile0Granularity = "tile0-gran";

--- a/Tensile/Source/client/main.cpp
+++ b/Tensile/Source/client/main.cpp
@@ -158,6 +158,8 @@ namespace Tensile
                 ("perf-l2-read-bw-mul",      po::value<double>()->default_value(2.0), "L2 read bandwidth multiplier")
                 ("perf-read-efficiency",     po::value<double>()->default_value(0.85), "Read efficiency")
                 ("perf-ops-per-cycle",       po::value<int>()->default_value(64), "Ops per cycle")
+                ("csv-export-extra-cols",    po::value<bool>()->default_value(false), "CSV exports winner information")
+                ("csv-merge-same-problems",  po::value<bool>()->default_value(false), "CSV merge rows of same problem id")
 
                 ("problem-size,p",           vector_default_empty<std::string>(), "Specify a problem size.  Comma-separated list of "
                                                                                   "sizes, in the order of the Einstein notation.")

--- a/Tensile/Source/client/source/CSVStackFile.cpp
+++ b/Tensile/Source/client/source/CSVStackFile.cpp
@@ -86,6 +86,21 @@ namespace Tensile
                 m_currentRow = m_stack.back();
         }
 
+        void CSVStackFile::readCurrentRow(std::unordered_map<std::string, std::string>& outMap)
+        {
+            // we still write the header to csv first, then read the data to map
+            if(m_firstRow && !m_headers.empty())
+                writeRow(m_headers);
+
+            m_firstRow = false;
+            outMap = m_currentRow;
+        }
+
+        void CSVStackFile::clearCurrentRow()
+        {
+            m_currentRow.clear();
+        }
+
         void CSVStackFile::writeRow(std::unordered_map<std::string, std::string> const& row)
         {
             bool firstCol = true;

--- a/Tensile/Source/client/source/ResultFileReporter.cpp
+++ b/Tensile/Source/client/source/ResultFileReporter.cpp
@@ -35,11 +35,13 @@ namespace Tensile
         std::shared_ptr<ResultFileReporter>
             ResultFileReporter::Default(po::variables_map const& args)
         {
-            return std::make_shared<ResultFileReporter>(args["results-file"].as<std::string>());
+            return std::make_shared<ResultFileReporter>(args["results-file"].as<std::string>(), args["csv-export-extra-cols"].as<bool>(), args["csv-merge-same-problems"].as<bool>());
         }
 
-        ResultFileReporter::ResultFileReporter(std::string const& filename)
+        ResultFileReporter::ResultFileReporter(std::string const& filename, bool exportExtraCols, bool mergeSameProblems)
             : m_output(filename)
+            , m_extraCol(exportExtraCols)
+            , m_mergeSameProblems(mergeSameProblems)
         {
             m_output.setHeaderForKey(ResultKey::ProblemIndex, "GFlops");
         }
@@ -62,10 +64,34 @@ namespace Tensile
                 m_solutionName = valueStr;
                 m_output.setHeaderForKey(valueStr, valueStr);
             }
+            else if(key == ResultKey::TimeUS)
+            {
+                // cascade from BenchmarkTimer, Time-US first
+                ++m_currSolutionIdx;
+                double timeUS = std::stod(valueStr);
+                if(!m_invalidSolution)
+                {
+                    if (m_fasterTimeUS < 0 || m_fasterTimeUS > timeUS)
+                    {
+                        m_fasterTimeUS = timeUS;
+                    }
+                }
+            }
             else if(key == ResultKey::SpeedGFlops)
             {
+                // cascade from BenchmarkTimer, SpeedGFlops second
                 if(!m_invalidSolution)
+                {
                     m_output.setValueForKey(m_solutionName, value);
+
+                    int64_t gflops = std::stoull(valueStr);
+                    if (m_fastestGflops < gflops)
+                    {
+                        m_winnerSolution = m_solutionName;
+                        m_winnerSolutionIdx = m_currSolutionIdx;
+                        m_fastestGflops = gflops;
+                    }
+                }
             }
             else
             {
@@ -112,12 +138,99 @@ namespace Tensile
                 m_output.setHeaderForKey(ResultKey::LDA, "LDA");
                 m_output.setHeaderForKey(ResultKey::LDB, "LDB");
                 m_output.setHeaderForKey(ResultKey::TotalFlops, "TotalFlops");
+                if (m_extraCol)
+                {
+                    m_output.setHeaderForKey(ResultKey::FastestGFlops, "WinnerGFlops");
+                    m_output.setHeaderForKey(ResultKey::TimeUS, "WinnerTimeUS");
+                    m_output.setHeaderForKey(ResultKey::SolutionWinnerIdx, "WinnerIdx");
+                    m_output.setHeaderForKey(ResultKey::SolutionWinner, "WinnerName");
+                }
+            }
+        }
+
+        void ResultFileReporter::mergeRow(std::unordered_map<std::string,std::string>& newRow)
+        {
+            m_currProbID = std::stoull(newRow[ResultKey::ProblemIndex]);
+            if ( m_probMap.count(m_currProbID) == 0 )
+            {
+                m_probMap[m_currProbID] = newRow;
+                return;
+            }
+
+            auto& oldRow = m_probMap[m_currProbID];
+            for ( auto& oldRowIter : oldRow )
+            {
+                const std::string& key = oldRowIter.first;
+                if ( key.compare(ResultKey::ProblemIndex) == 0 ||
+                     key.find_first_of("Size") != std::string::npos ||
+                     key.compare(ResultKey::LDD) == 0 || key.compare(ResultKey::LDC) == 0 || key.compare(ResultKey::LDA) == 0 || key.compare(ResultKey::LDB) == 0 ||
+                     key.compare(ResultKey::TotalFlops) == 0 )
+                {
+                    // these data should be the same for same problem
+                    assert(oldRowIter.second == newRow[key]);
+                }
+                else if ( key.compare(ResultKey::FastestGFlops) == 0 )
+                {
+                    // if new row is better, update
+                    uint64_t oldFastest = std::stoull(oldRowIter.second);
+                    uint64_t newFastest = std::stoull(newRow[key]);
+                    if ( newFastest > oldFastest)
+                    {
+                        oldRow[ResultKey::FastestGFlops]     = newRow[ResultKey::FastestGFlops];
+                        oldRow[ResultKey::TimeUS]            = newRow[ResultKey::TimeUS];
+                        oldRow[ResultKey::SolutionWinnerIdx] = newRow[ResultKey::SolutionWinnerIdx];
+                        oldRow[ResultKey::SolutionWinner]    = newRow[ResultKey::SolutionWinner];
+                    }
+                }
+                else if ( key.compare(ResultKey::TimeUS) == 0 || key.compare(ResultKey::SolutionWinnerIdx) == 0 || key.compare(ResultKey::SolutionWinner) == 0 )
+                {
+                    // skip, we update these together with FastestGFlops
+                    continue;
+                }
+                else
+                {
+                    // these are gflops for each solution
+                    // if new row is better, update
+                    uint64_t oldFastest = std::stoull(oldRowIter.second);
+                    uint64_t newFastest = std::stoull(newRow[key]);
+                    if ( newFastest > oldFastest)
+                    {
+                        oldRow[key] = newRow[key];
+                    }
+                }
             }
         }
 
         void ResultFileReporter::postProblem()
         {
-            m_output.writeCurrentRow();
+            if (m_extraCol)
+            {
+                // update winner
+                m_output.setValueForKey(ResultKey::FastestGFlops, m_fastestGflops);
+                m_output.setValueForKey(ResultKey::TimeUS, m_fasterTimeUS);
+                m_output.setValueForKey(ResultKey::SolutionWinnerIdx, m_winnerSolutionIdx);
+                m_output.setValueForKey(ResultKey::SolutionWinner, m_winnerSolution);
+            }
+            // reset
+            m_winnerSolution = "";
+            m_currSolutionIdx = -1;
+            m_winnerSolutionIdx = -1;
+            m_fastestGflops  = -1;
+            m_fasterTimeUS = -1;
+
+            if (!m_mergeSameProblems)
+            {
+                m_output.writeCurrentRow();
+            }
+            else
+            {
+                std::unordered_map<std::string,std::string> curRow;
+                m_output.readCurrentRow(curRow);
+                m_output.clearCurrentRow();
+                // for (auto & field : curRow )
+                //     std::cout << "key:" << field.first << ", value:" << field.second << std::endl;
+                this->mergeRow(curRow);
+            }
         }
 
         void ResultFileReporter::postSolution()
@@ -126,6 +239,20 @@ namespace Tensile
             m_invalidSolution = false;
         }
 
-        void ResultFileReporter::finalizeReport() {}
+        void ResultFileReporter::finalizeReport()
+        {
+            if ( m_mergeSameProblems )
+            {
+                for (auto& probIter : m_probMap)
+                {
+                    auto& single_row = probIter.second;
+                    for (auto & field : single_row )
+                    {
+                        m_output.setValueForKey(field.first, field.second);
+                    }
+                    m_output.writeCurrentRow();
+                }
+            }
+        }
     } // namespace Client
 } // namespace Tensile


### PR DESCRIPTION
Adding two global paramters:

globalParameters[ "CSVExportWinner" ]: 
  - Export extra columns "FastestGFlogs", "FastestTimeUS", "WinnerIndex", "WinnerKernel"
  - Avoid later manual excel-editing
  - Can speed-up librarylogic analyzing ( in addFromCSV(), we can directly fetch the winner, saving loops)
  - For both old client and new client
  - Default False for now, no bothering other scripts
 
globalParameters[ "CSVMergeSameProblemID" ]: 
  - When numBenchmarks > 1:  do we want to merge rows of same problem (true), or export full un-merged data (false)?
  - Can speed-up librarylogic analyzing (data size is reduced, addFromCSV() and getResults() can be faster)
  - For new client (since old client always exports only the last benchmark loop...)
  - Default False for now, no bothering other scripts

main modified files are ResultFileReporter , CSVStackFile, and Tensile getResults(), addFromCSV()