### PR TITLE
Refactor RunGemmKernelTests to allow configurable contraction input types

### DIFF
--- a/HostLibraryTests/hip/RunGEMMKernel_test.cpp
+++ b/HostLibraryTests/hip/RunGEMMKernel_test.cpp
@@ -70,47 +70,279 @@ namespace Tensile
     } // namespace hip
 } // namespace Tensile
 
-struct RunGEMMKernelTest
-    : public ::testing::TestWithParam<
-          std::tuple<ContractionProblem,
-                     std::tuple<std::shared_ptr<SolutionLibrary<ContractionProblem>>,
-                                std::shared_ptr<hip::SolutionAdapter>,
-                                bool // is a solution required?
-                                >,
-                     bool // align allocations to start or end of pages?
-                     >>
+namespace std
 {
-    std::vector<float> a_h;
-    std::vector<float> b_h;
-    std::vector<float> c_h;
-    std::vector<float> d_h;
-    std::vector<float> d_in_h;
-    std::vector<float> d_ref_h;
+    template <>
+    struct hash<std::complex<float>>
+    {
+        inline size_t operator()(std::complex<float> const& obj) const
+        {
+            return Tensile::hash_combine(obj.real(), obj.imag());
+        }
+    };
+    template <>
+    struct hash<std::complex<double>>
+    {
+        inline size_t operator()(std::complex<double> const& obj) const
+        {
+            return Tensile::hash_combine(obj.real(), obj.imag());
+        }
+    };
 
-    float* a_d     = nullptr;
-    float* b_d     = nullptr;
-    float* c_d     = nullptr;
-    float* d_d     = nullptr;
-    float* d_ref_d = nullptr;
+    template <>
+    struct hash<Tensile::BFloat16>
+    {
+        inline size_t operator()(Tensile::BFloat16 const& obj) const
+        {
+            return hash<decltype(obj.data)>()(obj.data);
+        }
+    };
 
-    float* a_d_alloc     = nullptr;
-    float* b_d_alloc     = nullptr;
-    float* c_d_alloc     = nullptr;
-    float* d_d_alloc     = nullptr;
-    float* d_ref_d_alloc = nullptr;
+#ifdef TENSILE_USE_HALF
 
-    TypedContractionInputs<float> inputs;
+    template <>
+    struct hash<Tensile::Half>
+    {
+        inline size_t operator()(Tensile::Half const& obj) const
+        {
+            return hash<float>()(static_cast<float>(obj));
+        }
+    };
 
-    static std::unordered_map<ContractionProblem, std::vector<float>> referenceCache;
+#else
+    template <>
+    struct hash<Tensile::Half>
+    {
+        inline size_t operator()(Tensile::Half const& obj) const
+        {
+            return hash<decltype(obj.value)>()(obj.value);
+        }
+    };
+
+#endif // TENSILE_USE_HALF
+
+} // namespace std
+
+/* Types */
+using ProblemParams = std::tuple<bool, //   transA
+                                 bool, //   transB
+                                 size_t, // m
+                                 size_t, // n
+                                 size_t, // k
+                                 size_t, // lda
+                                 size_t, // ldb
+                                 size_t, // ldc
+                                 double, // beta
+                                 size_t>; // batchCount
+
+ProblemParams RandomGEMMParams = std::make_tuple(false, false, -1, -1, -1, -1, -1, -1, -1.0, -1);
+
+using SolutionParams = std::tuple<std::shared_ptr<SolutionLibrary<ContractionProblem>>,
+                                  std::shared_ptr<hip::SolutionAdapter>,
+                                  bool>; // is a solution required?
+
+enum class MemoryPageAlignment : int
+{
+    BEGIN = 0,
+    END   = 1
+};
+
+/* Utils */
+template <typename T>
+inline void expectEqual(T const& l, T const& r, size_t i, bool& fail)
+{
+    if(!fail)
+    {
+        EXPECT_EQ(l, r) << i << ": " << (fail = true);
+    }
+}
+
+template <>
+inline void expectEqual(float const& l, float const& r, size_t i, bool& fail)
+{
+    if(!fail)
+    {
+        EXPECT_FLOAT_EQ(l, r) << i << ": " << (fail = true);
+    }
+}
+
+template <>
+inline void expectEqual(double const& l, double const& r, size_t i, bool& fail)
+{
+    if(!fail)
+    {
+        EXPECT_DOUBLE_EQ(l, r) << i << ": " << (fail = true);
+    }
+}
+
+template <typename T>
+void expectEqual(std::vector<T> const& l, std::vector<T> const& r)
+{
+    bool fail = false;
+
+    auto size = std::min(l.size(), r.size());
+
+#pragma omp parallel for
+    for(size_t i = 0; i < size; i++)
+    {
+#pragma omp flush(fail)
+        expectEqual(l[i], r[i], i, fail);
+    }
+    ASSERT_EQ(fail, false);
+}
+
+/* Test interface */
+struct GEMMKernelTest
+{
+    virtual void SetUp(ProblemParams const&, SolutionParams const&, MemoryPageAlignment const&) = 0;
+    virtual void TestBestSolution()                                                             = 0;
+    virtual void TestAllSolutions()                                                             = 0;
+    virtual void TearDown()                                                                     = 0;
+    virtual void OverrideAlpha(double)                                                          = 0;
+    virtual void NullifyAPtr()                                                                  = 0;
+    virtual void NullifyBPtr()                                                                  = 0;
+    virtual std::string ToString() const                                                        = 0;
+};
+
+inline std::ostream& operator<<(std::ostream& stream, std::shared_ptr<GEMMKernelTest> const& ptr)
+{
+    if(ptr)
+        return stream << "*" << ptr->ToString();
+    else
+        return stream << "(nullptr)";
+}
+
+/* Typed test implementation */
+template <typename TypedInputs>
+struct TypedGEMMKernelTest : public GEMMKernelTest
+{
+    // Extract type info
+    using AType     = typename TypedInputs::AType;
+    using BType     = typename TypedInputs::BType;
+    using CType     = typename TypedInputs::CType;
+    using DType     = typename TypedInputs::DType;
+    using AlphaType = typename TypedInputs::AlphaType;
+    using BetaType  = typename TypedInputs::BetaType;
+
+    std::vector<AType> a_h;
+    std::vector<BType> b_h;
+    std::vector<CType> c_h;
+    std::vector<DType> d_h;
+    std::vector<DType> d_in_h;
+    std::vector<DType> d_ref_h;
+
+    AType* a_d     = nullptr;
+    BType* b_d     = nullptr;
+    CType* c_d     = nullptr;
+    DType* d_d     = nullptr;
+    DType* d_ref_d = nullptr;
+
+    AType* a_d_alloc     = nullptr;
+    BType* b_d_alloc     = nullptr;
+    CType* c_d_alloc     = nullptr;
+    DType* d_d_alloc     = nullptr;
+    DType* d_ref_d_alloc = nullptr;
+
+    TypedInputs inputs_h;
+    TypedInputs inputs_d;
 
     std::shared_ptr<Hardware> hardware;
 
-    void SetUp() override
+    // Test input components
+    ContractionProblem                                   problem;
+    std::shared_ptr<SolutionLibrary<ContractionProblem>> library;
+    std::shared_ptr<hip::SolutionAdapter>                adapter;
+    std::shared_ptr<ContractionSolution>                 solution;
+    bool                                                 requiredMatch;
+    MemoryPageAlignment                                  memoryAlignment;
+
+    static std::unordered_map<size_t, std::vector<DType>> referenceCache;
+
+    static Tensile::ContractionProblem createProblem(ProblemParams const& props)
     {
+        if(props == RandomGEMMParams)
+        {
+            return RandomGEMM<AType, BType, CType, DType>();
+        }
+        else
+        {
+            bool   transA     = std::get<0>(props);
+            bool   transB     = std::get<1>(props);
+            size_t m          = std::get<2>(props);
+            size_t n          = std::get<3>(props);
+            size_t k          = std::get<4>(props);
+            size_t lda        = std::get<5>(props);
+            size_t ldb        = std::get<6>(props);
+            size_t ldc        = std::get<7>(props);
+            double beta       = std::get<8>(props);
+            size_t batchCount = std::get<9>(props);
+
+            ContractionProblem::FreeIndices free(2);
+            ContractionProblem::BoundIndex  bound;
+
+            free[0].isA = true;
+            free[0].i = free[0].c = free[0].d = 0;
+            free[1].isA                       = false;
+            free[1].i = free[1].c = free[1].d = 1;
+
+            TensorDescriptor a, b, c, d;
+            if(transA)
+            {
+                a         = TensorDescriptor(TypeInfo<AType>::Enum, {k, m}, {1, lda});
+                free[0].i = 1;
+                bound.a   = 0;
+            }
+            else
+            {
+                a         = TensorDescriptor(TypeInfo<AType>::Enum, {m, k}, {1, lda});
+                free[0].i = 0;
+                bound.a   = 1;
+            }
+
+            if(transB)
+            {
+                b         = TensorDescriptor(TypeInfo<BType>::Enum, {n, k}, {1, ldb});
+                free[1].i = 0;
+                bound.b   = 1;
+            }
+            else
+            {
+                b         = TensorDescriptor(TypeInfo<BType>::Enum, {k, n}, {1, ldb});
+                free[1].i = 1;
+                bound.b   = 0;
+            }
+
+            ContractionProblem::FreeIndices  freeIndices{free};
+            ContractionProblem::BatchIndices batchIndices;
+            ContractionProblem::BoundIndices boundIndices{bound};
+
+            d = TensorDescriptor(TypeInfo<DType>::Enum, {m, n}, {1, ldc});
+
+            a.appendDim(batchCount);
+            b.appendDim(batchCount);
+            d.appendDim(batchCount);
+
+            batchIndices.push_back({2, 2, 2, 2});
+
+            c = d;
+
+            TensorOps nop;
+
+            return ContractionProblem(
+                a, nop, b, nop, c, nop, d, nop, freeIndices, batchIndices, boundIndices, beta);
+        }
+    }
+
+    void SetUp(ProblemParams const&       probParams,
+               SolutionParams const&      solParams,
+               MemoryPageAlignment const& alignment) override
+    {
+        // Extract testing inputs
+        problem                                   = createProblem(probParams);
+        std::tie(library, adapter, requiredMatch) = solParams;
+        memoryAlignment                           = alignment;
+
         HIP_CHECK_EXC(hipSetDevice(0));
-        ContractionProblem problem     = std::get<0>(GetParam());
-        bool               startOfPage = std::get<2>(GetParam());
-        // std::cout << problem << std::endl;
 
         a_h.resize(problem.a().totalAllocatedElements());
         b_h.resize(problem.b().totalAllocatedElements());
@@ -120,15 +352,10 @@ struct RunGEMMKernelTest
 
         std::mt19937 rng;
 
-        InitTensor(a_h.data(), problem.a(), RandomInt<float>(), rng);
-        InitTensor(b_h.data(), problem.b(), RandomAlternatingInt<float>(), rng);
-        InitTensor(c_h.data(), problem.c(), RandomInt<float>(), rng);
-        InitTensor(d_in_h.data(), problem.d(), RandomInt<float>(), rng);
-
-        // InitTensor(a_h.data(), problem.a, Iota<float>());
-        // InitTensor(b_h.data(), problem.b, Iota<float>());
-        // InitTensor(c_h.data(), problem.c, RandomInt<float>());
-        // InitTensor(d_h.data(), problem.d, RandomInt<float>());
+        InitTensor(a_h.data(), problem.a(), RandomInt<AType>(), rng);
+        InitTensor(b_h.data(), problem.b(), RandomAlternatingInt<BType>(), rng);
+        InitTensor(c_h.data(), problem.c(), RandomInt<CType>(), rng);
+        InitTensor(d_in_h.data(), problem.d(), RandomInt<DType>(), rng);
 
         d_ref_h = d_h;
 
@@ -141,13 +368,14 @@ struct RunGEMMKernelTest
         size_t cSize = RoundUpToMultiple(problem.c().totalAllocatedBytes(), pageSize);
         size_t dSize = RoundUpToMultiple(problem.d().totalAllocatedBytes(), pageSize);
 
+        // Initialize device allocations and data
         HIP_CHECK_EXC(hipMalloc(&a_d_alloc, aSize));
         HIP_CHECK_EXC(hipMalloc(&b_d_alloc, bSize));
         HIP_CHECK_EXC(hipMalloc(&c_d_alloc, cSize));
         HIP_CHECK_EXC(hipMalloc(&d_d_alloc, dSize));
         HIP_CHECK_EXC(hipMalloc(&d_ref_d_alloc, dSize));
 
-        if(startOfPage)
+        if(alignment == MemoryPageAlignment::BEGIN)
         {
             a_d     = a_d_alloc;
             b_d     = b_d_alloc;
@@ -157,11 +385,11 @@ struct RunGEMMKernelTest
         }
         else
         {
-            a_d     = a_d_alloc + ((aSize - problem.a().totalAllocatedBytes()) / sizeof(float));
-            b_d     = b_d_alloc + ((bSize - problem.b().totalAllocatedBytes()) / sizeof(float));
-            c_d     = c_d_alloc + ((cSize - problem.c().totalAllocatedBytes()) / sizeof(float));
-            d_d     = d_d_alloc + ((dSize - problem.d().totalAllocatedBytes()) / sizeof(float));
-            d_ref_d = d_ref_d_alloc + ((dSize - problem.d().totalAllocatedBytes()) / sizeof(float));
+            a_d     = a_d_alloc + ((aSize - problem.a().totalAllocatedBytes()) / sizeof(AType));
+            b_d     = b_d_alloc + ((bSize - problem.b().totalAllocatedBytes()) / sizeof(BType));
+            c_d     = c_d_alloc + ((cSize - problem.c().totalAllocatedBytes()) / sizeof(CType));
+            d_d     = d_d_alloc + ((dSize - problem.d().totalAllocatedBytes()) / sizeof(DType));
+            d_ref_d = d_ref_d_alloc + ((dSize - problem.d().totalAllocatedBytes()) / sizeof(DType));
         }
 
         HIP_CHECK_EXC(
@@ -175,40 +403,164 @@ struct RunGEMMKernelTest
         HIP_CHECK_EXC(hipMemcpy(
             d_ref_d, d_ref_h.data(), problem.d().totalAllocatedBytes(), hipMemcpyHostToDevice));
 
-        inputs.a = a_d;
-        inputs.b = b_d;
-        inputs.c = c_d;
-        inputs.d = d_d;
+        // Initialize inputs for device calcs
+        inputs_d.a = a_d;
+        inputs_d.b = b_d;
+        inputs_d.c = c_d;
+        inputs_d.d = d_d;
 
-        inputs.alpha = RandomInt<float>()(rng);
+        // Initialize alpha
+        inputs_d.alpha = RandomInt<AlphaType>()(rng);
+
+        // Initialize beta
         if(problem.beta() == 1.0)
-            inputs.beta = 1.0;
+        {
+            inputs_d.beta = static_cast<BetaType>(1.0);
+        }
         else if(problem.beta() == 0.0)
-            inputs.beta = 0.0;
+        {
+            inputs_d.beta = static_cast<BetaType>(0.0);
+        }
         else
-            inputs.beta = RandomInt<float>()(rng);
+        {
+            inputs_d.beta = RandomInt<BetaType>()(rng);
+        }
 
+        // Initialize inputs for CPU reference calcs
+        inputs_h.a     = a_h.data();
+        inputs_h.b     = b_h.data();
+        inputs_h.c     = c_h.data();
+        inputs_h.d     = d_ref_h.data();
+        inputs_h.alpha = inputs_d.alpha;
+        inputs_h.beta  = inputs_d.beta;
+
+        // Initialize hardware
         hardware = hip::GetCurrentDevice();
         ASSERT_NE(hardware, nullptr);
+    }
 
-        auto iter = referenceCache.find(problem);
+    void OverrideAlpha(double val) override
+    {
+        inputs_h.alpha = inputs_d.alpha = static_cast<AlphaType>(val);
+    }
+
+    void NullifyAPtr() override
+    {
+        inputs_h.a = inputs_d.a = nullptr;
+    }
+
+    void NullifyBPtr() override
+    {
+        inputs_h.b = inputs_d.b = nullptr;
+    }
+
+    void calcCPU()
+    {
+        // Run reference CPU calc.
+        auto key  = Tensile::hash_combine(problem, inputs_h.alpha, inputs_h.beta);
+        auto iter = referenceCache.find(key);
         if(iter == referenceCache.end())
         {
-            TypedContractionInputs<float> inputsRefHost;
-            inputsRefHost.a     = a_h.data();
-            inputsRefHost.b     = b_h.data();
-            inputsRefHost.c     = c_h.data();
-            inputsRefHost.d     = d_ref_h.data();
-            inputsRefHost.alpha = inputs.alpha;
-            inputsRefHost.beta  = inputs.beta;
-
-            Client::SolveCPU(problem, inputsRefHost);
-
-            referenceCache[problem] = d_ref_h;
+            Client::SolveCPU(problem, inputs_h);
+            referenceCache[key] = d_ref_h;
         }
         else
         {
             d_ref_h = iter->second;
+        }
+    }
+
+    void calcGPU()
+    {
+        {
+            ASSERT_NE(solution->problemPredicate, nullptr);
+            EXPECT_EQ((*solution->problemPredicate)(problem), true);
+
+            std::ostringstream msg;
+            ASSERT_EQ(solution->problemPredicate->debugEval(problem, msg), true) << msg.str();
+        }
+
+        {
+            ASSERT_NE(solution->hardwarePredicate, nullptr);
+            EXPECT_EQ((*solution->hardwarePredicate)(*hardware), true);
+
+            std::ostringstream msg;
+            ASSERT_EQ(solution->hardwarePredicate->debugEval(*hardware, msg), true) << msg.str();
+        }
+
+        if(Debug::Instance().printPredicateEvaluation())
+        {
+            std::cout << "a: " << std::hex << inputs_d.a << ".."
+                      << inputs_d.a + problem.a().totalAllocatedElements() << std::endl;
+            std::cout << "b: " << std::hex << inputs_d.b << ".."
+                      << inputs_d.b + problem.b().totalAllocatedElements() << std::endl;
+            std::cout << "c: " << std::hex << inputs_d.c << ".."
+                      << inputs_d.c + problem.c().totalAllocatedElements() << std::endl;
+            std::cout << "d: " << std::hex << inputs_d.d << ".."
+                      << inputs_d.d + problem.d().totalAllocatedElements() << std::endl;
+        }
+
+        std::vector<KernelInvocation> result = solution->solve(problem, inputs_d, *hardware);
+
+        adapter->launchKernels(result);
+
+        HIP_CHECK_EXC(
+            hipMemcpy(d_h.data(), d_d, problem.d().totalAllocatedBytes(), hipMemcpyDeviceToHost));
+    }
+
+    void TestBestSolution() override
+    {
+        if(Debug::Instance().printPredicateEvaluation())
+        {
+            std::cout << problem << std::endl << adapter << std::endl;
+        }
+
+        ASSERT_NE(library, nullptr);
+        ASSERT_NE(adapter, nullptr);
+
+        solution = library->findBestSolution(problem, *hardware);
+
+        if(requiredMatch)
+        {
+            ASSERT_NE(solution, nullptr);
+        }
+        else
+        {
+            if(!solution)
+            {
+                return;
+            }
+        }
+
+        calcCPU();
+        calcGPU();
+        expectEqual(d_h, d_ref_h);
+    }
+
+    void TestAllSolutions() override
+    {
+        if(Debug::Instance().printPredicateEvaluation())
+        {
+            std::cout << problem << std::endl << adapter << std::endl;
+        }
+
+        ASSERT_NE(library, nullptr);
+        ASSERT_NE(adapter, nullptr);
+
+        auto solutions = library->findAllSolutions(problem, *hardware);
+
+        if(requiredMatch)
+        {
+            ASSERT_GT(solutions.size(), 0);
+        }
+
+        calcCPU();
+
+        for(auto const& testSolution : solutions)
+        {
+            solution = testSolution;
+            calcGPU();
+            expectEqual(d_h, d_ref_h);
         }
     }
 
@@ -221,289 +573,204 @@ struct RunGEMMKernelTest
         hipFree(d_ref_d_alloc);
 
         hipDeviceReset();
+
+        a_h.clear();
+        b_h.clear();
+        c_h.clear();
+        d_h.clear();
+        d_in_h.clear();
+    }
+
+    inline std::string ToString() const override
+    {
+        return std::string("TypedKernelShortCircuitTest<") + TypeInfo<AType>::Name() + ", "
+               + TypeInfo<BType>::Name() + ", " + TypeInfo<CType>::Name() + ", "
+               + TypeInfo<DType>::Name() + ", " + TypeInfo<AlphaType>::Name() + ", "
+               + TypeInfo<BetaType>::Name() + ", " + std::string(">");
     }
 };
 
