### PR TITLE
Hotfix: Remove reference to old client target from TensileCreateLibraryFiles cmake function

### DIFF
--- a/Tensile/cmake/TensileConfig.cmake
+++ b/Tensile/cmake/TensileConfig.cmake
@@ -143,7 +143,6 @@ function(TensileCreateLibraryFiles
   if(Tensile_LIBRARY_FORMAT)
     set(Options ${Options} "--library-format=${Tensile_LIBRARY_FORMAT}")
     if(Tensile_LIBRARY_FORMAT MATCHES "yaml")
-        target_compile_definitions( Tensile PUBLIC -DTENSILE_YAML=1)
         target_compile_definitions( TensileHost PUBLIC -DTENSILE_YAML=1)
     endif()
   endif()


### PR DESCRIPTION
This function is intended to be used with the new client only.
Removed attempt to modify old tensile client target (specifically when yaml format is requested) - otherwise it will break the build.