### PR TITLE
Framework for filtering solutions

### DIFF
--- a/Tensile/ClientWriter.py
+++ b/Tensile/ClientWriter.py
@@ -689,6 +689,7 @@ def writeClientConfigIni(problemSizes, problemType, sourceDir, codeObjectFiles, 
         param("csv-merge-same-problems",  globalParameters["CSVMergeSameProblemID"])
         param("log-level",                ClientLogLevel(globalParameters["ClientLogLevel"]).name)
         param("max-workspace-size",       globalParameters["MaxWorkspaceSize"])
+        param("granularity-threshold",    globalParameters["GranularityThreshold"])
 
 def writeClientConfig(forBenchmark, solutions, problemSizes, stepName, stepBaseDir, newLibrary, codeObjectFiles, tileAwareSelection, configBase = "ClientParameters", libraryFile = None):
 

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -239,6 +239,9 @@ globalParameters["PerfModelReadEfficiency"] = 0.85
 globalParameters["MaxWorkspaceSize"] = 32 * 1024 * 1024 # max workspace for training (32M)
 globalParameters["MinKForGSU"] = 256 # min K size to use GlobalSplitU algorithm (only for HPA now)
 
+# control if a solution is run for a given problem
+globalParameters["GranularityThreshold"] = 0.0
+
 # Save a copy - since pytest doesn't re-run this initialization code and YAML files can override global settings - odd things can happen
 defaultGlobalParameters = deepcopy(globalParameters)
 
@@ -842,7 +845,7 @@ validParameters = {
     # If the ThreadTile is > VectorWidth then thread0 will next operate on the 4 elements in C at (4*NumThreads)
     # Typically the load vector width and store vector width are directly related to the VW.
     # The global load width is closely related to the width of local stores so
-    # GlobalReadVectorWidth also ontrols local write width.
+    # GlobalReadVectorWidth also controls local write width.
     # Local read width also matches since VectorWidth consec elements must be read
     # Typically matching 16 bytes is good choice since the stores will be optimally coalesced with 16 bytes/WI.
     # -1 means use the largest vector width up to 128 bits.

--- a/Tensile/Source/client/include/SolutionIterator.hpp
+++ b/Tensile/Source/client/include/SolutionIterator.hpp
@@ -129,8 +129,8 @@ namespace Tensile
         class AllSolutionsIterator : public SolutionIterator
         {
         public:
-            using RunCriteria = std::vector<
-                std::function<bool(ContractionSolution::ProjectedPerformance const&)>>;
+            using RunCriteria = std::vector<std::function<bool(
+                ContractionProblem const&, Hardware const&, ContractionSolution const&)>>;
 
             static RunCriteria
                 CreateCriteria(std::shared_ptr<MasterSolutionLibrary<ContractionProblem>> library,

--- a/Tensile/Source/client/include/SolutionIterator.hpp
+++ b/Tensile/Source/client/include/SolutionIterator.hpp
@@ -30,6 +30,9 @@
 
 #include <boost/program_options.hpp>
 
+#include <functional>
+#include <vector>
+
 #include "RunListener.hpp"
 
 namespace Tensile
@@ -126,10 +129,19 @@ namespace Tensile
         class AllSolutionsIterator : public SolutionIterator
         {
         public:
+            using RunCriteria = std::vector<
+                std::function<bool(ContractionSolution::ProjectedPerformance const&)>>;
+
+            static RunCriteria
+                CreateCriteria(std::shared_ptr<MasterSolutionLibrary<ContractionProblem>> library,
+                               std::shared_ptr<Hardware>                                  hardware,
+                               po::variables_map const&                                   args);
+
             AllSolutionsIterator(std::shared_ptr<MasterSolutionLibrary<ContractionProblem>> library,
                                  std::shared_ptr<Hardware> hardware,
                                  int                       firstSolutionIdx,
-                                 int                       numSolutions);
+                                 int                       numSolutions,
+                                 RunCriteria               runCriteria = RunCriteria());
 
             virtual void preProblem(ContractionProblem const& problem) override;
             virtual void postProblem() override;
@@ -139,12 +151,15 @@ namespace Tensile
 
             virtual bool                                 moreSolutionsInProblem() const override;
             virtual std::shared_ptr<ContractionSolution> getSolution() override;
+            virtual bool                                 runCurrentSolution() override;
 
         private:
             int m_firstSolutionIdx;
             int m_lastSolutionIdx;
 
             int m_currentSolutionIdx;
+
+            RunCriteria m_runCriteria;
         };
 
         class BestSolutionIterator : public SolutionIterator

--- a/Tensile/Source/client/main.cpp
+++ b/Tensile/Source/client/main.cpp
@@ -139,7 +139,7 @@ namespace Tensile
                 ("print-tensor-d",           po::value<bool>()->default_value(false), "Print tensor D.")
                 ("print-tensor-ref",         po::value<bool>()->default_value(false), "Print reference tensor D.")
 
-                ("dump-tensors",           po::value<bool>()->default_value(false),  "Binary dump tensors instead of printing.")
+                ("dump-tensors",             po::value<bool>()->default_value(false),  "Binary dump tensors instead of printing.")
 
                 ("convolution-identifier",   po::value<std::string>(), "Convolution problem identifer:  ConvolutionType_ActFormat_FilterFormat_Filter_Stride_Dilation_Groups.  Example: ConvolutionBackwardWeights_NCHW_filter:3x3_stride:1x1_dilation:1x1_groups:1.  Batch count, spacial dimensions (H,W,D), Cin and Cout filters are determined by the problem dimensions.")
                 ("convolution-vs-contraction",  po::value<bool>()->default_value(false), "Compare reference convolution against contraction.")
@@ -214,6 +214,7 @@ namespace Tensile
                 ("exit-on-failure",          po::value<bool>()->default_value(false), "Exit run early on failed kernels.")
                 ("selection-only",           po::value<bool>()->default_value(false), "Don't run any solutions, only print kernel selections.")
                 ("max-workspace-size",       po::value<size_t>()->default_value(32*1024*1024), "Max workspace for training")
+                ("granularity-threshold",    po::value<double>()->default_value(0.0), "Don't run a solution if total granularity is below")
                 ;
             // clang-format on
 

--- a/Tensile/Source/client/main.cpp
+++ b/Tensile/Source/client/main.cpp
@@ -139,7 +139,7 @@ namespace Tensile
                 ("print-tensor-d",           po::value<bool>()->default_value(false), "Print tensor D.")
                 ("print-tensor-ref",         po::value<bool>()->default_value(false), "Print reference tensor D.")
 
-                ("dump-tensors",             po::value<bool>()->default_value(false),  "Binary dump tensors instead of printing.")
+                ("dump-tensors",             po::value<bool>()->default_value(false), "Binary dump tensors instead of printing.")
 
                 ("convolution-identifier",   po::value<std::string>(), "Convolution problem identifer:  ConvolutionType_ActFormat_FilterFormat_Filter_Stride_Dilation_Groups.  Example: ConvolutionBackwardWeights_NCHW_filter:3x3_stride:1x1_dilation:1x1_groups:1.  Batch count, spacial dimensions (H,W,D), Cin and Cout filters are determined by the problem dimensions.")
                 ("convolution-vs-contraction",  po::value<bool>()->default_value(false), "Compare reference convolution against contraction.")
@@ -203,14 +203,14 @@ namespace Tensile
                 ("problem-start-idx",        po::value<int>()->default_value(0),  "First problem to run")
                 ("num-problems",             po::value<int>()->default_value(-1), "Number of problems to run")
 
-                ("solution-start-idx",       po::value<int>()->default_value(-1),  "First solution to run")
+                ("solution-start-idx",       po::value<int>()->default_value(-1), "First solution to run")
                 ("num-solutions",            po::value<int>()->default_value(-1), "Number of solutions to run")
                 ("best-solution",            po::value<bool>()->default_value(false), "Best solution benchmark mode")
 
                 ("results-file",             po::value<std::string>()->default_value("results.csv"), "File name to write results.")
                 ("log-file",                 po::value<std::string>(),                               "File name for output log.")
                 ("log-file-append",          po::value<bool>()->default_value(false),                "Append to log file.")
-                ("log-level",                po::value<LogLevel>()->default_value(LogLevel::Debug),                "Log level")
+                ("log-level",                po::value<LogLevel>()->default_value(LogLevel::Debug),  "Log level")
                 ("exit-on-failure",          po::value<bool>()->default_value(false), "Exit run early on failed kernels.")
                 ("selection-only",           po::value<bool>()->default_value(false), "Don't run any solutions, only print kernel selections.")
                 ("max-workspace-size",       po::value<size_t>()->default_value(32*1024*1024), "Max workspace for training")

--- a/Tensile/Source/client/source/SolutionIterator.cpp
+++ b/Tensile/Source/client/source/SolutionIterator.cpp
@@ -48,10 +48,12 @@ namespace Tensile
                 int firstSolutionIdx = args["solution-start-idx"].as<int>();
                 int numSolutions     = args["num-solutions"].as<int>();
 
-                auto criteria = AllSolutionsIterator::CreateCriteria(library, hardware, args);
-
                 return std::make_shared<AllSolutionsIterator>(
-                    library, hardware, firstSolutionIdx, numSolutions, criteria);
+                    library,
+                    hardware,
+                    firstSolutionIdx,
+                    numSolutions,
+                    AllSolutionsIterator::CreateCriteria(library, hardware, args));
             }
         }
 
