### PR TITLE
Remove of assertion for sizes > 0

### DIFF
--- a/Tensile/Source/lib/include/Tensile/TensorDescriptor.hpp
+++ b/Tensile/Source/lib/include/Tensile/TensorDescriptor.hpp
@@ -162,11 +162,6 @@ namespace Tensile
                 return;
             }
 
-            // for(int i = 0; i < m_sizes.size(); i++)
-            // {
-            //     TENSILE_ASSERT_EXC(m_sizes[i] > 0);
-            // }
-
             m_strides.resize(m_sizes.size(), UseDefaultStride);
             if(m_strides[0] == UseDefaultStride)
             {

--- a/Tensile/Source/lib/include/Tensile/TensorDescriptor.hpp
+++ b/Tensile/Source/lib/include/Tensile/TensorDescriptor.hpp
@@ -162,10 +162,10 @@ namespace Tensile
                 return;
             }
 
-            for(int i = 0; i < m_sizes.size(); i++)
-            {
-                TENSILE_ASSERT_EXC(m_sizes[i] > 0);
-            }
+            // for(int i = 0; i < m_sizes.size(); i++)
+            // {
+            //     TENSILE_ASSERT_EXC(m_sizes[i] > 0);
+            // }
 
             m_strides.resize(m_sizes.size(), UseDefaultStride);
             if(m_strides[0] == UseDefaultStride)


### PR DESCRIPTION
Causes issues when k=0, failures observed in rocBLAS for no valid solutions found.

Removing the assertion as k=0 does produce some valid cases with alpha=1 and beta=0