### PR TITLE
Fix bug of CopyTensor function

### DIFF
--- a/Tensile/Source/lib/include/Tensile/hip/HipUtils.hpp
+++ b/Tensile/Source/lib/include/Tensile/hip/HipUtils.hpp
@@ -94,13 +94,13 @@ namespace Tensile
             // dimensions that are contiguous in memory.
             for(size_t i = 0; i < desc.dimensions(); i++)
             {
-                contiguousDimensions = i + 1;
-
                 if(strides[i] > expectedStride)
                     break;
 
+                contiguousDimensions = i + 1;
+
                 if(i < desc.dimensions() - 1)
-                    expectedStride = strides[i] * sizes[i + 1];
+                    expectedStride = strides[i] * sizes[i];
             }
 
             auto copyCount = CoordCount(sizes.begin() + contiguousDimensions, sizes.end());

--- a/Tensile/Tests/pre_checkin/sgemm_exact_dict.yaml
+++ b/Tensile/Tests/pre_checkin/sgemm_exact_dict.yaml
@@ -2,8 +2,7 @@ GlobalParameters:
   NumElementsToValidate: 16384
   KernelTime: True
   NewClient: 2
-  BoundsCheck: False # FIXME: temporarily disable it since CI silently
-                     # writes bounds-check=true even when this param != -1
+  BoundsCheck: True
 
 BenchmarkProblems:
   ########################################


### PR DESCRIPTION
CopyTensor would calculate the maximum memory continuous block of tensor, then copy each memory block one by one.
The max memory block should not cover the padding area.
without fix, the max memory block may cover the padding area.
Correct the calculation to avoid out-of-boundary access.

Only BoundsCheck=1 uses CopyTensor().
Without this fix, it would hit crash when run pre_checkin/sgemm_exact_dict.yaml with boundsCheck enable. 