-std::unordered_map<ContractionProblem, std::vector<float>> RunGEMMKernelTest::referenceCache;
+template <typename TypedInputs>
+std::unordered_map<size_t, std::vector<typename TypedInputs::DType>>
+    TypedGEMMKernelTest<TypedInputs>::referenceCache;
 
-TEST_P(RunGEMMKernelTest, BestSolution)
+struct RunGEMMKernelTest
+    : public ::testing::TestWithParam<std::tuple<std::shared_ptr<GEMMKernelTest>,
+                                                 ProblemParams,
+                                                 SolutionParams,
+                                                 MemoryPageAlignment>>
 {
-    bool debug = Debug::Instance().printPredicateEvaluation();
-
-    auto params = GetParam();
-
-    ContractionProblem problem = std::get<0>(params);
-
-    std::shared_ptr<SolutionLibrary<ContractionProblem>> library;
-    std::shared_ptr<hip::SolutionAdapter>                adapter;
-    bool                                                 requiredMatch;
-
-    std::tie(library, adapter, requiredMatch) = std::get<1>(params);
-    if(debug)
-        std::cout << problem << std::endl << adapter << std::endl;
-
-    ASSERT_NE(library, nullptr);
-    ASSERT_NE(adapter, nullptr);
-
-    auto solution = library->findBestSolution(problem, *hardware);
-
-    if(requiredMatch)
+    void SetUp() override
     {
-        ASSERT_NE(solution, nullptr);
+        auto param          = GetParam();
+        auto typedTest      = std::get<0>(param);
+        auto problemParams  = std::get<1>(param);
+        auto solutionParams = std::get<2>(param);
+        auto pageAlignment  = std::get<3>(param);
+        typedTest->SetUp(problemParams, solutionParams, pageAlignment);
     }
-    else
+    void TearDown() override
     {
-        if(!solution)
-            return;
+        auto param     = GetParam();
+        auto typedTest = std::get<0>(param);
+        typedTest->TearDown();
     }
+};
 
