### PR TITLE
Allowing support for using built-in float 16. New define

### DIFF
--- a/Tensile/Source/lib/include/Tensile/DataTypes_Half.hpp
+++ b/Tensile/Source/lib/include/Tensile/DataTypes_Half.hpp
@@ -34,7 +34,7 @@
 
 namespace Tensile
 {
-#ifdef TENSILE_USE_HIP
+#if defined(TENSILE_USE_HIP) || defined(TENSILE_USE_FLOAT16_BUILTIN)
     /**
  * \ingroup DataTypes
  */


### PR DESCRIPTION
TENSILE_USE_FLOAT16_BUILTIN can be turned on if compiler
being used has the _Float16 type.