### PR TITLE
Fix the incorrect CSV-merge function

### DIFF
--- a/Tensile/Source/client/source/CSVStackFile.cpp
+++ b/Tensile/Source/client/source/CSVStackFile.cpp
@@ -93,7 +93,17 @@ namespace Tensile
                 writeRow(m_headers);
 
             m_firstRow = false;
-            outMap     = m_currentRow;
+
+            // only copy the fields that are in headers
+            for(auto const& key : m_keyOrder)
+            {
+                std::string value = "";
+
+                auto it = m_currentRow.find(key);
+                if(it != m_currentRow.end())
+                    value = escape(it->second);
+                outMap[key] = value;
+            }
         }
 
         void CSVStackFile::clearCurrentRow()

--- a/Tensile/Source/client/source/ResultFileReporter.cpp
+++ b/Tensile/Source/client/source/ResultFileReporter.cpp
@@ -166,10 +166,9 @@ namespace Tensile
             {
                 const std::string& key = oldRowIter.first;
                 if(key.compare(ResultKey::ProblemIndex) == 0
-                   || key.find_first_of("Size") != std::string::npos
-                   || key.compare(ResultKey::LDD) == 0 || key.compare(ResultKey::LDC) == 0
-                   || key.compare(ResultKey::LDA) == 0 || key.compare(ResultKey::LDB) == 0
-                   || key.compare(ResultKey::TotalFlops) == 0)
+                   || key.find("Size") != std::string::npos || key.compare(ResultKey::LDD) == 0
+                   || key.compare(ResultKey::LDC) == 0 || key.compare(ResultKey::LDA) == 0
+                   || key.compare(ResultKey::LDB) == 0 || key.compare(ResultKey::TotalFlops) == 0)
                 {
                     // these data should be the same for same problem
                     assert(oldRowIter.second == newRow[key]);


### PR DESCRIPTION
bug-fix for csv exporter:
* Using string.find() instead of string.find_first_of(), the wrong find-result causes assert() fail
  - string key = "solution-idx";
  - key.find_first_of("Size") will return 5, which is position of "i"
  - key.find("Size") will return std::npos, means not found. This is what I expected.
* When readCurrentRow(), only get the fields that are in the headers