### PR TITLE
Check environment variables to override path to rocm

### DIFF
--- a/Tensile/ClientExecutable.py
+++ b/Tensile/ClientExecutable.py
@@ -60,7 +60,7 @@ def clientExecutableEnvironment(builddir=None):
     options = {'CMAKE_BUILD_TYPE': globalParameters["CMakeBuildType"],
                'TENSILE_NEW_CLIENT': 'ON',
                'Tensile_LIBRARY_FORMAT': globalParameters["LibraryFormat"],
-               'CMAKE_CXX_COMPILER': os.path.join('/opt/rocm/bin/', globalParameters['CxxCompiler'])}
+               'CMAKE_CXX_COMPILER': os.path.join(globalParameters["ROCmBinPath"], globalParameters['CxxCompiler'])}
 
     return CMakeEnvironment(sourcedir, builddir, **options)
 

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -1537,8 +1537,6 @@ def assignGlobalParameters( config ):
       print2(" %24s: %8s (unspecified)" % (key, defaultValue))
 
   globalParameters["ROCmPath"] = "/opt/rocm"
-  if "ROCM_ROOT" in os.environ:
-    globalParameters["ROCmPath"] = os.environ.get("ROCM_ROOT")
   if "ROCM_PATH" in os.environ:
     globalParameters["ROCmPath"] = os.environ.get("ROCM_PATH")
   if "TENSILE_ROCM_PATH" in os.environ:

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -1536,24 +1536,34 @@ def assignGlobalParameters( config ):
     else:
       print2(" %24s: %8s (unspecified)" % (key, defaultValue))
 
+  globalParameters["ROCmPath"] = "/opt/rocm"
+  if "ROCM_ROOT" in os.environ:
+    globalParameters["ROCmPath"] = os.environ.get("ROCM_ROOT")
+  if "ROCM_PATH" in os.environ:
+    globalParameters["ROCmPath"] = os.environ.get("ROCM_PATH")
+  if "TENSILE_ROCM_PATH" in os.environ:
+    globalParameters["ROCmPath"] = os.environ.get("TENSILE_ROCM_PATH")
+
+  globalParameters["ROCmBinPath"] = os.path.join(globalParameters["ROCmPath"], "bin")
+
   # ROCm Agent Enumerator Path
-  globalParameters["ROCmAgentEnumeratorPath"] = locateExe("/opt/rocm/bin", "rocm_agent_enumerator")
+  globalParameters["ROCmAgentEnumeratorPath"] = locateExe(globalParameters["ROCmBinPath"], "rocm_agent_enumerator")
   if "CxxCompiler" in config:
     globalParameters["CxxCompiler"] = config["CxxCompiler"]
 
   if "TENSILE_ROCM_ASSEMBLER_PATH" in os.environ:
     globalParameters["AssemblerPath"] = os.environ.get("TENSILE_ROCM_ASSEMBLER_PATH")
   elif globalParameters["AssemblerPath"] is None and globalParameters["CxxCompiler"] == "hipcc":
-    globalParameters["AssemblerPath"] = locateExe("/opt/rocm/llvm/bin", "clang++")
+    globalParameters["AssemblerPath"] = locateExe(os.path.join(globalParameters["ROCmPath"], "llvm/bin"), "clang++")
   elif globalParameters["AssemblerPath"] is None and globalParameters["CxxCompiler"] == "hcc":
-    globalParameters["AssemblerPath"] = locateExe("/opt/rocm/bin", "hcc")
+    globalParameters["AssemblerPath"] = locateExe(globalParameters["ROCmBinPath"], "hcc")
 
-  globalParameters["ROCmSMIPath"] = locateExe("/opt/rocm/bin", "rocm-smi")
+  globalParameters["ROCmSMIPath"] = locateExe(globalParameters["ROCmBinPath"], "rocm-smi")
   if globalParameters["CxxCompiler"] == "hcc":
-    globalParameters["ExtractKernelPath"] = locateExe("/opt/rocm/bin", "extractkernel")
+    globalParameters["ExtractKernelPath"] = locateExe(globalParameters["ROCmBinPath"], "extractkernel")
   else:
-    globalParameters["ExtractKernelPath"] = locateExe("/opt/rocm/hip/bin", "extractkernel")
-    globalParameters["ClangOffloadBundlerPath"] = locateExe("/opt/rocm/llvm/bin", "clang-offload-bundler")
+    globalParameters["ExtractKernelPath"] = locateExe(os.path.join(globalParameters["ROCmPath"], "hip/bin"), "extractkernel")
+    globalParameters["ClangOffloadBundlerPath"] = locateExe(os.path.join(globalParameters["ROCmPath"], "llvm/bin"), "clang-offload-bundler")
 
   if "ROCmAgentEnumeratorPath" in config:
     globalParameters["ROCmAgentEnumeratorPath"] = config["ROCmAgentEnumeratorPath"]

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -108,7 +108,7 @@ def getAssemblyCodeObjectFiles(kernels, kernelWriterAssembly, outputPath):
 def which(p):
     exes = [p+x for x in ['', '.exe', '.bat']]
     system_path = os.environ['PATH'].split(os.pathsep)
-    for dirname in system_path+['/opt/rocm/bin']:
+    for dirname in system_path+[globalParameters["ROCmBinPath"]]:
         for exe in exes:
             candidate = os.path.join(os.path.expanduser(dirname), exe)
             if os.path.isfile(candidate):

--- a/Tensile/Tests/yaml_only/test_config.py
+++ b/Tensile/Tests/yaml_only/test_config.py
@@ -145,7 +145,14 @@ def configMarks(filepath, rootDir, availableArchs):
 
 def findAvailableArchs():
     availableArchs = []
-    rocmAgentEnum = "/opt/rocm/bin/rocm_agent_enumerator"
+    rocmpath = "/opt/rocm"
+    if "ROCM_ROOT" in os.environ:
+        rocmpath = os.environ.get("ROCM_ROOT")
+    if "ROCM_PATH" in os.environ:
+        rocmpath = os.environ.get("ROCM_PATH")
+    if "TENSILE_ROCM_PATH" in os.environ:
+        rocmpath = os.environ.get("TENSILE_ROCM_PATH")
+    rocmAgentEnum = os.path.join(rocmpath, "bin/rocm_agent_enumerator")
     output = subprocess.check_output([rocmAgentEnum, "-t", "GPU"])
     lines = output.decode().splitlines()
     for line in lines:

--- a/Tensile/Tests/yaml_only/test_config.py
+++ b/Tensile/Tests/yaml_only/test_config.py
@@ -146,8 +146,6 @@ def configMarks(filepath, rootDir, availableArchs):
 def findAvailableArchs():
     availableArchs = []
     rocmpath = "/opt/rocm"
-    if "ROCM_ROOT" in os.environ:
-        rocmpath = os.environ.get("ROCM_ROOT")
     if "ROCM_PATH" in os.environ:
         rocmpath = os.environ.get("ROCM_PATH")
     if "TENSILE_ROCM_PATH" in os.environ:


### PR DESCRIPTION
default to /opt/rocm, but overridden by ROCM_ROOT, ROCM_PATH, TENSILE_ROCM_PATH