+TEST_P(RunGEMMKernelTest, TestBestSolution)
+{
+    auto param     = GetParam();
+    auto typedTest = std::get<0>(param);
+    typedTest->TestBestSolution();
+}
+
+TEST_P(RunGEMMKernelTest, TestAllSolutions)
+{
+    auto param     = GetParam();
+    auto typedTest = std::get<0>(param);
+    typedTest->TestAllSolutions();
+}
+
+TEST_P(RunGEMMKernelTest, TestAlphaZero)
+{
+    auto param     = GetParam();
+    auto typedTest = std::get<0>(param);
+    typedTest->OverrideAlpha(0.0);
+    typedTest->TestBestSolution();
+}
+
+TEST_P(RunGEMMKernelTest, TestAlphaZeroABNull)
+{
+    auto param     = GetParam();
+    auto typedTest = std::get<0>(param);
+    typedTest->OverrideAlpha(0.0);
+    typedTest->NullifyAPtr();
+    typedTest->NullifyBPtr();
+    auto fail = false;
+    try
     {
-        ASSERT_NE(solution->problemPredicate, nullptr);
-        EXPECT_EQ((*solution->problemPredicate)(problem), true);
-
-        std::ostringstream msg;
-        ASSERT_EQ(solution->problemPredicate->debugEval(problem, msg), true) << msg.str();
+        ASSERT_NO_THROW();
     }
-
+    catch(...)
     {
-        ASSERT_NE(solution->hardwarePredicate, nullptr);
-        EXPECT_EQ((*solution->hardwarePredicate)(*hardware), true);
-
-        std::ostringstream msg;
-        ASSERT_EQ(solution->hardwarePredicate->debugEval(*hardware, msg), true) << msg.str();
-    }
-
-    if(debug)
-    {
-        std::cout << "a: " << std::hex << inputs.a << ".."
-                  << inputs.a + problem.a().totalAllocatedElements() << std::endl;
-        std::cout << "b: " << std::hex << inputs.b << ".."
-                  << inputs.b + problem.b().totalAllocatedElements() << std::endl;
-        std::cout << "c: " << std::hex << inputs.c << ".."
-                  << inputs.c + problem.c().totalAllocatedElements() << std::endl;
-        std::cout << "d: " << std::hex << inputs.d << ".."
-                  << inputs.d + problem.d().totalAllocatedElements() << std::endl;
-    }
-
-    std::vector<KernelInvocation> result = solution->solve(problem, inputs, *hardware);
-
-    adapter->launchKernels(result);
-
-    HIP_CHECK_EXC(
-        hipMemcpy(d_h.data(), d_d, problem.d().totalAllocatedBytes(), hipMemcpyDeviceToHost));
-
-    /*
-  std::cout << "alpha: " << inputs.alpha << ", beta: " << inputs.beta
-            << ", transA: " << problem.transA() << ", transB: " <<
-  problem.transB() << std::endl; std::cout << "A:"; WriteTensor(std::cout,
-  a_h.data(), problem.a());
-
-  std::cout << "B:";
-  WriteTensor(std::cout, b_h.data(), problem.b());
-
-  std::cout << "C Input:";
-  WriteTensor(std::cout, c_h.data(), problem.c());
-
-  std::cout << "D Input:";
-  WriteTensor(std::cout, d_in_h.data(), problem.c());
-
-  std::cout << "D Reference:";
-  WriteTensor(std::cout, d_ref_h.data(), problem.d());
-
-  std::cout << "D Result:";
-  WriteTensor(std::cout, d_h.data(), problem.c());
-  */
-
-    bool fail = false;
-
-#pragma omp parallel for
-    for(int i = 0; i < d_ref_h.size(); i++)
-    {
-#pragma omp flush(fail)
-        if(!fail)
-            EXPECT_FLOAT_EQ(d_h[i], d_ref_h[i]) << i << ": " << (fail = true);
+        fail = true;
     }
     ASSERT_EQ(fail, false);
 }
 
