### PR TITLE
Instruction scheduling to reduce LDS by half in TN problems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ Tensile.egg-info
 build*
 dist
 .cache
+*.yaml
+*.txt
+log
 
 0_Build
 1_BenchmarkProblems

--- a/Tensile/Code.py
+++ b/Tensile/Code.py
@@ -167,6 +167,16 @@ class Module(Item):
       | | |--GlobalReadInst bogusGlobalReadInst                                // comments
     """
 
+  def countTypeList(self, ttypeList):
+    count = 0
+    # add "Module" type to type list filter, where we want to count recursively
+    # the types under "Module"
+    if Module not in ttypeList:
+      ttypeList.append(Module)
+    for ttype in ttypeList:
+      count += self.countType(ttype)
+    return count
+
   def countType(self,ttype):
     """
     Count number of items with specified type in this Module

--- a/Tensile/Code.py
+++ b/Tensile/Code.py
@@ -25,6 +25,18 @@ import ctypes
 # Global to print module names around strings
 printModuleNames = 0
 
+def printItemList(listOfItems, tag="__unnamed__"):
+  header = "="*40
+  print("%s\nbegin list %s\n%s"%(header, tag, header))
+  for i, item in enumerate(listOfItems):
+    item = list(item) if isinstance(item, tuple) else [item]
+    print("list[%s] %s"%(i, "-"*30))
+    for j, t in enumerate(item):
+      ostream = t.prettyPrint()
+      ostream = ostream[:-1] if len(ostream)>0 and ostream[-1:] == '\n' else ostream
+      print(ostream)
+  print("%s\nend list %s\n%s"%(header, tag, header))
+
 class Item:
   """
   Base class for Modules, Instructions, etc
@@ -38,6 +50,11 @@ class Item:
   def countType(self,ttype):
     return int(isinstance(self, ttype))
 
+  def prettyPrint(self, indent=""):
+    ostream = ""
+    ostream += "%s%s "%(indent, type(self).__name__)
+    ostream += str(self)
+    return ostream
 
 class Module(Item):
   """
@@ -110,15 +127,45 @@ class Module(Item):
     self.addCode(TextBlock(text))
 
   def prettyPrint(self,indent=""):
-    print("%sModule %s:"% (indent,self.name))
+    ostream = ""
+    ostream += '%s%s "%s"\n'%(indent, type(self).__name__, self.name)
     for i in self.itemList:
-      if isinstance(i, Module):
-        i.prettyPrint(indent+"  ")
-      elif isinstance(i, str):
-        print(indent, '"', str(i).strip('\n'), '"')
-      else: # Inst
-          print(indent, "%s: [ %s ]" % \
-              (i.__class__.__name__, str(i).strip('\n')))
+      ostream += i.prettyPrint(indent.replace("|--", "| ") + "|--")
+    return ostream
+    """
+    Test code:
+      mod1 = Code.Module("TopModule")
+      mod2 = Code.Module("Module-lvl2")
+      mod2.addCode(Code.Inst("bogusInst", "comments"))
+      mod3 = Code.Module("Module-lvl3")
+      mod3.addCode(Code.TextBlock("bogusTextBlock\nbogusTextBlock2\nbogusTextBlock3"))
+      mod3.addCode(Code.GlobalReadInst("bogusGlobalReadInst", "comments"))
+      mod2.addCode(mod3)
+      mod1.addCode(mod2)
+      mod1.addCode(Code.Inst("bogusInst", "comments"))
+      mod1.addCode(mod2)
+
+      print(mod1.prettyPrint())
+    Output:
+      Module "TopModule"
+      |--Module "Module-lvl2"
+      | |--Inst bogusInst                                          // comments
+      | |--Module "Module-lvl3"
+      | | |--TextBlock
+      | | | |--bogusTextBlock
+      | | | |--bogusTextBlock2
+      | | | |--bogusTextBlock3
+      | | |--GlobalReadInst bogusGlobalReadInst                                // comments
+      |--Inst bogusInst                                          // comments
+      |--Module "Module-lvl2"
+      | |--Inst bogusInst                                          // comments
+      | |--Module "Module-lvl3"
+      | | |--TextBlock
+      | | | |--bogusTextBlock
+      | | | |--bogusTextBlock2
+      | | | |--bogusTextBlock3
+      | | |--GlobalReadInst bogusGlobalReadInst                                // comments
+    """
 
   def countType(self,ttype):
     """
@@ -207,6 +254,14 @@ class TextBlock(Item):
   def __str__(self):
     return self.text
 
+  def prettyPrint(self, indent=""):
+    ostream = ""
+    ostream += "%s%s "%(indent, type(self).__name__)
+    l = [_i for _i in str(self).split("\n") if len(_i)>0]
+    l.insert(0, "")
+    ostream += "%s"%(("\n"+indent.replace("|-", "| |-")).join(l))
+    ostream += "\n"
+    return ostream
 
 class Inst(Item):
   """
@@ -246,6 +301,9 @@ class WaitCnt (Module):
     self.lgkmcnt = lgkmcnt
     self.vmcnt   = vmcnt
     self.comment = comment
+
+    # let this derived class play nicely with Module.prettyPrint()
+    self.__dict__.update(self.instructions().__dict__)
 
   def instructions(self):
     rv = Module()

--- a/Tensile/KernelWriter.py
+++ b/Tensile/KernelWriter.py
@@ -1271,11 +1271,14 @@ class KernelWriter(metaclass=abc.ABCMeta):
         else:
           self.localWriteACode = Code.Module()
           self.localWriteBCode = Code.Module()
-        if kernel["PrefetchGlobalRead"] and kernel["LoopIters"] == 1 and uDu > 0:
+
+        # TODO schedule waitcnt/barrier in makeSubIterSchedule()
+        if kernel["PrefetchGlobalRead"] and kernel["LoopIters"] in [1, 2] and uDu > 0:
           if self.enable["Wait"]:
             kl.append(self.wait(kernel, tensorParametersA, tensorParametersB, 1, 0, -1, "wait for local write"))
           if self.enable["Sync"]:
             kl.append(self.syncThreads(kernel, "sync for local read after write"))
+
         if not isNGLL:
           # PAP would have GlobalRead and GlobalInc, but no localWrite
           # Get the perIterGlobalReadCode code for PAP (if PAP=On), else would be empty
@@ -1695,7 +1698,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
             self.localWriteBCode = Code.Module()
 
           # TODO schedule waitcnt/barrier in makeSubIterSchedule()
-          if kernel["PrefetchGlobalRead"] and kernel["LoopIters"] == 1 and uDu > 0:
+          if kernel["PrefetchGlobalRead"] and kernel["LoopIters"] in [1, 2] and uDu > 0:
             if self.enable["Wait"]:
               kl.append(self.wait(kernel, tensorParametersA, tensorParametersB, 1, 0, -1, "wait for local write"))
             if self.enable["Sync"]:

--- a/Tensile/KernelWriter.py
+++ b/Tensile/KernelWriter.py
@@ -1304,7 +1304,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
       extraComment = ""
       if isLastLoop:
         extraComment += " (last unrolled loop)"
-      if not isLastLoop:
+      else:
         if isResetLroIter:
             extraComment += " (reset local read pointers iteration) "
         if isSwapAndResetLwoIter:

--- a/Tensile/KernelWriter.py
+++ b/Tensile/KernelWriter.py
@@ -30,6 +30,7 @@ import os
 import shutil
 import subprocess
 import copy
+from itertools import zip_longest
 
 ################################################################################
 # Kernel Writer
@@ -83,16 +84,23 @@ class KernelWriter(metaclass=abc.ABCMeta):
   #   self.unrollLoopHeaderCode:
   #      - Code module that should be added into the unroll loop header
   #        In unscheduled code this contains global loads and global address increment
-  #   self.perIterCode[]
+  #   self.perIterGlobalReadCode[], self.perIterLocalWriteCode[]
   #      - List indexed by unroll iteration.
   #        Each entry in the list is a code module that should be added into that iteration.
   #        May be None, indicating no extra code for that iteration
-  #
+  #   self.grEndMfmaIndex
+  #   self.lwStartMfmaIndex
+  #   self.lwEndMfmaIndex
+  #   self.barrierMfmaIndex
+  #   self.perIterLocalWriteCanSkip
+  #   self.numGlobalReadInsPerMfma
+  #   self.numReadsIterCoalescedB
+  #   self.numMfmaForNextLoopLR
   # This routine is responsible for setting the schedule including determining
   # that all necessary dependency are met.  The driver code in kernelBody
   # blindly follows the plan set in unrollLoopHeaderCode and perIterCode
   ##############################################################################
-  def makeSchedule(self, kernel, tensorParametersA, tensorParametersB, localWriteEndIter):
+  def makeSchedule(self, kernel, tensorParametersA, tensorParametersB, localWriteEndIter, uDu=0):
     # 0x2=print GR and LW code blocks, 0x1= print info messages
     schedDb = 0
 
@@ -178,7 +186,13 @@ class KernelWriter(metaclass=abc.ABCMeta):
       self.barrierMfmaIndex = numMfmaPerIter*(kernel["LoopIters"]-self.numItersPLR+1) - self.numMfmaForNextLoopLR - 1 if self.numItersPLR else 0
       self.nextLoopLRMfmaIndex = self.barrierMfmaIndex if self.numItersPLR else numMfmaPerIter*kernel["LoopIters"] - self.numMfmaForNextLoopLR - 1
       self.lwEndMfmaIndex = max(self.barrierMfmaIndex - numMfmaBetweenLWandBarrier,0) if self.numItersPLR else numMfmaPerIter*kernel["LoopIters"] - 1
+      if kernel["DepthULdsDivisor"] > 1:
+        # SplitLDS's schedule looks like: # (LW/GR) x N -> (GR address increment) x 2
+        self.lwEndMfmaIndex = min(self.lwEndMfmaIndex + 2, numMfmaPerIter*kernel["LoopIters"] - 1)
       localWriteEndIter = self.lwEndMfmaIndex//numMfmaPerIter
+      localWriteEndIter = min(kernel["LoopIters"] - 1, localWriteEndIter)
+      assert localWriteEndIter < kernel["LoopIters"]
+      assert self.lwEndMfmaIndex < numMfmaPerIter*kernel["LoopIters"]
     else:
       numGlobalReadInsPerIter = 1
       numLocalWriteModPerIter = 1
@@ -206,12 +220,10 @@ class KernelWriter(metaclass=abc.ABCMeta):
       self.unrollLoopHeaderCode.addCode(self.globalReadACode.header)
       self.unrollLoopHeaderCode.addCode(self.globalReadBCode.header)
 
-      readCnt = self.globalReadACode.middle.countType(Code.GlobalReadInst) + \
-                self.globalReadBCode.middle.countType(Code.GlobalReadInst)
 
       # Add all loads from middle as individual schedulable items
       # when using PGR2, put global read instruction right after corresponding localWrite instruction
-      if kernel["PrefetchGlobalRead"] == 2:
+      if kernel["PrefetchGlobalRead"] == 2 or kernel["DepthULdsDivisor"] > 1:
         itemsGRToSched =  []
         itemsGRToSchedLater = list(self.globalReadACode.middle.items()) + \
                          list(self.globalReadBCode.middle.items())
@@ -222,16 +234,24 @@ class KernelWriter(metaclass=abc.ABCMeta):
 
       itemsGRToSched.append(globalReadIncACode)
       for i in range(numEmptyGlobalReadIncCode):
-        itemsGRToSched.append(Code.Module())
+        imod = Code.Module()
+        imod.addCode(Code.Inst("// ", "globalReadIncA scheduler placeholder"))
+        itemsGRToSched.append(imod)
       itemsGRToSched.append(globalReadIncBCode)
       for i in range(numEmptyGlobalReadIncCode):
-        itemsGRToSched.append(Code.Module())
+        imod = Code.Module()
+        imod.addCode(Code.Inst("// ", "globalReadIncB scheduler placeholder"))
+        itemsGRToSched.append(imod)
+
+      if kernel["DepthULdsDivisor"] > 1:
+        itemsGRToSchedLater.extend(itemsGRToSched) # GR addr inc after GR code
+        itemsGRToSched.clear()
+
+      readCnt = len(itemsGRToSched)
 
       if kernel["EnableMatrixInstruction"] and kernel["ScheduleIterAlg"] == 3:
-        if kernel["PrefetchGlobalRead"] == 2:
-          self.grEndMfmaIndex = roundUp(len(itemsGRToSched)/self.numGlobalReadInsPerMfma) - 1
-        else:
-          self.grEndMfmaIndex = roundUp(readCnt/self.numGlobalReadInsPerMfma) - 1
+        loadsToSched = sum(1 for item in itemsGRToSched if item.countType(Code.GlobalReadInst))
+        self.grEndMfmaIndex = max(0, roundUp(loadsToSched/self.numGlobalReadInsPerMfma) - 1)
         if self.grEndMfmaIndex > self.lwEndMfmaIndex:
           firstStep = (numMfmaPerIter + (self.grEndMfmaIndex - self.lwEndMfmaIndex)) * self.numGlobalReadInsPerMfma
           self.grEndMfmaIndex = self.lwEndMfmaIndex
@@ -288,6 +308,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
 
     if kernel["1LDSBuffer"]:
       barrier = Code.Module()
+      barrier.addComment0("1 LDS buffer: read-sync-write")
       barrier.addInst("s_waitcnt lgkmcnt(0)","")
       barrier.addInst("s_barrier","")
       if self.localWriteACode.items():
@@ -314,22 +335,31 @@ class KernelWriter(metaclass=abc.ABCMeta):
     else:
       # create a plan:
       itemsLWToSched = list(self.localWriteACode.items()) + list(self.localWriteBCode.items())
