### PR TITLE
Hotfix for PR #1214: count the right instruction type under different scheduling

### DIFF
--- a/Tensile/Tests/pre_checkin/mfma/hpa_hgemm_asm.yaml
+++ b/Tensile/Tests/pre_checkin/mfma/hpa_hgemm_asm.yaml
@@ -32,13 +32,12 @@ BenchmarkProblems:
           - [32, 32, 4, 2]
           - [32, 32, 8, 1]
         - PrefetchLocalRead: [0, 1, 3]
-        - PrefetchGlobalRead: [True]
+        - PrefetchGlobalRead: [1, 2]
         - ThreadTile:
           - [ 2, 32 ]
         - WorkGroup:
           - [  16,16, 1 ]
           - [  32, 8, 1 ]
-          - [  64, 4, 1 ]
           - [ 128, 2, 1 ]
         - WorkGroupMapping: [8]
         - GlobalSplitU: [1]
@@ -64,13 +63,12 @@ BenchmarkProblems:
           - [16, 16,  4, 4]
           - [16, 16, 16, 1]
         - PrefetchLocalRead: [0, 1, 3]
-        - PrefetchGlobalRead: [True]
+        - PrefetchGlobalRead: [1, 2]
         - ThreadTile:
           - [ 2, 32 ]
         - WorkGroup:
           - [  16,16, 1 ]
           - [  32, 8, 1 ]
-          - [  64, 4, 1 ]
           - [ 128, 2, 1 ]
         - WorkGroupMapping: [8]
         - GlobalSplitU: [1]
@@ -95,7 +93,7 @@ BenchmarkProblems:
         - MatrixInstruction:
           - [ 4,  4,  4, 16]
         - PrefetchLocalRead: [0, 1]
-        - PrefetchGlobalRead: [True]
+        - PrefetchGlobalRead: [1, 2]
         - ThreadTile:
           - [ 2, 8 ]
         - WorkGroup:
@@ -126,12 +124,11 @@ BenchmarkProblems:
           - [32, 32, 4, 2]
           - [32, 32, 8, 1]
         - PrefetchLocalRead: [1]
-        - PrefetchGlobalRead: [True]
+        - PrefetchGlobalRead: [1, 2]
         - ThreadTile:
           - [ 2, 32 ]
         - WorkGroup:
           - [  32, 8, 1 ]
-          - [  64, 4, 1 ]
         - WorkGroupMapping: [8]
         - InnerUnroll: [2]
         - DepthU: [32]
@@ -168,13 +165,12 @@ BenchmarkProblems:
           - [32, 32, 4, 2]
           - [32, 32, 8, 1]
         - PrefetchLocalRead: [0, 1, 3]
-        - PrefetchGlobalRead: [True]
+        - PrefetchGlobalRead: [1, 2]
         - ThreadTile:
           - [ 2, 32 ]
         - WorkGroup:
           - [  16,16, 1 ]
           - [  32, 8, 1 ]
-          - [  64, 4, 1 ]
           - [ 128, 2, 1 ]
         - WorkGroupMapping: [8]
         - GlobalSplitU: [1]
@@ -200,13 +196,12 @@ BenchmarkProblems:
           - [16, 16,  4, 4]
           - [16, 16, 16, 1]
         - PrefetchLocalRead: [0, 1, 3]
-        - PrefetchGlobalRead: [True]
+        - PrefetchGlobalRead: [1, 2]
         - ThreadTile:
           - [ 2, 32 ]
         - WorkGroup:
           - [  16,16, 1 ]
           - [  32, 8, 1 ]
-          - [  64, 4, 1 ]
           - [ 128, 2, 1 ]
         - WorkGroupMapping: [8]
         - GlobalSplitU: [1]
@@ -231,7 +226,7 @@ BenchmarkProblems:
         - MatrixInstruction:
           - [ 4,  4,  4, 16]
         - PrefetchLocalRead: [0, 1]
-        - PrefetchGlobalRead: [True]
+        - PrefetchGlobalRead: [1, 2]
         - ThreadTile:
           - [ 2, 8 ]
         - WorkGroup:
@@ -262,12 +257,11 @@ BenchmarkProblems:
           - [32, 32, 4, 2]
           - [32, 32, 8, 1]
         - PrefetchLocalRead: [1]
-        - PrefetchGlobalRead: [True]
+        - PrefetchGlobalRead: [1, 2]
         - ThreadTile:
           - [ 2, 32 ]
         - WorkGroup:
           - [  32, 8, 1 ]
-          - [  64, 4, 1 ]
         - WorkGroupMapping: [8]
         - InnerUnroll: [2]
         - DepthU: [32]
@@ -304,13 +298,12 @@ BenchmarkProblems:
           - [32, 32, 4, 2]
           - [32, 32, 8, 1]
         - PrefetchLocalRead: [0, 1, 3]
-        - PrefetchGlobalRead: [True]
+        - PrefetchGlobalRead: [1, 2]
         - ThreadTile:
           - [ 2, 32 ]
         - WorkGroup:
           - [  16,16, 1 ]
           - [  32, 8, 1 ]
-          - [  64, 4, 1 ]
           - [ 128, 2, 1 ]
         - WorkGroupMapping: [8]
         - GlobalSplitU: [1]
@@ -336,13 +329,12 @@ BenchmarkProblems:
           - [16, 16,  4, 4]
           - [16, 16, 16, 1]
         - PrefetchLocalRead: [0, 1, 3]
-        - PrefetchGlobalRead: [True]
+        - PrefetchGlobalRead: [1, 2]
         - ThreadTile:
           - [ 2, 32 ]
         - WorkGroup:
           - [  16,16, 1 ]
           - [  32, 8, 1 ]
-          - [  64, 4, 1 ]
           - [ 128, 2, 1 ]
         - WorkGroupMapping: [8]
         - GlobalSplitU: [1]
@@ -367,7 +359,7 @@ BenchmarkProblems:
         - MatrixInstruction:
           - [ 4,  4,  4, 16]
         - PrefetchLocalRead: [0, 1]
-        - PrefetchGlobalRead: [True]
+        - PrefetchGlobalRead: [1, 2]
         - ThreadTile:
           - [ 2, 8 ]
         - WorkGroup:
@@ -398,12 +390,11 @@ BenchmarkProblems:
           - [32, 32, 4, 2]
           - [32, 32, 8, 1]
         - PrefetchLocalRead: [1]
-        - PrefetchGlobalRead: [True]
+        - PrefetchGlobalRead: [1, 2]
         - ThreadTile:
           - [ 2, 32 ]
         - WorkGroup:
           - [  32, 8, 1 ]
-          - [  64, 4, 1 ]
         - WorkGroupMapping: [8]
         - InnerUnroll: [2]
         - DepthU: [32]
@@ -440,13 +431,12 @@ BenchmarkProblems:
           - [32, 32, 4, 2]
           - [32, 32, 8, 1]
         - PrefetchLocalRead: [0, 1, 3]
-        - PrefetchGlobalRead: [True]
+        - PrefetchGlobalRead: [1, 2]
         - ThreadTile:
           - [ 2, 32 ]
         - WorkGroup:
           - [  16,16, 1 ]
           - [  32, 8, 1 ]
-          - [  64, 4, 1 ]
           - [ 128, 2, 1 ]
         - WorkGroupMapping: [8]
         - GlobalSplitU: [1]
@@ -472,13 +462,12 @@ BenchmarkProblems:
           - [16, 16,  4, 4]
           - [16, 16, 16, 1]
         - PrefetchLocalRead: [0, 1, 3]
-        - PrefetchGlobalRead: [True]
+        - PrefetchGlobalRead: [1, 2]
         - ThreadTile:
           - [ 2, 32 ]
         - WorkGroup:
           - [  16,16, 1 ]
           - [  32, 8, 1 ]
-          - [  64, 4, 1 ]
           - [ 128, 2, 1 ]
         - WorkGroupMapping: [8]
         - GlobalSplitU: [1]
