### PR TITLE
New BoundsCheck design: guard page

### DIFF
--- a/HostLibraryTests/client/DataInitialization_test.cpp
+++ b/HostLibraryTests/client/DataInitialization_test.cpp
@@ -79,7 +79,7 @@ public:
         return rv;
     }
 
-    void RunDataContaminationTest(bool cEqualD, bool pristineGPU, bool boundsCheck)
+    void RunDataContaminationTest(bool cEqualD, bool pristineGPU, int boundsCheck)
     {
         using val = po::variable_value;
 

--- a/HostLibraryTests/client/DataInitialization_test.cpp
+++ b/HostLibraryTests/client/DataInitialization_test.cpp
@@ -79,7 +79,7 @@ public:
         return rv;
     }
 
-    void RunDataContaminationTest(bool cEqualD, bool pristineGPU, int boundsCheck)
+    void RunDataContaminationTest(bool cEqualD, bool pristineGPU, BoundsCheckMode boundsCheck)
     {
         using val = po::variable_value;
 
@@ -161,42 +161,42 @@ TYPED_TEST_SUITE(DataInitializationTest, InputTypes);
 
 TYPED_TEST(DataInitializationTest, Contamination_false_false_false)
 {
-    this->RunDataContaminationTest(false, false, false);
+    this->RunDataContaminationTest(false, false, BoundsCheckMode::Disable);
 }
 
 TYPED_TEST(DataInitializationTest, Contamination_false_true_false)
 {
-    this->RunDataContaminationTest(false, true, false);
+    this->RunDataContaminationTest(false, true, BoundsCheckMode::Disable);
 }
 
 TYPED_TEST(DataInitializationTest, Contamination_true_false_false)
 {
-    this->RunDataContaminationTest(true, false, false);
+    this->RunDataContaminationTest(true, false, BoundsCheckMode::Disable);
 }
 
 TYPED_TEST(DataInitializationTest, Contamination_true_true_false)
 {
-    this->RunDataContaminationTest(true, true, false);
+    this->RunDataContaminationTest(true, true, BoundsCheckMode::Disable);
 }
 
 TYPED_TEST(DataInitializationTest, Contamination_false_false_true)
 {
-    this->RunDataContaminationTest(false, false, true);
+    this->RunDataContaminationTest(false, false, BoundsCheckMode::NaN);
 }
 
 TYPED_TEST(DataInitializationTest, Contamination_false_true_true)
 {
-    this->RunDataContaminationTest(false, true, true);
+    this->RunDataContaminationTest(false, true, BoundsCheckMode::NaN);
 }
 
 TYPED_TEST(DataInitializationTest, Contamination_true_false_true)
 {
-    this->RunDataContaminationTest(true, false, true);
+    this->RunDataContaminationTest(true, false, BoundsCheckMode::NaN);
 }
 
 TYPED_TEST(DataInitializationTest, Contamination_true_true_true)
 {
-    this->RunDataContaminationTest(true, true, true);
+    this->RunDataContaminationTest(true, true, BoundsCheckMode::NaN);
 }
 
 template <typename T>

--- a/Tensile/ClientWriter.py
+++ b/Tensile/ClientWriter.py
@@ -613,8 +613,7 @@ def writeClientConfigIni(problemSizes, problemType, sourceDir, codeObjectFiles, 
         if globalParameters["PrintTensorRef"]:
           param("print-tensor-ref",         1)
 
-        if globalParameters["BoundsCheck"]:
-          param("bounds-check", 1)
+        param("bounds-check", int(globalParameters["BoundsCheck"]))
 
         param("print-valids",             globalParameters["ValidationPrintValids"])
         param("print-max",                globalParameters["ValidationMaxToPrint"])

--- a/Tensile/ClientWriter.py
+++ b/Tensile/ClientWriter.py
@@ -566,6 +566,7 @@ def boundsCheckName(mode):
     if mode == 1: return 'NaN'
     if mode == 2: return 'GuardPageFront'
     if mode == 3: return 'GuardPageBack'
+    if mode == 4: return 'GuardPageAll'
 
 def writeClientConfigIni(problemSizes, problemType, sourceDir, codeObjectFiles, resultsFileName, parametersFilePath):
 
@@ -618,8 +619,7 @@ def writeClientConfigIni(problemSizes, problemType, sourceDir, codeObjectFiles, 
         if globalParameters["PrintTensorRef"]:
           param("print-tensor-ref",         1)
 
-        param("bounds-check", boundsCheckName(int(globalParameters["BoundsCheck"])))
-
+        param("bounds-check",             boundsCheckName(int(globalParameters["BoundsCheck"])))
         param("print-valids",             globalParameters["ValidationPrintValids"])
         param("print-max",                globalParameters["ValidationMaxToPrint"])
         param("num-benchmarks",           globalParameters["NumBenchmarks"])

--- a/Tensile/ClientWriter.py
+++ b/Tensile/ClientWriter.py
@@ -561,6 +561,11 @@ def dataInitParams(problemType):
             ('init-alpha', DataInitName(initAlpha).name),
             ('init-beta',  DataInitName(initBeta).name)]
 
+def boundsCheckName(mode):
+    if mode == 0: return 'Disable'
+    if mode == 1: return 'NaN'
+    if mode == 2: return 'GuardPageFront'
+    if mode == 3: return 'GuardPageBack'
 
 def writeClientConfigIni(problemSizes, problemType, sourceDir, codeObjectFiles, resultsFileName, parametersFilePath):
 
@@ -613,7 +618,7 @@ def writeClientConfigIni(problemSizes, problemType, sourceDir, codeObjectFiles, 
         if globalParameters["PrintTensorRef"]:
           param("print-tensor-ref",         1)
 
-        param("bounds-check", int(globalParameters["BoundsCheck"]))
+        param("bounds-check", boundsCheckName(int(globalParameters["BoundsCheck"])))
 
         param("print-valids",             globalParameters["ValidationPrintValids"])
         param("print-max",                globalParameters["ValidationMaxToPrint"])

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -71,6 +71,7 @@ globalParameters["BoundsCheck"] = 0   # Bounds check
 #1: Perform bounds check to find out of bounds reads/writes.  NumElementsToValidate must be -1.
 #2: Perform bounds check by front side guard page
 #3: Perform bounds check by back side guard page
+#4: Perform bounds check by both back and front side guard page
 
 globalParameters["ValidationMaxToPrint"] = 4      # maximum number of mismatches to print
 globalParameters["ValidationPrintValids"] = False # print matches too

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -67,7 +67,11 @@ globalParameters["EnqueuesPerSync"] = 1           # how many solution enqueues t
 globalParameters["SleepPercent"] = 300            # how long to sleep after every data point: 25 means 25% of solution time. Sleeping lets gpu cool down more.
 # validation
 globalParameters["NumElementsToValidate"] = 128   # number of elements to validate, 128 will be evenly spaced out (with prime number stride) across C tensor
-globalParameters["BoundsCheck"] = False   # Perform bounds check to find out of bounds reads/writes.  NumElementsToValidate must be -1.
+globalParameters["BoundsCheck"] = 0   # Bounds check
+#1: Perform bounds check to find out of bounds reads/writes.  NumElementsToValidate must be -1.
+#2: Perform bounds check by front side guard page
+#3: Perform bounds check by back side guard page
+
 globalParameters["ValidationMaxToPrint"] = 4      # maximum number of mismatches to print
 globalParameters["ValidationPrintValids"] = False # print matches too
 # steps

--- a/Tensile/Source/client/include/DataInitialization.hpp
+++ b/Tensile/Source/client/include/DataInitialization.hpp
@@ -57,6 +57,16 @@ namespace Tensile
             Count
         };
 
+        enum class BoundCheckMode
+        {
+            Disable = 0,
+            NaN,
+            GuardPageFront,
+            GuardPageEnd
+        };
+
+        const int pageSize = 2 * 1024 * 1024;
+
         static bool IsProblemDependent(InitMode const& mode)
         {
             return mode == InitMode::SerialIdx || mode == InitMode::SerialDim0
@@ -67,6 +77,11 @@ namespace Tensile
 
         std::ostream& operator<<(std::ostream& stream, InitMode const& mode);
         std::istream& operator>>(std::istream& stream, InitMode& mode);
+
+        inline bool operator==(const int& lhs, const BoundCheckMode& rhs)
+        {
+            return lhs == static_cast<int>(rhs);
+        }
 
         template <typename TypedInputs>
         class TypedDataInitialization;
@@ -320,7 +335,7 @@ namespace Tensile
             /// If true, we will initialize all out-of-bounds inputs to NaN, and
             /// all out-of-bounds outputs to a known value. This allows us to
             /// verify that out-of-bounds values are not used or written to.
-            bool m_boundsCheck = false;
+            int m_boundsCheck = 0;
 
             /// If true, the data is dependent on the problem size (e.g. serial)
             /// and must be reinitialized for each problem. Pristine copy on GPU

--- a/Tensile/Source/client/include/DataInitialization.hpp
+++ b/Tensile/Source/client/include/DataInitialization.hpp
@@ -34,6 +34,8 @@
 
 #include <cstddef>
 
+#include "RunListener.hpp"
+
 namespace po = boost::program_options;
 
 namespace Tensile
@@ -76,6 +78,7 @@ namespace Tensile
             NaN,
             GuardPageFront,
             GuardPageBack,
+            GuardPageAll,
             MaxMode
         };
 
@@ -85,7 +88,7 @@ namespace Tensile
         template <typename TypedInputs>
         class TypedDataInitialization;
 
-        class DataInitialization
+        class DataInitialization : public RunListener
         {
         public:
             static double GetRepresentativeBetaValue(po::variables_map const& args);
@@ -310,6 +313,67 @@ namespace Tensile
                 return m_workspaceSize;
             }
 
+            BoundsCheckMode getCurBoundsCheck()
+            {
+                return m_curBoundsCheck;
+            }
+
+            virtual bool needMoreBenchmarkRuns() const override
+            {
+                return false;
+            };
+            virtual void preBenchmarkRun() override{};
+            virtual void postBenchmarkRun() override{};
+            virtual void preProblem(ContractionProblem const& problem) override{};
+            virtual void postProblem() override{};
+            virtual void preSolution(ContractionSolution const& solution) override{};
+            virtual void postSolution() override{};
+            virtual bool needMoreRunsInSolution() const override
+            {
+                return m_numRunsInSolution < m_numRunsPerSolution;
+            };
+
+            virtual size_t numWarmupRuns() override
+            {
+                return 0;
+            };
+            virtual void setNumWarmupRuns(size_t count) override{};
+            virtual void preWarmup() override{};
+            virtual void postWarmup() override{};
+            virtual void validateWarmups(std::shared_ptr<ContractionInputs> inputs,
+                                         TimingEvents const&                startEvents,
+                                         TimingEvents const&                stopEvents) override
+            {
+                m_numRunsInSolution++;
+            };
+
+            virtual size_t numSyncs() override
+            {
+                return 0;
+            };
+            virtual void setNumSyncs(size_t count) override{};
+            virtual void preSyncs() override{};
+            virtual void postSyncs() override{};
+
+            virtual size_t numEnqueuesPerSync() override
+            {
+                return 0;
+            };
+            virtual void setNumEnqueuesPerSync(size_t count) override{};
+            virtual void preEnqueues() override{};
+            virtual void postEnqueues(TimingEvents const& startEvents,
+                                      TimingEvents const& stopEvents) override{};
+            virtual void validateEnqueues(std::shared_ptr<ContractionInputs> inputs,
+                                          TimingEvents const&                startEvents,
+                                          TimingEvents const&                stopEvents) override{};
+
+            virtual void finalizeReport() override{};
+
+            virtual int error() const override
+            {
+                return 0;
+            };
+
         protected:
             InitMode m_aInit, m_bInit, m_cInit, m_dInit;
             InitMode m_alphaInit, m_betaInit;
@@ -337,7 +401,14 @@ namespace Tensile
             /// If set "::GuardPageFront/::GuardPageBack", we will allocate matrix memory
             /// with page aligned, and put matrix start/end address to memory start/end address.
             /// Out-of-bounds access would trigger memory segmentation faults.
-            BoundsCheckMode m_boundsCheck = BoundsCheckMode::Disable;
+            /// m_boundsCheck keep the setting from args.
+            /// m_curBoundsCheck keep the current running boundsCheck mode.
+            /// If set "::GuardPageAll", DataInit would need 2 runs per solution.
+            /// First run would apply "::GuardPageFront" and second run would apply "::GuardPageBack".
+            BoundsCheckMode m_boundsCheck        = BoundsCheckMode::Disable;
+            BoundsCheckMode m_curBoundsCheck     = BoundsCheckMode::Disable;
+            int             m_numRunsPerSolution = 0;
+            int             m_numRunsInSolution  = 0;
 
             /// If true, the data is dependent on the problem size (e.g. serial)
             /// and must be reinitialized for each problem. Pristine copy on GPU

--- a/Tensile/Source/client/include/DataInitializationTyped.hpp
+++ b/Tensile/Source/client/include/DataInitializationTyped.hpp
@@ -137,7 +137,8 @@ namespace Tensile
                 if(!m_cpuInputsPristine)
                     m_cpuInputsPristine = createNewCPUInputs(problem);
 
-                if(m_cpuInputs && !m_boundsCheck && !m_problemDependentData)
+                if(m_cpuInputs && m_boundsCheck == BoundsCheckMode::Disable
+                   && !m_problemDependentData)
                 {
                     copyD(m_cpuInputs, m_cpuInputsPristine);
                 }
@@ -149,7 +150,7 @@ namespace Tensile
                     if(m_problemDependentData)
                         initializeCPUInputs(*m_cpuInputsPristine, problem);
 
-                    if(m_boundsCheck == BoundCheckMode::NaN && !m_cpuBadInputs)
+                    if(m_boundsCheck == BoundsCheckMode::NaN && !m_cpuBadInputs)
                     {
                         m_cpuBadInputs = createNewCPUBadInputs();
                     }
@@ -166,7 +167,7 @@ namespace Tensile
                         m_cpuConvInputs = allocNewCPUInputs();
                     }
 
-                    if(allocated || m_boundsCheck == BoundCheckMode::NaN)
+                    if(allocated || m_boundsCheck == BoundsCheckMode::NaN)
                         copyInputs(m_cpuConvInputs, m_cpuInputsPristine, m_cpuBadInputs, problem);
                 }
 
