### PR TITLE
Update test config to avoid large memory usage

### DIFF
--- a/Tensile/Configs/rocblas_dgemm_bufferload_limit.yaml
+++ b/Tensile/Configs/rocblas_dgemm_bufferload_limit.yaml
@@ -2,14 +2,12 @@ GlobalParameters:
   BoundsCheck: False
   KernelTime: True
   NewClient: 2
-  # PrintSolutionRejectionReason: True
-  # NumElementsToValidate: 65535
-  # CMakeBuildType: Debug
+  PrintSolutionRejectionReason: True
 
 BenchmarkProblems:
 
   ########################################
-  # NN
+  # NN / TLUA = 1, TLUB = 0
   ########################################
   -
     - # ProblemType
@@ -30,30 +28,22 @@ BenchmarkProblems:
         - LoopTail: [True]
         - WorkGroupMapping: [8]
       ForkParameters:
-        - VectorWidth: [2]          # 4 never wins
+        - VectorWidth: [2]
         - ThreadTile:
           - [ 2, 4 ]
         - WorkGroup:
-          - [ 32, 2, 1 ]  # 64x8
-          - [ 16, 4, 1 ]  # 32x16
           - [ 16, 8, 1 ]  # 32x32
-        - DepthU: [8,16,32]
-        # - DepthU: [8]
-        - StaggerU: [0]
-        - StaggerUStride: [256]
-        - StaggerUMapping: [0]
+        - DepthU: [16,32]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [33554432], [32], [1], [32] ]  # strideA = 33554432, should fail on DU >= 16 (For tensorA-N) # MT32x32x8: PassBufferLoadAssert but FailBufferStoreAssert
-          - Range: [ [16777216], [32], [1], [32] ]  # strideA = 16777216, should fail on DU >= 32 (For tensorA-N) # MT32x32x8/MT32x32x16: PassBufferLoadAssert but FailBufferStoreAssert
-          - Range: [ [32], [32], [1], [33554432] ]  # strideB = 33554432, should fail on MT1 >= 16 (For tensorB-N)
-          - Range: [ [32], [32], [1], [16777216] ]  # strideB = 16777216, should fail on MT1 >= 32 (For tensorB-N)
+          - Range: [ [16777216], [16], [1], [16] ]  # strideA = 16777216, should fail on DU >= 32 (For tensorA-N)
+          - Range: [ [16], [16], [1], [16777216] ]  # strideB = 16777216, should fail on MT1 >= 32 (For tensorB-N)
 
   ########################################
-  # NT
+  # NT / TLUA = 1, TLUB = 1
   ########################################
   -
     - # ProblemType
@@ -74,30 +64,22 @@ BenchmarkProblems:
         - LoopTail: [True]
         - WorkGroupMapping: [8]
       ForkParameters:
-        - VectorWidth: [2]          # 4 never wins
+        - VectorWidth: [2]
         - ThreadTile:
           - [ 2, 2 ]
         - WorkGroup:
-          - [ 8, 8, 1 ]  # 16x16
-          - [ 8, 16, 1 ]  # 16x32
-          - [ 16, 8, 1 ]  # 32x16
-        - DepthU: [8,16,32]
-        # - DepthU: [8,16]
-        - StaggerU: [0]
-        - StaggerUStride: [256]
-        - StaggerUMapping: [0]
+          - [ 16, 16, 1 ]  # 32x32
+        - DepthU: [16,32]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [33554432], [32], [1], [32] ]  # strideA = 33554432, should fail on DU >= 16 (For tensorA-N) # DU8: PassBufferLoadAssert but FailBufferStoreAssert
-          - Range: [ [16777216], [32], [1], [32] ]  # strideA = 16777216, should fail on DU >= 32 (For tensorA-N) # MT16x32x8 / MT16x32x16: PassBufferLoadAssert but FailBufferStoreAssert
-          - Range: [ [32], [33554432], [1], [32] ]  # strideB = 33554432, should fail on DU >= 16 (For tensorB-T)
-          - Range: [ [32], [16777216], [1], [32] ]  # strideB = 16777216, should fail on DU >= 32 (For tensorB-T)
+          - Range: [ [16777216], [16], [1], [16] ]  # strideA = 16777216, should fail on DU >= 32 (For tensorA-N)
+          - Range: [ [16], [16777216], [1], [16] ]  # strideB = 16777216, should fail on DU >= 32 (For tensorB-T)
 
   ########################################
