### PR TITLE
Don't generate legacy components for new client builds

### DIFF
--- a/Tensile/cmake/TensileConfig.cmake
+++ b/Tensile/cmake/TensileConfig.cmake
@@ -96,7 +96,7 @@ function(TensileCreateLibraryFiles
   set(Script "${Tensile_ROOT}/bin/TensileCreateLibrary")
   message(STATUS "Tensile script: ${Script}")
 
-  set(Options "--new-client-only --no-legacy-components")
+  set(Options "--new-client-only" "--no-legacy-components")
 
   if(Tensile_MERGE_FILES)
     set(Options ${Options} "--merge-files")

--- a/Tensile/cmake/TensileConfig.cmake
+++ b/Tensile/cmake/TensileConfig.cmake
@@ -96,7 +96,7 @@ function(TensileCreateLibraryFiles
   set(Script "${Tensile_ROOT}/bin/TensileCreateLibrary")
   message(STATUS "Tensile script: ${Script}")
 
-  set(Options "--new-client-only")
+  set(Options "--new-client-only --no-legacy-components")
 
   if(Tensile_MERGE_FILES)
     set(Options ${Options} "--merge-files")


### PR DESCRIPTION
- Previously caused issues when the MERGE_FILES is OFF because it tries to create very long solution source file names. These legacy components should be skipped when using TensileCreateLibraryFiles in cmake as it is designed for the new client only