@@ -190,7 +191,7 @@ namespace Tensile
 
                     pristine = m_gpuInputsPristine;
 
-                    if(m_boundsCheck == BoundCheckMode::NaN)
+                    if(m_boundsCheck == BoundsCheckMode::NaN)
                     {
                         if(!m_gpuBadInputs)
                             m_gpuBadInputs = createNewGPUBadInputs();
@@ -205,7 +206,7 @@ namespace Tensile
 
                     pristine = m_cpuInputsPristine;
 
-                    if(m_boundsCheck == BoundCheckMode::NaN)
+                    if(m_boundsCheck == BoundsCheckMode::NaN)
                     {
                         if(!m_cpuBadInputs)
                             m_cpuBadInputs = createNewCPUBadInputs();
@@ -214,7 +215,8 @@ namespace Tensile
                     }
                 }
 
-                if(m_gpuInputs && !m_boundsCheck && !m_problemDependentData)
+                if(m_gpuInputs && m_boundsCheck == BoundsCheckMode::Disable
+                   && !m_problemDependentData)
                 {
                     if(m_elementsToValidate)
                         copyD(m_gpuInputs, pristine);
@@ -347,7 +349,7 @@ namespace Tensile
             std::shared_ptr<ManagedInputs> allocNewGPUInputs(std::shared_ptr<ManagedInputs> pristine
                                                              = nullptr)
             {
-                if(m_boundsCheck || (pristine && !pristine->gpu))
+                if(m_boundsCheck != BoundsCheckMode::Disable || (pristine && !pristine->gpu))
                     pristine = nullptr;
 
                 std::shared_ptr<AType> a;
@@ -359,8 +361,8 @@ namespace Tensile
 
                 std::vector<std::shared_ptr<void>> guardPage;
                 void*                              guardPagePtr;
-                bool enableGuardPage = (m_boundsCheck == BoundCheckMode::GuardPageFront
-                                        || m_boundsCheck == BoundCheckMode::GuardPageEnd);
+                bool enableGuardPage = (m_boundsCheck == BoundsCheckMode::GuardPageFront
+                                        || m_boundsCheck == BoundsCheckMode::GuardPageBack);
 
                 if(pristine)
                 {
@@ -593,7 +595,7 @@ namespace Tensile
             {
                 hipMemcpyKind kind = getCopyKind(dst, src);
 
-                if(m_boundsCheck == BoundCheckMode::NaN)
+                if(m_boundsCheck == BoundsCheckMode::NaN)
                 {
                     if(!bad)
                         throw std::runtime_error(
@@ -643,7 +645,7 @@ namespace Tensile
                     dst->alpha = src->alpha;
                     dst->beta  = src->beta;
                 }
-                else if(m_boundsCheck == BoundCheckMode::GuardPageEnd)
+                else if(m_boundsCheck == BoundsCheckMode::GuardPageBack)
                 {
                     {
                         ptrdiff_t aPadding = dst->aElements - problem.a().totalAllocatedElements();

--- a/Tensile/Source/client/include/ReferenceValidator.hpp
+++ b/Tensile/Source/client/include/ReferenceValidator.hpp
@@ -129,11 +129,11 @@ namespace Tensile
 
             bool m_enabled;
 
-            int  m_elementsToValidate;
-            bool m_printValids;
-            int  m_printMax;
-            int  m_validationStride;
-            int  m_boundsCheck;
+            int             m_elementsToValidate;
+            bool            m_printValids;
+            int             m_printMax;
+            int             m_validationStride;
+            BoundsCheckMode m_boundsCheck;
 
             bool m_printTensorA;
             bool m_printTensorB;

--- a/Tensile/Source/client/include/ReferenceValidator.hpp
+++ b/Tensile/Source/client/include/ReferenceValidator.hpp
@@ -129,11 +129,10 @@ namespace Tensile
 
             bool m_enabled;
 
-            int             m_elementsToValidate;
-            bool            m_printValids;
-            int             m_printMax;
-            int             m_validationStride;
-            BoundsCheckMode m_boundsCheck;
+            int  m_elementsToValidate;
+            bool m_printValids;
+            int  m_printMax;
+            int  m_validationStride;
 
             bool m_printTensorA;
             bool m_printTensorB;

--- a/Tensile/Source/client/include/ReferenceValidator.hpp
+++ b/Tensile/Source/client/include/ReferenceValidator.hpp
@@ -133,7 +133,7 @@ namespace Tensile
             bool m_printValids;
             int  m_printMax;
             int  m_validationStride;
-            bool m_boundsCheck;
+            int  m_boundsCheck;
 
             bool m_printTensorA;
             bool m_printTensorB;

--- a/Tensile/Source/client/main.cpp
+++ b/Tensile/Source/client/main.cpp
@@ -127,7 +127,7 @@ namespace Tensile
                 ("print-valids",             po::value<bool>()->default_value(false), "Print values that pass validation")
                 ("print-max",                po::value<int>()->default_value(-1), "Max number of values to print")
                 ("num-elements-to-validate", po::value<int>()->default_value(0), "Number of elements to validate")
-                ("bounds-check",             po::value<int>()->default_value(0),
+                ("bounds-check",             po::value<BoundsCheckMode>()->default_value(BoundsCheckMode::Disable),
                 "1:Use sentinel values to check memory boundaries."
                 "2:Memory bound check by front guard page"
                 "3:Memory bound check by back guard page")

--- a/Tensile/Source/client/main.cpp
+++ b/Tensile/Source/client/main.cpp
@@ -127,8 +127,10 @@ namespace Tensile
                 ("print-valids",             po::value<bool>()->default_value(false), "Print values that pass validation")
                 ("print-max",                po::value<int>()->default_value(-1), "Max number of values to print")
                 ("num-elements-to-validate", po::value<int>()->default_value(0), "Number of elements to validate")
-                ("bounds-check", po::value<bool>()->default_value(false),
-                "Use sentinel values to check memory boundaries.")
+                ("bounds-check",             po::value<int>()->default_value(0),
+                "1:Use sentinel values to check memory boundaries."
+                "2:Memory bound check by front guard page"
+                "3:Memory bound check by back guard page")
 
                 ("print-tensor-a",           po::value<bool>()->default_value(false), "Print tensor A.")
                 ("print-tensor-b",           po::value<bool>()->default_value(false), "Print tensor B.")

--- a/Tensile/Source/client/main.cpp
+++ b/Tensile/Source/client/main.cpp
@@ -130,7 +130,8 @@ namespace Tensile
                 ("bounds-check",             po::value<BoundsCheckMode>()->default_value(BoundsCheckMode::Disable),
                 "1:Use sentinel values to check memory boundaries."
                 "2:Memory bound check by front guard page"
-                "3:Memory bound check by back guard page")
+                "3:Memory bound check by back guard page"
+                "4:Memory bound check by both side guard page")
 
                 ("print-tensor-a",           po::value<bool>()->default_value(false), "Print tensor A.")
                 ("print-tensor-b",           po::value<bool>()->default_value(false), "Print tensor B.")
@@ -467,6 +468,7 @@ int main(int argc, const char* argv[])
 
     MetaRunListener listeners;
 
+    listeners.addListener(dataInit);
     listeners.addListener(solutionIterator);
     listeners.addListener(std::make_shared<ProgressListener>(args));
     if(runKernels)

--- a/Tensile/Source/client/source/ReferenceValidator.cpp
+++ b/Tensile/Source/client/source/ReferenceValidator.cpp
@@ -48,7 +48,7 @@ namespace Tensile
             m_printValids        = args["print-valids"].as<bool>();
             m_printMax           = args["print-max"].as<int>();
 
-            m_boundsCheck = args["bounds-check"].as<bool>();
+            m_boundsCheck = args["bounds-check"].as<int>();
 
             m_printTensorA   = args["print-tensor-a"].as<bool>();
             m_printTensorB   = args["print-tensor-b"].as<bool>();
@@ -392,23 +392,32 @@ namespace Tensile
             using Type         = typename ManagedInputs::DType;
             auto const& tensor = m_problem.d();
 
-            size_t elementsToCopy = tensor.totalAllocatedElements();
-            if(m_boundsCheck)
+            size_t elementsToCopy       = tensor.totalAllocatedElements();
+            size_t elementsOffsetToCopy = 0;
+            size_t elementsBeforeData   = 0;
+            size_t elementsAfterData    = 0;
+
+            if(m_boundsCheck == BoundCheckMode::NaN)
                 elementsToCopy = result.dElements;
             size_t bytesToCopy = elementsToCopy * sizeof(Type);
 
             if(m_cpuResultBuffer.size() < bytesToCopy)
                 m_cpuResultBuffer.resize(bytesToCopy);
 
+            if(m_boundsCheck == BoundCheckMode::GuardPageEnd)
+                elementsOffsetToCopy = result.dElements - tensor.totalAllocatedElements();
+
             HIP_CHECK_EXC(hipMemcpy(m_cpuResultBuffer.data(),
-                                    result.managedD.get(),
+                                    result.managedD.get() + elementsOffsetToCopy,
                                     bytesToCopy,
                                     hipMemcpyDeviceToHost));
 
-            auto elementsBeforeData = result.d - result.managedD.get();
-            auto elementsAfterData
-                = elementsToCopy - (tensor.totalAllocatedElements() + elementsBeforeData);
-
+            if(m_boundsCheck == BoundCheckMode::NaN)
+            {
+                elementsBeforeData = result.d - result.managedD.get();
+                elementsAfterData
+                    = elementsToCopy - (tensor.totalAllocatedElements() + elementsBeforeData);
+            }
             // If there was extra data allocated before the tensor to do bounds
             // checking, resultBuffer is the whole allocation, while resultData
             // points directly to the result.
@@ -479,7 +488,7 @@ namespace Tensile
                                   tensor.sizes().end());
                     size_t baseElemIndex = tensor.index(coord);
 
-                    if(m_boundsCheck && baseElemIndex != 0
+                    if(m_boundsCheck == BoundCheckMode::NaN && baseElemIndex != 0
                        && baseElemIndex != prevBaseIndex + innerDimSize)
                     {
                         for(auto innerIndex = prevBaseIndex + innerDimSize;

--- a/Tensile/Source/client/source/ReferenceValidator.cpp
+++ b/Tensile/Source/client/source/ReferenceValidator.cpp
@@ -48,7 +48,7 @@ namespace Tensile
             m_printValids        = args["print-valids"].as<bool>();
             m_printMax           = args["print-max"].as<int>();
 
-            m_boundsCheck = args["bounds-check"].as<int>();
+            m_boundsCheck = args["bounds-check"].as<BoundsCheckMode>();
 
             m_printTensorA   = args["print-tensor-a"].as<bool>();
             m_printTensorB   = args["print-tensor-b"].as<bool>();
@@ -397,14 +397,14 @@ namespace Tensile
             size_t elementsBeforeData   = 0;
             size_t elementsAfterData    = 0;
 
-            if(m_boundsCheck == BoundCheckMode::NaN)
+            if(m_boundsCheck == BoundsCheckMode::NaN)
                 elementsToCopy = result.dElements;
             size_t bytesToCopy = elementsToCopy * sizeof(Type);
 
             if(m_cpuResultBuffer.size() < bytesToCopy)
                 m_cpuResultBuffer.resize(bytesToCopy);
 
-            if(m_boundsCheck == BoundCheckMode::GuardPageEnd)
+            if(m_boundsCheck == BoundsCheckMode::GuardPageBack)
                 elementsOffsetToCopy = result.dElements - tensor.totalAllocatedElements();
 
             HIP_CHECK_EXC(hipMemcpy(m_cpuResultBuffer.data(),
@@ -412,7 +412,7 @@ namespace Tensile
                                     bytesToCopy,
                                     hipMemcpyDeviceToHost));
 
-            if(m_boundsCheck == BoundCheckMode::NaN)
+            if(m_boundsCheck == BoundsCheckMode::NaN)
             {
                 elementsBeforeData = result.d - result.managedD.get();
                 elementsAfterData
@@ -488,7 +488,7 @@ namespace Tensile
                                   tensor.sizes().end());
                     size_t baseElemIndex = tensor.index(coord);
 
-                    if(m_boundsCheck == BoundCheckMode::NaN && baseElemIndex != 0
+                    if(m_boundsCheck == BoundsCheckMode::NaN && baseElemIndex != 0
                        && baseElemIndex != prevBaseIndex + innerDimSize)
                     {
                         for(auto innerIndex = prevBaseIndex + innerDimSize;

--- a/Tensile/Source/client/source/ReferenceValidator.cpp
+++ b/Tensile/Source/client/source/ReferenceValidator.cpp
@@ -48,8 +48,6 @@ namespace Tensile
             m_printValids        = args["print-valids"].as<bool>();
             m_printMax           = args["print-max"].as<int>();
 
-            m_boundsCheck = args["bounds-check"].as<BoundsCheckMode>();
-
             m_printTensorA   = args["print-tensor-a"].as<bool>();
             m_printTensorB   = args["print-tensor-b"].as<bool>();
             m_printTensorC   = args["print-tensor-c"].as<bool>();
@@ -397,14 +395,15 @@ namespace Tensile
             size_t elementsBeforeData   = 0;
             size_t elementsAfterData    = 0;
 
-            if(m_boundsCheck == BoundsCheckMode::NaN)
+            BoundsCheckMode boundsCheck = m_dataInit->getCurBoundsCheck();
+            if(boundsCheck == BoundsCheckMode::NaN)
                 elementsToCopy = result.dElements;
             size_t bytesToCopy = elementsToCopy * sizeof(Type);
 
             if(m_cpuResultBuffer.size() < bytesToCopy)
                 m_cpuResultBuffer.resize(bytesToCopy);
 
-            if(m_boundsCheck == BoundsCheckMode::GuardPageBack)
+            if(boundsCheck == BoundsCheckMode::GuardPageBack)
                 elementsOffsetToCopy = result.dElements - tensor.totalAllocatedElements();
 
             HIP_CHECK_EXC(hipMemcpy(m_cpuResultBuffer.data(),
@@ -412,7 +411,7 @@ namespace Tensile
                                     bytesToCopy,
                                     hipMemcpyDeviceToHost));
 
-            if(m_boundsCheck == BoundsCheckMode::NaN)
+            if(boundsCheck == BoundsCheckMode::NaN)
             {
                 elementsBeforeData = result.d - result.managedD.get();
                 elementsAfterData
@@ -488,7 +487,7 @@ namespace Tensile
                                   tensor.sizes().end());
                     size_t baseElemIndex = tensor.index(coord);
 
-                    if(m_boundsCheck == BoundsCheckMode::NaN && baseElemIndex != 0
+                    if(boundsCheck == BoundsCheckMode::NaN && baseElemIndex != 0
                        && baseElemIndex != prevBaseIndex + innerDimSize)
                     {
                         for(auto innerIndex = prevBaseIndex + innerDimSize;


### PR DESCRIPTION
[Background]
Tensile and Rocblas-test memory allocation behavior are different with real framework use cases. It would allocate a huge memory for max problems size one time.  And ABCD matrix could be allocated continuously. Not easy to trigger memory fault when out-of-boundary access.  Better to have a way to detect all out of boundary cases for each size and each problems.

[New Design purpose]
Let MMU detect out-of-boundary access automatically for each problems. Even if single byte access before Matrix or after Matrix also can be detected for all problems.
BoundsCheck = 2 : Front side guard page
BoundsCheck = 3 : Back side guard page
BoundsCheck = 4 : both Front side and Back side guard page. Needs 2 benchmark runs per solution. (Recommended)

[How This new Design work]
Make sure all matrix allocated page aligned memory. (2MB by default)
Let the memory addressing between different matrix are un-allocated. (free guard page)
Detect front side: Put the Matrix start address to allocated memory start address.
Detect back side: Put the Matrix end address to allocated memory end address. 
Any single byte overrun would trigger GPU memory segmentation fault.