-      if 1:
-        # This counts the number of modules which contain a ds_write
-        # Scheduler below keeps all writes in the same module in same iteration
-        # so this is better match to what it is trying to do
-        writesToSched = sum(1 for item in itemsLWToSched if item.countType(Code.LocalWriteInst))
-      else:
-        # count the number of writes, this doesn't match how they are
-        # scheduled so pushes writes up too far
-        writesToSched = self.localWriteACode.countType(Code.LocalWriteInst) + \
-                     self.localWriteBCode.countType(Code.LocalWriteInst)
+      # piggyback each global read instruction after each local write instruction to maximize G2L buffer utilization
+      if kernel["PrefetchGlobalRead"] == 2 or kernel["DepthULdsDivisor"]>1:
+        itemsLWToSched = list(zip_longest(itemsLWToSched, itemsGRToSchedLater, fillvalue=Code.Module("Placeholder")))
+      try:
+        # count how many items to schedule (local writes as well as global reads)
+        _filterType = [Code.LocalWriteInst, Code.GlobalReadInst]
+        writesToSched = sum(1 for p, q in itemsLWToSched if p.countTypeList(_filterType) or q.countTypeList(_filterType))
+      except TypeError: # itemsLWToSched not tuple -> no piggybacked GR code
+        if 1:
+          # This counts the number of modules which contain a ds_write
+          # Scheduler below keeps all writes in the same module in same iteration
+          # so this is better match to what it is trying to do
+          writesToSched = sum(1 for item in itemsLWToSched if item.countType(Code.LocalWriteInst))
+        else:
+          # count the number of writes, this doesn't match how they are
+          # scheduled so pushes writes up too far
+          writesToSched = self.localWriteACode.countType(Code.LocalWriteInst) + \
+                      self.localWriteBCode.countType(Code.LocalWriteInst)
       # assign schedule index
       if kernel["EnableMatrixInstruction"] and kernel["ScheduleIterAlg"] == 3:
-        self.lwStartMfmaIndex = self.lwEndMfmaIndex - roundUp(writesToSched/self.numLocalWriteModPerMfma) + 1
+        self.lwStartMfmaIndex = self.lwEndMfmaIndex - max(1,roundUp(writesToSched/self.numLocalWriteModPerMfma)) + 1
         if self.lwStartMfmaIndex < self.grEndMfmaIndex:
           self.lwStartMfmaIndex = self.grEndMfmaIndex
         startIter = self.lwStartMfmaIndex//numMfmaPerIter
+        assert startIter < localWriteEndIter+1 # startIter should be at or before the endIter
       else:
         startIter = localWriteEndIter - writesToSched + 1
         # - can't move a write past the load it depends on
@@ -360,6 +390,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
             if not kernel["DirectToLdsB"]:
               assert self.globalReadBCode.middle.countType(Code.GlobalReadInst) == \
                   len(list(self.localWriteBCode.items()))
+      # Code.printItemList(itemsLWToSched)
       for u in range(startIter, localWriteEndIter+1):
         if u==(localWriteEndIter):
           itemPerIter = len(itemsLWToSched) # schedule all remaining activity
@@ -376,8 +407,12 @@ class KernelWriter(metaclass=abc.ABCMeta):
           imod = Code.Module("LocalWriteMod%u"%u)
           imodNGLL = Code.Module("LocalWriteMod%u"%u)
 
-          # Prepend a waitcnt if needed
-          writesPerItem = item.countType(Code.LocalWriteInst)
+          # Prepend a waitcnt if needed. List item could be a tuple of Code.Module's depending on whether
+          # other code modules (e.g., GR codes) are piggybacked on LW module
+          try:
+            writesPerItem = item[0].countType(Code.LocalWriteInst)
+          except TypeError: # itemsLWToSched not tuple -> no piggybacked GR code
+            writesPerItem = item.countType(Code.LocalWriteInst)
           imod.addComment0("sched write - iter %u writesPerItem=%u"%(u,writesPerItem))
           imodNGLL.addComment0("sched write - iter %u writesPerItem=%u"%(u,writesPerItem))
           if writesPerItem:
@@ -390,19 +425,28 @@ class KernelWriter(metaclass=abc.ABCMeta):
             readsToWaitNGLL = readsToWaitNGLL - 1
             # TODO - gfx9 supports higher max VMCNT
             if 1:
-              imod.addCode(Code.WaitCnt(self.version, -1, min(maxVmcnt, readsToWait), \
+              if uDu < kernel["DepthULdsDivisor"]-1:
+                imod.addComment0("no wait vmcnt except for in the last subLdsLoop")
+              else:
+                imod.addCode(Code.WaitCnt(self.version, -1, min(maxVmcnt, readsToWait), \
                   "wait for global read before writing to local"))
-              imodNGLL.addCode(Code.WaitCnt(self.version, -1, min(maxVmcnt, readsToWaitNGLL), \
+                imodNGLL.addCode(Code.WaitCnt(self.version, -1, min(maxVmcnt, readsToWaitNGLL), \
                   "wait for global read before writing to local"))
             else:
               print("warning - scheduleLocalWrite adding conservative vmcnt(0)")
               imod.addCode(Code.WaitCnt(self.version, -1, 0, "conservative waitcnt"))
-          imod.addCode(item)
-          if kernel["PrefetchGlobalRead"] == 2:
-            imod.addCode(itemsGRToSchedLater.pop(0))
-            readsToWait = readsToWait + 1
-          self.perIterLocalWriteCode[u].addCode(imod) 
-          imodNGLL.addCode(copy.deepcopy(item))
+          try:
+            imod.addCode(item[0]) # original LW code
+            imod.addCode(item[1]) # GR code piggybacked alongside LW code
+            readsToWait = readsToWait + item[1].countType(Code.GlobalReadInst) # GR instruction increments vmcnt
+          except TypeError: # itemsLWToSched not tuple -> no piggybacked GR code
+            imod.addCode(item)
+          self.perIterLocalWriteCode[u].addCode(imod)
+          try:
+            imodNGLL.addCode(copy.deepcopy(item[0])) # original LW code
+            #imodNGLL.addCode(copy.deepcopy(item[1])) # omit GR code piggybacked alongside LW code
+          except TypeError: # itemsLWToSched not tuple -> no piggybacked GR code
+            imodNGLL.addCode(copy.deepcopy(item))
           self.perIterLocalWriteCodeNGLL[u].addCode(imodNGLL)
         itemsLWToSched = itemsLWToSched[itemPerIter:]
 
@@ -1207,13 +1251,37 @@ class KernelWriter(metaclass=abc.ABCMeta):
       if self.enable["Sync"]:
         kl.append(self.syncThreads(kernel))
 
-    if not isNGLL:
-      # PAP would have GlobalRead and GlobalInc, but no localWrite
-      # Get the perIterGlobalReadCode code for PAP (if PAP=On), else would be empty
-      self.makeSchedule(kernel, tensorParametersA, tensorParametersB, localWriteEndIter)
-      kl.append(str(self.unrollLoopHeaderCode))
+    for uIdx in range(0, kernel["LoopIters"]*kernel["DepthULdsDivisor"]):
+      u = uIdx % kernel["LoopIters"]    #   u: index in compute loop (in contrast to the notion of global read loop)
+      uDu = uIdx // kernel["LoopIters"] # uDu: index of compute loop
+      isLastLoop = (uDu == kernel["DepthULdsDivisor"] -1 ) and not isNGLL
+      if u == 0:
+        if uDu > 0:
+          if self.enable["GlobalRead"]:
+            assert len(self.globalReadACode.items()) > 0 and len(self.globalReadBCode.items()) > 0 # already issued in first uDu
+            self.globalReadACode = Code.StructuredModule() # empty
+            self.globalReadBCode = Code.StructuredModule() # empty
+          if self.enable["GlobalReadInc"]:
+            self.globalReadIncrements = Code.Module() # empty
+            self.globalReadIncrements.addCode(Code.Module("globalReadIncrementA"))
+            self.globalReadIncrements.addCode(Code.Module("globalReadIncrementB"))
+        if not isLastLoop:
+          self.localWriteACode = self.localWriteDo(kernel, tensorParametersA, (uDu+1)%kernel["DepthULdsDivisor"])  # local write in loopcnt N targets data for loopcnt N+1
+          self.localWriteBCode = self.localWriteDo(kernel, tensorParametersB, (uDu+1)%kernel["DepthULdsDivisor"])
+        else:
+          self.localWriteACode = Code.Module()
+          self.localWriteBCode = Code.Module()
+        if kernel["PrefetchGlobalRead"] and kernel["LoopIters"] == 1 and uDu > 0:
+          if self.enable["Wait"]:
+            kl.append(self.wait(kernel, tensorParametersA, tensorParametersB, 1, 0, -1, "wait for local write"))
+          if self.enable["Sync"]:
+            kl.append(self.syncThreads(kernel, "sync for local read after write"))
+        if not isNGLL:
+          # PAP would have GlobalRead and GlobalInc, but no localWrite
+          # Get the perIterGlobalReadCode code for PAP (if PAP=On), else would be empty
+          self.makeSchedule(kernel, tensorParametersA, tensorParametersB, localWriteEndIter, uDu)
+          kl.append(str(self.unrollLoopHeaderCode))
 
-    for u in range(0, kernel["LoopIters"]):
       # which loop iteration to reset the LRO,
       # note if PLR=0, isResetLroIter is False for all u
       isResetLroIter = (u == localWriteEndIter)
@@ -1224,7 +1292,9 @@ class KernelWriter(metaclass=abc.ABCMeta):
           isSwapAndResetLwoIter = (u == self.lwEndMfmaIndex//(self.numMfmaPerIter))
 
       extraComment = ""
-      if isNGLL:
+      if isLastLoop:
+        extraComment += " (last unrolled loop)"
+      if not isLastLoop:
         if isResetLroIter:
             extraComment += " (reset local read pointers iteration) "
         if isSwapAndResetLwoIter:
@@ -1244,13 +1314,14 @@ class KernelWriter(metaclass=abc.ABCMeta):
       syncCode = Code.Module()
 
       if self.enable["LocalRead"]:
+        hasLiveLdsData = kernel["PrefetchGlobalRead"] or (uDu < kernel["DepthULdsDivisor"]-1)
+        hasLiveLdsData = hasLiveLdsData and not isLastLoop
         # reads for current loop are done in previous iteration because of wider local read
         doReadA = (u < kernel["LoopIters"]/self.numIterPerCoalescedReadA - self.numItersPLR)
         doReadB = (u < kernel["LoopIters"]/self.numIterPerCoalescedReadB - self.numItersPLR)
-        if isNGLL:
-          # reads for next loop
-          doReadA = doReadA or (kernel["PrefetchGlobalRead"] and u > localWriteEndIter)
-          doReadB = doReadB or (kernel["PrefetchGlobalRead"] and u > localWriteEndIter)
+        # reads for next loop
+        doReadA = doReadA or (hasLiveLdsData and u > localWriteEndIter)
+        doReadB = doReadB or (hasLiveLdsData and u > localWriteEndIter)
         for iui in range(0,kernel["InnerUnroll"]):
           doReadA = doReadA and iui*self.numReadsIterCoalescedA < kernel["InnerUnroll"]
           doReadB = doReadB and iui*self.numReadsIterCoalescedB < kernel["InnerUnroll"]
@@ -1272,7 +1343,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
               localReads.addText(self.comment("local read increment b"))
               localReads.addText(self.localReadInc(kernel, iui, tensorParametersB))
 
-      if isNGLL:
+      if not isLastLoop:
         if kernel["PrefetchGlobalRead"]:
           # put barrier at localWriteEndIter+1
           if u == localWriteEndIter+1 or (u == (localWriteEndIter+1)%kernel["LoopIters"] and kernel["ScheduleIterAlg"] == 2):
@@ -1295,9 +1366,9 @@ class KernelWriter(metaclass=abc.ABCMeta):
             if self.enable["LocalRead"]:
               # Swap, reset, or increment the LRO:
               pointerLRCode.addText(self.comment("local read swap offsets a"))
-              pointerLRCode.addText(self.localReadSwapOffsets(kernel, 0, tensorParametersA))
+              pointerLRCode.addText(self.localReadSwapOffsets(kernel, kernel["ExpandPointerSwap"], tensorParametersA))
               pointerLRCode.addText(self.comment("local read swap offsets b"))
-              pointerLRCode.addText(self.localReadSwapOffsets(kernel, 0, tensorParametersB))
+              pointerLRCode.addText(self.localReadSwapOffsets(kernel, kernel["ExpandPointerSwap"], tensorParametersB))
 
         if isResetLroIter: # ResetLroIter
           if self.enable["LocalRead"]:
@@ -1434,9 +1505,9 @@ class KernelWriter(metaclass=abc.ABCMeta):
       if self.enable["LocalWrite"]:
         # local write
         kl.append(self.comment("local write a"))
-        kl.append(self.localWriteDo(kernel, tensorParametersA))
+        kl.append(self.localWriteDo(kernel, tensorParametersA, 0))
         kl.append(self.comment("local write b"))
-        kl.append(self.localWriteDo(kernel, tensorParametersB))
+        kl.append(self.localWriteDo(kernel, tensorParametersB, 0))
         # swap local ptrs
         kl.append(self.comment("local write swap a"))
         kl.append(self.localWriteSwapOffsets(kernel, tensorParametersA))
@@ -1493,7 +1564,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
     loopCopies = 2 if expand else 1
     for lc in range(0, loopCopies):
       finalLoop = not expand or lc==loopCopies-1
-      kl.append(self.comment3("Unroll Loop %u/%u - Begin" % (lc+1, loopCopies)))
+      kl.append(self.comment3("Unrolled Loop %u/%u - Begin" % (lc+1, loopCopies)))
       kl.append(self.openLoopCopy(kernel, lc))
       if kernel["PrefetchGlobalRead"] and not self.numItersPLR and not kernel["ScheduleIterAlg"] == 2:
         if self.enable["Wait"]:
@@ -1536,8 +1607,11 @@ class KernelWriter(metaclass=abc.ABCMeta):
       localWriteEndIter = kernel["LoopIters"] - self.numItersPLR - 1
 
       # Schedule the global read, global read inc, and writes:
-      self.makeSchedule(kernel, tensorParametersA, tensorParametersB, localWriteEndIter)
-      kl.append(str(self.unrollLoopHeaderCode))
+      unrollLoopHeaderCodeScheduled = False
+      if not kernel["PrefetchGlobalRead"]:
+        unrollLoopHeaderCodeScheduled = True
+        self.makeSchedule(kernel, tensorParametersA, tensorParametersB, localWriteEndIter)
+        kl.append(str(self.unrollLoopHeaderCode))
 
       # if not prefetch global, localWrite before mac's
       if not kernel["PrefetchGlobalRead"]:
@@ -1596,7 +1670,68 @@ class KernelWriter(metaclass=abc.ABCMeta):
       # unrolled loop: mac iterations
       ############################################################################
 
-      for u in range(0, kernel["LoopIters"]):
+      # double/quadruple the number of compute loop for each DepthU's worth of data read
+      for uIdx in range(0, kernel["LoopIters"]*kernel["DepthULdsDivisor"]):
+        u = uIdx % kernel["LoopIters"]    #   u: index in compute loop (in contrast to the notion of global read loop)
+        uDu = uIdx // kernel["LoopIters"] # uDu: index of compute loop
+        if u==0: # if at start of subloop...
+          # ...do not issue global reads if not in first uDu
+          if uDu > 0:
+            if self.enable["GlobalRead"]:
+              assert len(self.globalReadACode.items()) > 0 and len(self.globalReadBCode.items()) > 0 # already issued in first uDu
+              self.globalReadACode = Code.StructuredModule() # empty
+              self.globalReadBCode = Code.StructuredModule() # empty
+            if self.enable["GlobalReadInc"]:
+              self.globalReadIncrements = Code.Module()
+              self.globalReadIncrements.addCode(Code.Module("globalReadIncrementA"))
+              self.globalReadIncrements.addCode(Code.Module("globalReadIncrementB"))
+
+          # ...update local write code
+          if self.enable["LocalWrite"]:
+            self.localWriteACode = self.localWriteDo(kernel, tensorParametersA, (uDu+1)%kernel["DepthULdsDivisor"])  # local write in loopcnt N targets data for loopcnt N+1
+            self.localWriteBCode = self.localWriteDo(kernel, tensorParametersB, (uDu+1)%kernel["DepthULdsDivisor"])
+          else:
+            self.localWriteACode = Code.Module()
+            self.localWriteBCode = Code.Module()
+
+          # TODO schedule waitcnt/barrier in makeSubIterSchedule()
+          if kernel["PrefetchGlobalRead"] and kernel["LoopIters"] == 1 and uDu > 0:
+            if self.enable["Wait"]:
+              kl.append(self.wait(kernel, tensorParametersA, tensorParametersB, 1, 0, -1, "wait for local write"))
+            if self.enable["Sync"]:
+              kl.append(self.syncThreads(kernel, "sync for local read after write"))
+
+          if not unrollLoopHeaderCodeScheduled:
+            self.makeSchedule(kernel, tensorParametersA, tensorParametersB, localWriteEndIter, uDu)
+            kl.append(str(self.unrollLoopHeaderCode))
+
+        # for PGR=0 where generator can't schedule the instructions (yet),
+        # we duplicate the local write codegen and append to string list directly
+        if not kernel["PrefetchGlobalRead"]:
+          doWrite = False
+          if uDu<kernel["DepthULdsDivisor"]-1 and u==kernel["LoopIters"]-self.numItersPLR:
+            doWrite = True
+            writeForNextLoop = 1
+          if uDu>0 and self.numItersPLR==0 and u==0:
+            assert doWrite==False # should be exclusive with the previous condition
+            doWrite = True
+            writeForNextLoop = 0
+          # unrolled loop: local write A, B
+          if doWrite:
+            if self.enable["Wait"]:
+              kl.append(self.wait(kernel, tensorParametersA, tensorParametersB, -1, -1, 0, "5wait for local read"))
+            if self.enable["Sync"]:
+              kl.append(self.syncThreads(kernel, "PGR=0, prior iter done reading lds"))
+            if self.enable["LocalWrite"]:
+              kl.append(self.comment("local write a"))
+              kl.append(self.localWriteDo(kernel, tensorParametersA, (uDu+writeForNextLoop)%kernel["DepthULdsDivisor"]))
+              kl.append(self.comment("local write b"))
+              kl.append(self.localWriteDo(kernel, tensorParametersB, (uDu+writeForNextLoop)%kernel["DepthULdsDivisor"]))
+            if self.enable["Wait"]:
+              kl.append(self.wait(kernel, tensorParametersA, tensorParametersB, -1, 0, -1, "2prefetch wait for local write"))
+            if self.enable["Sync"]:
+              kl.append(self.syncThreads(kernel))
+
         # which loop iteration to reset the LRO,
         # note if PLR=0, isResetLroIter is False for all u
         isResetLroIter = (u == localWriteEndIter)
@@ -1628,12 +1763,13 @@ class KernelWriter(metaclass=abc.ABCMeta):
         syncCode = Code.Module()
 
         if self.enable["LocalRead"]:
+          hasLiveLdsData = kernel["PrefetchGlobalRead"] or (uDu < kernel["DepthULdsDivisor"]-1)
           # reads for current loop are done in previous iteration because of wider local read
-          doReadA = (u < kernel["LoopIters"]/self.numIterPerCoalescedReadA - self.numItersPLR) 
+          doReadA = (u < kernel["LoopIters"]/self.numIterPerCoalescedReadA - self.numItersPLR)
           doReadB = (u < kernel["LoopIters"]/self.numIterPerCoalescedReadB - self.numItersPLR)
           # reads for next loop
-          doReadA = doReadA or (kernel["PrefetchGlobalRead"] and u > localWriteEndIter)
-          doReadB = doReadB or (kernel["PrefetchGlobalRead"] and u > localWriteEndIter)
+          doReadA = doReadA or (hasLiveLdsData and u > localWriteEndIter)
+          doReadB = doReadB or (hasLiveLdsData and u > localWriteEndIter)
           for iui in range(0,kernel["InnerUnroll"]):
             doReadA = doReadA and iui*self.numReadsIterCoalescedA < kernel["InnerUnroll"]
             doReadB = doReadB and iui*self.numReadsIterCoalescedB < kernel["InnerUnroll"]
@@ -1968,75 +2104,98 @@ class KernelWriter(metaclass=abc.ABCMeta):
         kl.append(self.wait(kernel, tensorParametersA, tensorParametersB, 0, -1, -1, "2wait for global read"))
       if self.enable["Sync"]:
         kl.append(self.syncThreads(kernel))
-      if self.enable["LocalWrite"]:
-        # tail: local write
-        kl.append(self.localWriteInitPointers(kernel, tensorParametersA))
-        kl.append(self.localWriteInitPointers(kernel, tensorParametersB))
-        kl.append(self.comment("local write a"))
-        kl.append(self.localWriteDo(kernel, tensorParametersA))
-        kl.append(self.comment("local write b"))
-        kl.append(self.localWriteDo(kernel, tensorParametersB))
-      if self.enable["Wait"]:
-        kl.append(self.wait(kernel, tensorParametersA, tensorParametersB, -1, 0, -1, "5wait for local write"))
-      if self.enable["Sync"]:
-        kl.append(self.syncThreads(kernel))
-      #kl.append(self.dumpLds(kernel, 0, 8))
 
-      # tail: re-init local read addresses
-      if kernel["PrefetchGlobalRead"]:
-        kl.append(self.comment("local read reset offsets a"))
-        kl.append(self.localReadResetOffsets(kernel, tensorParametersA))
-        kl.append(self.comment("local read reset offsets b"))
-        kl.append(self.localReadResetOffsets(kernel, tensorParametersB))
-        kl.append(self.comment("local read init pointers a"))
-        kl.append(self.localReadInitPointers(kernel, tensorParametersA))
-        kl.append(self.comment("local read init pointers b"))
-        kl.append(self.localReadInitPointers(kernel, tensorParametersB))
-      # tail: macs
-      kl.append(self.comment("tail loop: macs"))
-      kl.append(self.openLoop(kernel, -1))
+      # the following read/write addresses could be modified in recalcLocal(Read|Write)Addresses due to policy change
+      self.oriLraA = None # back up original local read address vgpr
+      self.oriLraB = None
+      self.oriLwaA = None # back up original local write address vgpr
+      self.oriLwaB = None
+      for uDu in range(0, kernel["DepthULdsDivisor"]):
+        if kernel["DepthULdsDivisor"] > 1:
+          # change local write poilcy from interleave-K to fractional as tail loop
+          # iterate LDS read address one unit of K at a time
+          kl.append(self.comment("Recalc local write offsets"))
+          kl.append(self.recalcLocalWriteAddresses(kernel, tensorParametersA, uDu))
+          kl.append(self.recalcLocalWriteAddresses(kernel, tensorParametersB, uDu))
+        if self.enable["Sync"]:
+          if uDu > 0:
+            kl.append(self.comment("sync before local write"))
+            kl.append(self.syncThreads(kernel))
+        if self.enable["LocalWrite"]:
+          # tail: local write
+          kl.append(self.localWriteInitPointers(kernel, tensorParametersA))
+          kl.append(self.localWriteInitPointers(kernel, tensorParametersB))
+          kl.append(self.comment("local write a"))
+          kl.append(self.localWriteDo(kernel, tensorParametersA, None))
+          kl.append(self.comment("local write b"))
+          kl.append(self.localWriteDo(kernel, tensorParametersB, None))
+        # change local read policy from wider local read to one unit of K at a time
+        kl.append(self.comment("Recalc local read offsets"))
+        kl.append(self.recalcLocalReadAddressesAB(kernel))
+        if self.enable["Wait"]:
+          kl.append(self.wait(kernel, tensorParametersA, tensorParametersB, -1, 0, -1, "5wait for local write"))
+        if self.enable["Sync"]:
+          kl.append(self.syncThreads(kernel))
+        #kl.append(self.dumpLds(kernel, 0, 8))
 
-      # Try to use InnerUnroll in the tail loop if allowed:
-      KinInnerUnroll = kernel["InnerUnroll"]
-      if kernel["EnableMatrixInstruction"]:
-        KinInnerUnroll *= kernel["MatrixInstK"]
-      tailLoopInnerUnroll = kernel["InnerUnroll"] if (kernel["AssertSummationElementMultiple"] % KinInnerUnroll == 0) else 1
+        # tail: re-init local read addresses
+        if kernel["PrefetchGlobalRead"]:
+          kl.append(self.comment("local read reset offsets a"))
+          kl.append(self.localReadResetOffsets(kernel, tensorParametersA))
+          kl.append(self.comment("local read reset offsets b"))
+          kl.append(self.localReadResetOffsets(kernel, tensorParametersB))
+          kl.append(self.comment("local read init pointers a"))
+          kl.append(self.localReadInitPointers(kernel, tensorParametersA))
+          kl.append(self.comment("local read init pointers b"))
+          kl.append(self.localReadInitPointers(kernel, tensorParametersB))
+        # tail: macs
+        kl.append(self.comment("tail loop: macs"))
+        kl.append(self.openLoop(kernel, -1, uDu if kernel["DepthULdsDivisor"]>1 else None))
 
-      pack[0] = Code.Module()
-      for iui in range(0,tailLoopInnerUnroll):
-        if self.enable["LocalRead"]:
-          # Reading 16-bit data from LDS requires packing when ECC enabled
-          kl.append(self.comment("local read a"))
-          localReadCodeA, packCodeA = self.localReadDo(kernel, 0, iui, 0, tensorParametersA)
-          kl.append(localReadCodeA)
-          kl.append(self.comment("local read b"))
-          localReadCodeB, packCodeB = self.localReadDo(kernel, 0, iui, 0, tensorParametersB)
-          kl.append(localReadCodeB)
-          pack[0].addCode(packCodeA)
-          pack[0].addCode(packCodeB)
-
-          kl.append(self.comment("local read inc a"))
-          kl.append(self.localReadInc(kernel, iui, tensorParametersA))
-          kl.append(self.comment("local read inc b"))
-          kl.append(self.localReadInc(kernel, iui, tensorParametersB))
-      if self.enable["Wait"]:
-        kl.append(self.wait(kernel, tensorParametersA, tensorParametersB, -1, -1, 0, "4wait for local read"))
-
-      if kernel["EnableMatrixInstruction"]:
-        kl.append(pack[0])
-        for item in list(pack[0].items()):
-          if item.tempVgpr != None:
-            self.vgprPool.checkIn(item.tempVgpr)
-            item.tempVgpr = None
-        pack[0] = Code.Module()
-      if self.enable["MAC"]:
+        # Try to use InnerUnroll in the tail loop if allowed:
+        KinInnerUnroll = kernel["InnerUnroll"]
         if kernel["EnableMatrixInstruction"]:
-          kl.append(self.mfmaIter(kernel, 0, tailLoopInnerUnroll, True))
-        else:
-          kl.append(self.macIter(kernel, 0, tailLoopInnerUnroll, True))
+          KinInnerUnroll *= kernel["MatrixInstK"]
+        tailLoopInnerUnroll = kernel["InnerUnroll"] if (kernel["AssertSummationElementMultiple"] % KinInnerUnroll == 0) else 1
 
-      # tail: close
-      kl.append(self.closeLoop(kernel, -1, True))
+        pack[0] = Code.Module()
+        for iui in range(0,tailLoopInnerUnroll):
+          if self.enable["LocalRead"]:
+            # Reading 16-bit data from LDS requires packing when ECC enabled
+            kl.append(self.comment("local read a"))
+            localReadCodeA, packCodeA = self.localReadDo(kernel, 0, iui, 0, tensorParametersA)
+            kl.append(localReadCodeA)
+            kl.append(self.comment("local read b"))
+            localReadCodeB, packCodeB = self.localReadDo(kernel, 0, iui, 0, tensorParametersB)
+            kl.append(localReadCodeB)
+            pack[0].addCode(packCodeA)
+            pack[0].addCode(packCodeB)
+
+            kl.append(self.comment("local read inc a"))
+            kl.append(self.localReadInc(kernel, iui, tensorParametersA))
+            kl.append(self.comment("local read inc b"))
+            kl.append(self.localReadInc(kernel, iui, tensorParametersB))
+        if self.enable["Wait"]:
+          kl.append(self.wait(kernel, tensorParametersA, tensorParametersB, -1, -1, 0, "4wait for local read"))
+
+        if kernel["EnableMatrixInstruction"]:
+          kl.append(pack[0])
+          for item in list(pack[0].items()):
+            if item.tempVgpr != None:
+              self.vgprPool.checkIn(item.tempVgpr)
+              item.tempVgpr = None
+          pack[0] = Code.Module()
+        if self.enable["MAC"]:
+          if kernel["EnableMatrixInstruction"]:
+            kl.append(self.mfmaIter(kernel, 0, tailLoopInnerUnroll, True))
+          else:
+            kl.append(self.macIter(kernel, 0, tailLoopInnerUnroll, True))
+
+        kl.append(self.closeLoop(kernel, -1, True, uDu if kernel["DepthULdsDivisor"]>1 else None))
+    if kernel["DepthULdsDivisor"]>1:
+      kl.append(self.closeLoop(kernel, -1, None, emitEndLabelOnly=True))
+    # tail: close
+    self.inTailLoop = False
 
     # extra summation loops: global increment and close
     for i in reversed(range(self.otherSummationLoops)):
@@ -2434,7 +2593,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
     # writeCoal indicates writes should be done in the coal dim
     # else in perp
     if writeCoal:
-      self.numWritesCoalVecCompA = vwa
+      self.numWritesCoalVecCompA = vwa // kernel["DepthULdsDivisor"]
       self.numWritesPerpVecCompA = 1
     else:
       self.numWritesCoalVecCompA = 1
@@ -2547,7 +2706,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
     # writeCoal indicates writes should be done in the coal dim
     # else in perp
     if writeCoal:
-      self.numWritesCoalVecCompB = vwb
+      self.numWritesCoalVecCompB = vwb // kernel["DepthULdsDivisor"]
       self.numWritesPerpVecCompB = 1
     else:
       self.numWritesCoalVecCompB = 1
@@ -2900,7 +3059,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
   # Local Write Addresses: First Offset A/B
   ##############################################################################
   @abc.abstractmethod
-  def lwaFirstOffset(self, kernel, tP):
+  def lwaFirstOffset(self, kernel, tP, uDu):
     return ""
 
   ##############################################################################
@@ -2943,6 +3102,20 @@ class KernelWriter(metaclass=abc.ABCMeta):
   ##############################################################################
   @abc.abstractmethod
   def lraDeclareAddresses(self, kernel, tP):
+    return ""
+
+  ##############################################################################
+  # Recalculate local read addresses A/B
+  ##############################################################################
+  @abc.abstractmethod
+  def recalcLocalReadAddressesAB(self, kernel):
+    return ""
+
+  ##############################################################################
+  # Recalculate local write addresses A/B
+  ##############################################################################
+  @abc.abstractmethod
+  def recalcLocalWriteAddresses(self, kernel, tP, uDu):
     return ""
 
   ##############################################################################
@@ -3010,14 +3183,14 @@ class KernelWriter(metaclass=abc.ABCMeta):
   # loopIdx<0 : tail loop
   ##############################################################################
   @abc.abstractmethod
-  def openLoop(self, kernel, loopIdx):
+  def openLoop(self, kernel, loopIdx, uDu):
     return ""
 
   ##############################################################################
   # Close Loop
   ##############################################################################
   @abc.abstractmethod
-  def closeLoop(self, kernel, loopIdx, finalLoop):
+  def closeLoop(self, kernel, loopIdx, finalLoop, uDu, emitEndLabelOnly):
     return ""
 
   ##############################################################################
@@ -3108,7 +3281,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
   # Local Write: Do It A/B
   ##############################################################################
   @abc.abstractmethod
-  def localWriteDo(self, kernel, tP):
+  def localWriteDo(self, kernel, tP, uDu):
     return ""
 
   ##############################################################################

--- a/Tensile/KernelWriterSource.py
+++ b/Tensile/KernelWriterSource.py
@@ -1617,7 +1617,7 @@ class KernelWriterSource(KernelWriter):
   ##############################################################################
   # Local Write Addresses: First Offset A/B
   ##############################################################################
-  def lwaFirstOffset(self, kernel, tP):
+  def lwaFirstOffset(self, kernel, tP, uDu=0):
     kStr = ""
     kStr += "  unsigned int localWriteFirstOffset%s = lw%s%s + lw%s%s*(MT%s+PAD)%s;%s" \
         % (tP["tensorChar"], tP["tensorChar"], tP["tileChar"], \
@@ -1698,6 +1698,18 @@ class KernelWriterSource(KernelWriter):
     kStr += "  %sDATA_TYPE *localRead%s;%s" % (self.sharedPtrStr, \
         tP["tensorChar"], self.endLine)
     return kStr
+
+  ##############################################################################
+  # Recalculate local write addresses A/B
+  ##############################################################################
+  def recalcLocalWriteAddresses(self, kernel, tP, uDu):
+    return ""
+
+  ##############################################################################
+  # Recalculate local read addresses A/B
+  ##############################################################################
+  def recalcLocalReadAddressesAB(self, kernel):
+    return ""
 
   ##############################################################################
   # openShadowInit
@@ -1988,7 +2000,7 @@ class KernelWriterSource(KernelWriter):
   ##############################################################################
   # Open Loop
   ##############################################################################
-  def openLoop(self, kernel, loopIdx):
+  def openLoop(self, kernel, loopIdx, uDu=0):
     problemType = kernel["ProblemType"]
     tailLoop = loopIdx < 0
     if tailLoop:
@@ -2026,8 +2038,10 @@ class KernelWriterSource(KernelWriter):
   ##############################################################################
   # Close Loop
   ##############################################################################
-  def closeLoop(self, kernel, loopIdx, finalLoop):
+  def closeLoop(self, kernel, loopIdx, finalLoop, uDu=0, emitEndLabelOnly=False):
     kStr = ""
+    if emitEndLabelOnly:
+      return kStr
     problemType = kernel["ProblemType"]
     loopDim = problemType["IndicesSummation"][loopIdx]
     loopChar = self.indexChars[loopDim]
@@ -2447,7 +2461,7 @@ class KernelWriterSource(KernelWriter):
   ##############################################################################
   # Local Write: Do It A/B
   ##############################################################################
-  def localWriteDo(self, kernel, tP):
+  def localWriteDo(self, kernel, tP, uDu=0):
     kStr = ""
     if self.language == "HIP":
       kStr += "#pragma clang diagnostic push" + self.endLine

--- a/Tensile/Tests/pre_checkin/mfma/hpa_hgemm_split_lds.yaml
+++ b/Tensile/Tests/pre_checkin/mfma/hpa_hgemm_split_lds.yaml
@@ -1,0 +1,56 @@
+TestParameters:
+  marks: [skip-gfx900, skip-gfx906, skip-gfx1010, skip-gfx1011] # not supported by arch
+
+GlobalParameters:
+  NumElementsToValidate: 65536
+  BoundsCheck: True
+  NewClient: 2
+BenchmarkProblems:
+
+  ########################################
+  # TN - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: h
+      HighPrecisionAccumulate: True
+      TransposeA: True
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - TransposeLDS: [0, 1]
+        - MatrixInstruction:
+          - [32, 32, 4, 2]
+          - [32, 32, 8, 1]
+        - PrefetchLocalRead: [0, 1, 3, 5, 9]
+        - PrefetchGlobalRead: [0, 1]
+        - ThreadTile:
+          - [ 2, 32 ]
+        - WorkGroup:
+          - [  16,16, 1 ]
+        - WorkGroupMapping: [8]
+        - InnerUnroll: [2]
+        - DepthU: [64, 128]
+        - DepthULdsDivisor: [2]
+        - ScheduleIterAlg: [3]
+        - VectorWidth: [4, 8]
+        - 1LDSBuffer: [0, 1]
+        - PersistentKernel: [0, 1]
+        - PersistentKernelAlongBatch: [1]
+        - PrefetchAcrossPersistent: [0, 1]
+        - GlobalSplitUAlgorithm: ["SingleBuffer", "MultipleBuffer"]
+        - GlobalSplitU: [2, 5, 15]
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [1024], [1024], [1], [1024] ]
+          - Range: [ [1031], [1031], [16], [1031] ]

--- a/Tensile/Tests/pre_checkin/mfma/hpa_hgemm_split_lds.yaml
+++ b/Tensile/Tests/pre_checkin/mfma/hpa_hgemm_split_lds.yaml
@@ -54,3 +54,32 @@ BenchmarkProblems:
         - ProblemSizes:
           - Range: [ [1024], [1024], [1], [1024] ]
           - Range: [ [1031], [1031], [16], [1031] ]
+
+    # test cases when each compute loop contains 1 or 2 loopIter
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - TransposeLDS: [1]
+        - MatrixInstruction:
+          - [32, 32, 8, 1, 1, 1, 1, 2, 2]  # 64x64
+        - PrefetchLocalRead: [1,2]
+        - PrefetchGlobalRead: [1]
+        - ThreadTile:
+          - [ 1, 32 ] # param ignored since 9-tuple MI format
+        - WorkGroup:
+          - [ 16, 16, 1 ] # param ignored since 9-tuple MI format
+        - DepthU: [64]
+        - InnerUnroll: [2,4]
+        - DepthULdsDivisor: [2]
+        - ScheduleIterAlg: [3]
+        - GlobalReadVectorWidth: [4]
+        - LocalReadVectorWidth: [8]
+        - 1LDSBuffer: [0]
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [128], [128], [1], [256] ]

--- a/Tensile/Tests/pre_checkin/mfma/sgemm_split_lds.yaml
+++ b/Tensile/Tests/pre_checkin/mfma/sgemm_split_lds.yaml
@@ -1,0 +1,55 @@
+TestParameters:
+  marks: [skip-gfx900, skip-gfx906, skip-gfx1010, skip-gfx1011] # not supported by arch
+
+GlobalParameters:
+  NumElementsToValidate: 65536
+  BoundsCheck: True
+  NewClient: 2
+BenchmarkProblems:
+
+  ########################################
+  # TN - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: s
+      TransposeA: True
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - TransposeLDS: [0, 1]
+        - MatrixInstruction:
+          - [32, 32, 1, 2]
+          - [32, 32, 2, 1]
+        - PrefetchLocalRead: [0, 1, 3, 5, 9]
+        - PrefetchGlobalRead: [0, 1]
+        - ThreadTile:
+          - [ 2, 32 ]
+        - WorkGroup:
+          - [  16,16, 1 ]
+        - WorkGroupMapping: [8]
+        - InnerUnroll: [2]
+        - DepthU: [64, 128]
+        - DepthULdsDivisor: [2]
+        - ScheduleIterAlg: [3]
+        - VectorWidth: [4, 8]
+        - 1LDSBuffer: [0, 1]
+        - PersistentKernel: [0, 1]
+        - PersistentKernelAlongBatch: [1]
+        - PrefetchAcrossPersistent: [0, 1]
+        - GlobalSplitUAlgorithm: ["SingleBuffer", "MultipleBuffer"]
+        - GlobalSplitU: [2, 5, 15]
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [1024], [1024], [1], [1024] ]
+          - Range: [ [1031], [1031], [16], [1031] ]


### PR DESCRIPTION
Proposed a scheduling technique that reduces LDS usage by half, while maintaining the same DepthU in TN problems.

## Goal
The initial goal is to increase global read efficiency of TN-layout problems by allowing deeper DepthU (ideally DepthU=128 for half types) kernels, which are often LDS limited.

## Result
When enabled, code gen saves 50% of LDS usage (in addition to savings from enable single LDS buffer 1LDSBuffer).  Actual tuning suggests increasing to occupancy 2 may be a better utilization of overall resources. For example, MT256x128x64 occupancy 2 rather than MT256x128x128 occupancy 1. 

## Implementation
By splitting the in-flight data (from global memory to LDS) held by registers into 2 portions, kernel writes one portion into LDS at any given time. Allowing for deeper DepthU (eg MT128x128x128) or higher occupancy.

To this end, the implementation separates the concept of DepthU: that DepthU determines the global read depth in the same old sense, while DepthULDS determines the local write depth. 

DepthULDS is not directly exposed as tuning parameter (defined internally). Rather it's DepthULdsDivisor such that DepthULds * DepthULdsDivisor = DepthU. Default value is 1, meaning DepthU equals DepthULDS. When value is 2, then DepthULds is 1/2 of DepthU.

Sometimes this feature is referred to as "SplitLDS" informally in some part of the code. But I am not sure whether the name is accurate/appropriate.

## Local test results
| Test item \ Arch | gfx906 | gfx908 |
| -- | -- | -- | 
| pre_checkin* | Passed | Passed |
| extended | Passed | Passed |
| rocblas-test | Passed | Passed |

*Added 2 more test yamls to pre_checkin. Time span increased by ~2min after this patch (27m30s -> 29m37s):