### PR TITLE
Print warning for unexpected rejection during TensileCreateLibrary

### DIFF
--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -50,6 +50,17 @@ def reject(state, *args):
     for a in args:
       print(a)
     #traceback.print_stack(None, 2)
+    solutionIndex = state["SolutionIndex"] if (state != None and "SolutionIndex" in state) else -1
+    if solutionIndex != -1:
+      # If we have valid solutionIndex, this means we are during TensileCreateLibrary stage
+      # In this stage, all solutions in the logic should be valid
+      # So if any rejection happens, print the warning for further check
+      # This will be done only when --global-parameters=PrintSolutionRejectionReason=True
+      solutionNameMin = state["SolutionNameMin"] if ("SolutionNameMin" in state) else None
+      # if we don't have SolutionNameMin, we simply use the problemTypeName
+      solutionNameMin = str(state["ProblemType"]) if (solutionNameMin == None) else solutionNameMin
+      print("!! Warning: Any rejection of a LibraryLogic is not expected, please check. \
+        SolutionIndex: %d (or SolutionName/ProblemType: %s)"%(solutionIndex, solutionNameMin))
   if state != None:
     state["Valid"] = False
 

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -930,7 +930,7 @@ def writeSolutionCall(solutionName, problemType):
 def getSolutionAndKernelWriters(solutions, kernels):
 
   # if any kernels are assembly, append every ISA supported
-  
+
   if globalParameters["ShortNames"] and not globalParameters["MergeFiles"]:
     solutionSerialNaming = Solution.getSerialNaming(solutions)
     kernelSerialNaming   = Solution.getSerialNaming(kernels)
@@ -1209,7 +1209,7 @@ def writeBenchmarkClientFiles(libraryWorkingPath, tensileSourcePath, solutions, 
   codeObjectFiles = writeSolutionsAndKernels( \
     libraryWorkingPath, cxxCompiler, [problemType], solutions, kernels, kernelsBetaOnly, \
     solutionWriter, kernelWriterSource, kernelWriterAssembly, errorTolerant=True )
-    
+
   newLibraryDir = ensurePath(os.path.join(libraryWorkingPath, 'library'))
   newLibraryFile = os.path.join(newLibraryDir, "TensileLibrary.yaml")
   newLibrary = MasterSolutionLibrary.BenchmarkingLibrary(solutions)
@@ -1229,14 +1229,14 @@ def WriteClientLibraryFromSolutions(solutionList, libraryWorkingPath, tensileSou
   problemType["DestDataType"] = problemType["DestDataType"].value
   problemType["ComputeDataType"] = problemType["ComputeDataType"].value
   cxxCompiler = globalParameters["CxxCompiler"]
- 
-  effectiveWorkingPath = os.path.join(libraryWorkingPath, "library") 
+
+  effectiveWorkingPath = os.path.join(libraryWorkingPath, "library")
   ensurePath(effectiveWorkingPath)
   mataDataFilePath = os.path.join(effectiveWorkingPath, 'metadata.yaml')
 
   metaData = {"ProblemType":problemType}
   LibraryIO.YAMLWriter().write(mataDataFilePath, metaData)
-  
+
   codeObjectFiles, newLibrary = writeBenchmarkClientFiles(libraryWorkingPath, tensileSourcePath, solutionList, cxxCompiler )
 
   return (codeObjectFiles, newLibrary)
@@ -1254,6 +1254,15 @@ def TensileCreateLibrary():
   ##############################################################################
   # Parse Command Line Arguments
   ##############################################################################
+  def splitExtraParameters(par):
+    """
+    Allows the --global-parameters option to specify any parameters from the command line.
+    """
+
+    (key, value) = par.split("=")
+    value = eval(value)
+    return (key, value)
+
   print2("Arguments: %s" % sys.argv)
   argParser = argparse.ArgumentParser()
   argParser.add_argument("LogicPath",       help="Path to LibraryLogic.yaml files.")
@@ -1288,6 +1297,8 @@ def TensileCreateLibrary():
                           default=-1, help="Number of parallel jobs to launch.")
   argParser.add_argument("--verbose", "-v", dest="PrintLevel", type=int,
                           default=1, help="Set printout verbosity level.")
+
+  argParser.add_argument("--global-parameters", nargs="+", type=splitExtraParameters, default=[])
   args = argParser.parse_args()
 
   logicPath = args.LogicPath
@@ -1325,6 +1336,9 @@ def TensileCreateLibrary():
 
   arguments["CpuThreads"] = args.CpuThreads
   arguments["PrintLevel"] = args.PrintLevel
+
+  for key, value in args.global_parameters:
+    arguments[key] = value
 
   assignGlobalParameters(arguments)
 
@@ -1400,7 +1414,7 @@ def TensileCreateLibrary():
 
 
   kernels, kernelHelperOjbs, _ = generateKernelObjectsFromSolutions(solutions)
-  
+
   # if any kernels are assembly, append every ISA supported
   solutionWriter, kernelWriterSource, kernelWriterAssembly, \
     kernelMinNaming, _ = getSolutionAndKernelWriters(solutions, kernels)


### PR DESCRIPTION
* Main purpose for this is to show more msgs when TensileCreaetLibrary failed, espcially due to unexpected solution rejection. 
* Print the rejection reason and the SolutionID/Name **can help us spot which solution and which rejection is the root cause. Can help us to find the error quickly**.
---
* **Support new arguments** for ${​​​​TensileCreateLibrary} cmd​​​​:  --global-parameters=[.....]
  * Example: ${​​​​TensileCreateLibrary}​​​​ **--global-parameters=PrintSolutionRejectionReason=True**
  * This enables the globalParam["PrintSolutionRejectionReason"] =True. 
  * Useful when we are directly calling TensileCreateLibary
---
* If a LibraryLogic contains a solution that is rejected (any rejection in a LibraryLogic is unexpected)
  * It will show the warning messsage, like:
```
 reject: HalfEcc requires GLVWA > 1
 !! Warning: Any rejection of a LibraryLogic is not expected, please check. SolutionIndex:0, (or SolutionName/ProblemType: Cijk_Alik_Bjlk_HBH_MT016x128x08_PGR1_PLR1_TT04_04)
```   
 * So we can find that solution either by Id or name, and check why it was rejected by the reason.