@@ -503,7 +492,7 @@ BenchmarkProblems:
         - MatrixInstruction:
           - [ 4,  4,  4, 16]
         - PrefetchLocalRead: [0, 1]
-        - PrefetchGlobalRead: [True]
+        - PrefetchGlobalRead: [1, 2]
         - ThreadTile:
           - [ 2, 8 ]
         - WorkGroup:
@@ -534,12 +523,11 @@ BenchmarkProblems:
           - [32, 32, 4, 2]
           - [32, 32, 8, 1]
         - PrefetchLocalRead: [1]
-        - PrefetchGlobalRead: [True]
+        - PrefetchGlobalRead: [1, 2]
         - ThreadTile:
           - [ 2, 32 ]
         - WorkGroup:
           - [  32, 8, 1 ]
-          - [  64, 4, 1 ]
         - WorkGroupMapping: [8]
         - InnerUnroll: [2]
         - DepthU: [32]

--- a/Tensile/Tests/pre_checkin/mfma/hpa_hgemm_split_lds.yaml
+++ b/Tensile/Tests/pre_checkin/mfma/hpa_hgemm_split_lds.yaml
@@ -83,3 +83,36 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Range: [ [128], [128], [1], [256] ]
+
+    # test cases for a regression case in scheduler due to recent refactor to do
+    # scheduling which depends on the information provided by the instruction type
+    #
+    # since some part of the codes were still in form of raw string, they were eff`ectively ignored by the scheduler
+    #
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - TransposeLDS: [1]
+        - MatrixInstruction:
+          - [32, 32, 8, 1, 1, 1, 1, 2, 2]  # 64x64
+        - PrefetchLocalRead: [5]
+        - PrefetchGlobalRead: [2]
+        - ThreadTile:
+          - [ 1, 32 ] # param ignored since 9-tuple MI format
+        - WorkGroup:
+          - [ 16, 16, 1 ] # param ignored since 9-tuple MI format
+        - DepthU: [32]
+        - DepthULdsDivisor: [1]
+        - ScheduleIterAlg: [3]
+        - GlobalReadVectorWidth: [4]
+        - LocalReadVectorWidth: [8]
+        - 1LDSBuffer: [0,1]
+        - StaggerU: [0,16]
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [128], [128], [1], [256] ]

--- a/Tensile/Tests/pre_checkin/mfma/sgemm_asm.yaml
+++ b/Tensile/Tests/pre_checkin/mfma/sgemm_asm.yaml
@@ -29,11 +29,9 @@ BenchmarkProblems:
       ForkParameters:
         - MatrixInstruction:
           - [32, 32, 1, 2]
-        - PrefetchGlobalRead: [True]
+        - PrefetchGlobalRead: [1, 2]
         - ThreadTile:
           - [ 1, 32 ]
-          - [ 2, 32 ]
-          - [ 4, 32 ]
           - [ 1, 64 ]
           - [ 2, 64 ]
           - [ 4, 64 ]
@@ -63,10 +61,9 @@ BenchmarkProblems:
       ForkParameters:
         - MatrixInstruction:
           - [32, 32, 2, 1]
-        - PrefetchGlobalRead: [True]
+        - PrefetchGlobalRead: [1, 2]
         - ThreadTile:
           - [ 1, 32 ]
-          - [ 2, 32 ]
           - [ 4, 32 ]
           - [ 1, 64 ]
           - [ 2, 64 ]
@@ -95,12 +92,11 @@ BenchmarkProblems:
       ForkParameters:
         - MatrixInstruction:
           - [16, 16, 1, 4]
-        - PrefetchGlobalRead: [True]
+        - PrefetchGlobalRead: [1, 2]
         - ThreadTile:
           - [ 2, 16 ]
           - [ 4, 16 ]
           - [ 8, 16 ]
-          - [ 2, 32 ]
           - [ 4, 32 ]
           - [ 2, 64 ]
         - WorkGroup:
@@ -129,12 +125,11 @@ BenchmarkProblems:
       ForkParameters:
         - MatrixInstruction:
           - [16, 16, 4, 1]
-        - PrefetchGlobalRead: [True]
+        - PrefetchGlobalRead: [1, 2]
         - ThreadTile:
           - [ 2, 16 ]
           - [ 4, 16 ]
           - [ 8, 16 ]
-          - [ 2, 32 ]
           - [ 4, 32 ]
           - [ 2, 64 ]
         - WorkGroup:
@@ -162,7 +157,7 @@ BenchmarkProblems:
       ForkParameters:
         - MatrixInstruction:
           - [ 4, 4, 1, 16]
-        - PrefetchGlobalRead: [True]
+        - PrefetchGlobalRead: [1, 2]
         - ThreadTile:
           - [ 2,  8 ]
           - [ 2, 16 ]
@@ -201,10 +196,9 @@ BenchmarkProblems:
       ForkParameters:
         - MatrixInstruction:
           - [32, 32, 1, 2]
-        - PrefetchGlobalRead: [True]
+        - PrefetchGlobalRead: [1, 2]
         - ThreadTile:
           - [ 1, 32 ]
-          - [ 2, 32 ]
           - [ 4, 32 ]
           - [ 1, 64 ]
           - [ 2, 64 ]
@@ -235,10 +229,9 @@ BenchmarkProblems:
       ForkParameters:
         - MatrixInstruction:
           - [32, 32, 2, 1]
-        - PrefetchGlobalRead: [True]
+        - PrefetchGlobalRead: [1, 2]
         - ThreadTile:
           - [ 1, 32 ]
-          - [ 2, 32 ]
           - [ 4, 32 ]
           - [ 1, 64 ]
           - [ 2, 64 ]
@@ -267,12 +260,11 @@ BenchmarkProblems:
       ForkParameters:
         - MatrixInstruction:
           - [16, 16, 1, 4]
-        - PrefetchGlobalRead: [True]
+        - PrefetchGlobalRead: [1, 2]
         - ThreadTile:
           - [ 2, 16 ]
           - [ 4, 16 ]
           - [ 8, 16 ]
-          - [ 2, 32 ]
           - [ 4, 32 ]
           - [ 2, 64 ]
         - WorkGroup:
@@ -301,12 +293,11 @@ BenchmarkProblems:
       ForkParameters:
         - MatrixInstruction:
           - [16, 16, 4, 1]
-        - PrefetchGlobalRead: [True]
+        - PrefetchGlobalRead: [1, 2]
         - ThreadTile:
           - [ 2, 16 ]
           - [ 4, 16 ]
           - [ 8, 16 ]
-          - [ 2, 32 ]
           - [ 4, 32 ]
           - [ 2, 64 ]
         - WorkGroup:
@@ -334,7 +325,7 @@ BenchmarkProblems:
       ForkParameters:
         - MatrixInstruction:
           - [ 4, 4, 1, 16]
-        - PrefetchGlobalRead: [True]
+        - PrefetchGlobalRead: [1, 2]
         - ThreadTile:
           - [ 2,  8 ]
           - [ 2, 16 ]
@@ -373,10 +364,9 @@ BenchmarkProblems:
       ForkParameters:
         - MatrixInstruction:
           - [32, 32, 1, 2]
-        - PrefetchGlobalRead: [True]
+        - PrefetchGlobalRead: [1, 2]
         - ThreadTile:
           - [ 1, 32 ]
-          - [ 2, 32 ]
           - [ 4, 32 ]
           - [ 1, 64 ]
           - [ 2, 64 ]
@@ -407,10 +397,9 @@ BenchmarkProblems:
       ForkParameters:
         - MatrixInstruction:
           - [32, 32, 2, 1]
-        - PrefetchGlobalRead: [True]
+        - PrefetchGlobalRead: [1, 2]
         - ThreadTile:
           - [ 1, 32 ]
-          - [ 2, 32 ]
           - [ 4, 32 ]
           - [ 1, 64 ]
           - [ 2, 64 ]
