### PR TITLE
Fix the misleading/outdated comments for DataInitType

### DIFF
--- a/Tensile/ClientWriter.py
+++ b/Tensile/ClientWriter.py
@@ -33,6 +33,7 @@ from enum import Enum
 from .Contractions import FreeIndex
 from .Contractions import ProblemType as ContractionsProblemType
 
+# NOTE- For NewClient only
 class DataInitName(Enum):
   Zero = 0
   One = 1

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -136,6 +136,13 @@ globalParameters["CSVMergeSameProblemID"] = False
 # trig_float initializes with the sin function to have non-zero values in the mantissa
 # and exponent. It cannot be used for int8 or int32. Need to use tensileAlmostEqual
 # not tensileEqual for checking the result.
+# NOTE- the following comments explaining the DataInitType are for OldClient and should be obsolete.
+#       For NewClient, please read ClientWriter.py, the DataInitName(Enum)
+#       - Problem-Independent: 0=0, 1=1, 2=2, 3=rand, 4=Nan, 5=Infinity, 6=BadInput(Nan), 7=BadOutput(Inf), 16=RandomNarrow
+#       - Problem-dependent: 8=SerialID, 9=SerialDim0, 10=SerialDim1, 11=Identity, 12~15= Cos/Sin, Abs or Not
+#       For A, B, C, D: All the InitMode (0~16) can be used
+#       For Alpha/Beta: Only problem-independent init (0~7, 16) can be used,
+#                       problem-dependent init (8~15) would cause a exception (Invalid InitMode) in New Client
 globalParameters["DataInitTypeAB"] = 3            # 0=0, 1=1, 2=serial, 3=rand, 4=NaN, 5=serial-in-u, 6=trig_float.  Can be overridden by the DataInitTypeA or DataInitTypeB.  Eventually DataInitTypeAB will be retired.
 globalParameters["DataInitTypeA"] = -1            # 0=0, 1=1, 2=serial, 3=rand, 4=NaN, 5=serial-in-u, 6=trig_float.  -1 uses value from DataInitTypeAB
 globalParameters["DataInitTypeB"] = -1            # 0=0, 1=1, 2=serial, 3=rand, 4=NaN, 5=serial-in-u, 6=trig_float.  -1 uses value from DataInitTypeAB
@@ -143,6 +150,7 @@ globalParameters["DataInitTypeC"]  = 3            # 0=0, 1=1, 2=serial, 3=rand, 
 globalParameters["DataInitTypeD"]  = 0            # 0=0, 1=1, 2=serial, 3=rand, 4=Na, 5=serial-in-uN, 6=trig_float.
 globalParameters["DataInitTypeAlpha"] = 2         # 0=0, 1=1, 2=2, 3=rand, 4=NaN
 globalParameters["DataInitTypeBeta"] = 2          # 0=0, 1=1, 2=2, 3=rand, 4=NaN
+
 globalParameters["CEqualD"] = True               # Set to true if testing for the case where the pointer to C is the same as D.
 # build parameters
 globalParameters["CMakeCXXFlags"] = ""            # pass flags to cmake

--- a/Tensile/Source/client/include/DataInitialization.hpp
+++ b/Tensile/Source/client/include/DataInitialization.hpp
@@ -43,6 +43,8 @@ namespace Tensile
 {
     namespace Client
     {
+        // Problem-indept. from 0~7, and 16 (fixed values for every problem)
+        // And problem-dept. from 8~15 (values depend on problem)
         enum class InitMode
         {
             Zero = 0, // 0


### PR DESCRIPTION
Comments explaining the **DataInitType** are outdated and could be mis-leading since **new-client** is different from old-client.
Just update some new comments to clarify the meaning.

Adding this PR due to #1239 , this should help
NoCI since this is a pure comment-editing