### PR TITLE
Support UseBeta for special Conv which can be expressed as GEMM

### DIFF
--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -897,7 +897,19 @@ class ProblemType(collections.abc.Mapping):
 
     self.convolution = Convolution(self, convolutionType, convolutionConfig)
     self["NumIndicesLD"] = 0
-    self["UseBeta"] = False
+    # For Conv with filter 1x1, unit-stride, no padding case, we can let UseBeta = True
+    self["UseBeta"] = ("UseBeta" in config and config["UseBeta"] == True) and (self.canExpressedAsGEMM() == True)
+
+  ########################################
+  def canExpressedAsGEMM(self):
+    rv = self.convolution != None and \
+         self.convolution.cc != None and \
+         self.convolution.cc.fil == [1,1] and \
+         self.convolution.cc.stride == [1,1] and \
+         self.convolution.cc.dilation == [1,1] and \
+         self.convolution.cc.padStart == [0,0] and \
+         self.convolution.cc.padEnd == [0,0]
+    return rv
 
   ########################################
   def isGEMM(self):


### PR DESCRIPTION
- **A workaroud to generate UseBeta=True kernels for convolution**. (We don't want to use any UseBeta=False kernel for now)

  - For 2D Convolution with filter1x1, unit stride, no-padding and dilation1x1
It could be directly converted to GEMM, either NT(BWD) or NN (FWD)

  - Currently, using OperationType: Convolution[BWD/FWD] will produce un-wanted UseBeta=False kernels.
The alternative is use OperationType: GEMM and convert the problem size manually to produce the kernels with UseBeta=True

- However, the **benchmark run by GEMM will be much slower than run by Convolution**.
Main reason is the TensorB is duplicated #batch-times in GEMM, while in convolution, the strideBK is forced to be 0 so the memory usage is relatively small.

  - In order to get the more accurate benchmark result, we add the flexibility to allow UseBeta=True when the convolution can be expressed as GEMM.
  - Thus we still can tune the convolution problem with **OperationType: Convolution, and set UseBeta**, the also get the better benchmark result.