@@ -439,12 +428,11 @@ BenchmarkProblems:
       ForkParameters:
         - MatrixInstruction:
           - [16, 16, 1, 4]
-        - PrefetchGlobalRead: [True]
+        - PrefetchGlobalRead: [1, 2]
         - ThreadTile:
           - [ 2, 16 ]
           - [ 4, 16 ]
           - [ 8, 16 ]
-          - [ 2, 32 ]
           - [ 4, 32 ]
           - [ 2, 64 ]
         - WorkGroup:
@@ -473,12 +461,11 @@ BenchmarkProblems:
       ForkParameters:
         - MatrixInstruction:
           - [16, 16, 4, 1]
-        - PrefetchGlobalRead: [True]
+        - PrefetchGlobalRead: [1, 2]
         - ThreadTile:
           - [ 2, 16 ]
           - [ 4, 16 ]
           - [ 8, 16 ]
-          - [ 2, 32 ]
           - [ 4, 32 ]
           - [ 2, 64 ]
         - WorkGroup:
@@ -506,7 +493,7 @@ BenchmarkProblems:
       ForkParameters:
         - MatrixInstruction:
           - [ 4, 4, 1, 16]
-        - PrefetchGlobalRead: [True]
+        - PrefetchGlobalRead: [1, 2]
         - ThreadTile:
           - [ 2,  8 ]
           - [ 2, 16 ]
@@ -545,10 +532,9 @@ BenchmarkProblems:
       ForkParameters:
         - MatrixInstruction:
           - [32, 32, 1, 2]
-        - PrefetchGlobalRead: [True]
+        - PrefetchGlobalRead: [1, 2]
         - ThreadTile:
           - [ 1, 32 ]
-          - [ 2, 32 ]
           - [ 4, 32 ]
           - [ 1, 64 ]
           - [ 2, 64 ]
@@ -579,10 +565,9 @@ BenchmarkProblems:
       ForkParameters:
         - MatrixInstruction:
           - [32, 32, 2, 1]
-        - PrefetchGlobalRead: [True]
+        - PrefetchGlobalRead: [1, 2]
         - ThreadTile:
           - [ 1, 32 ]
-          - [ 2, 32 ]
           - [ 4, 32 ]
           - [ 1, 64 ]
           - [ 2, 64 ]
@@ -611,12 +596,11 @@ BenchmarkProblems:
       ForkParameters:
         - MatrixInstruction:
           - [16, 16, 1, 4]
-        - PrefetchGlobalRead: [True]
+        - PrefetchGlobalRead: [1, 2]
         - ThreadTile:
           - [ 2, 16 ]
           - [ 4, 16 ]
           - [ 8, 16 ]
-          - [ 2, 32 ]
           - [ 4, 32 ]
           - [ 2, 64 ]
         - WorkGroup:
@@ -645,12 +629,11 @@ BenchmarkProblems:
       ForkParameters:
         - MatrixInstruction:
           - [16, 16, 4, 1]
-        - PrefetchGlobalRead: [True]
+        - PrefetchGlobalRead: [1, 2]
         - ThreadTile:
           - [ 2, 16 ]
           - [ 4, 16 ]
           - [ 8, 16 ]
-          - [ 2, 32 ]
           - [ 4, 32 ]
           - [ 2, 64 ]
         - WorkGroup:
@@ -678,7 +661,7 @@ BenchmarkProblems:
       ForkParameters:
         - MatrixInstruction:
           - [ 4, 4, 1, 16]
-        - PrefetchGlobalRead: [True]
+        - PrefetchGlobalRead: [1, 2]
         - ThreadTile:
           - [ 2,  8 ]
           - [ 2, 16 ]


### PR DESCRIPTION
Fixed instruction scheduler regression.  rocblas-test passed when built against latest rocBLAS logic files. 

Regression due to recent refactor to do scheduling depending on the information provided by the instruction type. Since some of the codes emitted were still in form of raw string instead of `Code.Inst`, they were effectively ignored by the scheduler and therefore failed to generate valid codes