### PR TITLE
Fix: Hold back some kick-out rules for rocBLAS library

### DIFF
--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -2870,8 +2870,6 @@ class KernelWriterAssembly(KernelWriter):
         msg = "Occupancy limit"
       elif self.overflowedResources == 5:
         msg = "reading and writing LDS at same time require 2 LDS buffer"
-      elif self.overflowedResources == 6:
-        msg = "Persistent Kernel is better for only occupancy < 2"
       else:
         msg = "unknown"
 
@@ -11493,11 +11491,6 @@ class KernelWriterAssembly(KernelWriter):
       self.overflowedResources = 1
     elif self.sgprPool.size() > self.maxSgprs:
       self.overflowedResources = 2
-
-    # Persistent Kernel is better for small occupancy
-    if kernel["PersistentKernel"] and \
-        self.getOccupancy(kernel["NumThreads"], self.vgprPool.size(), self.getLdsSize(kernel), self.agprPool.size()) > 2:
-      self.overflowedResources = 6
 
     vgprPerCU = 65536
     vgprPerThreadPerOccupancy = vgprPerCU // kernel["NumThreads"]

--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -2330,10 +2330,6 @@ class Solution:
       # warn("PrefetchAcrossPersistent requires PersistentKernel != 0, forcing PrefetchAcrossPersistent = False")
       state["PrefetchAcrossPersistent"] = False
 
-    if state["PersistentKernel"] and (state["MacroTileA"] * state["MacroTileB"] <= 64 * 64 ):
-      reject(state, "Quick reject small MT-size[%ux%u] which have larger occupancy and wouldn't gain for PersistentKernel" \
-        % (state["MacroTileA"], state["MacroTileB"]))
-
     problemType = state["ProblemType"]
     if not problemType["UseInitialStridesAB"]:
       for (tc) in ('A','B'):

--- a/Tensile/Source/lib/source/ContractionProblem.cpp
+++ b/Tensile/Source/lib/source/ContractionProblem.cpp
@@ -601,13 +601,6 @@ namespace Tensile
         if(sizeMapping.persistentKernel == 0)
             return;
 
-        // PK barely gains performance when size-K >> DepthU
-        if(m_boundSizes[0] / sizeMapping.depthU > 16)
-        {
-            m_eligibleForPK = false;
-            return;
-        }
-
         size_t persistentGroups
             = dynamic_cast<AMDGPU const&>(hardware).computeUnitCount * sizeMapping.persistentKernel;
 


### PR DESCRIPTION
Disable the kernel rejection/kick-out rules for small MT and high occupancy.
* Although this two rules may skip some benchmarks that are not likely having gain for persistent-kernel. 
However it's not proved yet for all kinds of data-type (H,S,D,BF...) so it's better to hold back this hypothesis for now.
* There are a few existing dgemm kernels in rocBLAS having PK on. We have to prevent those kernels from being kicked-out and not complied to .co files.