### PR TITLE
TensileCreateLibrary Recursive logic file search 

### DIFF
--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -1210,11 +1210,13 @@ def TensileCreateLibrary():
     if arguments["Architecture"] == key:
       arguments["Architecture"] = mapArchitecture[key]
 
-  logicFiles = [os.path.join(logicPath, f) for f in os.listdir(logicPath) \
-      if (os.path.isfile(os.path.join(logicPath, f)) \
-      and os.path.splitext(f)[1]==".yaml") \
-      and arguments["Architecture"] in os.path.splitext(f)[0] \
-      or "hip" in os.path.splitext(f)[0]]
+  # Recursive directory search
+  logicFiles = []
+  for root, dirs, files in os.walk(logicPath):
+    logicFiles += [os.path.join(root, f) for f in files
+                       if os.path.splitext(f)[1]==".yaml" \
+                       and arguments["Architecture"] in os.path.splitext(f)[0] \
+                       or "hip" in os.path.splitext(f)[0] ]
 
   print1("# LibraryLogicFiles:" % logicFiles)
   for logicFile in logicFiles:


### PR DESCRIPTION
Proposal: To recursively search the logic directory for input .yaml files

Rationale:

Flat directory organization requires that logic file names be unique, which can get cumbersome when we want to combine logic coming from many different contexts.

Directory hierarchy allows logic files to have the same name, and are differentiated by their path. Hierarchies also allow more flexibility from an organization and context sorting standpoint for storing logic yaml files.