-  # TN
+  # TN / TLUA = 0, TLUB = 0
   ########################################
   -
     - # ProblemType
@@ -118,30 +100,23 @@ BenchmarkProblems:
         - LoopTail: [True]
         - WorkGroupMapping: [8]
       ForkParameters:
-        - VectorWidth: [2]          # 4 never wins
+        - VectorWidth: [2]
         - ThreadTile:
           - [ 2, 2 ]
         - WorkGroup:
-          - [ 4, 4, 4 ]   # 8x8x4
-          - [ 4, 8, 2 ]   # 8x16x2
-          - [ 8, 4, 2 ]   # 16x8x2
           - [ 8, 8, 1 ]   # 16x16
           - [ 8, 16, 1 ]  # 16x32
           - [ 16, 8, 1 ]  # 32x16
         - DepthU: [16]      # DU doesn't affect bufferload limit in TN
-        - StaggerU: [0]
-        - StaggerUStride: [256]
-        - StaggerUMapping: [0]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [32], [32], [1], [33554432] ]  # strideA = 33554432, should fail on MT0 >= 16 (For tensorA-T)  # strideB = 33554432, should fail on MT1 >= 16 (For tensorB-N)
-          - Range: [ [32], [32], [1], [16777216] ]  # strideA = 16777216, should fail on MT0 >= 32 (For tensorA-T)  # strideB = 16777216, should fail on MT1 >= 32 (For tensorB-N)
+          - Range: [ [16], [16], [1], [16777216] ]  # strideA = 16777216, should fail on MT0 >= 32 (For tensorA-T)  # strideB = 16777216, should fail on MT1 >= 32 (For tensorB-N)
 
   ########################################
-  # TT
+  # TT / TLUA = 0, TLUB = 1
   ########################################
   -
     - # ProblemType
@@ -162,34 +137,17 @@ BenchmarkProblems:
         - LoopTail: [True]
         - WorkGroupMapping: [8]
       ForkParameters:
-        - VectorWidth: [2]          # 4 never wins
+        - VectorWidth: [2]
         - ThreadTile:
           - [ 2, 2 ]
         - WorkGroup:
-          - [ 4, 4, 4 ]   # 8x8
           - [ 8, 4, 2 ]   # 16x8
           - [ 16, 4, 1 ]  # 32x8
-        - DepthU: [8,16,32]
-        - StaggerU: [0]
-        - StaggerUStride: [256]
-        - StaggerUMapping: [0]
+        - DepthU: [16,32]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [32], [32], [1], [33554432] ]  # strideA = 33554432, should fail on MT0 >= 16 (For tensorA-T)
-          # - Range: [ [32], [32], [1], [16777216] ]  # strideA = 16777216, should fail on MT0 >= 32 (For tensorA-T)  # TODO - this randomly causes a segfault, Skip for now
-          - Range: [ [32], [33554432], [1], [32] ]  # strideB = 33554432, should fail on DU >= 16 (For tensorB-T)
-          - Range: [ [32], [16777216], [1], [32] ]  # strideB = 16777216, should fail on DU >= 32 (For tensorB-T)
-
-LibraryLogic:
-    ScheduleName: "vega20"
-    DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Device 66af", "Vega 20"]
-    ArchitectureName: "gfx906"
-
-    ScheduleName: "arcturus"
-    DeviceNames: ["Device 7380", "Device 7388", "Device 738c", "Device 7390"]
-    ArchitectureName: "gfx908"
-
-LibraryClient:
+          - Range: [ [16], [16], [1], [16777216] ]  # strideA = 16777216, should fail on MT0 >= 32 (For tensorA-T)
+          - Range: [ [16], [16777216], [1], [16] ]  # strideB = 16777216, should fail on DU >= 32 (For tensorB-T)

--- a/Tensile/Configs/rocblas_sgemm_bufferload_limit.yaml
+++ b/Tensile/Configs/rocblas_sgemm_bufferload_limit.yaml
@@ -2,9 +2,7 @@ GlobalParameters:
   BoundsCheck: False
   KernelTime: True
   NewClient: 2
