### PR TITLE
Added --generate-sources-and-exit option

### DIFF
--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -87,6 +87,7 @@ globalParameters["ShowProgressBar"] = True     # if False and library client alr
 globalParameters["SolutionSelectionAlg"] = 1          # algorithm to detetermine which solutions to keep. 0=removeLeastImportantSolutions, 1=keepWinnerSolutions (faster)
 globalParameters["ExpandRanges"] = True          # expand ranges into exact configs before writing logic file.  False ignores ranges.
 globalParameters["ExitAfterKernelGen"] = False     # Exit after generating kernels
+globalParameters["GenerateSourcesAndExit"] = False # Exit after kernel source generation.
 globalParameters["ShowProgressBar"] = True     # if False and library client already built, then building library client will be skipped when tensile is re-run
 globalParameters["WavefrontWidth"] = 64     # if False and library client already built, then building library client will be skipped when tensile is re-run
 globalParameters["ExitOnFails"] = 1     # Exit if failures detected.

--- a/Tensile/KernelWriter.py
+++ b/Tensile/KernelWriter.py
@@ -3355,18 +3355,23 @@ for codeObjectFileName in codeObjectFileNames:
 
     try:
       if kernel["KernelLanguage"] == "Assembly":
-        self.writeByteArrayScript()
-
         asmPath = self.getAssemblyDirectory()
-        coFile = self.getSingleCodeObjectFile(kernel)
         kernelName = self.getKernelName(kernel)
 
-        if globalParameters["CodeFromFiles"] or globalParameters["NewClient"] > 1:
-          # I guess in this case we are making sure that the code object file exists by executing the code
-          # above but we aren't placing it into the source.
+        if globalParameters["GenerateSourcesAndExit"]:
+          # only create the assembly file.
+          self.getKernelObjectAssemblyFile(kernel)
           return (0, "")
+        else:
+          self.writeByteArrayScript()
+          coFile = self.getSingleCodeObjectFile(kernel)
 
-        return (0, self.getFileCobaDefinition(kernelName, os.path.join(asmPath, coFile)))
+          if globalParameters["CodeFromFiles"] or globalParameters["NewClient"] > 1:
+            # I guess in this case we are making sure that the code object file exists by executing the code
+            # above but we aren't placing it into the source.
+            return (0, "")
+
+          return (0, self.getFileCobaDefinition(kernelName, os.path.join(asmPath, coFile)))
 
       else:
         return (0, self.getKernelSource(kernel))

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -424,8 +424,9 @@ def writeSolutionsAndKernels(outputPath, CxxCompiler, problemTypes, solutions, k
     if kernelHeaderFile:
       kernelHeaderFile.close()
 
-  codeObjectFiles += buildSourceCodeObjectFiles(CxxCompiler, kernelFiles, outputPath)
-  codeObjectFiles += getAssemblyCodeObjectFiles(kernelsToBuild, kernelWriterAssembly, outputPath)
+  if not globalParameters["GenerateSourcesAndExit"]:
+    codeObjectFiles += buildSourceCodeObjectFiles(CxxCompiler, kernelFiles, outputPath)
+    codeObjectFiles += getAssemblyCodeObjectFiles(kernelsToBuild, kernelWriterAssembly, outputPath)
 
   stop = time.time()
   print("# Kernel Building elapsed time = %.1f secs" % (stop-start))
@@ -1196,7 +1197,8 @@ def generateKernelObjectsFromSolutions(solutions):
 ################################################################################
 def writeBenchmarkClientFiles(libraryWorkingPath, tensileSourcePath, solutions, cxxCompiler):
 
-  copyStaticFiles(libraryWorkingPath)
+  if not globalParameters["GenerateSourcesAndExit"]:
+      copyStaticFiles(libraryWorkingPath)
 
   kernels, kernelsBetaOnly, _ = generateKernelObjectsFromSolutions(solutions)
   solutionWriter, kernelWriterSource, kernelWriterAssembly, \
@@ -1280,6 +1282,12 @@ def TensileCreateLibrary():
                           default=False, help="Output manifest file with list of expected library objects and exit.")
   argParser.add_argument("--library-format", dest="LibraryFormat", choices=["yaml", "msgpack"], \
       action="store", default="msgpack", help="select which library format to use")
+  argParser.add_argument("--generate-sources-and-exit",   dest="GenerateSourcesAndExit", action="store_true",
+                          default=False, help="Output source files only and exit.")
+  argParser.add_argument("--jobs", "-j", dest="CpuThreads", type=int,
+                          default=-1, help="Number of parallel jobs to launch.")
+  argParser.add_argument("--verbose", "-v", dest="PrintLevel", type=int,
+                          default=-1, help="Set printout verbosity level.")
   args = argParser.parse_args()
 
   logicPath = args.LogicPath
@@ -1309,6 +1317,14 @@ def TensileCreateLibrary():
 
   # Output manifest only applies to the new client
   arguments["GenerateManifestAndExit"] = args.new_client_only and args.GenerateManifestAndExit
+
+  arguments["GenerateSourcesAndExit"] = args.GenerateSourcesAndExit
+  if arguments["GenerateSourcesAndExit"]:
+    # Generated sources are preserved and go into output dir
+    arguments["WorkingPath"] = outputPath
+
+  arguments["CpuThreads"] = args.CpuThreads
+  arguments["PrintLevel"] = args.PrintLevel
 
   assignGlobalParameters(arguments)
 
@@ -1423,7 +1439,8 @@ def TensileCreateLibrary():
     return
 
   # generate cmake for the source kernels
-  writeCMake(outputPath, solutionFiles, sourceKernelFiles, staticFiles)
+  if not arguments["GenerateSourcesAndExit"]:
+    writeCMake(outputPath, solutionFiles, sourceKernelFiles, staticFiles)
 
   # Make sure to copy the library static files.
   for fileName in staticFiles:
@@ -1440,7 +1457,8 @@ def TensileCreateLibrary():
   sanityCheck1 = set(sourceLibPaths + asmLibPaths) - set(codeObjectFiles)
 
   assert len(sanityCheck0) == 0, "Unexpected code object files: {}".format(sanityCheck0)
-  assert len(sanityCheck1) == 0, "Missing expected code object files: {}".format(sanityCheck1)
+  if not globalParameters["GenerateSourcesAndExit"]:
+    assert len(sanityCheck1) == 0, "Missing expected code object files: {}".format(sanityCheck1)
 
   if globalParameters["LegacyComponents"]:
     # write logic


### PR DESCRIPTION
When specified, TensileCreateLibray generates asm and source kernels
and exists without compiling them. Assembly sources will be placed in
the output directory.

Also added -v and -j to control output verbosity and the number of
threads launched by the script.