### PR TITLE
Introduce hardware predicate for CUCount

### DIFF
--- a/Tensile/Hardware.py
+++ b/Tensile/Hardware.py
@@ -27,3 +27,49 @@ class HardwarePredicate(Properties.Predicate):
         gfxArch = 'gfx'+''.join(map(str, isa))
         return cls("AMDGPU", value=cls("Processor", value=gfxArch))
 
+    @classmethod
+    def FromHardware(cls, isa, cuCount=None):
+        gfxArch = 'gfx'+''.join(map(str, isa))
+        if cuCount == None:
+            return cls("AMDGPU", value=cls("Processor", value=gfxArch))
+        else:
+            return cls("AMDGPU", value=cls.And([cls("Processor", value=gfxArch),
+                                                cls("CUCount", value=cuCount)]))
+
+    def __lt__(self, other):
+        # Use superclass logic for TruePreds
+        if other.tag == 'TruePred' or self.tag == 'TruePred':
+            return super().__lt__(other)
+
+        # Compute unit counts are embedded as 'And' with
+        # 'Processor' and 'ComputeUnitCount' as children
+        if self.value.tag == 'And':
+            myAndPred = self.value
+            myProcPred = next(iter(x for x in myAndPred.value if x.tag == "Processor"), None)
+            myCUPred = next(iter(x for x in myAndPred.value if x.tag == "CUCount"), None)
+            myCUCount = myCUPred.value if myCUPred != None else 0
+        else:
+            myProcPred = self.value
+            myCUCount = 0
+
+        if other.value.tag == 'And':
+            otherAndPred = other.value
+            otherProcPred = next(iter(x for x in otherAndPred.value if x.tag == "Processor"), None)
+            otherCUPred = next(iter(x for x in otherAndPred.value if x.tag == "CUCount"), None)
+            otherCUCount = otherCUPred.value if otherCUPred != None else 0
+        else:
+            otherProcPred = other.value
+            otherCUCount = 0
+
+        # If CU properties are empty, then compare processor predicates
+        if myCUCount == otherCUCount == 0:
+            # Make sure that we have valid processor preds
+            assert myProcPred != None and otherProcPred != None, "Missing processor predicate"
+            assert myProcPred.tag == otherProcPred.tag == "Processor", "Invalid processor predicate"
+
+            # Downgrade to base class so that we don't recurse
+            myProcPred.__class__ = otherProcPred.__class__ = Properties.Predicate
+            return myProcPred < otherProcPred
+
+        # Higher priority given to higher CU count
+        return myCUCount > otherCUCount

--- a/Tensile/LibraryIO.py
+++ b/Tensile/LibraryIO.py
@@ -131,8 +131,7 @@ def readLibraryLogicForSchedule( filename ):
     printExit("len(%s) %u < 7" % (filename, len(data)))
 
   # parse out objects
-  dataIndex = 0
-  versionString     = data[dataIndex]["MinimumRequiredVersion"]
+  versionString     = data[0]["MinimumRequiredVersion"]
   scheduleName      = data[1]
   architectureName  = data[2] if isinstance(data[2], str) else data[2]["Architecture"]
   deviceNames       = data[3]

--- a/Tensile/LibraryIO.py
+++ b/Tensile/LibraryIO.py
@@ -131,9 +131,10 @@ def readLibraryLogicForSchedule( filename ):
     printExit("len(%s) %u < 7" % (filename, len(data)))
 
   # parse out objects
-  versionString     = data[0]["MinimumRequiredVersion"]
+  dataIndex = 0
+  versionString     = data[dataIndex]["MinimumRequiredVersion"]
   scheduleName      = data[1]
-  architectureName  = data[2]
+  architectureName  = data[2] if isinstance(data[2], str) else data[2]["Architecture"]
   deviceNames       = data[3]
   problemTypeState  = data[4]
   solutionStates    = data[5]

--- a/Tensile/SolutionLibrary.py
+++ b/Tensile/SolutionLibrary.py
@@ -247,13 +247,22 @@ class MasterSolutionLibrary:
                 library = GranularitySelectionLibrary.FromOriginalState(origLibrary, selectionIndices)
 
             elif libName == 'Hardware':
+
+                if isinstance(deviceSection[1], dict):
+                    architectureProps = deviceSection[1]
+                    assert "Architecture" in architectureProps, "Invalid device section [1]"
+                    assert "CUCount" in architectureProps, "Invalid device section [1]"
+                    devicePart = architectureProps["Architecture"]
+                    cuCount = architectureProps["CUCount"]
+                else:
+                    devicePart = deviceSection[1]
+                    cuCount = None
+
                 newLib = PredicateLibrary(tag='Hardware')
-                devicePart = deviceSection[1]
                 if devicePart == 'fallback':
                     pred = Hardware.HardwarePredicate("TruePred")
                 else:
-                    isa = Common.gfxArch(devicePart)
-                    pred = Hardware.HardwarePredicate.FromISA(isa)
+                    pred = Hardware.HardwarePredicate.FromHardware(Common.gfxArch(devicePart), cuCount)
 
                 newLib.rows.append({'predicate': pred, 'library': library})
                 library = newLib

