### PR TITLE
Fix bugs of tail-loop branch label, and LR addr restore

### DIFF
--- a/Tensile/KernelWriter.py
+++ b/Tensile/KernelWriter.py
@@ -2202,8 +2202,8 @@ class KernelWriter(metaclass=abc.ABCMeta):
             kl.append(self.macIter(kernel, 0, tailLoopInnerUnroll, True))
 
         kl.append(self.closeLoop(kernel, -1, True, uDu if kernel["DepthULdsDivisor"]>1 else None))
-    if kernel["DepthULdsDivisor"]>1:
-      kl.append(self.closeLoop(kernel, -1, None, emitEndLabelOnly=True))
+    # always emit the skip-tail-loop label
+    kl.append(self.closeLoop(kernel, -1, None, emitEndLabelOnly=True))
     # tail: close
     self.inTailLoop = False
 

--- a/Tensile/Tests/pre_checkin/mfma/hpa_hgemm_split_lds.yaml
+++ b/Tensile/Tests/pre_checkin/mfma/hpa_hgemm_split_lds.yaml
@@ -39,15 +39,16 @@ BenchmarkProblems:
         - WorkGroupMapping: [8]
         - InnerUnroll: [2]
         - DepthU: [64, 128]
-        - DepthULdsDivisor: [2]
+        - DepthULdsDivisor: [1,2]
         - ScheduleIterAlg: [3]
         - VectorWidth: [4, 8]
         - 1LDSBuffer: [0, 1]
         - PersistentKernel: [0, 1]
-        - PersistentKernelAlongBatch: [1]
+        - PersistentKernelAlongBatch: [False]
         - PrefetchAcrossPersistent: [0, 1]
         - GlobalSplitUAlgorithm: ["SingleBuffer", "MultipleBuffer"]
-        - GlobalSplitU: [2, 5, 15]
+        - GlobalSplitU: [1, 2, 5]
+        - LocalReadVectorWidth: [8]
       JoinParameters:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:

--- a/Tensile/Tests/pre_checkin/mfma/sgemm_split_lds.yaml
+++ b/Tensile/Tests/pre_checkin/mfma/sgemm_split_lds.yaml
@@ -38,15 +38,16 @@ BenchmarkProblems:
         - WorkGroupMapping: [8]
         - InnerUnroll: [2]
         - DepthU: [64, 128]
-        - DepthULdsDivisor: [2]
+        - DepthULdsDivisor: [1,2]
         - ScheduleIterAlg: [3]
         - VectorWidth: [4, 8]
         - 1LDSBuffer: [0, 1]
         - PersistentKernel: [0, 1]
-        - PersistentKernelAlongBatch: [1]
+        - PersistentKernelAlongBatch: [False]
         - PrefetchAcrossPersistent: [0, 1]
         - GlobalSplitUAlgorithm: ["SingleBuffer", "MultipleBuffer"]
-        - GlobalSplitU: [2, 5, 15]
+        - GlobalSplitU: [1, 2, 5]
+        - LocalReadVectorWidth: [2]
       JoinParameters:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:


### PR DESCRIPTION
Fix summary:
* UnrollMajorLDSA/B typo
* Buggy if-else breaks local-read-address restoration in tail-loop
* Incorrect location to insert TailLoopEndLabel
* New test cases added to test the above bugs

I have added comments in the conversation