### PR TITLE
Workflow for manually editing Kernels

### DIFF
--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -559,8 +559,8 @@ class KernelWriterAssembly(KernelWriter):
     self.overlapVgprC = False
     self.serializedStore = False
 
-  def getCompileArgs(self, sourceFileName, objectFileName, *moreArgs):
-    isa = self.version
+  def getCompileArgs(self, sourceFileName, objectFileName, *moreArgs, useGlobalISA=False):
+    isa = self.version if not useGlobalISA else globalParameters["CurrentISA"]
     archHasV3 = globalParameters["AsmCaps"][isa]["HasCodeObjectV3"]
 
     rv = [globalParameters['AssemblerPath'],

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -280,14 +280,14 @@ def prepAsmNewClient(kernelWriterAssembly):
     assemblerFile.write("copy %1.s %1.o\n")
     assemblerFile.write("copy %1.o %1.co\n")
   else:
-    assemblerFile.write("#!/bin/sh %s\n" % ("-x" if globalParameters["PrintLevel"] >=2  else ""))
+    assemblerFile.write("#!/bin/sh {log}\n".format(log = "-x" if globalParameters["PrintLevel"] >=2  else ""))
     assemblerFile.write("# usage: asm-new.sh kernelName(no extension)\n")
 
     assemblerFile.write("f=$1\n")
     assemblerFile.write("shift\n")
 
     isa = globalParameters["CurrentISA"]
-    assemblerFile.write("h=gfx%s\n" % "".join(map(str,isa)))
+    assemblerFile.write("h={gfxName}\n".format(gfxName = Common.gfxName(isa)))
 
     cArgs = kernelWriterAssembly.getCompileArgs("$f.s", "$f.o", useGlobalISA=True)
     lArgs = kernelWriterAssembly.getLinkCodeObjectArgs(["$f.o"], "$f.co")


### PR DESCRIPTION
The old tensile client allowed making manual edits to generated kernels and testing them out using the generated `asm` script. Added a similar generated script, `asm-new`, which accomplishes a similar workflow for use with the new client.