-TEST_P(RunGEMMKernelTest, AllSolutions)
+std::vector<std::shared_ptr<GEMMKernelTest>> TypedTests()
 {
-    bool debug = Debug::Instance().printPredicateEvaluation();
-
-    auto params = GetParam();
-
-    ContractionProblem problem = std::get<0>(params);
-
-    std::shared_ptr<SolutionLibrary<ContractionProblem>> library;
-    std::shared_ptr<hip::SolutionAdapter>                adapter;
-    bool                                                 requiredMatch;
-
-    std::tie(library, adapter, requiredMatch) = std::get<1>(params);
-
-    ASSERT_NE(library, nullptr);
-    ASSERT_NE(adapter, nullptr);
-
-    auto solutions = library->findAllSolutions(problem, *hardware);
-
-    if(requiredMatch)
-    {
-        ASSERT_GT(solutions.size(), 0);
-    }
-
-    for(auto const& solution : solutions)
-    {
-        ASSERT_NE(solution, nullptr);
-
-        {
-            ASSERT_NE(solution->problemPredicate, nullptr);
-            EXPECT_EQ((*solution->problemPredicate)(problem), true);
-
-            std::ostringstream msg;
-            ASSERT_EQ(solution->problemPredicate->debugEval(problem, msg), true) << msg.str();
-            if(debug)
-                std::cout << msg.str() << std::endl;
-        }
-
-        {
-            ASSERT_NE(solution->hardwarePredicate, nullptr);
-            EXPECT_EQ((*solution->hardwarePredicate)(*hardware), true);
-
-            std::ostringstream msg;
-            ASSERT_EQ(solution->hardwarePredicate->debugEval(*hardware, msg), true) << msg.str();
-            if(debug)
-                std::cout << msg.str() << std::endl;
-        }
-
-        // std::cout << solution->name() << std::endl;
-
-        std::vector<KernelInvocation> result = solution->solve(problem, inputs, *hardware);
-
-        adapter->launchKernels(result);
-
-        HIP_CHECK_EXC(
-            hipMemcpy(d_h.data(), d_d, problem.d().totalAllocatedBytes(), hipMemcpyDeviceToHost));
-
-        /*
-    std::cout << "alpha: " << inputs.alpha << ", beta: " << inputs.beta
-              << ", transA: " << problem.transA() << ", transB: " <<
-    problem.transB() << std::endl; std::cout << "A:"; WriteTensor(std::cout,
-    a_h.data(), problem.a());
-
-    std::cout << "B:";
-    WriteTensor(std::cout, b_h.data(), problem.b());
-
-    std::cout << "C Input:";
-    WriteTensor(std::cout, c_h.data(), problem.c());
-
-    std::cout << "D Input:";
-    WriteTensor(std::cout, d_in_h.data(), problem.c());
-
-    std::cout << "D Reference:";
-    WriteTensor(std::cout, d_ref_h.data(), problem.d());
-
-    std::cout << "D Result:";
-    WriteTensor(std::cout, d_h.data(), problem.c());
-    */
-
-        bool fail = false;
-
-#pragma omp parallel for
-        for(int i = 0; i < d_ref_h.size(); i++)
-        {
-#pragma omp flush(fail)
-            if(!fail)
-                EXPECT_FLOAT_EQ(d_h[i], d_ref_h[i]) << i << ": " << (fail = true);
-        }
-        ASSERT_EQ(fail, false);
-    }
+    static auto testFloat = std::make_shared<TypedGEMMKernelTest<TypedContractionInputs<float>>>();
+    //static auto testDouble
+    //    = std::make_shared<TypedGEMMKernelTest<TypedContractionInputs<double>>>();
+    //     static auto testCFloat = std::make_shared<TypedGEMMKernelTest<TypedContractionInputs<std::complex<float>>>>();
+    //     static auto testCDouble = std::make_shared<TypedGEMMKernelTest<TypedContractionInputs<std::complex<double>>>>();
+    //     static auto testInt8x4 = std::make_shared<TypedGEMMKernelTest<TypedContractionInputs<Int8x4, Int8x4, int32_t, int32_t>>>();
+    //     static auto testInt32 = std::make_shared<TypedGEMMKernelTest<TypedContractionInputs<int32_t>>>();
+    //     static auto testHalf = std::make_shared<TypedGEMMKernelTest<TypedContractionInputs<Tensile::Half>>>();
+    // #ifdef TENSILE_USE_BF16
+    //     static auto testBF16 = std::make_shared<TypedGEMMKernelTest<BFloat16ContractionInputs>>();
+    // #endif
+    return std::vector<std::shared_ptr<GEMMKernelTest>>{
+        testFloat,
+        // testDouble,
+        //         testCFloat,
+        //         testCDouble,
+        //         testInt8x4,
+        //         testInt32,
+        //         testHalf,
+        // #ifdef TENSILE_USE_BF16
+        //         testBF16,
+        // #endif
+    };
 }
 
