### PR TITLE
fix strideC assignment

### DIFF
--- a/Tensile/ClientWriter.py
+++ b/Tensile/ClientWriter.py
@@ -496,9 +496,16 @@ def problemSizeParams(problemType, problem):
         else:
             bstrides[index.b] = sc[1]
 
+    if problem.stridesC:
+      cstrides = list(problem.stridesC)
+    else:
+      cstrides = [-1] * problemType.cDims
 
-    cstrides = problem.stridesC
-    dstrides = problem.stridesD
+    if problem.stridesD:
+      dstrides = list(problem.stridesD)
+    else:
+      dstrides = [-1] * problemType.dDims
+
     if len(problem.sizes) == numIndices:
         None
     elif len(problem.sizes) == numIndices + 4:
@@ -516,8 +523,12 @@ def problemSizeParams(problemType, problem):
           raise RuntimeError("problem-specified ldb(%u) conflicts with setConstStrideB(%u)" % \
               (bstrides[1], problem.sizes[numIndices+3]))
 
-        cstrides = (-1, problem.sizes[numIndices+1])
-        dstrides = (-1, problem.sizes[numIndices+0])
+        if cstrides[1] == -1:
+          cstrides[1] = problem.sizes[numIndices+1]
+
+        if dstrides[1] == -1:
+          dstrides[1] = problem.sizes[numIndices+0]
+
     else:
         raise RuntimeError(
             "Invalid number of problem type indices: {0} - Indices: {1}, problemSize: {2}".format(len(problem.sizes), numIndices,


### PR DESCRIPTION
when using dictionary size in Tensile, ClientWriter miss to put stride informant into ClientParameters.ini

Ex.
In Tensile tuning yaml
`- Exact: { sizes: [ 64, 26, 6272, 26 ], stridesA: [ -1, 1204224, 192 ], stridesB: [ -1, 26, 676 ], stridesC: [ -1, 1204224, 192 ], stridesD: [ -1, 1204224, 192 ] } # gemm_strided_batched`

In ClientParameters.ini
`problem-size=64,26,6272,26`
`a-strides=-1,1204224,192`
`b-strides=-1,26,676`
`c-strides=-1,1204224`
`d-strides=-1,1204224`

since no c-strides[2], it will use default value which is 64x1204224x6272=450GB

this PR helps to put value correctly
In ClientParameters.ini
`problem-size=64,26,6272,26`
`a-strides=-1,1204224,192`
`b-strides=-1,26,676`
`c-strides=-1,1204224,192`
`d-strides=-1,1204224,192`