### PR TITLE
restore default PrintLevel to 1

### DIFF
--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -1287,7 +1287,7 @@ def TensileCreateLibrary():
   argParser.add_argument("--jobs", "-j", dest="CpuThreads", type=int,
                           default=-1, help="Number of parallel jobs to launch.")
   argParser.add_argument("--verbose", "-v", dest="PrintLevel", type=int,
-                          default=-1, help="Set printout verbosity level.")
+                          default=1, help="Set printout verbosity level.")
   args = argParser.parse_args()
 
   logicPath = args.LogicPath


### PR DESCRIPTION
#1166 sets default PrintLevel to -1 in error while the default for PrintLevel in Common.py should be 1.  This causes some important information to fail to show up, in particular the replacement_kernel logging.