### PR TITLE
Fix NCHW bugs 

### DIFF
--- a/Tensile/Components/Signature.py
+++ b/Tensile/Components/Signature.py
@@ -472,6 +472,17 @@ class SignatureCOV3(Signature):
             kStr += self.v3Argument(     "MagicNumberSize%s"%idxChar,     '4', offset,      "by_value",        "u32"); offset += 4
             kStr += self.v3Argument(      "MagicShiftSize%s"%idxChar,     '4', offset,      "by_value",        "u32"); offset += 4
 
+        for idx in kernel["ProblemType"]["IndicesSummation"]:
+          for tc in ('A','B'):
+            for zp in kernel["ProblemType"]["ZeroPad%s"%tc]:
+              (freeDim, sumDim, padStart, padEnd) = zp
+              if sumDim == idx:
+                freeDimChar = globalParameters["IndexChars"][freeDim]
+                sumDimChar  = globalParameters["IndexChars"][sumDim]
+                # These will eventually be read as kernel args:
+                kStr += self.v3Argument(   "PadStart%s%s%s"%(tc, freeDimChar, sumDimChar),     '4', offset,      "by_value",        "u32"); offset += 4
+                kStr += self.v3Argument(     "PadEnd%s%s%s"%(tc, freeDimChar, sumDimChar),     '4', offset,      "by_value",        "u32"); offset += 4
+
         kStr += self.v3Argument(              "OrigStaggerUIter",       '4', offset,      "by_value",        "i32"); offset += 4
 
         kStr += self.v3Argument(                  "NumWorkGroups0",     '4', offset,      "by_value",        "u32"); offset += 4

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -9922,7 +9922,7 @@ class KernelWriterAssembly(KernelWriter):
           addr = self.sharedColVgprs
         elif self.optSharedColVgpr:
           if kernel["EnableMatrixInstruction"]:
-            elementCol = (d0 * gwvw + vc0) / gwvw
+            elementCol = (d0 * kernel["MIOutputVectorWidth"] + vc0) / gwvw
           else:
             elementCol = (d0 * kernel["VectorWidth"] + vc0) / gwvw
           assert (modf(elementCol)[0] < 0.001)

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -9016,7 +9016,9 @@ class KernelWriterAssembly(KernelWriter):
       kStr   += inst("v_add_u32", vgpr(tid1), vgpr(tmpVgpr0), vgpr(tid1), "coordination 1 = wave_id1 + tid1")
 
     # coord 1 : offset part
-    kStr += inst("v_mul_lo_u32", vgpr(self.cinRowPtr), vgpr(tid1), sgpr("StridesC"), " offset 1")
+    packedC1 = kernel["PackedC1IndicesX"]
+    strideC1 = "StrideC%s" % (self.indexChars[packedC1[0]])
+    kStr += inst("v_mul_lo_u32", vgpr(self.cinRowPtr), vgpr(tid1), sgpr(strideC1), " offset 1")
 
     # coord 0 : wave part
     kStr += vectorStaticRemainder(dummy, tmpVgpr0, wave_id, kernel["MIWaveGroup"][0], tmpVgpr1, tmpSgpr)

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -4117,9 +4117,9 @@ class KernelWriterAssembly(KernelWriter):
   def computeLoadSrd(self, kernel, tP, tc, indices, bpe):
     kStr = ""
 
-    stmp = self.getTmpSgpr(2+2).idx()
+    stmp = self.getTmpSgpr(2+2+1).idx()
     tileStart = stmp+2
-    prePadSgpr = self.getTmpSgpr(1).idx()
+    prePadSgpr = stmp+4
     wroteTileStart = False
     #---
     # Compute tileStart #elements from the 2D array start
@@ -4177,12 +4177,12 @@ class KernelWriterAssembly(KernelWriter):
       # override the const pre-pad with an SGPR based on the leading/trailing items:
       prePad = sgpr(prePadSgpr)
       if i==0:
-        kStr += inst("s_add_u32", prePadSgpr, \
+        kStr += inst("s_add_u32", prePad, \
                  sgpr("PadStart%s%s%s"%(tc, freeDimChar,sumDimChar)), \
                  prePadConst, "prePadSgpr = PadStart + ptr-shift-pad")
       else:
-        kStr += inst("s_add_u32", prePadSgpr, \
-                 prePadSgpr, sgpr("PadStart%s%s%s"%(tc,freeDimChar, sumDimChar)), \
+        kStr += inst("s_add_u32", prePad, \
+                 prePad, sgpr("PadStart%s%s%s"%(tc,freeDimChar, sumDimChar)), \
                  "prepadSgpr += PadStart")
 
 

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -6994,7 +6994,10 @@ class KernelWriterAssembly(KernelWriter):
       sumChar = self.indexChars[sumDim]
 
       codeMod.addComment1("guardZeroPad: "+zpr.regName)
-      iterX = "Iter"+sumChar if kernel["PackSummationDims"] else "LoopCounter"+sumChar
+      iterX = "Iter"+sumChar if kernel["PackSummationDims"] else tmpSgpr
+      if not kernel["PackSummationDims"]:
+        codeMod.addInst("s_sub_u32", sgpr(tmpSgpr), sgpr("Size%s"%sumChar) , sgpr("LoopCounter%s"%sumChar),
+                          "loop = Size - remaining loop counter")
       codeMod.addInst("s_mul_i32", sgpr(tmpSgpr), sgpr(iterX), \
                         self.strideRef(tc,sumDim), "LoopCounterZp*strideSum")
       codeMod.addInst("s_lshl_b32", sgpr(tmpSgpr), sgpr(tmpSgpr), \

--- a/Tensile/KernelWriterSource.py
+++ b/Tensile/KernelWriterSource.py
@@ -2400,10 +2400,9 @@ class KernelWriterSource(KernelWriter):
               if sumDim in kernel["ProblemType"]["MirrorDims%s"%(tc)]:
                 iterVar = "-" + iterVar
 
-              globalReadOffsetZp = "globalReadOffset%s_%u_%u_%u_%u_ZP%s%s + %u" \
+              globalReadOffsetZp = "globalReadOffset%s_%u_%u_%u_%u_ZP%s%s" \
                   % (tc, para, 0 if tP["rc"] else sPara, perp, sPerp, \
-                     freeDimChar, sumChar,
-                     sPara if tP["rc"] else 0);
+                     freeDimChar, sumChar);
               kStr += " ( (%s * stride%s%s + %s) >= elementEdge%s%s )" \
                       % (iterVar, tc, sumChar, globalReadOffsetZp, tc, sumChar)
 

--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -588,6 +588,7 @@ class Convolution:
     sizes[self.convolutionDims['C'].idx]=c
     sizes[self.convolutionDims['K'].idx]=k
 
+    astrides[self.convolutionDims['N'].idx] = reduce((lambda x, y: x * y), pcc.spatial) * c
     bstrides[self.convolutionDims['N'].idx] = 0 # broadcast b matrix
 
     if len(pcc.spatial) != self.formatNumSpatialDims:

--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -596,7 +596,7 @@ class Convolution:
     # convert to Output dimensions:
     spatialOut=[0]*len(pcc.spatial)
     for i in range(self.formatNumSpatialDims):
-      spatialOut[i] = int((pcc.spatial[i] - pcc.fil[i] + 1 + pcc.padStart[i] + pcc.padEnd[i]) / pcc.stride[i])
+      spatialOut[i] = int((pcc.spatial[i] + pcc.padStart[i] + pcc.padEnd[i] - ((pcc.fil[i]-1) * pcc.dilation[i] + 1)) / pcc.stride[i]) + 1
 
     #print ("spatialOut=", spatialOut, "padStart=", pcc.padStart, "padEnd=", pcc.padEnd)
 

--- a/Tensile/Source/client/include/ConvolutionProblem.hpp
+++ b/Tensile/Source/client/include/ConvolutionProblem.hpp
@@ -248,8 +248,9 @@ namespace Tensile
 
         size_t m_groups = 1;
 
-        size_t m_numFilterDims  = 0;
-        size_t m_numSpatialDims = 0;
+        size_t m_numFilterDims        = 0;
+        size_t m_numSpatialDims       = 0;
+        size_t m_numFormatSpatialDims = 0;
 
         ActivationFormat m_formatA;
         ComboFormat      m_formatB;

--- a/Tensile/Source/client/source/ConvolutionProblem.cpp
+++ b/Tensile/Source/client/source/ConvolutionProblem.cpp
@@ -259,6 +259,7 @@ namespace Tensile
 
         m_operationIdentifier       = parts[0];
         size_t formatNumSpatialDims = parts[1].size() - 2;
+        m_numFormatSpatialDims      = formatNumSpatialDims;
 
         for(auto part = parts.begin() + 4; part != parts.end(); part++)
         {
@@ -381,6 +382,8 @@ namespace Tensile
         // Mimic the expected dimension order in formatA:
         std::vector<size_t>  activationDims;
         std::vector<int64_t> activationStri;
+        int64_t              batchStride;
+
         switch(formatA().format())
         {
         case ConvolutionProblem::TensorFormat::NCHW:
@@ -400,7 +403,12 @@ namespace Tensile
             activationDims.push_back(problem.a().sizes()[formatA().channelPosition()]);
             activationStri.push_back(-1);
             activationDims.push_back(problem.a().sizes()[formatA().batchPosition()]);
-            activationStri.push_back(-1);
+            batchStride = problem.a().sizes()[formatA().channelPosition()];
+            for(int si = 0; si < m_numFormatSpatialDims; si++)
+            {
+                batchStride *= spatials().at(si);
+            }
+            activationStri.push_back(batchStride);
             break;
         case ConvolutionProblem::TensorFormat::NHWC:
             assert(0); // need strides

--- a/Tensile/Tests/extended/convolution_config/YamlBuilder/YamlBuilder.py
+++ b/Tensile/Tests/extended/convolution_config/YamlBuilder/YamlBuilder.py
@@ -152,6 +152,34 @@ class Solutions:
         return s
 
     @classmethod
+    def asm3_mi(cls):
+        s = cls.commonSetup()
+
+        s["ForkParameters"] = \
+                [
+                    {"PrefetchGlobalRead": [1]},
+                    {"KernelLanguage": ["Assembly"]},
+                    {"MatrixInstruction": [
+                        [32,32,1,2]
+                        ]},
+                    {"ThreadTile": [
+                        [ 1, 32 ]
+                        ]},
+                    {"WorkGroup": [
+                        [ 16, 16, 1],
+                        [ 64, 4, 1]
+                        ]},
+                    {"DepthU": [8]},
+                    {"GlobalReadVectorWidth": [-1,2]},
+                    {"PackSummationDims": [0,1]},
+                    {"VectorWidth": [1,4]},
+                    {"FractionalLoad": [1]},
+                    {"PackBatchDims": [0,1]},
+                ]
+
+        return s
+
+    @classmethod
     def defaultSolution(cls):
         return cls.asm3_pbd
 

--- a/Tensile/Tests/extended/convolution_config/conftest.py
+++ b/Tensile/Tests/extended/convolution_config/conftest.py
@@ -10,7 +10,7 @@ Runner=namedtuple("Runner", ["level", "func", "solution"])
 TensileState=namedtuple("TensileState", ["args"])
 
 # this control the default solutions used for each test.
-solutions = ["src1", "src5_gsu", "asm3_pbd", "asm3_splitu"]
+solutions = ["src1", "src5_gsu", "asm3_pbd", "asm3_splitu", "asm3_mi"]
 #solutions = ["asm3_pbd"] # run a smaller set of tests
 
 @pytest.fixture(scope="function")

--- a/Tensile/Tests/extended/convolution_config/test_forward_pad.py
+++ b/Tensile/Tests/extended/convolution_config/test_forward_pad.py
@@ -25,9 +25,6 @@ def test_nchw_filter2x2(tensile_state, run_convolution_level, problemSizes):
         assert(conv.solutionParms["AssertStrideBEqual"] == {3:0})
         assert(conv.solutionParms["AssertSizeEqual"] == {filterDims[0]:2})
 
-    solutionName = run_convolution_level.solution.__name__
-    if solutionName.startswith("asm") or solutionName == 'src1':
-        pytest.skip("skip configs w/o PBD")
     run_convolution_level.func(conv, z, run_convolution_level.solution, problemSizes[0], problemSizes[1])
 
 @pytest.mark.parametrize("problemSizes", [defaultSizes, resnetSizes, inceptionSizes])
@@ -51,9 +48,6 @@ def test_nchw_filter7x1(tensile_state, run_convolution_level, problemSizes):
         assert(conv.solutionParms["AssertStrideAEqual"] == {1:1})
         assert(conv.solutionParms["AssertStrideBEqual"] == {3:0})
         assert(conv.solutionParms["AssertSizeEqual"] == {filterDims[0]:7})
-    solutionName = run_convolution_level.solution.__name__
-    if solutionName.startswith("asm") or solutionName == 'src1':
-        pytest.skip("skip configs w/o PBD")
     run_convolution_level.func(conv, z, run_convolution_level.solution, problemSizes[0], problemSizes[1])
 
 def test_nchw_filter2x1_dilation(tensile_state, run_convolution_level):
@@ -77,9 +71,6 @@ def test_nchw_filter2x1_dilation(tensile_state, run_convolution_level):
         assert(conv.solutionParms["AssertStrideAEqual"] == {1:1})
         assert(conv.solutionParms["AssertStrideBEqual"] == {3:0})
         assert(conv.solutionParms["AssertSizeEqual"] == {filterDims[0]:2})
-    solutionName = run_convolution_level.solution.__name__
-    if solutionName.startswith("asm") or solutionName == 'src1':
-        pytest.skip("skip configs w/o PBD")
     run_convolution_level.func(conv, z, run_convolution_level.solution)
 
 def test_nchw_filter1x2(tensile_state, run_convolution_level):
@@ -102,9 +93,6 @@ def test_nchw_filter1x2(tensile_state, run_convolution_level):
         assert(conv.solutionParms["AssertStrideAEqual"] == {0:1,1:1})
         assert(conv.solutionParms["AssertStrideBEqual"] == {0:1,3:0})
         assert(conv.solutionParms["AssertSizeEqual"] == {filterDims[0]:2})
-    solutionName = run_convolution_level.solution.__name__
-    if solutionName.startswith("asm") or solutionName == 'src1':
-        pytest.skip("skip configs w/o PBD")
     run_convolution_level.func(conv, z, run_convolution_level.solution)
 
 def test_nchw_filter1x2_dilation(tensile_state, run_convolution_level):
@@ -128,9 +116,6 @@ def test_nchw_filter1x2_dilation(tensile_state, run_convolution_level):
         assert(conv.solutionParms["AssertStrideAEqual"] == {0:2,1:1})
         assert(conv.solutionParms["AssertStrideBEqual"] == {0:1,3:0})
         assert(conv.solutionParms["AssertSizeEqual"] == {filterDims[0]:2})
-    solutionName = run_convolution_level.solution.__name__
-    if solutionName.startswith("asm") or solutionName == 'src1':
-        pytest.skip("skip configs w/o PBD")
     run_convolution_level.func(conv, z, run_convolution_level.solution)
 
 def test_nchw_dilation_filter4x4_pad(tensile_state, run_convolution_level):
@@ -151,9 +136,6 @@ def test_nchw_dilation_filter4x4_pad(tensile_state, run_convolution_level):
         assert(conv.solutionParms["AssertStrideAEqual"] == {0:2,2:1})
         assert(conv.solutionParms["AssertStrideBEqual"] == {0:1,filterDims[0]:0})
         assert(conv.solutionParms["AssertSizeEqual"] == {filterDims[0]:1, filterDims[1]:1})
-    solutionName = run_convolution_level.solution.__name__
-    if solutionName.startswith("asm") or solutionName == 'src1':
-        pytest.skip("skip configs w/o PBD")
     run_convolution_level.func(conv, z, run_convolution_level.solution)
 
 def test_nchw_stride_filter(tensile_state, run_convolution_level):
@@ -176,8 +158,4 @@ def test_nchw_stride_filter(tensile_state, run_convolution_level):
         assert(conv.solutionParms["AssertStrideAEqual"] == {0:1})
         assert(conv.solutionParms["AssertStrideBEqual"] == {0:1,4:0})
         assert(conv.solutionParms["AssertSizeEqual"] == {filterDims[0]:2, filterDims[1]:2})
-
-    solutionName = run_convolution_level.solution.__name__
-    if solutionName.startswith("asm") or solutionName == 'src1':
-        pytest.skip("skip configs w/o PBD")
     run_convolution_level.func(conv, z, run_convolution_level.solution)

--- a/Tensile/Tests/unit/test_conv_problem.py
+++ b/Tensile/Tests/unit/test_conv_problem.py
@@ -11,8 +11,8 @@ def test_stride2x3():
     log.debug(conv.printUsage(z))
     e= { 'n':64, 'c':256, 'h':20, 'w':14, 'k':1024, 'x':1, 'y':1, 'u':2, 'v':3 }
     ec = ConvProblem(e, conv)
-    assert (ec.sizes == (4, 10, e['k'], e['n'], e['c']))
-    assert (ec.stridesA == (3, 28, -1, -1))
+    assert (ec.sizes == (5, 10, e['k'], e['n'], e['c']))
+    assert (ec.stridesA == (3, 28, -1, 71680))
 
 def test_stride2x3_defaults():
     z={} # problemType definition
@@ -23,8 +23,8 @@ def test_stride2x3_defaults():
     log.debug(conv.printUsage(z))
     e= { 'n':64, 'c':256, 'h':20, 'w':14, 'k':1024}
     ec = ConvProblem(e, conv)
-    assert (ec.sizes == (4, 10, e['k'], e['n'], e['c']))
-    assert (ec.stridesA == (3, 28, -1, -1))
+    assert (ec.sizes == (5, 10, e['k'], e['n'], e['c']))
+    assert (ec.stridesA == (3, 28, -1, 71680))
 
 @pytest.mark.skip(reason="no X filter, ZeroPadA has one entry and it is for Y filter")
 def test_pad_4x1():

--- a/Tensile/Tests/unit/test_makeProblem.py
+++ b/Tensile/Tests/unit/test_makeProblem.py
@@ -12,7 +12,7 @@ def test_spatial_in():
     pcc = ConvolutionConfig(spatial=[14,15])
     p = conv.makeProblem(n=64, c=1024, k=256, pcc=pcc)
     assert(p[0] == [210, 256, 64, 1024])
-    assert(p[1] == [1, -1, -1])
+    assert(p[1] == [1, -1, 215040])
     assert(p[2] == [-1, -1, 0])
 
 def test_spatial_parm():
@@ -26,7 +26,7 @@ def test_spatial_parm():
     pcc = ConvolutionConfig()
     p = conv.makeProblem(n=64, c=1024, k=256, pcc=pcc)
     assert(p[0] == [182, 256, 64, 1024])
-    assert(p[1] == [1, -1, -1])
+    assert(p[1] == [1, -1, 186368])
     assert(p[2] == [-1, -1, 0])
 
 
@@ -40,8 +40,8 @@ def test_stride():
 
     log.debug(conv.printUsage(z))
     p = conv.makeProblem(n=64, c=1024, k=256, pcc=conv.cc)
-    assert(p[0] == [4, 6, 256, 64, 1024])
-    assert(p[1] == [3, 28, -1, -1])
+    assert(p[0] == [5, 7, 256, 64, 1024])
+    assert(p[1] == [3, 28, -1, 186368])
     assert(p[2] == [-1, -1, 0])
 
 
@@ -56,8 +56,8 @@ def test_stride_filter():
 
     log.debug(conv.printUsage(z))
     p = conv.makeProblem(n=64, c=1024, k=256, pcc=conv.cc)
-    assert(p[0] == [3, 5, 256, 64, 3, 4, 1024])
-    assert(p[1] == [1, 14, 3, 28, -1, -1])
+    assert(p[0] == [4, 6, 256, 64, 3, 4, 1024])
+    assert(p[1] == [1, 14, 3, 28, -1, 186368])
     assert(p[2] == [-1, -1, -1, -1, 0])
 
 def test_stride_filter_dilated():
@@ -72,8 +72,8 @@ def test_stride_filter_dilated():
 
     log.debug(conv.printUsage(z))
     p = conv.makeProblem(n=64, c=1024, k=256, pcc=conv.cc)
-    assert(p[0] == [3, 5, 256, 64, 3, 4, 1024])
-    assert(p[1] == [3, 28, 3, 28, -1, -1])
+    assert(p[0] == [2, 5, 256, 64, 3, 4, 1024])
+    assert(p[1] == [3, 28, 3, 28, -1, 186368])
     assert(p[2] == [-1, -1, -1, -1, 0])
 
 def test_spatial_unspecified():


### PR DESCRIPTION
Fix NCHW bugs including:
- MatrixInstruction not work
- incorrect output tensor shape formula for dilation and stride
- batch stride calculation is incorrect
- ZeroPad not work if PSD0 is enabled
- ZeroPad not work with hipcc
- Coord calculation is incorrect of ZeroPad Source kernel
- refer to wrong prePad sgpr in ZeroPad cases

Enable CI tests for:
-Convolution ZeroPad
-MatrixInstructions assembly kernel