### PR TITLE
Git-ignore top level *.yaml and *.txt files only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,9 @@ Tensile.egg-info
 build*
 dist
 .cache
-*.yaml
-*.txt
-log
+/*.yaml
+/*.txt
+/*log*
 
 0_Build
 1_BenchmarkProblems


### PR DESCRIPTION
Originally added in 71b64859, the git-ignore patterns was meant for filtering out temporarily log files and yaml files in the top level folder. But was actually filtering out every matching files not just the top level ones.