-std::vector<ContractionProblem> TestProblems()
+std::vector<ProblemParams> TestProblems()
 {
-    return std::vector<ContractionProblem>{
-        //ContractionProblem::GEMM(false, false, 5760, 5760, 5760, 5760, 5760, 5760, 1.5, false,  4),
-        //ContractionProblem::GEMM(false,  true, 5760, 5760, 5760, 5760, 5760, 5760, 1.5, false,  4),
-        //ContractionProblem::GEMM( true, false, 5760, 5760, 5760, 5760, 5760, 5760, 1.5, false,  4),
-        //ContractionProblem::GEMM( true,  true, 5760, 5760, 5760, 5760, 5760, 5760, 1.5, false,  4),
-        ContractionProblem::GEMM(false, false, 4, 4, 6, 4, 6, 4, 1.5, false, 2),
-        ContractionProblem::GEMM(false, true, 4, 4, 6, 4, 4, 4, 1.5, false, 2),
-        ContractionProblem::GEMM(true, false, 4, 4, 6, 6, 6, 4, 1.5, false, 2),
-        ContractionProblem::GEMM(true, true, 4, 4, 6, 6, 4, 4, 1.5, false, 2),
+    return std::vector<ProblemParams>{
 
-        ContractionProblem::GEMM(false, false, 15, 15, 15, 15, 15, 15, 1.5, false, 1),
-        ContractionProblem::GEMM(false, true, 15, 15, 15, 15, 15, 15, 1.5, false, 1),
-        ContractionProblem::GEMM(true, false, 15, 15, 15, 15, 15, 15, 1.5, false, 1),
-        ContractionProblem::GEMM(true, true, 15, 15, 15, 15, 15, 15, 1.5, false, 1),
+        //{false, false, 5760, 5760, 5760, 5760, 5760, 5760, 1.5, 4},
+        //{false,  true, 5760, 5760, 5760, 5760, 5760, 5760, 1.5, 4},
+        //{ true, false, 5760, 5760, 5760, 5760, 5760, 5760, 1.5, 4},
+        //{ true,  true, 5760, 5760, 5760, 5760, 5760, 5760, 1.5, 4},
+        std::make_tuple(false, false, 4, 4, 6, 4, 6, 4, 1.5, 2),
+        std::make_tuple(false, true, 4, 4, 6, 4, 4, 4, 1.5, 2),
+        std::make_tuple(true, false, 4, 4, 6, 6, 6, 4, 1.5, 2),
+        std::make_tuple(true, true, 4, 4, 6, 6, 4, 4, 1.5, 2),
 
-        ContractionProblem::GEMM(false, false, 16, 16, 16, 16, 16, 16, 1.5, false, 1),
-        ContractionProblem::GEMM(false, true, 16, 16, 16, 16, 16, 16, 1.5, false, 1),
-        ContractionProblem::GEMM(true, false, 16, 16, 16, 16, 16, 16, 1.5, false, 1),
-        ContractionProblem::GEMM(true, true, 16, 16, 16, 16, 16, 16, 1.5, false, 1),
+        std::make_tuple(false, false, 15, 15, 15, 15, 15, 15, 1.5, 1),
+        std::make_tuple(false, true, 15, 15, 15, 15, 15, 15, 1.5, 1),
+        std::make_tuple(true, false, 15, 15, 15, 15, 15, 15, 1.5, 1),
+        std::make_tuple(true, true, 15, 15, 15, 15, 15, 15, 1.5, 1),
 
-        ContractionProblem::GEMM(false, false, 17, 17, 17, 17, 17, 17, 1.5, false, 1),
-        ContractionProblem::GEMM(false, true, 17, 17, 17, 17, 17, 17, 1.5, false, 1),
-        ContractionProblem::GEMM(true, false, 17, 17, 17, 17, 17, 17, 1.5, false, 1),
-        ContractionProblem::GEMM(true, true, 17, 17, 17, 17, 17, 17, 1.5, false, 1),
+        std::make_tuple(false, false, 16, 16, 16, 16, 16, 16, 1.5, 1),
+        std::make_tuple(false, true, 16, 16, 16, 16, 16, 16, 1.5, 1),
+        std::make_tuple(true, false, 16, 16, 16, 16, 16, 16, 1.5, 1),
+        std::make_tuple(true, true, 16, 16, 16, 16, 16, 16, 1.5, 1),
 
-        ContractionProblem::GEMM(false, false, 31, 31, 31, 31, 31, 31, 1.5, false, 1),
-        ContractionProblem::GEMM(false, true, 31, 31, 31, 31, 31, 31, 1.5, false, 1),
-        ContractionProblem::GEMM(true, false, 31, 31, 31, 31, 31, 31, 1.5, false, 1),
-        ContractionProblem::GEMM(true, true, 31, 31, 31, 31, 31, 31, 1.5, false, 1),
+        std::make_tuple(false, false, 17, 17, 17, 17, 17, 17, 1.5, 1),
+        std::make_tuple(false, true, 17, 17, 17, 17, 17, 17, 1.5, 1),
+        std::make_tuple(true, false, 17, 17, 17, 17, 17, 17, 1.5, 1),
+        std::make_tuple(true, true, 17, 17, 17, 17, 17, 17, 1.5, 1),
 
-        ContractionProblem::GEMM(false, false, 32, 32, 32, 32, 32, 32, 1.5, false, 1),
-        ContractionProblem::GEMM(false, true, 32, 32, 32, 32, 32, 32, 1.5, false, 1),
-        ContractionProblem::GEMM(true, false, 32, 32, 32, 32, 32, 32, 1.5, false, 1),
-        ContractionProblem::GEMM(true, true, 32, 32, 32, 32, 32, 32, 1.5, false, 1),
+        std::make_tuple(false, false, 31, 31, 31, 31, 31, 31, 1.5, 1),
+        std::make_tuple(false, true, 31, 31, 31, 31, 31, 31, 1.5, 1),
+        std::make_tuple(true, false, 31, 31, 31, 31, 31, 31, 1.5, 1),
+        std::make_tuple(true, true, 31, 31, 31, 31, 31, 31, 1.5, 1),
 
-        ContractionProblem::GEMM(false, false, 33, 33, 33, 33, 33, 33, 1.5, false, 1),
-        ContractionProblem::GEMM(false, true, 33, 33, 33, 33, 33, 33, 1.5, false, 1),
-        ContractionProblem::GEMM(true, false, 33, 33, 33, 33, 33, 33, 1.5, false, 1),
-        ContractionProblem::GEMM(true, true, 33, 33, 33, 33, 33, 33, 1.5, false, 1),
+        std::make_tuple(false, false, 32, 32, 32, 32, 32, 32, 1.5, 1),
+        std::make_tuple(false, true, 32, 32, 32, 32, 32, 32, 1.5, 1),
+        std::make_tuple(true, false, 32, 32, 32, 32, 32, 32, 1.5, 1),
+        std::make_tuple(true, true, 32, 32, 32, 32, 32, 32, 1.5, 1),
 
-        ContractionProblem::GEMM(false, false, 34, 34, 34, 34, 34, 34, 1.5, false, 1),
-        ContractionProblem::GEMM(false, true, 34, 34, 34, 34, 34, 34, 1.5, false, 1),
-        ContractionProblem::GEMM(true, false, 34, 34, 34, 34, 34, 34, 1.5, false, 1),
-        ContractionProblem::GEMM(true, true, 34, 34, 34, 34, 34, 34, 1.5, false, 1),
+        std::make_tuple(false, false, 33, 33, 33, 33, 33, 33, 1.5, 1),
+        std::make_tuple(false, true, 33, 33, 33, 33, 33, 33, 1.5, 1),
+        std::make_tuple(true, false, 33, 33, 33, 33, 33, 33, 1.5, 1),
+        std::make_tuple(true, true, 33, 33, 33, 33, 33, 33, 1.5, 1),
 
-        ContractionProblem::GEMM(false, false, 234, 123, 634, 234, 634, 234, 1.5, false, 1),
-        ContractionProblem::GEMM(false, false, 234, 123, 634, 245, 768, 249, 1.5, false, 12),
-        ContractionProblem::GEMM(false, true, 234, 123, 634, 245, 768, 249, 1.5, false, 12),
-        ContractionProblem::GEMM(true, false, 234, 123, 634, 768, 768, 249, 1.5, false, 12),
-        ContractionProblem::GEMM(true, true, 234, 123, 634, 768, 768, 249, 1.5, false, 12),
-        RandomGEMM(),
-        RandomGEMM(),
-        RandomGEMM(),
-        RandomGEMM(),
-        RandomGEMM(),
-        RandomGEMM(),
-        RandomGEMM(),
-        RandomGEMM(),
-        RandomGEMM(),
+        std::make_tuple(false, false, 34, 34, 34, 34, 34, 34, 1.5, 1),
+        std::make_tuple(false, true, 34, 34, 34, 34, 34, 34, 1.5, 1),
+        std::make_tuple(true, false, 34, 34, 34, 34, 34, 34, 1.5, 1),
+        std::make_tuple(true, true, 34, 34, 34, 34, 34, 34, 1.5, 1),
 
-        ContractionProblem::GEMM(false, false, 1, 4, 6, 1, 6, 1, 1.5, false, 1),
-        ContractionProblem::GEMM(false, false, 4, 1, 6, 4, 6, 4, 1.5, false, 1),
-        ContractionProblem::GEMM(false, false, 4, 4, 1, 4, 1, 4, 1.5, false, 1),
+        std::make_tuple(false, false, 234, 123, 634, 234, 634, 234, 1.5, 1),
+        std::make_tuple(false, false, 234, 123, 634, 245, 768, 249, 1.5, 12),
+        std::make_tuple(false, true, 234, 123, 634, 245, 768, 249, 1.5, 12),
+        std::make_tuple(true, false, 234, 123, 634, 768, 768, 249, 1.5, 12),
+        std::make_tuple(true, true, 234, 123, 634, 768, 768, 249, 1.5, 12),
+        RandomGEMMParams,
+        RandomGEMMParams,
+        RandomGEMMParams,
+        RandomGEMMParams,
+        RandomGEMMParams,
+        RandomGEMMParams,
+        RandomGEMMParams,
+        RandomGEMMParams,
+        RandomGEMMParams,
+        std::make_tuple(false, false, 1, 4, 6, 1, 6, 1, 1.5, 1),
+        std::make_tuple(false, false, 4, 1, 6, 4, 6, 4, 1.5, 1),
+        std::make_tuple(false, false, 4, 4, 1, 4, 1, 4, 1.5, 1),
 
-        ContractionProblem::GEMM(false, true, 1, 4, 6, 1, 4, 1, 1.5, false, 1),
-        ContractionProblem::GEMM(false, true, 4, 1, 6, 4, 1, 4, 1.5, false, 1),
-        ContractionProblem::GEMM(false, true, 4, 4, 1, 4, 4, 4, 1.5, false, 1),
+        std::make_tuple(false, true, 1, 4, 6, 1, 4, 1, 1.5, 1),
+        std::make_tuple(false, true, 4, 1, 6, 4, 1, 4, 1.5, 1),
+        std::make_tuple(false, true, 4, 4, 1, 4, 4, 4, 1.5, 1),
 
-        ContractionProblem::GEMM(true, false, 1, 4, 6, 6, 6, 1, 1.5, false, 1),
-        ContractionProblem::GEMM(true, false, 4, 1, 6, 6, 6, 4, 1.5, false, 1),
-        ContractionProblem::GEMM(true, false, 4, 4, 1, 1, 1, 4, 1.5, false, 1),
+        std::make_tuple(true, false, 1, 4, 6, 6, 6, 1, 1.5, 1),
+        std::make_tuple(true, false, 4, 1, 6, 6, 6, 4, 1.5, 1),
+        std::make_tuple(true, false, 4, 4, 1, 1, 1, 4, 1.5, 1),
 
-        ContractionProblem::GEMM(true, true, 1, 4, 6, 6, 4, 1, 1.5, false, 1),
-        ContractionProblem::GEMM(true, true, 4, 1, 6, 6, 1, 4, 1.5, false, 1),
-        ContractionProblem::GEMM(true, true, 4, 4, 1, 1, 4, 4, 1.5, false, 1),
+        std::make_tuple(true, true, 1, 4, 6, 6, 4, 1, 1.5, 1),
+        std::make_tuple(true, true, 4, 1, 6, 6, 1, 4, 1.5, 1),
+        std::make_tuple(true, true, 4, 4, 1, 1, 4, 4, 1.5, 1),
 
-        ContractionProblem::GEMM(false, true, 1, 128, 256, 1, 270, 49928, 1.5, false, 1),
-        ContractionProblem::GEMM(false, true, 384, 1, 384, 384, 270, 49928, 1.5, false, 1),
-        ContractionProblem::GEMM(true, true, 4, 4, 1, 1, 4, 4, 1.5, false, 1),
+        std::make_tuple(false, true, 1, 128, 256, 1, 270, 49928, 1.5, 1),
+        std::make_tuple(false, true, 384, 1, 384, 384, 270, 49928, 1.5, 1),
+        std::make_tuple(true, true, 4, 4, 1, 1, 4, 4, 1.5, 1),
 
-        ContractionProblem::GEMM(false, false, 16328, 384, 384, 16328, 384, 16328, 2.0, false, 1),
-        ContractionProblem::GEMM(false, true, 16328, 384, 384, 16328, 16328, 16328, 2.0, false, 1),
-        ContractionProblem::GEMM(true, false, 16328, 384, 384, 384, 384, 16328, 2.0, false, 1),
-        ContractionProblem::GEMM(true, true, 16328, 384, 384, 384, 16328, 16328, 2.0, false, 1)};
+        std::make_tuple(false, false, 16328, 384, 384, 16328, 384, 16328, 2.0, 1),
+        std::make_tuple(false, true, 16328, 384, 384, 16328, 16328, 16328, 2.0, 1),
+        std::make_tuple(true, false, 16328, 384, 384, 384, 384, 16328, 2.0, 1),
+        std::make_tuple(true, true, 16328, 384, 384, 384, 16328, 16328, 2.0, 1)};
 }
 
 std::vector<std::tuple<std::shared_ptr<SolutionLibrary<ContractionProblem>>,