-  # PrintSolutionRejectionReason: True
-  # NumElementsToValidate: 65535
-  # CMakeBuildType: Debug
+  PrintSolutionRejectionReason: True
 
 BenchmarkProblems:
 
@@ -34,22 +32,15 @@ BenchmarkProblems:
         - ThreadTile:
           - [ 2, 8 ]
         - WorkGroup:
-          - [ 32, 2, 1 ]  # 64x16
-          - [ 16, 4, 1 ]  # 32x32
           - [ 16, 8, 1 ]  # 32x64
-        - DepthU: [16,32,64]
-        - StaggerU: [0]
-        - StaggerUStride: [256]
-        - StaggerUMapping: [0]
+        - DepthU: [32,64]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [33554432], [64], [1], [64] ]  # strideA = 33554432, should fail on DU >= 32 (For tensorA-N)
-          - Range: [ [16777216], [64], [1], [64] ]  # strideA = 16777216, should fail on DU >= 64 (For tensorA-N)
-          - Range: [ [64], [64], [1], [33554432] ]  # strideB = 33554432, should fail on MT1 >= 32 (For tensorB-N)
-          # - Range: [ [64], [64], [1], [16777216] ]  # strideB = 16777216, should fail on MT1 >= 64 (For tensorB-N)  # TODO - this randomly causes a segfault, Skip for now
+          - Range: [ [16777216], [32], [1], [32] ]  # strideA = 16777216, should fail on DU >= 64 (For tensorA-N)
+          - Range: [ [32], [32], [1], [16777216] ]  # strideB = 16777216, should fail on MT1 >= 64 (For tensorB-N)
 
   ########################################
   # NT / TLUA = 1, TLUB = 1
@@ -77,23 +68,15 @@ BenchmarkProblems:
         - ThreadTile:
           - [ 2, 2 ]
         - WorkGroup:
-          - [ 8, 8, 1 ]  # 16x16
-          - [ 8, 16, 1 ]  # 16x32
-          - [ 16, 8, 1 ]  # 32x16
-        - DepthU: [16,32,64]
-        # - DepthU: [16]
-        - StaggerU: [0]
-        - StaggerUStride: [256]
-        - StaggerUMapping: [0]
+          - [ 16, 16, 1 ]  # 32x32
+        - DepthU: [32,64]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [33554432], [64], [1], [64] ]  # strideA = 33554432, should fail on DU >= 32 (For tensorA-N) # MT16x32x16: PassBufferLoadAssert but FailBufferStoreAssert
-          - Range: [ [16777216], [64], [1], [64] ]  # strideA = 16777216, should fail on DU >= 64 (For tensorA-N)
-          - Range: [ [64], [33554432], [1], [64] ]  # strideB = 33554432, should fail on DU >= 32 (For tensorB-T)
-          - Range: [ [64], [16777216], [1], [64] ]  # strideB = 16777216, should fail on DU >= 64 (For tensorB-T)
+          - Range: [ [16777216], [32], [1], [32] ]  # strideA = 16777216, should fail on DU >= 64 (For tensorA-N)
+          - Range: [ [32], [16777216], [1], [32] ]  # strideB = 16777216, should fail on DU >= 64 (For tensorB-T)
 
   ########################################
   # TN / TLUA = 0, TLUB = 0
@@ -121,23 +104,16 @@ BenchmarkProblems:
         - ThreadTile:
           - [ 2, 2 ]
         - WorkGroup:
-          - [ 8, 8, 1 ]   # 16x16
-          - [ 8, 16, 1 ]  # 16x32
-          - [ 16, 8, 1 ]  # 32x16
           - [ 16, 16, 1 ] # 32x32
           - [ 16, 32, 1 ] # 32x64
           - [ 32, 16, 1 ] # 64x32
         - DepthU: [16]      # DU doesn't affect bufferload limit in TN