--- a/Tensile/Source/lib/include/Tensile/AMDGPUPredicates.hpp
+++ b/Tensile/Source/lib/include/Tensile/AMDGPUPredicates.hpp
@@ -70,6 +70,32 @@ namespace Tensile
                 }
             };
 
+            struct CUCountEqual : public Predicate_CRTP<CUCountEqual, AMDGPU>
+            {
+                enum
+                {
+                    HasIndex = false,
+                    HasValue = true
+                };
+                int value;
+
+                CUCountEqual() = default;
+                CUCountEqual(int val)
+                    : value(val)
+                {
+                }
+
+                static std::string Type()
+                {
+                    return "CUCount";
+                }
+
+                virtual bool operator()(AMDGPU const& gpu) const
+                {
+                    return gpu.computeUnitCount == value;
+                }
+            };
+
             struct RunsKernelTargeting : public Predicate_CRTP<RunsKernelTargeting, AMDGPU>
             {
                 enum

--- a/Tensile/Source/lib/include/Tensile/Serialization/Predicates.hpp
+++ b/Tensile/Source/lib/include/Tensile/Serialization/Predicates.hpp
@@ -164,6 +164,7 @@ namespace Tensile
             static SubclassMap GetSubclasses()
             {
                 SubclassMap rv({Base::template Pair<Predicates::GPU::ProcessorEqual>(),
+                                Base::template Pair<Predicates::GPU::CUCountEqual>(),
                                 Base::template Pair<Predicates::GPU::RunsKernelTargeting>()});
 
                 auto gmap = Generic::GetSubclasses();
@@ -183,6 +184,12 @@ namespace Tensile
         template <typename IO>
         struct MappingTraits<Predicates::GPU::ProcessorEqual, IO>
             : public AutoMappingTraits<Predicates::GPU::ProcessorEqual, IO>
+        {
+        };
+
+        template <typename IO>
+        struct MappingTraits<Predicates::GPU::CUCountEqual, IO>
+            : public AutoMappingTraits<Predicates::GPU::CUCountEqual, IO>
         {
         };
 

--- a/Tensile/Tests/unit/test_PredicateOrdering.py
+++ b/Tensile/Tests/unit/test_PredicateOrdering.py
@@ -29,23 +29,42 @@ def test_hardware_predicate_comparison():
     a = HardwarePredicate.FromISA((9,0,0))
     b = HardwarePredicate.FromISA((9,0,6))
     c = HardwarePredicate("TruePred")
+    d = HardwarePredicate.FromHardware((9,0,8), 60)
+    e = HardwarePredicate.FromHardware((9,0,8), 64)
 
     assert a < b
     assert a < c
     assert b < c
 
+    assert d < a
+    assert d < b
+    assert d < c
+
+    assert e < a
+    assert e < b
+    assert e < c
+    assert e < d
+
     assert not b < a
     assert not c < a
     assert not c < b
+    assert not a < e
+    assert not b < e
+    assert not c < e
+    assert not d < e
 
     assert not a < a
     assert not b < b
     assert not c < c
+    assert not d < d
+    assert not e < e
 
 def predicate_library_objects():
     objs = [PredicateLibrary('Hardware', [{'predicate': HardwarePredicate.FromISA((9,0,0))}]),
             PredicateLibrary('Hardware', [{'predicate': HardwarePredicate.FromISA((9,0,6))}]),
             PredicateLibrary('Hardware', [{'predicate': HardwarePredicate.FromISA((9,0,8))}]),
+            PredicateLibrary('Hardware', [{'predicate': HardwarePredicate.FromHardware((9,0,8), 60)}]),
+            PredicateLibrary('Hardware', [{'predicate': HardwarePredicate.FromHardware((9,0,8), 64)}]),
             PredicateLibrary('Hardware', [{'predicate': HardwarePredicate('TruePred')}])
     ]
 
@@ -58,5 +77,7 @@ def test_predicate_library_merge(libraries):
         lib.merge(lib2)
 
     assert lib.rows[-1]['predicate'] == HardwarePredicate('TruePred')
+    assert lib.rows[0]['predicate'] == HardwarePredicate.FromHardware((9,0,8), 64)
+    assert lib.rows[1]['predicate'] == HardwarePredicate.FromHardware((9,0,8), 60)
     for r in lib.rows[:-1]:
         assert r['predicate'] != HardwarePredicate('TruePred')


### PR DESCRIPTION
The data in the 'architecture' section in the Logic .yaml files can now be optionally expanded with a property for CUCount.

Existing .yaml snip:
```
- MinimumRequiredVersion: 4.12.0
- arcturus
- gfx908
- - Device 7380
  - Device 7388
  - Device 738c
  - Device 7390
```

Optional property added:
```
- MinimumRequiredVersion: 4.12.0
- arcturus
- Architecture: gfx908
  CUCount: 64
- - Device 7380
  - Device 7388
  - Device 738c
  - Device 7390
```

Purpose:
- Cards might identify under the same architecture, but differ slightly in compute unit counts : CUCount
- Tuning for these cards may be slightly different, so we need to differentiate them
- Solution libs can be differentiated on CUCount, but may share solutions and kernels.

Changes:
- Parse additional CUCount property if present.
- Add sorting such that libraries with CUCount present will have raised priorities over those that do not. CUCounts priorities are in descending order.
- Add HardwarePredicate for CUCount
- Add HardwareSelection test and python unit tests