@@ -594,8 +861,13 @@ std::vector<std::tuple<std::shared_ptr<SolutionLibrary<ContractionProblem>>,
     return rv;
 }
 
+std::vector<MemoryPageAlignment> TestMemoryAlignments()
+{
+    return std::vector<MemoryPageAlignment>{MemoryPageAlignment::BEGIN, MemoryPageAlignment::END};
+}
 INSTANTIATE_TEST_SUITE_P(HipSolutionAdapter,
                          RunGEMMKernelTest,
-                         ::testing::Combine(::testing::ValuesIn(TestProblems()),
+                         ::testing::Combine(::testing::ValuesIn(TypedTests()),
+                                            ::testing::ValuesIn(TestProblems()),
                                             ::testing::ValuesIn(TestLibraries()),
-                                            ::testing::Values(false, true)));
+                                            ::testing::ValuesIn(TestMemoryAlignments())));

--- a/HostLibraryTests/testlib/include/TestUtils.hpp
+++ b/HostLibraryTests/testlib/include/TestUtils.hpp
@@ -42,7 +42,7 @@ namespace Tensile
         template <typename RNG, typename... Args>
         T operator()(RNG& rng, Args&&...)
         {
-            return dist(rng);
+            return static_cast<T>(dist(rng));
         }
     };
 
