### PR TITLE
Disable gtest-cmake integration by default so HostLibraryTests can be…

### DIFF
--- a/HostLibraryTests/CMakeLists.txt
+++ b/HostLibraryTests/CMakeLists.txt
@@ -31,7 +31,7 @@ option(TENSILE_USE_LLVM      "Use LLVM for parsing config files." ON)
 option(TENSILE_USE_MSGPACK   "Use msgpack for parsing config files." ON)
 option(TENSILE_USE_OPENMP    "Enable OpenMP multithreading." ON)
 option(TENSILE_STATIC_ONLY   "Disable exposing Tensile symbols in a shared library." ON)
-option(TENSILE_DISABLE_CTEST "Disable CTest integration." OFF)
+option(TENSILE_DISABLE_CTEST "Disable CTest integration." ON)
 
 if(TENSILE_USE_HIP)
     set(TENSILE_COMPONENTS HIP)


### PR DESCRIPTION
… built on a node with no GPU