-        - StaggerU: [0]
-        - StaggerUStride: [256]
-        - StaggerUMapping: [0]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [64], [64], [1], [33554432] ]  # strideA = 33554432, should fail on MT0 >= 32 (For tensorA-T)  # strideB = 33554432, should fail on MT1 >= 32 (For tensorB-N)
-          - Range: [ [64], [64], [1], [16777216] ]  # strideA = 16777216, should fail on MT0 >= 64 (For tensorA-T)  # strideB = 16777216, should fail on MT1 >= 64 (For tensorB-N)
+          - Range: [ [32], [32], [1], [16777216] ]  # strideA = 16777216, should fail on MT0 >= 64 (For tensorA-T)  # strideB = 16777216, should fail on MT1 >= 64 (For tensorB-N)
 
   ########################################
   # TT / TLUA = 0, TLUB = 1
@@ -165,30 +141,13 @@ BenchmarkProblems:
         - ThreadTile:
           - [ 2, 2 ]
         - WorkGroup:
-          - [ 8, 8, 1 ]   # 16x16
           - [ 16, 8, 1 ]  # 32x16
           - [ 32, 8, 1 ]  # 64x16
-        - DepthU: [16,32,64]
-        - StaggerU: [0]
-        - StaggerUStride: [256]
-        - StaggerUMapping: [0]
+        - DepthU: [32,64]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [64], [64], [1], [33554432] ]  # strideA = 33554432, should fail on MT0 >= 32 (For tensorA-T)
-          # - Range: [ [64], [64], [1], [16777216] ]  # strideA = 16777216, should fail on MT0 >= 64 (For tensorA-T)  # TODO - this randomly causes a segfault, Skip for now
-          - Range: [ [64], [33554432], [1], [64] ]  # strideB = 33554432, should fail on DU >= 32 (For tensorB-T)
-          - Range: [ [64], [16777216], [1], [64] ]  # strideB = 16777216, should fail on DU >= 64 (For tensorB-T)
-
-LibraryLogic:
-    ScheduleName: "vega20"
-    DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Device 66af", "Vega 20"]
-    ArchitectureName: "gfx906"
-
-    ScheduleName: "arcturus"
-    DeviceNames: ["Device 7380", "Device 7388", "Device 738c", "Device 7390"]
-    ArchitectureName: "gfx908"
-
-LibraryClient:
+          - Range: [ [32], [32], [1], [16777216] ]  # strideA = 16777216, should fail on MT0 >= 64 (For tensorA-T)
+          - Range: [ [32], [16777216], [1], [32] ]  # strideB = 16777216, should fail on DU >= 64 (For tensorB-T)

--- a/Tensile/Tests/extended/bufferload_offset/rocblas_dgemm_bufferload_limit.yaml
+++ b/Tensile/Tests/extended/bufferload_offset/rocblas_dgemm_bufferload_limit.yaml
@@ -32,7 +32,6 @@ BenchmarkProblems:
         - ThreadTile:
           - [ 2, 4 ]
         - WorkGroup:
-          - [ 16, 4, 1 ]  # 32x16
           - [ 16, 8, 1 ]  # 32x32
         - DepthU: [16,32]
       BenchmarkForkParameters:
@@ -40,10 +39,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [33554432], [32], [1], [32] ]  # strideA = 33554432, should fail on DU >= 16 (For tensorA-N)
-          - Range: [ [16777216], [32], [1], [32] ]  # strideA = 16777216, should fail on DU >= 32 (For tensorA-N)
-          - Range: [ [32], [32], [1], [33554432] ]  # strideB = 33554432, should fail on MT1 >= 16 (For tensorB-N)
-          - Range: [ [32], [32], [1], [16777216] ]  # strideB = 16777216, should fail on MT1 >= 32 (For tensorB-N)
+          - Range: [ [16777216], [16], [1], [16] ]  # strideA = 16777216, should fail on DU >= 32 (For tensorA-N)
+          - Range: [ [16], [16], [1], [16777216] ]  # strideB = 16777216, should fail on MT1 >= 32 (For tensorB-N)
 
   ########################################
   # NT / TLUA = 1, TLUB = 1
@@ -67,7 +64,7 @@ BenchmarkProblems:
         - LoopTail: [True]
         - WorkGroupMapping: [8]
       ForkParameters:
-        - VectorWidth: [2]          # 4 never wins
+        - VectorWidth: [2]
         - ThreadTile:
           - [ 2, 2 ]
         - WorkGroup:
@@ -78,10 +75,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [33554432], [32], [1], [32] ]  # strideA = 33554432, should fail on DU >= 16 (For tensorA-N)
-          - Range: [ [16777216], [32], [1], [32] ]  # strideA = 16777216, should fail on DU >= 32 (For tensorA-N)
-          - Range: [ [32], [33554432], [1], [32] ]  # strideB = 33554432, should fail on DU >= 16 (For tensorB-T)
-          - Range: [ [32], [16777216], [1], [32] ]  # strideB = 16777216, should fail on DU >= 32 (For tensorB-T)
+          - Range: [ [16777216], [16], [1], [16] ]  # strideA = 16777216, should fail on DU >= 32 (For tensorA-N)
+          - Range: [ [16], [16777216], [1], [16] ]  # strideB = 16777216, should fail on DU >= 32 (For tensorB-T)
 
   ########################################
   # TN / TLUA = 0, TLUB = 0
@@ -105,12 +100,10 @@ BenchmarkProblems:
         - LoopTail: [True]
         - WorkGroupMapping: [8]
       ForkParameters:
-        - VectorWidth: [2]          # 4 never wins
+        - VectorWidth: [2]
         - ThreadTile:
           - [ 2, 2 ]
         - WorkGroup:
-          - [ 4, 8, 2 ]   # 8x16x2
-          - [ 8, 4, 2 ]   # 16x8x2
           - [ 8, 8, 1 ]   # 16x16
           - [ 8, 16, 1 ]  # 16x32
           - [ 16, 8, 1 ]  # 32x16
@@ -120,8 +113,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [32], [32], [1], [33554432] ]  # strideA = 33554432, should fail on MT0 >= 16 (For tensorA-T)  # strideB = 33554432, should fail on MT1 >= 16 (For tensorB-N)
-          - Range: [ [32], [32], [1], [16777216] ]  # strideA = 16777216, should fail on MT0 >= 32 (For tensorA-T)  # strideB = 16777216, should fail on MT1 >= 32 (For tensorB-N)
+          - Range: [ [16], [16], [1], [16777216] ]  # strideA = 16777216, should fail on MT0 >= 32 (For tensorA-T)  # strideB = 16777216, should fail on MT1 >= 32 (For tensorB-N)
 
   ########################################
   # TT / TLUA = 0, TLUB = 1
@@ -145,7 +137,7 @@ BenchmarkProblems:
         - LoopTail: [True]
         - WorkGroupMapping: [8]
       ForkParameters:
-        - VectorWidth: [2]          # 4 never wins
+        - VectorWidth: [2]
         - ThreadTile:
           - [ 2, 2 ]
         - WorkGroup:
@@ -157,17 +149,5 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [32], [32], [1], [33554432] ]  # strideA = 33554432, should fail on MT0 >= 16 (For tensorA-T)
-          - Range: [ [32], [33554432], [1], [32] ]  # strideB = 33554432, should fail on DU >= 16 (For tensorB-T)
-          - Range: [ [32], [16777216], [1], [32] ]  # strideB = 16777216, should fail on DU >= 32 (For tensorB-T)
-
-LibraryLogic:
-    ScheduleName: "vega20"
-    DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Device 66af", "Vega 20"]
-    ArchitectureName: "gfx906"
-
-    ScheduleName: "arcturus"
-    DeviceNames: ["Device 7380", "Device 7388", "Device 738c", "Device 7390"]
-    ArchitectureName: "gfx908"
-
-LibraryClient:
+          - Range: [ [16], [16], [1], [16777216] ]  # strideA = 16777216, should fail on MT0 >= 32 (For tensorA-T)
+          - Range: [ [16], [16777216], [1], [16] ]  # strideB = 16777216, should fail on DU >= 32 (For tensorB-T)

--- a/Tensile/Tests/extended/bufferload_offset/rocblas_sgemm_bufferload_limit.yaml
+++ b/Tensile/Tests/extended/bufferload_offset/rocblas_sgemm_bufferload_limit.yaml
@@ -32,7 +32,6 @@ BenchmarkProblems:
         - ThreadTile:
           - [ 2, 8 ]
         - WorkGroup:
-          - [ 16, 4, 1 ]  # 32x32
           - [ 16, 8, 1 ]  # 32x64
         - DepthU: [32,64]
       BenchmarkForkParameters:
@@ -40,9 +39,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [33554432], [64], [1], [64] ]  # strideA = 33554432, should fail on DU >= 32 (For tensorA-N)
-          - Range: [ [16777216], [64], [1], [64] ]  # strideA = 16777216, should fail on DU >= 64 (For tensorA-N)
-          - Range: [ [64], [64], [1], [33554432] ]  # strideB = 33554432, should fail on MT1 >= 32 (For tensorB-N)
+          - Range: [ [16777216], [32], [1], [32] ]  # strideA = 16777216, should fail on DU >= 64 (For tensorA-N)
+          - Range: [ [32], [32], [1], [16777216] ]  # strideB = 16777216, should fail on MT1 >= 64 (For tensorB-N)
 
   ########################################
   # NT / TLUA = 1, TLUB = 1
@@ -77,10 +75,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [33554432], [64], [1], [64] ]  # strideA = 33554432, should fail on DU >= 32 (For tensorA-N)
-          - Range: [ [16777216], [64], [1], [64] ]  # strideA = 16777216, should fail on DU >= 64 (For tensorA-N)
-          - Range: [ [64], [33554432], [1], [64] ]  # strideB = 33554432, should fail on DU >= 32 (For tensorB-T)
-          - Range: [ [64], [16777216], [1], [64] ]  # strideB = 16777216, should fail on DU >= 64 (For tensorB-T)
+          - Range: [ [16777216], [32], [1], [32] ]  # strideA = 16777216, should fail on DU >= 64 (For tensorA-N)
+          - Range: [ [32], [16777216], [1], [32] ]  # strideB = 16777216, should fail on DU >= 64 (For tensorB-T)
 
   ########################################
   # TN / TLUA = 0, TLUB = 0
@@ -108,8 +104,6 @@ BenchmarkProblems:
         - ThreadTile:
           - [ 2, 2 ]
         - WorkGroup:
-          - [ 8, 16, 1 ]  # 16x32
-          - [ 16, 8, 1 ]  # 32x16
           - [ 16, 16, 1 ] # 32x32
           - [ 16, 32, 1 ] # 32x64
           - [ 32, 16, 1 ] # 64x32
@@ -119,8 +113,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [64], [64], [1], [33554432] ]  # strideA = 33554432, should fail on MT0 >= 32 (For tensorA-T)  # strideB = 33554432, should fail on MT1 >= 32 (For tensorB-N)
-          - Range: [ [64], [64], [1], [16777216] ]  # strideA = 16777216, should fail on MT0 >= 64 (For tensorA-T)  # strideB = 16777216, should fail on MT1 >= 64 (For tensorB-N)
+          - Range: [ [32], [32], [1], [16777216] ]  # strideA = 16777216, should fail on MT0 >= 64 (For tensorA-T)  # strideB = 16777216, should fail on MT1 >= 64 (For tensorB-N)
 
   ########################################
   # TT / TLUA = 0, TLUB = 1
@@ -156,17 +149,5 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [ [64], [64], [1], [33554432] ]  # strideA = 33554432, should fail on MT0 >= 32 (For tensorA-T)
-          - Range: [ [64], [33554432], [1], [64] ]  # strideB = 33554432, should fail on DU >= 32 (For tensorB-T)
-          - Range: [ [64], [16777216], [1], [64] ]  # strideB = 16777216, should fail on DU >= 64 (For tensorB-T)
-
-LibraryLogic:
-    ScheduleName: "vega20"
-    DeviceNames: ["Device 66a0", "Device 66a1", "Device 66a7", "Device 66af", "Vega 20"]
-    ArchitectureName: "gfx906"
-
-    ScheduleName: "arcturus"
-    DeviceNames: ["Device 7380", "Device 7388", "Device 738c", "Device 7390"]
-    ArchitectureName: "gfx908"
-
-LibraryClient:
+          - Range: [ [32], [32], [1], [16777216] ]  # strideA = 16777216, should fail on MT0 >= 64 (For tensorA-T)
+          - Range: [ [32], [16777216], [1], [32] ]  # strideB = 16777216, should fail on DU >= 64 (For tensorB-T)


### PR DESCRIPTION
Update the problem sizes using too large memory which sometimes failed on mem allocation
Keep those that are sufficient large and can test the offset limit