@@ -58,7 +58,7 @@ namespace Tensile
         template <typename RNG>
         T operator()(RNG& rng, std::vector<size_t> const& index3)
         {
-            T sign = ((index3[0] % 2) ^ (index3[1] % 2)) ? 1 : -1;
+            T sign = static_cast<T>(((index3[0] % 2) ^ (index3[1] % 2)) ? 1 : -1);
             return sign * parent(rng, index3);
         }
     };
@@ -149,6 +149,10 @@ namespace Tensile
             }
     }
 
+    template <typename AType = float,
+              typename BType = AType,
+              typename CType = AType,
+              typename DType = CType>
     inline ContractionProblem RandomGEMM()
     {
         static std::mt19937 rng;
@@ -230,10 +234,10 @@ namespace Tensile
 
         return ContractionProblem::GEMM_Strides(transA,
                                                 transB,
-                                                DataType::Float,
-                                                DataType::Float,
-                                                DataType::Float,
-                                                DataType::Float,
+                                                TypeInfo<AType>::Enum,
+                                                TypeInfo<BType>::Enum,
+                                                TypeInfo<CType>::Enum,
+                                                TypeInfo<DType>::Enum,
                                                 m,
                                                 n,
                                                 k,

--- a/Tensile/Source/TensileTypes.h
+++ b/Tensile/Source/TensileTypes.h
@@ -97,75 +97,76 @@ inline std::ostream& operator<<(std::ostream& os, const tensile_complex<T>& data
 }
 
 template <typename T>
-constexpr __host__ __device__ tensile_complex<T> operator+(tensile_complex<T> data)
+constexpr __host__ __device__ tensile_complex<T> operator+(tensile_complex<T> const& data)
 {
     return data;
 }
 
 template <typename T>
-constexpr __host__ __device__ tensile_complex<T> operator-(tensile_complex<T> data)
+constexpr __host__ __device__ tensile_complex<T> operator-(tensile_complex<T> const& data)
 {
     return tensile_complex<T>{-data.x, -data.y};
 }
 
 template <typename T>
-constexpr __host__ __device__ tensile_complex<T> operator+(tensile_complex<T> a,
-                                                           tensile_complex<T> b)
+constexpr __host__ __device__ tensile_complex<T> operator+(tensile_complex<T> const& a,
+                                                           tensile_complex<T> const& b)
 {
     return tensile_complex<T>{a.x + b.x, a.y + b.y};
 }
 
 template <typename T>
-constexpr __host__ __device__ tensile_complex<T> operator-(tensile_complex<T> a,
-                                                           tensile_complex<T> b)
+constexpr __host__ __device__ tensile_complex<T> operator-(tensile_complex<T> const& a,
+                                                           tensile_complex<T> const& b)
 {
     return tensile_complex<T>{a.x - b.x, a.y - b.y};
 }
 
 template <typename T>
-constexpr __host__ __device__ tensile_complex<T> operator*(tensile_complex<T> a,
-                                                           tensile_complex<T> b)
+constexpr __host__ __device__ tensile_complex<T> operator*(tensile_complex<T> const& a,
+                                                           tensile_complex<T> const& b)
 {
     return tensile_complex<T>{a.x * b.x - a.y * b.y, a.x * b.y + a.y * b.x};
 }
 
 template <typename T>
-constexpr __host__ __device__ tensile_complex<T> operator/(tensile_complex<T> a,
-                                                           tensile_complex<T> b)
+constexpr __host__ __device__ tensile_complex<T> operator/(tensile_complex<T> const& a,
+                                                           tensile_complex<T> const& b)
 {
     return tensile_complex<T>{(a.x * b.x + a.y * b.y) / (b.x * b.x + b.y * b.y),
                               (a.y * b.x - a.x * b.y) / (b.x * b.x + b.y * b.y)};
 }
 
 template <typename T>
-constexpr __host__ __device__ tensile_complex<T>& operator+=(tensile_complex<T>& a,
-                                                             tensile_complex<T>  b)
+constexpr __host__ __device__ tensile_complex<T>& operator+=(tensile_complex<T>&       a,
+                                                             tensile_complex<T> const& b)
 {
     return (a = a + b);
 }
 
 template <typename T>
-constexpr __host__ __device__ tensile_complex<T>& operator-=(tensile_complex<T>& a,
-                                                             tensile_complex<T>  b)
+constexpr __host__ __device__ tensile_complex<T>& operator-=(tensile_complex<T>&       a,
+                                                             tensile_complex<T> const& b)
 {
     return (a = a - b);
 }
 
 template <typename T>
-constexpr __host__ __device__ tensile_complex<T>& operator*=(tensile_complex<T>& a,
-                                                             tensile_complex<T>  b)
+constexpr __host__ __device__ tensile_complex<T>& operator*=(tensile_complex<T>&       a,
+                                                             tensile_complex<T> const& b)
 {
     return (a = a * b);
 }
 
 template <typename T>
-constexpr __host__ __device__ tensile_complex<T>& operator/=(tensile_complex<T>& a,
-                                                             tensile_complex<T>  b)
+constexpr __host__ __device__ tensile_complex<T>& operator/=(tensile_complex<T>&       a,
+                                                             tensile_complex<T> const& b)
 {
     return (a = a / b);
 }
 template <typename T>
-constexpr __host__ __device__ bool operator==(tensile_complex<T>& a, tensile_complex<T> b)
+constexpr __host__ __device__ bool operator==(tensile_complex<T> const& a,
+                                              tensile_complex<T> const& b)
 {
     return (a.x == b.x) && (a.y == b.y);
 }

--- a/Tensile/Source/lib/include/Tensile/DataTypes_Int8x4.hpp
+++ b/Tensile/Source/lib/include/Tensile/DataTypes_Int8x4.hpp
@@ -33,19 +33,30 @@ namespace Tensile
  */
     struct Int8x4
     {
+        Int8x4()
+            : a(0)
+            , b(0)
+            , c(0)
+            , d(0)
+        {
+        }
+
         Int8x4(int8_t xa, int8_t xb, int8_t xc, int8_t xd)
             : a(xa)
             , b(xb)
             , c(xc)
-            , d(xd){};
+            , d(xd)
+        {
+        }
 
         Int8x4(uint32_t v)
+            : a(v & 0xff)
+            , b((v << 8) & 0xff)
+            , c((v << 16) & 0xff)
+            , d((v << 24) & 0xff)
         {
-            a = (v)&0xff;
-            b = (v << 8) & 0xff;
-            c = (v << 16) & 0xff;
-            d = (v << 24) & 0xff;
-        };
+        }
+
         int8_t a, b, c, d;
 
         int32_t operator*(Int8x4 const& other) const


### PR DESCRIPTION
- Instead of holding all data inside the test fixture object, pass in typed test objects as arguments.
- Only need to instantiate test types that are subject of interest.
- The typed tests are stored in static space and are re-used, which may offer some performance improvements as test case counts increase.
- Instead of using a boolean for memory page alignment, use a more descriptive enum class
- Add a default constructor for the Int8x4 so that it can be used in the std::vector container class
- Fix parameter types on tensile_complex operators