### PR TITLE
Prefetch Global Read 2

### DIFF
--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -305,8 +305,15 @@ validParameters = {
     "WaveSeparateGlobalReadA":    [ 0, 1 ],
     "WaveSeparateGlobalReadB":    [ 0, 1 ],
 
-    # prefetch / double-buffer reads from global memory -> vgprs -> lds. Requires 2X LDS space, and VGPRs for buffering data on way into LDS
-    "PrefetchGlobalRead":         [ False, True ],
+    # PrefetchGlobalRead = 1:
+    # Requires 2X LDS space, and VGPRs for buffering data on way into LDS
+    #   prefetch / double-buffer reads from global memory -> vgprs -> lds.
+    #
+    # PrefetchGlobalRead = 2:
+    # Do another prefetch while writing data from vgpr to lds.
+    #   prefetch / double-buffer reads from global memory -> vgprs --> lds.
+    #                                                              |-> prefetch reads
+    "PrefetchGlobalRead":         [ 0, 1, 2 ],
 
     # number of iteration prefetch local reads from lds to VGPRs buffer = PLR % LoopIter
     # number of VGPRs buffer = min(PLR,LoopIters)
@@ -951,7 +958,7 @@ defaultBenchmarkCommonParameters = [
     {"WaveSeparateGlobalReadB":    [ 0 ] },
     {"GlobalReadCoalesceGroupA":  [ True ] },
     {"GlobalReadCoalesceGroupB":  [ True ] },
-    {"PrefetchGlobalRead":        [ True ] },
+    {"PrefetchGlobalRead":        [ 1 ] },
     {"PrefetchLocalRead":         [ 1 ] },
     {"UnrollMemFence":            [ False ] },
     {"GlobalRead2A":              [ True ] },

--- a/Tensile/KernelWriter.py
+++ b/Tensile/KernelWriter.py
@@ -1192,7 +1192,6 @@ class KernelWriter(metaclass=abc.ABCMeta):
     for u in range(0, kernel["LoopIters"]):
       kl.append(self.comment("iter %u"%u))
       plrIdx = (u+pflr) % (self.numVgprBuffer+1) % kernel["LoopIters"]
-      plrPIdx = (u+pflr) % (self.numVgprBuffer+1) % kernel["LoopIters"]
       localReads = Code.Module()
       isResetLroIter = (u == localWriteEndIter)
       isSwapAndResetLwoIter = isResetLroIter
@@ -1222,13 +1221,13 @@ class KernelWriter(metaclass=abc.ABCMeta):
               localReads.addText(self.comment("local read a"))
               localReadCodeA, packCodeA = self.localReadDo(kernel, plrIdx*self.numIterPerCoalescedReadA, iui*self.numReadsIterCoalescedA, 0, tensorParametersA)
               localReads.addCode(localReadCodeA)
-              pack[plrPIdx*self.numIterPerCoalescedReadA].addCode(packCodeA)
+              pack[plrIdx*self.numIterPerCoalescedReadA].addCode(packCodeA)
               localReads.addText(self.comment("local read b"))
           if u < kernel["LoopIters"]/self.numIterPerCoalescedReadB - self.numItersPLR or (kernel["PrefetchGlobalRead"] and u > localWriteEndIter):
             if iui*self.numReadsIterCoalescedB < kernel["InnerUnroll"]:
               localReadCodeB, packCodeB = self.localReadDo(kernel, plrIdx*self.numIterPerCoalescedReadB, iui*self.numReadsIterCoalescedB, 0, tensorParametersB)
               localReads.addCode(localReadCodeB)
-              pack[plrPIdx*self.numIterPerCoalescedReadB].addCode(packCodeB)
+              pack[plrIdx*self.numIterPerCoalescedReadB].addCode(packCodeB)
           if not isResetLroIter or iui != kernel["InnerUnroll"]-1:
             if u < kernel["LoopIters"]/self.numIterPerCoalescedReadA - self.numItersPLR or (kernel["PrefetchGlobalRead"] and u > localWriteEndIter):
               if iui*self.numReadsIterCoalescedA < kernel["InnerUnroll"]:

--- a/Tensile/KernelWriterSource.py
+++ b/Tensile/KernelWriterSource.py
@@ -2091,7 +2091,7 @@ class KernelWriterSource(KernelWriter):
     self.indent += "  "
     return kStr
 
-  def closeSumAtLeastUnroll(self, kernel, prefetch, isOptNLL):
+  def closeSumAtLeastUnroll(self, kernel, prefetch, isOptNLL, isNGLL):
     kStr = ""
     self.indent = self.indent[2:]
     kStr += "%s} // end %s%s" % \

--- a/Tensile/KernelWriterSource.py
+++ b/Tensile/KernelWriterSource.py
@@ -3011,6 +3011,15 @@ class KernelWriterSource(KernelWriter):
     return ""
 
   ##############################################################################
+  # PrefetchGlobalRead2
+  ##############################################################################
+  def openPrefetchGlobalRead2(self, kernel):
+    return ""
+
+  def closePrefetchGlobalRead2(self, kernel):
+    return ""
+
+  ##############################################################################
   # Function End
   ##############################################################################
   def functionEnd(self, kernel, addLabel):

--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -2455,10 +2455,20 @@ class Solution:
     #These modes only work under certain conditions, apply them here:
     #  - The "NoLoad" loop is only generated if PrefetchGlobalRead>0
     #  - And Suppress does not work if GSU>1 for some reason
-    state["SuppressNoLoadLoop"] &= (bufferLoad and state["PrefetchGlobalRead"] and (state["GlobalSplitU"]==1))
-    # Pointer swap only used if PGR=1 - so set ExpandPointerSwap=0 here
-    # EPS not supported with PAP yet
-    state["ExpandPointerSwap"]  &= (bufferLoad and state["PrefetchGlobalRead"] and not state["PrefetchAcrossPersistent"])
+    if state["SuppressNoLoadLoop"] == 1:
+      if not (bufferLoad and state["PrefetchGlobalRead"] and (state["GlobalSplitU"]==1)):
+        state["SuppressNoLoadLoop"] = 0
+
+    if state["ExpandPointerSwap"] == 1:
+      # Pointer swap only used if PGR=1 - so set ExpandPointerSwap=0 here
+      if not (bufferLoad and state["PrefetchGlobalRead"] == 1):
+        state["ExpandPointerSwap"] = 0
+      # EPS not supported with PGR=2 yet
+      if state["PrefetchGlobalRead"] == 2:
+        state["ExpandPointerSwap"] = 0
+      # EPS not supported with PAP yet
+      if state["PrefetchAcrossPersistent"]:
+        state["ExpandPointerSwap"] = 0
 
     #print("PackedC0IdxChars", state["PackedC0IdxChars"])
     #print("PackedC1IdxChars", state["PackedC1IdxChars"])

--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -2456,7 +2456,7 @@ class Solution:
     #  - The "NoLoad" loop is only generated if PrefetchGlobalRead>0
     #  - And Suppress does not work if GSU>1 for some reason
     if state["SuppressNoLoadLoop"] == 1:
-      if not (bufferLoad and state["PrefetchGlobalRead"] and (state["GlobalSplitU"]==1)):
+      if not (bufferLoad and state["PrefetchGlobalRead"] == 1 and (state["GlobalSplitU"]==1)):
         state["SuppressNoLoadLoop"] = 0
 
     if state["ExpandPointerSwap"] == 1:

--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -2292,6 +2292,7 @@ class Solution:
       state["InnerUnroll"] = state["DepthU"] // state["MatrixInstK"]
       state["PrefetchLocalRead"] = 1
       state["ExpandPointerSwap"] = 1
+      state["1LDSBuffer"] = 1
 
     if state["DisableVgprOverlapping"] is True and state["EnableMatrixInstruction"] is not True:
       reject(state, "Non-MI kernels are already non-overlapping in pre-allocated registers")
@@ -2935,8 +2936,7 @@ class Solution:
 
 
     if state["1LDSBuffer"] == -1:
-      if ldsNumElementsAB * state["ProblemType"]["DataType"].numBytes() > globalParameters["MaxLDS"] or \
-          state["ScheduleIterAlg"] == 2:
+      if ldsNumElementsAB * state["ProblemType"]["DataType"].numBytes() > globalParameters["MaxLDS"]:
         state["1LDSBuffer"] = 1
       else:
         state["1LDSBuffer"] = 0


### PR DESCRIPTION
prefetch 2 unroll loop data from global memory
1 store in LDS
1 store in VGPR

in unroll loop
issuing globalread immediately after localwrite instruction
can extend latency hiding reading global memory to whole loop latency.