### PR TITLE
Choose correct hipMemcpy type for ReferenceValidator

### DIFF
--- a/Tensile/Source/client/source/ReferenceValidator.cpp
+++ b/Tensile/Source/client/source/ReferenceValidator.cpp
@@ -422,10 +422,12 @@ namespace Tensile
             if(boundsCheck == BoundsCheckMode::GuardPageBack)
                 elementsOffsetToCopy = result.dElements - tensor.totalAllocatedElements();
 
+            auto copykind = result.gpu ? hipMemcpyDeviceToHost : hipMemcpyHostToHost;
+
             HIP_CHECK_EXC(hipMemcpy(m_cpuResultBuffer.data(),
                                     result.managedD.get() + elementsOffsetToCopy,
                                     bytesToCopy,
-                                    hipMemcpyDeviceToHost));
+                                    copykind));
 
             if(boundsCheck == BoundsCheckMode::NaN)
             {


### PR DESCRIPTION
Fixes some test failures on new rocm builds.