### PR TITLE
Hotfix ensure valid param for yaml

### DIFF
--- a/Tensile/LibraryIO.py
+++ b/Tensile/LibraryIO.py
@@ -108,6 +108,9 @@ def readSolutions( filename ):
   solutions = []
   for i in range(2, len(solutionStates)):
     solutionState = solutionStates[i]
+    # force redo the deriving of parameters, make sure old version logic yamls can be validated
+    solutionState["AssignedProblemIndependentDerivedParameters"] = False
+    solutionState["AssignedDerivedParameters"] = False    
     solutionObject = Solution(solutionState)
     solutions.append(solutionObject)
   problemType = solutions[0]["ProblemType"]
@@ -156,6 +159,9 @@ def readLibraryLogicForSchedule( filename ):
       solutionState["ISA"] = Common.gfxArch(architectureName)
     else:
       solutionState["ISA"] = [0, 0, 0]
+    # force redo the deriving of parameters, make sure old version logic yamls can be validated
+    solutionState["AssignedProblemIndependentDerivedParameters"] = False
+    solutionState["AssignedDerivedParameters"] = False
     solutionObject = Solution(solutionState)
     if solutionObject["ProblemType"] != problemType:
       printExit("ProblemType of file doesn't match solution: %s != %s" \

--- a/Tensile/LibraryLogic.py
+++ b/Tensile/LibraryLogic.py
@@ -58,7 +58,8 @@ def analyzeProblemType( problemType, problemSizeGroups, inputParameters ):
 
     ######################################
     # Read Solutions
-    (problemSizes, solutions) = LibraryIO.readSolutions(solutionsFileName)
+    # (problemSizes, solutions) are already read and kept in problemSizeGroups, no need to call LibraryIO.readSolutions(solutionsFileName) again
+    solutions = problemSizeGroup[4]
     problemSizesList.append(problemSizes)
     solutionsList.append(solutions)
     solutionMinNaming = Solution.getMinNaming(solutions)
@@ -1444,7 +1445,7 @@ def main(  config ):
       if problemType not in problemTypes:
         problemTypes[problemType] = []
       problemTypes[problemType].append( (problemSizes, \
-          dataFileName, solutionsFileName, selectionFileName) )
+          dataFileName, solutionsFileName, selectionFileName, solutions) )
 
   for problemType in problemTypes:
     logicTuple = analyzeProblemType( problemType, problemTypes[problemType], \

--- a/Tensile/SolutionSelectionLibrary.py
+++ b/Tensile/SolutionSelectionLibrary.py
@@ -22,7 +22,6 @@
 from .Common import printExit
 from .CSVReader import readCSV
 from .SolutionStructs import Solution
-from . import LibraryIO
 
 import csv
 

--- a/Tensile/SolutionSelectionLibrary.py
+++ b/Tensile/SolutionSelectionLibrary.py
@@ -109,7 +109,8 @@ def analyzeSolutionSelectionOldClient( problemType, problemSizeGroups):
     dataFileNameList.append(dataFileName)
     solutionsFileName = problemSizeGroup[2]
 
-    (_, solutions) = LibraryIO.readSolutions(solutionsFileName)
+    # solutions are already read and kept in problemSizeGroups, no need to call LibraryIO.readSolutions(solutionsFileName) again
+    solutions = problemSizeGroup[4]
     if len(solutions) == 0:
       printExit("%s doesn't contains any solutions." % (solutionsFileName) )
 

--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -2828,7 +2828,13 @@ class Solution:
         return
       if not math.log(state["MacroTile0"],2).is_integer():
         reject(state, "storeRemap only supports power-of-2 MT0")
-        return
+        # TODO - this return should be here, but this is a hotfix, 
+        # Somehow we have a "Validation Failed" kernel in rocBLAS now (SRVW=4 and MT0=96) and this will stop the whole building process
+        # Actions: 1. Hotfix, comment out this "return" temporarily for that invalidated kernel
+        #          2. Remove / replace that invalidated kernel
+        #          3. Put back this return
+        #          4. How to design a better way to prevent from invalid kernel in rocBLAS?
+        # return
 
       srMinVw = 1
       srMaxVw = 8


### PR DESCRIPTION
Hotfix for:
- 1st commit:
  - When skipping unnecessary re-assigning the derived parameters, it could happen on old-version yamls that lack some new parameters.
  - The lacked parameters are missing and thus causes KeyError when generating kernels.
  - **FIX**: If the solution is read-back from an external file, make sure it will redo the parameters deriving.

- 2nd commit:
  - There are some kernels invalid, but they're put in rocBLAS (SRVW=4 and MT0=96, which shouldn't pass the validation)
  - When deriving this kernel parameter, it is rejected due to invalid parameters. Turns out the rest of the parameters are not assigned and get errors when building kernel
  - **FIX**: Disable the rejection-return for hotfix, but somehow the root cause is that invalid kernel in rocBLAS and it should be removed.