### PR TITLE
[Hotfix] PK kernel is never picked in rocBLAS, causing perf. drop in dgemm

### DIFF
--- a/Tensile/Source/lib/include/Tensile/ContractionProblem.hpp
+++ b/Tensile/Source/lib/include/Tensile/ContractionProblem.hpp
@@ -545,7 +545,7 @@ namespace Tensile
         bool           m_transB;
         bool           m_highPrecisionAccumulate = false;
         bool           m_deterministicMode       = false;
-        bool           m_eligibleForPK           = false;
+        bool           m_eligibleForPK           = true;
         ArithmeticUnit m_arithmeticUnit          = ArithmeticUnit::Any;
         KernelLanguage m_kernelLanguage          = KernelLanguage::Any;
 


### PR DESCRIPTION
* PK-predicates function uses bool value **m_eligibleForPK** flag, which is tested in **checkSolution()** during benchmarks to speed up tunning.
* However, in rocBLAS, we never call **checkSolution()** but **findBestSolution()** instead, so the eligibleForPK value is not tested and hence is the dafule value = false. This makes the PK-predicates always fail so any PK-kernel wouldn't be picked (in rocBLAS).
* Makes the eligibleForPK to true as default, **checkSolution()** will turn it off if not eligible during benchmarks. In rocBLAS, we simply don't need to check the eligibility for assume it is true.