### PR TITLE
change gfx906 hardware target feature for sram-ecc to ON for assembly kernels

### DIFF
--- a/Tensile/Components/Signature.py
+++ b/Tensile/Components/Signature.py
@@ -325,7 +325,7 @@ class SignatureCOV3(Signature):
         # begin kernel descriptor
         kStr += ".amdgcn_target \"amdgcn-amd-amdhsa--gfx%s%s\"%s" \
             % ("".join(map(str,writer.version)), \
-            "+sram-ecc" if writer.version == (9,0,8) else "",  writer.endLine)
+            "+sram-ecc" if writer.version == (9,0,6) or writer.version == (9,0,8) else "",  writer.endLine)
 
         kStr += ".text%s" % writer.endLine
         kStr += ".protected %s%s" % (writer.kernelName, writer.endLine)

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -571,9 +571,7 @@ class KernelWriterAssembly(KernelWriter):
       rv += ['-mno-code-object-v3' if globalParameters["CodeObjectVersion"] == "V2" else '-mcode-object-v3']
 
     rv += ['-mcpu=gfx' + ''.join(map(str,isa)), '-mno-xnack']
-    if isa == (9,0,6):
-      rv += ['-mno-sram-ecc']
-    elif isa == (9,0,8):
+    if isa == (9,0,6) or isa == (9,0,8):
       rv += ['-msram-ecc']
 
     if isa[0] == 10:

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -241,7 +241,7 @@ def prepAsm():
     assemblerFile.write("#!/bin/sh %s\n" % ("-x" if globalParameters["PrintLevel"] >=2  else ""))
     assemblerFile.write("# usage: asm.sh kernelName ASM_ARGS\n")
     assemblerFile.write("# example: asm.sh kernelName -mno-xnack -mcpu=gfx900\n")
-    assemblerFile.write("# example: asm.sh kernelName -mno-xnack -mno-sram-ecc -mcpu=gfx906\n")
+    assemblerFile.write("# example: asm.sh kernelName -mno-xnack -msram-ecc -mcpu=gfx906\n")
     assemblerFile.write("# example: asm.sh kernelName -mno-xnack -msram-ecc -mcpu=gfx908\n")
     assemblerFile.write("f=$1\n")
     assemblerFile.write("shift\n")


### PR DESCRIPTION
The latest guidance from the compiler team is to treat gfx906 as having the target feature sram-ecc ON, even for our Tensile-generated assembly kernels.  This PR implements the guidance.

The rocblas-test built with this PR passed rocblas-test fully on gfx906.  Since the changes do not impact gfx900 and gfx908, rocblas-test should pass fully.  In any case, we'll run both precheckin and extended when updating rocBLAS's tensile_tag.txt.