### PR TITLE
resolves SWDEV-267920; value of targets to clang-offload-bundler updated

### DIFF
--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -190,10 +190,18 @@ def buildSourceCodeObjectFile(CxxCompiler, outputPath, kernelFile):
         print('hipcc:', ' '.join(compileArgs))
       subprocess.check_call(compileArgs)
 
+      infile = os.path.join(buildPath, objectFilename)
+      try:
+        bundlerArgs = [globalParameters["ClangOffloadBundlerPath"], "-type=o", "-inputs=%s" % infile, "-list"]
+        subprocess.check_output(bundlerArgs, stderr=subprocess.STDOUT).decode().split("\n")
+        # TODO - use the list of gfx entries returned as targets directly
+        hipVersion = "hipv4"
+      except subprocess.CalledProcessError:
+        hipVersion = "hip"
+
       for i in range(len(archs)):
-        infile = os.path.join(buildPath, objectFilename)
         outfile = os.path.join(buildPath, "{0}-000-{1}.hsaco".format(soFilename, archs[i]))
-        bundlerArgs = [globalParameters["ClangOffloadBundlerPath"], "-type=o", "-targets=hip-amdgcn-amd-amdhsa--%s" % cmdlineArchs[i], "-inputs=%s" % infile, "-outputs=%s" % outfile, "-unbundle"]
+        bundlerArgs = [globalParameters["ClangOffloadBundlerPath"], "-type=o", "-targets=%s-amdgcn-amd-amdhsa--%s" % (hipVersion, cmdlineArchs[i]), "-inputs=%s" % infile, "-outputs=%s" % outfile, "-unbundle"]
         if globalParameters["PrintCodeCommands"]:
           print(' '.join(bundlerArgs))
         subprocess.check_call(bundlerArgs)

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -193,9 +193,9 @@ def buildSourceCodeObjectFile(CxxCompiler, outputPath, kernelFile):
       infile = os.path.join(buildPath, objectFilename)
       try:
         bundlerArgs = [globalParameters["ClangOffloadBundlerPath"], "-type=o", "-inputs=%s" % infile, "-list"]
-        subprocess.check_output(bundlerArgs, stderr=subprocess.STDOUT).decode().split("\n")
+        buffer = subprocess.check_output(bundlerArgs, stderr=subprocess.STDOUT).decode()
         # TODO - use the list of gfx entries returned as targets directly
-        hipVersion = "hipv4"
+        hipVersion = "hipv4" if "hipv4" in buffer else "hip"
       except subprocess.CalledProcessError:
         hipVersion = "hip"
 


### PR DESCRIPTION
The value of -targets= to clang-offload-bundler has been changed from prefixing with hip to hipv4 for Code Object V4.  During transition, Tensile needs to support both generations of values based on whether clang-offload-bundler supports the new -list option and whether the list returned contains the string "hipv4".

We'll improve the implementation in a future pull request to utilize the list of target values returned by -list.