### PR TITLE
Fix configuration: ShortNames

### DIFF
--- a/Tensile/KernelWriter.py
+++ b/Tensile/KernelWriter.py
@@ -3483,14 +3483,14 @@ class KernelWriter(metaclass=abc.ABCMeta):
   # get kernel name
   ##############################################################################
   def getKernelFileBase(self, kernel):
-    rv = self.getKernelName(kernel)
-    return self.shortenFileBase(rv)
+    if globalParameters["ShortNames"]:
+      fileBase = Solution.getNameSerial(kernel, self.kernelSerialNaming)
+    else:
+      fileBase = self.shortenFileBase(kernel)
+    return fileBase
 
   def getKernelName(self, kernel):
-    if globalParameters["ShortNames"]:
-      kernelName = Solution.getNameSerial(kernel, self.kernelSerialNaming)
-    else:
-      kernelName = Solution.getNameMin(kernel, self.kernelMinNaming)
+    kernelName = Solution.getNameMin(kernel, self.kernelMinNaming)
     return kernelName
 
   def getKernelSource(self, kernel):
@@ -3596,7 +3596,8 @@ for codeObjectFileName in codeObjectFileNames:
     kernelName = self.getKernelName(kernel)
     return ReplacementKernels.Get(kernelName)
 
-  def shortenFileBase(self, base):
+  def shortenFileBase(self, kernel):
+    base = self.getKernelName(kernel)
     if len(base) <= globalParameters["MaxFileName"]:
       return base
 
@@ -3615,7 +3616,7 @@ for codeObjectFileName in codeObjectFileNames:
   def getKernelObjectAssemblyFile(self, kernel):
     asmPath = self.getAssemblyDirectory()
     # write assembly file to assembly directory
-    kernelName = self.shortenFileBase(self.getKernelName(kernel))
+    kernelName = self.getKernelFileBase(kernel)
     fileBase = os.path.join(asmPath, kernelName )
     assemblyFileName = "%s.s" % fileBase
 

--- a/Tensile/LibraryIO.py
+++ b/Tensile/LibraryIO.py
@@ -159,7 +159,7 @@ def readLibraryLogicForSchedule( filename ):
     if solutionState["KernelLanguage"] == "Assembly":
       solutionState["ISA"] = Common.gfxArch(architectureName)
     else:
-      solutionState["ISA"] = [0, 0, 0]
+      solutionState["ISA"] = (0, 0, 0)
     # force redo the deriving of parameters, make sure old version logic yamls can be validated
     solutionState["AssignedProblemIndependentDerivedParameters"] = False
     solutionState["AssignedDerivedParameters"] = False

--- a/Tensile/SolutionWriter.py
+++ b/Tensile/SolutionWriter.py
@@ -57,10 +57,7 @@ class SolutionWriter:
   # get solution name
   ##############################################################################
   def getSolutionName(self, solution):
-    if globalParameters["ShortNames"]:
-      solutionName = Solution.getNameSerial(solution, self.solutionSerialNaming)
-    else:
-      solutionName = Solution.getNameMin(solution, self.solutionMinNaming)
+    solutionName = Solution.getNameMin(solution, self.solutionMinNaming)
     return solutionName
 
   ##############################################################################

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -941,13 +941,8 @@ def writeSolutionCall(solutionName, problemType):
 def getSolutionAndKernelWriters(solutions, kernels):
 
   # if any kernels are assembly, append every ISA supported
-
-  if globalParameters["ShortNames"] and not globalParameters["MergeFiles"]:
-    solutionSerialNaming = Solution.getSerialNaming(solutions)
-    kernelSerialNaming   = Solution.getSerialNaming(kernels)
-  else:
-    solutionSerialNaming = None
-    kernelSerialNaming   = None
+  solutionSerialNaming = Solution.getSerialNaming(solutions)
+  kernelSerialNaming   = Solution.getSerialNaming(kernels)
 
   solutionMinNaming    = Solution.getMinNaming(solutions)
   kernelMinNaming      = Solution.getMinNaming(kernels)

--- a/Tensile/Tests/integration/test_integration.py
+++ b/Tensile/Tests/integration/test_integration.py
@@ -84,7 +84,7 @@ def str2bool(mergeFiles, shortNames, legacyComponents):
 @pytest.mark.parametrize("testYamls",         ["quick", "pre_checkin"])
 @pytest.mark.parametrize("mergeFiles",        ["mergeFiles", "noMergeFiles"])
 @pytest.mark.parametrize("libraryFormat",     ["yaml", pytest.param("msgpack", marks=pytest.mark.xfail)])
-@pytest.mark.parametrize("shortNames",        [pytest.param("shortNames", marks=pytest.mark.xfail), "noShortName"])
+@pytest.mark.parametrize("shortNames",        ["shortNames", "noShortName"])
 @pytest.mark.parametrize("legacyComponents",  ["legacyComponents", "noLegacyComponents"])
 def test_integration(useGlobalParameters, builddir, getLogicFileDir,
                      testYamls, mergeFiles, libraryFormat, shortNames, legacyComponents):


### PR DESCRIPTION
Depends on #1242

- Fix global parameter "ShortNames"; brought to you by @aazz44ss
- Remove `xfail` status of TensileCreateLibrary integration test involving the said parameter

