### PR TITLE
make implicit hardware target feature defaults explicit

### DIFF
--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -570,7 +570,12 @@ class KernelWriterAssembly(KernelWriter):
     if archHasV3:
       rv += ['-mno-code-object-v3' if globalParameters["CodeObjectVersion"] == "V2" else '-mcode-object-v3']
 
-    rv += ['-mcpu=gfx' + ''.join(map(str,isa))]
+    rv += ['-mcpu=gfx' + ''.join(map(str,isa)), '-mno-xnack']
+    if isa == (9,0,6):
+      rv += ['-mno-sram-ecc']
+    elif isa == (9,0,8):
+      rv += ['-msram-ecc']
+
     if isa[0] == 10:
       rv += ['-mwavefrontsize64']
 

--- a/Tensile/Source/CMakeLists.txt
+++ b/Tensile/Source/CMakeLists.txt
@@ -35,6 +35,17 @@ if(TENSILE_NEW_CLIENT)
     set(TENSILE_USE_OPENMP   ON CACHE BOOL "Use LLVM for parsing config files.")
     set(TENSILE_STATIC_ONLY  ON CACHE BOOL "Disable exposing Tensile symbols in a shared library.")
 
+    if(NOT DEFINED CXX_VERSION_STRING)
+        if(CMAKE_CXX_COMPILER MATCHES ".*/hipcc$" OR CMAKE_CXX_COMPILER MATCHES ".*/hcc$")
+          # Determine if CXX Compiler is hcc, hip-clang or nvcc
+          execute_process(COMMAND ${CMAKE_CXX_COMPILER} "--version" OUTPUT_VARIABLE CXX_OUTPUT
+                  OUTPUT_STRIP_TRAILING_WHITESPACE
+                  ERROR_STRIP_TRAILING_WHITESPACE)
+          string(REGEX MATCH "[A-Za-z]* ?clang version" TMP_CXX_VERSION ${CXX_OUTPUT})
+          string(REGEX MATCH "[A-Za-z]+" CXX_VERSION_STRING ${TMP_CXX_VERSION})
+        endif()
+    endif()
+
     if(CMAKE_CXX_COMPILER STREQUAL "hipcc")
       set(TENSILE_GPU_ARCHS gfx803 gfx900 gfx906 gfx908 gfx1010 CACHE STRING "GPU architectures")
     else()
@@ -60,7 +71,7 @@ if(TENSILE_NEW_CLIENT)
             if(EXISTS /etc/redhat-release)
                 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fopenmp=libgomp")
             else()
-	        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fopenmp")
+                set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fopenmp")
                 set(OPENMP_LIBRARY /usr/lib/x86_64-linux-gnu/libomp.so)
                 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OPENMP_LIBRARY}")
             endif()