@@ -115,7 +117,6 @@ namespace Tensile
             RunCriteria criteria;
 
             double granThresh = args["granularity-threshold"].as<double>();
-
             if(granThresh > 0.0)
             {
                 criteria.push_back(

--- a/Tensile/Source/client/source/SolutionIterator.cpp
+++ b/Tensile/Source/client/source/SolutionIterator.cpp
@@ -48,8 +48,10 @@ namespace Tensile
                 int firstSolutionIdx = args["solution-start-idx"].as<int>();
                 int numSolutions     = args["num-solutions"].as<int>();
 
+                auto criteria = AllSolutionsIterator::CreateCriteria(library, hardware, args);
+
                 return std::make_shared<AllSolutionsIterator>(
-                    library, hardware, firstSolutionIdx, numSolutions);
+                    library, hardware, firstSolutionIdx, numSolutions, criteria);
             }
         }
 
@@ -105,12 +107,33 @@ namespace Tensile
             return checkSolution(*solution);
         }
 
+        AllSolutionsIterator::RunCriteria AllSolutionsIterator::CreateCriteria(
+            std::shared_ptr<MasterSolutionLibrary<ContractionProblem>> library,
+            std::shared_ptr<Hardware>                                  hardware,
+            po::variables_map const&                                   args)
+        {
+            RunCriteria criteria;
+
+            double granThresh = args["granularity-threshold"].as<double>();
+
+            if(granThresh > 0.0)
+            {
+                criteria.push_back(
+                    [granThresh](ContractionSolution::ProjectedPerformance const& projPerf) {
+                        return projPerf.totalGranularity >= granThresh;
+                    });
+            }
+            return criteria;
+        }
+
         AllSolutionsIterator::AllSolutionsIterator(
             std::shared_ptr<MasterSolutionLibrary<ContractionProblem>> library,
             std::shared_ptr<Hardware>                                  hardware,
             int                                                        firstSolutionIdx,
-            int                                                        numSolutions)
+            int                                                        numSolutions,
+            RunCriteria                                                runCriteria)
             : SolutionIterator(library, hardware)
