### PR TITLE
correct Tensile time measurement by using CPU timer

### DIFF
--- a/Tensile/Source/client/main.cpp
+++ b/Tensile/Source/client/main.cpp
@@ -530,18 +530,15 @@ int main(int argc, const char* argv[])
                             auto kernels = solution->solve(problem, *inputs, *hardware);
 
                             size_t       warmupInvocations = listeners.numWarmupRuns();
-                            size_t       eventCount        = gpuTimer ? kernels.size() : 0;
+                            size_t       eventCount        = kernels.size();
                             TimingEvents warmupStartEvents(warmupInvocations, eventCount);
                             TimingEvents warmupStopEvents(warmupInvocations, eventCount);
 
                             for(int i = 0; i < warmupInvocations; i++)
                             {
                                 listeners.preWarmup();
-                                if(gpuTimer)
-                                    adapter.launchKernels(
-                                        kernels, stream, warmupStartEvents[i], warmupStopEvents[i]);
-                                else
-                                    adapter.launchKernels(kernels, stream, nullptr, nullptr);
+                                adapter.launchKernels(
+                                    kernels, stream, warmupStartEvents[i], warmupStopEvents[i]);
                                 listeners.postWarmup();
                             }
 

--- a/Tensile/Source/client/source/BenchmarkTimer.cpp
+++ b/Tensile/Source/client/source/BenchmarkTimer.cpp
@@ -141,6 +141,8 @@ namespace Tensile
                                              TimingEvents const&                startEvents,
                                              TimingEvents const&                stopEvents)
         {
+            if((stopEvents->size() > 0) && (stopEvents->back().size() > 0))
+                HIP_CHECK_EXC(hipEventSynchronize(stopEvents->back().back()));
         }
 
         size_t BenchmarkTimer::numSyncs()


### PR DESCRIPTION
1. CPU timer issue:
   time is not correct because Tensile didn't wait for warm up iteration finish. 
   We add device sync to wait for GPU idle before we start to run benchmark iteration.