--- a/Tensile/Source/client/CMakeLists.txt
+++ b/Tensile/Source/client/CMakeLists.txt
@@ -35,7 +35,16 @@ endif()
 target_include_directories(TensileClient PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")# "${rocm_smi_root}/include")
 
 if(CXX_VERSION_STRING MATCHES "clang")
-    target_compile_options(TensileClient PUBLIC -mno-xnack "SHELL:-Xarch_gfx906 -msram-ecc" "SHELL:-Xarch_gfx908 -msram-ecc")
+    target_compile_options(TensileClient PUBLIC -mno-xnack)
+    set(gfx906_options "-Xarch_gfx906 -msram-ecc")
+    set(gfx908_options "-Xarch_gfx908 -msram-ecc")
+    if(CMAKE_VERSION VERSION_LESS 3.12)
+        set_target_properties(TensileClient PROPERTIES
+          COMPILE_FLAGS "${gfx906_options} ${gfx908_options}")
+    else()
+	    target_compile_options(TensileClient PUBLIC
+          "SHELL:${gfx906_options}" "SHELL:${gfx908_options}")
+    endif()
 endif()
 
 target_link_libraries(TensileClient TensileHost ${Boost_LIBRARIES} rocm_smi)

--- a/Tensile/Source/client/CMakeLists.txt
+++ b/Tensile/Source/client/CMakeLists.txt
@@ -34,6 +34,10 @@ endif()
 
 target_include_directories(TensileClient PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")# "${rocm_smi_root}/include")
 
+if(CXX_VERSION_STRING MATCHES "clang")
+    target_compile_options(TensileClient PUBLIC -mno-xnack -Xarch_gfx906 -mno-sram-ecc -Xarch_gfx908 -msram-ecc)
+endif()
+
 target_link_libraries(TensileClient TensileHost ${Boost_LIBRARIES} rocm_smi)
 
 add_executable(tensile_client main.cpp)

--- a/Tensile/Source/client/CMakeLists.txt
+++ b/Tensile/Source/client/CMakeLists.txt
@@ -35,7 +35,7 @@ endif()
 target_include_directories(TensileClient PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")# "${rocm_smi_root}/include")
 
 if(CXX_VERSION_STRING MATCHES "clang")
-    target_compile_options(TensileClient PUBLIC -mno-xnack -Xarch_gfx906 -mno-sram-ecc -Xarch_gfx908 -msram-ecc)
+    target_compile_options(TensileClient PUBLIC -mno-xnack "SHELL:-Xarch_gfx906 -msram-ecc" "SHELL:-Xarch_gfx908 -msram-ecc")
 endif()
 
 target_link_libraries(TensileClient TensileHost ${Boost_LIBRARIES} rocm_smi)

--- a/Tensile/Source/lib/CMakeLists.txt
+++ b/Tensile/Source/lib/CMakeLists.txt
@@ -83,7 +83,16 @@ add_library (TensileHost STATIC ${tensile_sources})
 target_include_directories(TensileHost INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
 if(CXX_VERSION_STRING MATCHES "clang")
-    target_compile_options(TensileHost PUBLIC -mno-xnack "SHELL:-Xarch_gfx906 -msram-ecc" "SHELL:-Xarch_gfx908 -msram-ecc")
+    target_compile_options(TensileHost PUBLIC -mno-xnack)
+    set(gfx906_options "-Xarch_gfx906 -msram-ecc")
+    set(gfx908_options "-Xarch_gfx908 -msram-ecc")
+    if(CMAKE_VERSION VERSION_LESS 3.12)
+        set_target_properties(TensileHost PROPERTIES COMPILE_FLAGS
+          "${gfx906_options} ${gfx908_options}")
+    else()
+        target_compile_options(TensileHost PUBLIC
+          "SHELL:${gfx906_options}" "SHELL:${gfx908_options}")
+    endif()
 endif()
 
 if(TENSILE_USE_LLVM OR TENSILE_USE_MSGPACK)

--- a/Tensile/Source/lib/CMakeLists.txt
+++ b/Tensile/Source/lib/CMakeLists.txt
@@ -83,7 +83,7 @@ add_library (TensileHost STATIC ${tensile_sources})
 target_include_directories(TensileHost INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
 if(CXX_VERSION_STRING MATCHES "clang")
-    target_compile_options(TensileHost PUBLIC -mno-xnack -Xarch_gfx906 -mno-sram-ecc -Xarch_gfx908 -msram-ecc)
+    target_compile_options(TensileHost PUBLIC -mno-xnack "SHELL:-Xarch_gfx906 -msram-ecc" "SHELL:-Xarch_gfx908 -msram-ecc")
 endif()
 
 if(TENSILE_USE_LLVM OR TENSILE_USE_MSGPACK)

--- a/Tensile/Source/lib/CMakeLists.txt
+++ b/Tensile/Source/lib/CMakeLists.txt
@@ -82,6 +82,10 @@ add_library (TensileHost STATIC ${tensile_sources})
 
 target_include_directories(TensileHost INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
+if(CXX_VERSION_STRING MATCHES "clang")
+    target_compile_options(TensileHost PUBLIC -mno-xnack -Xarch_gfx906 -mno-sram-ecc -Xarch_gfx908 -msram-ecc)
+endif()
+
 if(TENSILE_USE_LLVM OR TENSILE_USE_MSGPACK)
     target_compile_definitions(TensileHost PUBLIC TENSILE_DEFAULT_SERIALIZATION)
 endif()

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -173,6 +173,8 @@ def buildSourceCodeObjectFile(CxxCompiler, outputPath, kernelFile):
 
       hipFlags += ['-I', outputPath]
 
+      archFlags += ['-mno-xnack', '-Xarch_gfx906', '-mno-sram-ecc', '-Xarch_gfx908', '-msram-ecc']
+
       compileArgs = [which('hipcc')] + hipFlags + archFlags + [kernelFile, '-c', '-o', os.path.join(buildPath, objectFilename)]
 
       if globalParameters["PrintCodeCommands"]:
@@ -238,7 +240,9 @@ def prepAsm():
   else:
     assemblerFile.write("#!/bin/sh %s\n" % ("-x" if globalParameters["PrintLevel"] >=2  else ""))
     assemblerFile.write("# usage: asm.sh kernelName ASM_ARGS\n")
-    assemblerFile.write("# example: asm.sh kernelName -mcpu=gfx900\n")
+    assemblerFile.write("# example: asm.sh kernelName -mno-xnack -mcpu=gfx900\n")
+    assemblerFile.write("# example: asm.sh kernelName -mno-xnack -mno-sram-ecc -mcpu=gfx906\n")
+    assemblerFile.write("# example: asm.sh kernelName -mno-xnack -msram-ecc -mcpu=gfx908\n")
     assemblerFile.write("f=$1\n")
     assemblerFile.write("shift\n")
     assemblerFile.write("ASM=%s\n"%globalParameters["AssemblerPath"])

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -173,7 +173,7 @@ def buildSourceCodeObjectFile(CxxCompiler, outputPath, kernelFile):
 
       hipFlags += ['-I', outputPath]
 
-      archFlags += ['-mno-xnack', '-Xarch_gfx906', '-mno-sram-ecc', '-Xarch_gfx908', '-msram-ecc']
+      archFlags += ['-mno-xnack', '-Xarch_gfx906', '-msram-ecc', '-Xarch_gfx908', '-msram-ecc']
 
       compileArgs = [which('hipcc')] + hipFlags + archFlags + [kernelFile, '-c', '-o', os.path.join(buildPath, objectFilename)]
 


### PR DESCRIPTION
Make implicit hardware target feature defaults explicit:
- for gfx803, xnack OFF
- for gfx900, xnack OFF
- for gfx906, xnack OFF, sram-ecc OFF (sram-ecc ON for hip-clang as per [Austin's comments](http://ontrack-internal.amd.com/browse/SWDEV-250318))
- for gfx908, xnack OFF, sram-ecc ON

Add `-mno-xnack -Xarch_gfx906 -msram-ecc -Xarch_gfx908 -msram-ecc` for hip-clang.
Add gfx-specific target feature defaults as listed above to assembler command line.

Note that all current Tensile-generated assembly kernels follow the [official documentation](https://llvm.org/docs/AMDGPUUsage.html#processors).  In particular for gfx906, sram-ecc is OFF.

After changing gfx906's sram-ecc to ON for hip-clang, rocblas-test passed fully on all 3 gfx platforms.

Many thanks to @cgmb for sharing his [pre-3.12 cmake workaround](https://github.com/ROCmSoftwarePlatform/rocSOLVER/pull/145).