### PR TITLE
avoid vgpr bank conflict in gfx10

### DIFF
--- a/Tensile/Code.py
+++ b/Tensile/Code.py
@@ -737,7 +737,8 @@ class SrdUpperFields10XX(BitfieldStructure):
               ("index_stride",   ctypes.c_uint, 2),
               ("add_tid_enable", ctypes.c_uint, 1),
               ("resource_level", ctypes.c_uint, 1),
-              ("_unusedB",       ctypes.c_uint, 3),
+              ("_unusedB",       ctypes.c_uint, 1),
+              ("LLC_noalloc",    ctypes.c_uint, 2),
               ("oob_select",     ctypes.c_uint, 2),
               ("type",           ctypes.c_uint, 2)]
 

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -1535,6 +1535,9 @@ class KernelWriterAssembly(KernelWriter):
     PLR = kernel["PrefetchLocalRead"] if kernel["PrefetchLocalRead"] < kernel["LoopIters"] else kernel["LoopIters"] - 1
     valuBlocks = (1+PLR) * kernel["InnerUnroll"]
 
+    # Avoid bank conflict between VgprA and VgprC
+    if (self.version[0] == 10) and ((vgprIdx % 4) == (self.startVgprValuC % 4)):
+      vgprIdx += 1
     self.startVgprValuA = vgprIdx; vgprIdx += numVgprValuA
     self.startVgprG2LA = None
     if not kernel["DirectToLdsA"] or self.do["KeepDirectToLdsAlloc"]:
@@ -11174,8 +11177,6 @@ class KernelWriterAssembly(KernelWriter):
 
   # rpv = regs per vector
     rpv = bpl/4.0
-    if self.version[0] == 10:
-      extraFields += " glc, slc, dlc"
 
     if useBuffer:
       tailFields = "offen offset:%u"%offset


### PR DESCRIPTION
1. avoid vgpr bank conflict
2. enable L2, L1, L0 cache in GFX10