### PR TITLE
Revert "merge rocm-3.10.x into master after hot-fix #1200"

### DIFF
--- a/Tensile/Source/lib/include/Tensile/ContractionProblem.hpp
+++ b/Tensile/Source/lib/include/Tensile/ContractionProblem.hpp
@@ -545,7 +545,7 @@ namespace Tensile
         bool           m_transB;
         bool           m_highPrecisionAccumulate = false;
         bool           m_deterministicMode       = false;
-        bool           m_eligibleForPK           = true;
+        bool           m_eligibleForPK           = false;
         ArithmeticUnit m_arithmeticUnit          = ArithmeticUnit::Any;
         KernelLanguage m_kernelLanguage          = KernelLanguage::Any;
 


### PR DESCRIPTION
Reverts ROCmSoftwarePlatform/Tensile#1202
Fast-Forward failed, revert and do FF merge again