### PR TITLE
Try and Install pyyaml and msgpack if not installed on user's system

### DIFF
--- a/Tensile/LibraryIO.py
+++ b/Tensile/LibraryIO.py
@@ -30,16 +30,22 @@ import subprocess
 try:
   import yaml
 except ImportError:
-  print("yaml module not found, attempting to install pyyaml using pip3")
-  subprocess.check_call(['python3', '-m', 'pip3', 'install', 'pyyaml'])
+  print("yaml module not found, attempting to install pyyaml using pip")
+  try:
+    subprocess.check_call(['python3', '-m', 'pip', 'install', 'pyyaml'])
+  except ImportError:
+    printExit("pip not found. Please install pip3 using Python >=3.5")
 finally:
   import yaml
 
 try:
   import msgpack
 except ImportError:
-  print("msgpack module not found, attempting to install msgpack using pip3")
-  subprocess.check_call(['python3', '-m', 'pip3', 'install', 'msgpack'])
+  print("msgpack module not found, attempting to install msgpack using pip")
+  try:
+    subprocess.check_call(['python3', '-m', 'pip', 'install', 'msgpack'])
+  except ImportError:
+    printExit("pip not found. Please install pip3 using Python >=3.5")
 finally:
   import msgpack
 

--- a/Tensile/LibraryIO.py
+++ b/Tensile/LibraryIO.py
@@ -25,16 +25,23 @@ from . import __version__
 from . import Common
 from . import SolutionLibrary
 import os
+import subprocess
 
 try:
   import yaml
 except ImportError:
-  printExit("You must install PyYAML to use Tensile (to parse config files). See http://pyyaml.org/wiki/PyYAML for installation instructions.")
+  print("yaml module not found, attempting to install pyyaml using pip3")
+  subprocess.check_call(['python3', '-m', 'pip3', 'install', 'pyyaml'])
+finally:
+  import yaml
 
 try:
   import msgpack
 except ImportError:
-  printExit("You must install MessagePack for Python to use Tensile (to parse config files). See https://github.com/msgpack/msgpack-python for installation instructions.")
+  print("msgpack module not found, attempting to install msgpack using pip3")
+  subprocess.check_call(['python3', '-m', 'pip3', 'install', 'msgpack'])
+finally:
+  import msgpack
 
 ################################################################################
 # Read Benchmark Config from YAML Files


### PR DESCRIPTION
Ideally, we shouldn't require msgpack if the user is trying to run Tensile using the yaml flag. However, due to it being imported in LibraryIO.py, which is loaded as a module in Tensile.py, TensileCreateLibrary.py, and ClientWriter.py, we need to install it no matter what. 

Using GlobalParameters to hide the msgpack import doesn't work as expected due to the way the ParallelMap function works. It works on single-threaded builds, but once ParallelMap is called, it breaks. I added this for pyyaml as well as it is not installed by default in some Python environment/package managers.