### PR TITLE
TensileCreateLibraryFiles: automatically create target for build time library generation

### DIFF
--- a/HostLibraryTests/CMakeLists.txt
+++ b/HostLibraryTests/CMakeLists.txt
@@ -177,8 +177,9 @@ endif()
 
 if(TENSILE_USE_HIP)
 
-    # Make sure the testing libraries get copied to avoid segfaults in test runs.
-    add_dependencies(TensileTests ${HIP_TEST_COPY_TARGET_DEPS})
+    # Make sure the testing libraries get built & copied before the client is built
+    # to avoid segfaults on gtest integration.
+    add_dependencies(TensileTests ${HIP_TEST_LIBRARY_TARGET_DEPS})
 
     target_link_libraries(TensileTests PRIVATE "-Xlinker --whole-archive")
     target_link_libraries(TensileTests PUBLIC ${HIP_TEST_LIBRARIES})

--- a/HostLibraryTests/hip/CMakeLists.txt
+++ b/HostLibraryTests/hip/CMakeLists.txt
@@ -17,12 +17,6 @@ TensileCreateLibraryFiles(
     CODE_OBJECT_VERSION ${CODE_OBJECT_VERSION}
     )
 
-TensileCreateCopyTarget(
-    copy_kernels_lite
-    "${LITE_ALL_FILES}"
-    ${TEST_DATA_DIR}/kernels_lite
-    )
-
 TensileCreateLibraryFiles(
     "${CMAKE_CURRENT_SOURCE_DIR}/../configs/lite_configs_mixed"
     "${CMAKE_CURRENT_BINARY_DIR}/test_kernels_lite_mixed"
@@ -33,12 +27,6 @@ TensileCreateLibraryFiles(
     NO_MERGE_FILES
     COMPILER ${COMPILER}
     CODE_OBJECT_VERSION ${CODE_OBJECT_VERSION}
-    )
-
-TensileCreateCopyTarget(
-    copy_kernels_lite_mixed
-    "${LITE_MIXED_ALL_FILES}"
-    ${TEST_DATA_DIR}/kernels_lite_mixed
     )
 
 TensileCreateLibraryFiles(
@@ -53,27 +41,16 @@ TensileCreateLibraryFiles(
     CODE_OBJECT_VERSION ${CODE_OBJECT_VERSION}
     )
 
-TensileCreateCopyTarget(
-    copy_kernels_lite_2
-    "${LITE_2_ALL_FILES}"
-    ${TEST_DATA_DIR}/kernels_lite_2
-    )
-
 TensileCreateLibraryFiles(
     "${CMAKE_CURRENT_SOURCE_DIR}/../configs/tile_aware_selection"
     "${CMAKE_CURRENT_BINARY_DIR}/test_tile_aware_selection"
     TENSILE_ROOT "${TENSILE_SCRIPT_ROOT}"
     EMBED_LIBRARY test_tile_aware_selection
     EMBED_KEY     tile_aware_selection
+    VAR_PREFIX TILE_AWARE
     NO_MERGE_FILES
     COMPILER ${COMPILER}
     CODE_OBJECT_VERSION ${CODE_OBJECT_VERSION}
-    )
-
-TensileCreateCopyTarget(
-    copy_kernels_tile_aware_selection
-    "${TENSILE_ALL_FILES}"
-    ${TEST_DATA_DIR}/tile_aware_selection/library
     )
 
 set(test_yaml rocblas_sgemm_asm_single_kernel.yaml)
@@ -97,11 +74,11 @@ set(HIP_TEST_LIBRARIES
 
 # Make sure that the TensileTests depends on targets below.
 # Otherwise the TensileTests executable will segfault out.
-set(HIP_TEST_COPY_TARGET_DEPS
-    copy_kernels_lite
-    copy_kernels_lite_2
-    copy_kernels_lite_mixed
-    copy_kernels_tile_aware_selection
+set(HIP_TEST_LIBRARY_TARGET_DEPS
+    LITE_LIBRARY_TARGET
+    LITE_MIXED_LIBRARY_TARGET
+    LITE_2_LIBRARY_TARGET
+    TILE_AWARE_LIBRARY_TARGET
     PARENT_SCOPE
 )
 

--- a/HostLibraryTests/hip/CMakeLists.txt
+++ b/HostLibraryTests/hip/CMakeLists.txt
@@ -17,6 +17,14 @@ TensileCreateLibraryFiles(
     CODE_OBJECT_VERSION ${CODE_OBJECT_VERSION}
     )
 
+# Tests need library and kernels copied to data folder
+TensileCreateCopyTarget(
+    copy_kernels_lite
+    "${LITE_ALL_FILES}"
+    ${TEST_DATA_DIR}/kernels_lite
+    )
+add_dependencies(copy_kernels_lite LITE_LIBRARY_TARGET)
+
 TensileCreateLibraryFiles(
     "${CMAKE_CURRENT_SOURCE_DIR}/../configs/lite_configs_mixed"
     "${CMAKE_CURRENT_BINARY_DIR}/test_kernels_lite_mixed"
@@ -28,6 +36,14 @@ TensileCreateLibraryFiles(
     COMPILER ${COMPILER}
     CODE_OBJECT_VERSION ${CODE_OBJECT_VERSION}
     )
+
+# Tests need library and kernels copied to data folder
+TensileCreateCopyTarget(
+    copy_kernels_lite_mixed
+    "${LITE_MIXED_ALL_FILES}"
+    ${TEST_DATA_DIR}/kernels_lite_mixed
+    )
+add_dependencies(copy_kernels_lite_mixed LITE_MIXED_LIBRARY_TARGET)
 
 TensileCreateLibraryFiles(
     "${CMAKE_CURRENT_SOURCE_DIR}/../configs/lite_configs"
@@ -41,6 +57,14 @@ TensileCreateLibraryFiles(
     CODE_OBJECT_VERSION ${CODE_OBJECT_VERSION}
     )
 
+# Tests need library and kernels copied to data folder
+TensileCreateCopyTarget(
+    copy_kernels_lite_2
+    "${LITE_2_ALL_FILES}"
+    ${TEST_DATA_DIR}/kernels_lite_2
+    )
+add_dependencies(copy_kernels_lite_2 LITE_2_LIBRARY_TARGET)
+
 TensileCreateLibraryFiles(
     "${CMAKE_CURRENT_SOURCE_DIR}/../configs/tile_aware_selection"
     "${CMAKE_CURRENT_BINARY_DIR}/test_tile_aware_selection"
@@ -52,6 +76,14 @@ TensileCreateLibraryFiles(
     COMPILER ${COMPILER}
     CODE_OBJECT_VERSION ${CODE_OBJECT_VERSION}
     )
+
+# Tests need library and kernels copied to data folder
+TensileCreateCopyTarget(
+    copy_kernels_tile_aware_selection
+    "${TILE_AWARE_ALL_FILES}"
+    ${TEST_DATA_DIR}/tile_aware_selection/library
+    )
+add_dependencies(copy_kernels_tile_aware_selection TILE_AWARE_LIBRARY_TARGET)
 
 set(test_yaml rocblas_sgemm_asm_single_kernel.yaml)
 file(COPY ${test_yaml} DESTINATION .)
@@ -75,10 +107,10 @@ set(HIP_TEST_LIBRARIES
 # Make sure that the TensileTests depends on targets below.
 # Otherwise the TensileTests executable will segfault out.
 set(HIP_TEST_LIBRARY_TARGET_DEPS
-    LITE_LIBRARY_TARGET
-    LITE_MIXED_LIBRARY_TARGET
-    LITE_2_LIBRARY_TARGET
-    TILE_AWARE_LIBRARY_TARGET
+    copy_kernels_lite
+    copy_kernels_lite_mixed
+    copy_kernels_lite_2
+    copy_kernels_tile_aware_selection
     PARENT_SCOPE
 )
 

--- a/Tensile/cmake/TensileConfig.cmake
+++ b/Tensile/cmake/TensileConfig.cmake
@@ -93,8 +93,16 @@ function(TensileCreateLibraryFiles
     message(FATAL_ERROR "TensileCreateLibraryFiles function should only be called for new client.")
   endif()
 
-  # Tensile_ROOT can be specified instead of using the installed path.
-  set(options NO_MERGE_FILES SHORT_FILE_NAMES PRINT_DEBUG GENERATE_PACKAGE)
+  # Boolean options
+  set(options
+       MERGE_FILES
+       NO_MERGE_FILES
+       SHORT_FILE_NAMES
+       PRINT_DEBUG
+       GENERATE_PACKAGE
+       )
+
+  # Single value settings
   set(oneValueArgs
        ARCHITECTURE
        CODE_OBJECT_VERSION
@@ -102,12 +110,19 @@ function(TensileCreateLibraryFiles
        EMBED_KEY
        EMBED_LIBRARY
        LIBRARY_FORMAT
-       MERGE_FILES
        TENSILE_ROOT
        VAR_PREFIX
        )
+
   set(multiValueArgs "")
   cmake_parse_arguments(Tensile "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+  if(Tensile_UNPARSED_ARGUMENTS)
+    message(WARNING "Unrecognized arguments: ${Tensile_UNPARSED_ARGUMENTS}")
+  endif()
+  if(Tensile_KEYWORDS_MISSING_VALUES)
+    message(WARNING "Malformed arguments: ${Tensile_KEYWORDS_MISSING_VALUES}")
+  endif()
 
   # Parse incoming options
   if(Tensile_TENSILE_ROOT)
@@ -120,9 +135,9 @@ function(TensileCreateLibraryFiles
 
   set(Options "--new-client-only" "--no-legacy-components")
 
-  # older NO_MERGE_FILES flag overrides MERGE_FILES option.
+  # Older NO_MERGE_FILES flag overrides MERGE_FILES option.
   if(Tensile_NO_MERGE_FILES)
-    set(Tensile_MERGE_FILES OFF)
+    set(Tensile_MERGE_FILES FALSE)
   endif()
 
   if(Tensile_MERGE_FILES)


### PR DESCRIPTION
TensileCreateLibraryFiles: automatically create a ${VAR_PREFIX}_LIBRARY_TARGET target as a dependency for other targets to force build time library generation.

- This change simply encapsulates the target creation for Tensile library generation at build time, removing an extra manual step.

- This cleanup is in preparation to apply to other projects such as miopentensile and rocblas (as requested)

- Extra copy targets are necessary to move libraries to the Data folder in HostLibraryTests.