+            , m_runCriteria(runCriteria)
         {
             m_firstSolutionIdx = firstSolutionIdx;
 
@@ -163,6 +186,22 @@ namespace Tensile
                 return std::shared_ptr<ContractionSolution>();
 
             return iter->second;
+        }
+
+        bool AllSolutionsIterator::runCurrentSolution()
+        {
+            auto solution = getSolution();
+
+            if(!checkSolution(*solution))
+                return false;
+
+            auto projPerf = solution->projectedPerformance(m_problem, *m_hardware);
+            for(auto const& criterion : m_runCriteria)
+            {
+                if(!criterion(projPerf))
+                    return false;
+            }
+            return true;
         }
 
         BestSolutionIterator::BestSolutionIterator(

--- a/Tensile/Source/client/source/SolutionIterator.cpp
+++ b/Tensile/Source/client/source/SolutionIterator.cpp
@@ -119,10 +119,12 @@ namespace Tensile
             double granThresh = args["granularity-threshold"].as<double>();
             if(granThresh > 0.0)
             {
-                criteria.push_back(
-                    [granThresh](ContractionSolution::ProjectedPerformance const& projPerf) {
-                        return projPerf.totalGranularity >= granThresh;
-                    });
+                criteria.push_back([granThresh](ContractionProblem const&  problem,
+                                                Hardware const&            hardware,
+                                                ContractionSolution const& solution) {
+                    auto projPerf = solution.projectedPerformance(problem, hardware);
+                    return projPerf.totalGranularity >= granThresh;
+                });
             }
             return criteria;
         }
@@ -196,10 +198,9 @@ namespace Tensile
             if(!checkSolution(*solution))
                 return false;
 
-            auto projPerf = solution->projectedPerformance(m_problem, *m_hardware);
             for(auto const& criterion : m_runCriteria)
             {
-                if(!criterion(projPerf))
+                if(!criterion(m_problem, *m_hardware, *solution))
                     return false;
             }
             return true;


### PR DESCRIPTION
Added framework for `AllSolutionsIterator` to filter which solutions to run based on the projected performance. The filtering criteria are implemented as a `std::vector<std::function<bool(ProjectedPerformance const&)>>`, which is provided to the iterator at construction.

Currently there is support for a granularity threshold criteria, which ensures solutions are only run if they meet a minimum total granularity.  