### PR TITLE
Refactor ConvolutionVsContraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 - Support offset for each input/output buffer in Tensile
 - support support ldc != ldd for all GEMM kernel
 
+### Optimizations
+- Refactor ConvolutionVsContraction
+
+### Fixed
+- channel stride is incorrect when converting conv problem into tensor contraction problem
 
 ## [Tensile 4.26.0 for ROCm 4.1.0]
 ### Added

--- a/Tensile/ClientWriter.py
+++ b/Tensile/ClientWriter.py
@@ -631,8 +631,8 @@ def writeClientConfigIni(problemSizes, problemType, sourceDir, codeObjectFiles, 
                 param("code-object", os.path.join(sourceDir,coFile))
 
         param('results-file', resultsFileName)
-
-        if problemType.convolution and globalParameters["ConvolutionVsContraction"]:
+        convValidation = problemType.convolution and globalParameters["ConvolutionVsContraction"];
+        if convValidation:
             param('convolution-identifier', problemType.convolution.identifier())
         param('problem-identifier', problemType.operationIdentifier)
         param('a-type',     problemType.aType.toEnum())
@@ -648,6 +648,8 @@ def writeClientConfigIni(problemSizes, problemType, sourceDir, codeObjectFiles, 
         for problem in problemSizes.problems:
             for key,value in problemSizeParams(problemType, problem):
                 param(key,value)
+            if convValidation:
+              param('convolution-problem', problemType.convolution.identifier(problem))
 
         param("device-idx",               globalParameters["Device"])
 
@@ -681,8 +683,7 @@ def writeClientConfigIni(problemSizes, problemType, sourceDir, codeObjectFiles, 
         param("num-syncs-per-benchmark",  globalParameters["SyncsPerBenchmark"])
         param("use-gpu-timer",            globalParameters["KernelTime"])
         param("hardware-monitor",         globalParameters["HardwareMonitor"])
-        if globalParameters["ConvolutionVsContraction"]:
-            assert(problemType.convolution)
+        if convValidation:
             param("convolution-vs-contraction", globalParameters["ConvolutionVsContraction"])
         if not globalParameters["KernelTime"]:
             param("num-warmups", 1)

--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -403,7 +403,7 @@ class Convolution:
     assert(type(self.packedFilterDims) == int)
     assert(type(self.packedSpatialDims) == int)
     assert(type(self.unrollOnChannel) == int)
-    if not all(i==1 for i in self.cc.dilation[1:]):
+    if not all(i==1 for i in self.cc.dilation[1:]) and not all (i==1 for i in self.cc.fil) :
       self.packedFilterDims = 0
     if not (\
        all(i==1 for i in self.cc.stride[1:]) and \
@@ -769,20 +769,25 @@ class Convolution:
           raise RuntimeError ("dimension %d('%s') expected to be summation dimension" % (idx, dim.shortChar))
 
 
-  def identifier(self):
-    id = self.convolutionType
-    id += "_" + self.tensorAFormat
-    id += "_" + self.tensorBFormat
-    id += "_" + self.tensorDFormat
-    id += "_spatialDims:" + str(self.numSpatialDims)
-    id += "_indices:" + '.'.join([x.dim.shortChar for x in self.indexAssignments])
-    if self.cc.spatial:
-      id += "_spatial:" + "x".join([str(x) for x in self.cc.spatial[::-1]])
-    id += "_filter:" + "x".join([str(x) for x in self.cc.fil[::-1]])
-    id += "_stride:" + "x".join([str(x) for x in self.cc.stride[::-1]])
-    id += "_dilation:" + "x".join([str(x) for x in self.cc.dilation[::-1]])
-    id += "_padStart:" + "x".join([str(x) for x in self.cc.padStart[::-1]])
-    id += "_padEnd:" + "x".join([str(x) for x in self.cc.padEnd[::-1]])
+  def identifier(self, problem = None):
+
+    if problem == None:
+      id = self.convolutionType
+      id += "_" + self.tensorAFormat
+      id += "_" + self.tensorBFormat
+      id += "_" + self.tensorDFormat
+      id += "_spatialDims:" + str(self.numSpatialDims)
+      id += "_indices:" + '.'.join([x.dim.shortChar for x in self.indexAssignments])
+    else:
+      id = ''
+      problemCC = problem.convConfig
+      id += ",".join([str(x) for x in problemCC.spatial])
+      id += "," + ",".join([str(x) for x in problemCC.fil])
+      id += "," + ",".join([str(x) for x in problemCC.stride])
+      id += "," + ",".join([str(x) for x in problemCC.dilation])
+      id += "," + ",".join([str(x) for x in problemCC.padStart])
+      id += "," + ",".join([str(x) for x in problemCC.padEnd])
+
     return id
 
 
@@ -1344,7 +1349,6 @@ class Problem:
 
     self.zeroPadA = zeroPadA
     self.zeroPadB = zeroPadB
-    self.convConfig = None
     self.count = count
 
   def __str__(self):

--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -589,6 +589,11 @@ class Convolution:
     sizes[self.convolutionDims['C'].idx]=c
     sizes[self.convolutionDims['K'].idx]=k
 
+    xIndexOfA = [index for index in range(len(self.regDimsA)) if self.regDimsA[index].dim.shortChar == 'W']
+    cIndexOfA = [index for index in range(len(self.regDimsA)) if self.regDimsA[index].dim.shortChar == 'C']
+    if xIndexOfA < cIndexOfA:
+      astrides[self.convolutionDims['C'].idx] = reduce((lambda x, y: x * y), pcc.spatial)
+
     astrides[self.convolutionDims['N'].idx] = reduce((lambda x, y: x * y), pcc.spatial) * c
     bstrides[self.convolutionDims['N'].idx] = 0 # broadcast b matrix
 

--- a/Tensile/Source/client/include/ClientProblemFactory.hpp
+++ b/Tensile/Source/client/include/ClientProblemFactory.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright 2019-2020 Advanced Micro Devices, Inc.
+ * Copyright 2019-2021 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -89,6 +89,7 @@ namespace Tensile
             std::vector<std::vector<size_t>> m_dStrides;
             std::vector<std::vector<size_t>> m_aZeroPads;
             std::vector<std::vector<size_t>> m_bZeroPads;
+            std::vector<std::vector<size_t>> m_convProblemSizes;
 
             TensorOps m_aOps;
             TensorOps m_bOps;

--- a/Tensile/Source/client/main.cpp
+++ b/Tensile/Source/client/main.cpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright 2019-2020 Advanced Micro Devices, Inc.
+ * Copyright 2019-2021 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -191,6 +191,10 @@ namespace Tensile
                                                                                   "specifying once applies to all problem sizes, "
                                                                                   "otherwise specify once per problem size.")
 
+                ("convolution-problem",      vector_default_empty<std::string>(), "Specify a Convolution problem size. Comma-separated list of sizes:"
+                                                                                  "Spatial(w,h,d),Filter(x,y,z),Stride(v,u,#),"
+                                                                                  "Dilation(j,l,^),Pad start(q,p,$),Pad end(q_,p_,$_)")
+
                 ("a-zero-pads",                vector_default_empty<std::string>(), "Comma-separated tuple(s) of anchor dim,"
                                                                                   "summation dim, leading pad, trailing pad."
                                                                                   "Each tuple must be separated with a semi-colon.")
@@ -364,6 +368,8 @@ namespace Tensile
             parse_arg_ints(args, "a-zero-pads");
             parse_arg_ints(args, "b-zero-pads");
 
+            if(args["convolution-vs-contraction"].as<bool>())
+                parse_arg_ints(args, "convolution-problem");
             return args;
         }
 

--- a/Tensile/Source/client/source/ClientProblemFactory.cpp
+++ b/Tensile/Source/client/source/ClientProblemFactory.cpp
@@ -97,6 +97,10 @@ namespace Tensile
 
             m_beta = DataInitialization::getValue<double>(args["init-beta"].as<InitMode>());
 
+            if(args["convolution-vs-contraction"].as<bool>())
+                m_convProblemSizes
+                    = args["convolution-problem"].as<std::vector<std::vector<size_t>>>();
+
             m_problems = createProblems();
         }
 
@@ -191,6 +195,9 @@ namespace Tensile
                 rv.back().setKernelLanguage(m_kernelLanguage);
                 rv.back().setDeterministicMode(m_deterministicMode);
                 rv.back().setArithmeticUnit(m_arithmeticUnit);
+
+                if(m_convProblemSizes.size())
+                    rv.back().setConvProblemSizes(m_convProblemSizes[i]);
             }
 
             return rv;

--- a/Tensile/Source/client/source/ConvolutionProblem.cpp
+++ b/Tensile/Source/client/source/ConvolutionProblem.cpp
@@ -352,6 +352,7 @@ namespace Tensile
         std::vector<size_t>  activationDims;
         std::vector<int64_t> activationStri;
         int64_t              batchStride;
+        int64_t              realSpatialSize = 1;
 
         auto formatA = counts.formatA();
         switch(formatA.format())
@@ -372,14 +373,12 @@ namespace Tensile
                                                  : counts.strideCount[si]
                                                        * counts.spatialCount[si - 1]);
             }
-            activationDims.push_back(problem.a().sizes()[formatA.channelPosition()]);
-            activationStri.push_back(-1);
-            activationDims.push_back(problem.a().sizes()[formatA.batchPosition()]);
-            batchStride = problem.a().sizes()[formatA.channelPosition()];
             for(int si = 0; si < m_numFormatSpatialDims; si++)
-            {
-                batchStride *= counts.spatialCount[si];
-            }
+                realSpatialSize *= counts.spatialCount[si];
+            activationDims.push_back(problem.a().sizes()[formatA.channelPosition()]);
+            activationStri.push_back(realSpatialSize);
+            activationDims.push_back(problem.a().sizes()[formatA.batchPosition()]);
+            batchStride = realSpatialSize * problem.a().sizes()[formatA.channelPosition()];
             activationStri.push_back(batchStride);
             break;
         case ConvolutionProblem::TensorFormat::NHWC:

--- a/Tensile/Source/client/source/Reference.cpp
+++ b/Tensile/Source/client/source/Reference.cpp
@@ -1,7 +1,7 @@
 /**
  * MIT License
  *
- * Copyright 2019-2020 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright 2019-2021 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -466,17 +466,21 @@ namespace Tensile
             ConvolutionProblem::LoopCounts counts;
             counts.setupForData(convProblem, problem);
 
+            convProblem.validate(problem, counts);
+
             TensorDescriptor activationTensor = convProblem.setupDataActivation(counts, problem);
             TensorDescriptor weightTensor     = convProblem.setupForwardWeights(counts, problem);
             TensorDescriptor outputTensor     = convProblem.setupDataOutput(counts, problem);
 
+            auto formatA = counts.formatA();
+            auto formatB = counts.formatB();
+            auto formatD = counts.formatD();
+
             if(db1)
             {
                 std::cout << "SolveCPUConvolution:\n";
-                std::cout << "  formatA=" << convProblem.formatA().description() << "\n";
-                std::cout << "  formatB=" << convProblem.formatB().weights().description() << "\n";
                 std::cout << "  activationTensor=" << activationTensor << "\n";
-                std::cout << " " << counts.description() << "\n";
+                std::cout << "counts:" << std::endl << counts.description() << "\n";
             }
 
             // Loops always traverse in same order but addressing in memory can be flexible to support different activation
@@ -488,7 +492,6 @@ namespace Tensile
                     for(size_t n = 0; n < counts.batchCount; n++)
                     {
                         std::vector<size_t> spatialCoord(ConvolutionProblem::MaxNumSpatialDims, 0);
-                        std::vector<size_t> filterCoord(ConvolutionProblem::MaxNumSpatialDims, 0);
 
                         CoordNumbered(spatialIndex,
                                       spatialCoord.begin(),
@@ -497,87 +500,75 @@ namespace Tensile
                                       counts.scount.end());
 
                         Accumulator value(0);
+                        size_t      filterCoordCount
+                            = CoordCount(counts.filterCount.begin(), counts.filterCount.end());
                         for(size_t cin = 0; cin < counts.cinCount; cin++)
-                            for(filterCoord[2] = 0; filterCoord[2] < counts.fcount[2];
-                                filterCoord[2]++)
-                                for(filterCoord[1] = 0; filterCoord[1] < counts.fcount[1];
-                                    filterCoord[1]++)
-                                    for(filterCoord[0] = 0; filterCoord[0] < counts.fcount[0];
-                                        filterCoord[0]++)
-                                    {
-                                        // Save coordinates from the looop and compute memeory index
-                                        // Each component stores in appropriate memory order
-                                        std::vector<size_t> aCoord(activationTensor.dimensions(),
-                                                                   0);
-                                        std::vector<size_t> bCoord(weightTensor.dimensions(), 0);
+                            for(size_t filterIndex = 0; filterIndex < filterCoordCount;
+                                filterIndex++)
+                            {
 
-                                        aCoord[convProblem.formatA().batchPosition()]   = n;
-                                        aCoord[convProblem.formatA().channelPosition()] = cin;
-                                        for(auto i = 0;
-                                            i < convProblem.formatA().spatialPositions().size();
-                                            i++)
-                                            aCoord[convProblem.formatA().spatialPositions()[i]]
-                                                = spatialCoord[i];
+                                std::vector<size_t> filterCoord(counts.filterCount.size(), 0);
+                                CoordNumbered(filterIndex,
+                                              filterCoord.begin(),
+                                              filterCoord.end(),
+                                              counts.filterCount.begin(),
+                                              counts.filterCount.end());
 
-                                        // add filters to address calc, if they have non-unit strides:
-                                        for(int fi = ConvolutionProblem::MaxNumSpatialDims - 1;
-                                            fi >= 0;
-                                            fi--)
-                                        {
-                                            auto fp = convProblem.formatA().filterPositions()[fi];
-                                            if(fp != ConvolutionProblem::InvalidPos)
-                                                aCoord[fp] = filterCoord[fi];
-                                            else
-                                                assert(filterCoord[fi] == 0);
-                                        }
+                                // Save coordinates from the looop and compute memeory index
+                                // Each component stores in appropriate memory order
+                                std::vector<int64_t> aCoord(activationTensor.dimensions(), 0);
+                                std::vector<int64_t> bCoord(weightTensor.dimensions(), 0);
 
-                                        bCoord[convProblem.formatB().weights().coutPosition()]
-                                            = cout;
-                                        bCoord[convProblem.formatB().weights().cinPosition()] = cin;
-                                        for(int fi = ConvolutionProblem::MaxNumSpatialDims - 1;
-                                            fi >= 0;
-                                            fi--)
-                                        {
-                                            auto fp = convProblem.formatB()
-                                                          .weights()
-                                                          .filterPositions()[fi];
-                                            if(fp != ConvolutionProblem::InvalidPos)
-                                                bCoord[fp] = filterCoord[fi];
-                                            else
-                                                assert(filterCoord[fi] == 0);
-                                        }
+                                aCoord[formatA.batchPosition()]   = n;
+                                aCoord[formatA.channelPosition()] = cin;
+                                for(auto i = 0; i < formatA.spatialPositions().size(); i++)
+                                    aCoord[formatA.spatialPositions()[i]] = spatialCoord[i];
 
-                                        auto aIndex = activationTensor.index(aCoord);
-                                        auto aVal   = Transform<typename Inputs::AType>::Input(
-                                            inputs.a[aIndex], false);
+                                // add filters to address calc, if they have non-unit strides:
+                                for(int fi = 0; fi < counts.filterCount.size(); fi++)
+                                {
+                                    auto fp = formatA.filterPositions()[fi];
+                                    if(fp != ConvolutionProblem::InvalidPos)
+                                        aCoord[fp] = filterCoord[fi];
+                                }
 
-                                        auto bIndex = weightTensor.index(bCoord);
-                                        auto bVal   = Transform<typename Inputs::BType>::Input(
-                                            inputs.b[bIndex], false);
+                                bCoord[formatB.weights().coutPosition()] = cout;
+                                bCoord[formatB.weights().cinPosition()]  = cin;
+                                for(int fi = 0; fi < counts.filterCount.size(); fi++)
+                                {
+                                    auto fp = formatB.weights().filterPositions()[fi];
+                                    if(fp != ConvolutionProblem::InvalidPos)
+                                        bCoord[fp] = filterCoord[fi];
+                                }
 
-                                        if(db2)
-                                        {
-                                            std::cout
-                                                << "  n,cin,spatialCoord,cout=" << n << "," << cin
-                                                << ","
-                                                << "," << cout << ","
-                                                << " spatialCoord[2,1,0]=" << spatialCoord[2] << ","
-                                                << spatialCoord[1] << "," << spatialCoord[0]
-                                                << " filterCoord[2,1,0]=" << filterCoord[2] << ","
-                                                << filterCoord[1] << "," << filterCoord[0]
-                                                << " aIndex=" << aIndex << " bIndex=" << bIndex
-                                                << " aVal=" << aVal << " bVal=" << bVal << "\n";
-                                        }
-                                        value += static_cast<Accumulator>(aVal * bVal);
-                                    }
+                                auto aIndex = activationTensor.index(aCoord);
+                                auto aVal   = Transform<typename Inputs::AType>::Input(
+                                    inputs.a[aIndex], false);
+
+                                auto bIndex = weightTensor.index(bCoord);
+                                auto bVal   = Transform<typename Inputs::BType>::Input(
+                                    inputs.b[bIndex], false);
+
+                                if(db2)
+                                {
+                                    std::cout << "  n,cin,spatialCoord,cout=" << n << "," << cin
+                                              << ","
+                                              << "," << cout << ","
+                                              << " spatialCoord[2,1,0]=" << spatialCoord[2] << ","
+                                              << spatialCoord[1] << "," << spatialCoord[0]
+                                              << " filterCoord[2,1,0]=" << filterCoord[2] << ","
+                                              << filterCoord[1] << "," << filterCoord[0]
+                                              << " aIndex=" << aIndex << " bIndex=" << bIndex
+                                              << " aVal=" << aVal << " bVal=" << bVal << "\n";
+                                }
+
+                                value += static_cast<Accumulator>(aVal * bVal);
+                            }
                         std::vector<size_t> dCoord(outputTensor.dimensions(), 0);
-                        dCoord[convProblem.formatD().activation().batchPosition()]   = n;
-                        dCoord[convProblem.formatD().activation().channelPosition()] = cout;
-                        for(auto i = 0;
-                            i < convProblem.formatD().activation().spatialPositions().size();
-                            i++)
-                            dCoord[convProblem.formatD().activation().spatialPositions()[i]]
-                                = spatialCoord[i];
+                        dCoord[formatD.activation().batchPosition()]   = n;
+                        dCoord[formatD.activation().channelPosition()] = cout;
+                        for(auto i = 0; i < formatD.activation().spatialPositions().size(); i++)
+                            dCoord[formatD.activation().spatialPositions()[i]] = spatialCoord[i];
 
                         auto dIndex = outputTensor.index(dCoord);
                         if(db1)

--- a/Tensile/Source/client/source/ReferenceValidator.cpp
+++ b/Tensile/Source/client/source/ReferenceValidator.cpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright 2019-2020 Advanced Micro Devices, Inc.
+ * Copyright 2019-2021 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -96,8 +96,6 @@ namespace Tensile
 
                 if(m_convolutionVsContraction)
                 {
-
-                    m_convolutionProblem.validate(problem);
 
                     SolveCPUConvolution(
                         m_convolutionProblem, problem, *(m_dataInit->cpuConvInputs()));

--- a/Tensile/Source/lib/include/Tensile/ContractionProblem.hpp
+++ b/Tensile/Source/lib/include/Tensile/ContractionProblem.hpp
@@ -1,7 +1,7 @@
 /**
  * MIT License
  *
- * Copyright 2019-2020 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright 2019-2021 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -485,6 +485,15 @@ namespace Tensile
             return m_problemStrides;
         }
 
+        std::vector<size_t> const& convProblemSizes() const
+        {
+            return m_convProblemSizes;
+        }
+        void setConvProblemSizes(std::vector<size_t>& convProblemSizes)
+        {
+            m_convProblemSizes.assign(convProblemSizes.begin(), convProblemSizes.end());
+        }
+
         void setAlphaType(DataType type)
         {
             m_alphaType = type;
@@ -753,6 +762,7 @@ namespace Tensile
 
         std::vector<size_t> m_problemSizes;
         std::vector<size_t> m_problemStrides;
+        std::vector<size_t> m_convProblemSizes;
 
         bool   m_transposeC01;
         double m_beta;

--- a/Tensile/Source/lib/source/ContractionProblem.cpp
+++ b/Tensile/Source/lib/source/ContractionProblem.cpp
@@ -1,7 +1,7 @@
 /**
  * MIT License
  *
- * Copyright 2019-2020 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright 2019-2021 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -735,19 +735,18 @@ namespace Tensile
 
     void ContractionProblem::addAZeroPad(const ZeroPad& zp)
     {
-        m_aZeroPads.push_back(zp);
-        m_boundIndices[toBoundsPos(zp.boundIndex)].aZeroPad = zp;
-
+        m_boundIndices[toBoundsPos(zp.boundIndex)].aZeroPad           = zp;
         m_boundIndices[toBoundsPos(zp.boundIndex)].aZeroPad.anchorPos = toAPos(zp.anchorIndex);
         m_boundIndices[toBoundsPos(zp.boundIndex)].aZeroPad.boundPos  = toAPos(zp.boundIndex);
+        m_aZeroPads.push_back(m_boundIndices[toBoundsPos(zp.boundIndex)].aZeroPad);
     }
 
     void ContractionProblem::addBZeroPad(const ZeroPad& zp)
     {
-        m_bZeroPads.push_back(zp);
         m_boundIndices[toBoundsPos(zp.boundIndex)].bZeroPad           = zp;
         m_boundIndices[toBoundsPos(zp.boundIndex)].bZeroPad.anchorPos = toBPos(zp.anchorIndex);
         m_boundIndices[toBoundsPos(zp.boundIndex)].bZeroPad.boundPos  = toBPos(zp.boundIndex);
+        m_bZeroPads.push_back(m_boundIndices[toBoundsPos(zp.boundIndex)].bZeroPad);
     }
 
     void ContractionProblem::checkPersistentKernelEligibility(ContractionSolution const& solution,

--- a/Tensile/Tests/extended/convolution_config/YamlBuilder/YamlBuilder.py
+++ b/Tensile/Tests/extended/convolution_config/YamlBuilder/YamlBuilder.py
@@ -415,12 +415,13 @@ class YamlBuilder:
             problem['d'] = spatialIn[2]
         problems.append(problem)
 
-        if problemLevel==2:
-            problems += cls.genProblems(conv, nRange=(1,2,8), ckRange=[64], spatialRange=(7,14,56))
-        elif problemLevel==3:
-            problems += cls.genProblems(conv, nRange=(1,2,8), ckRange=range(127,129), spatialRange=(7,14,56))
-        elif problemLevel==4:
-            problems += cls.genProblems(conv, nRange=(1,2,8), ckRange=range(127,129), spatialRange=(7,56,73,111,194))
+        if not conv.cc.spatial:
+          if problemLevel==2:
+              problems += cls.genProblems(conv, nRange=(1,2,8), ckRange=[64], spatialRange=(7,14,56))
+          elif problemLevel==3:
+              problems += cls.genProblems(conv, nRange=(1,2,8), ckRange=range(127,129), spatialRange=(7,14,56))
+          elif problemLevel==4:
+              problems += cls.genProblems(conv, nRange=(1,2,8), ckRange=range(127,129), spatialRange=(7,56,73,111,194))
 
         #try:
         #    asize = cls.memSize(problemType["IndexAssignmentsA"], problems)
@@ -439,7 +440,7 @@ class YamlBuilder:
         Generates a YamlBuilder object that will run in
         ConvolutionVsContraction mode.
         """
-        obj = cls.ConvolutionContraction(conv, {}, solution, problemFunc=cls.ProblemSizes, problemLevel=1, dataType=dataType)
+        obj = cls.ConvolutionContraction(conv, {}, solution, problemFunc=cls.ProblemSizes, problemLevel=2, dataType=dataType)
         obj.doc["GlobalParameters"]["ConvolutionVsContraction"] = 1
         for problem in obj.doc["BenchmarkProblems"]:
             problem[0]["OperationType"] = conv.convolutionType

--- a/Tensile/Tests/extended/convolution_config/conftest.py
+++ b/Tensile/Tests/extended/convolution_config/conftest.py
@@ -50,7 +50,7 @@ def run_contraction(tensile_args, tmp_path, run_generate_yaml, request, tensile_
 
 @pytest.fixture
 def run_convolution_vs_contraction(tensile_args, tmp_path, file_with_test_name, tensile_script_path):
-    def run(conv, problemType={}, solution=Solutions.defaultSolution(), dataType='s'):
+    def run(conv, problemType={}, solution=Solutions.src1, dataType='s'):
         config = YamlBuilder.ConvolutionVsContraction(conv, solution, dataType)
         configFile = file_with_test_name(".conv.yaml")
         config.write(configFile)

--- a/Tensile/Tests/extended/convolution_config/test_conv_vs_contraction.py
+++ b/Tensile/Tests/extended/convolution_config/test_conv_vs_contraction.py
@@ -1,4 +1,4 @@
-import logging,pytest
+import logging
 from Tensile.SolutionStructs import Convolution
 log =logging.getLogger("testlog")
 
@@ -10,10 +10,6 @@ def test_simple(run_convolution_vs_contraction):
     z={} # problemType definition
     conv = Convolution(z, 'ConvolutionForward',
               config={'TensorAFormat': 'NCHW',
-                      'Filter': '1x1',
-                      'Stride': '1x1',
-                      'Dilation': '1x1',
-                      'Spatial': '17x31',
                       })
     log.debug(conv.printUsage(z))
     run_convolution_vs_contraction(conv)
@@ -23,36 +19,25 @@ def test_stride1x2(run_convolution_vs_contraction):
     z={} # problemType definition
     conv = Convolution(z, 'ConvolutionForward',
               config={'TensorAFormat': 'NCHW',
-                      'Filter': '1x1',
                       'Stride': '1x2',
-                      'Dilation': '1x1',
-                      'Spatial': '17x31',
                       })
     log.debug(conv.printUsage(z))
     run_convolution_vs_contraction(conv)
 
-@pytest.mark.skip(reason="dilationY breaks conv reference model")
 def test_stride2x1(run_convolution_vs_contraction):
     z={} # problemType definition
     conv = Convolution(z, 'ConvolutionForward',
               config={'TensorAFormat': 'NCHW',
-                      'Filter': '1x1',
                       'Stride': '2x1',
-                      'Dilation': '1x1',
-                      'Spatial': '17x31',
                       })
     log.debug(conv.printUsage(z))
     run_convolution_vs_contraction(conv)
 
-@pytest.mark.skip(reason="dilationY breaks conv reference model")
 def test_stride2x3(run_convolution_vs_contraction):
     z={} # problemType definition
     conv = Convolution(z, 'ConvolutionForward',
               config={'TensorAFormat': 'NCHW',
-                      'Filter': '1x1',
                       'Stride': '2x3',
-                      'Dilation': '1x1',
-                      'Spatial': '17x31',
                       })
     log.debug(conv.printUsage(z))
     run_convolution_vs_contraction(conv)
@@ -62,9 +47,6 @@ def test_filter1x2(run_convolution_vs_contraction):
     conv = Convolution(z, 'ConvolutionForward',
               config={'TensorAFormat': 'NCHW',
                       'Filter': '1x2',
-                      'Stride': '1x1',
-                      'Dilation': '1x1',
-                      'Spatial': '17x31',
                       })
 
     log.debug(conv.printUsage(z))
@@ -76,9 +58,6 @@ def test_filter2x1(run_convolution_vs_contraction):
     conv = Convolution(z, 'ConvolutionForward',
               config={'TensorAFormat': 'NCHW',
                       'Filter': '2x1',
-                      'Stride': '1x1',
-                      'Dilation': '1x1',
-                      'Spatial': '17x31',
                       })
     log.debug(conv.printUsage(z))
     run_convolution_vs_contraction(conv)
@@ -88,9 +67,6 @@ def test_filter2x3(run_convolution_vs_contraction):
     conv = Convolution(z, 'ConvolutionForward',
               config={'TensorAFormat': 'NCHW',
                       'Filter': '2x3',
-                      'Stride': '1x1',
-                      'Dilation': '1x1',
-                      'Spatial': '17x31',
                       })
     log.debug(conv.printUsage(z))
     run_convolution_vs_contraction(conv)
@@ -99,39 +75,65 @@ def test_dilation1x2(run_convolution_vs_contraction):
     z={} # problemType definition
     conv = Convolution(z, 'ConvolutionForward',
               config={'TensorAFormat': 'NCHW',
-                      'Filter': '1x1',
-                      'Stride': '1x1',
+                      'Filter': '2x2',
                       'Dilation': '1x2',
-                      'Spatial': '17x31',
                       })
     log.debug(conv.printUsage(z))
     run_convolution_vs_contraction(conv)
 
-@pytest.mark.skip(reason="dilationY breaks conv reference model")
 def test_dilation2x1(run_convolution_vs_contraction):
     z={} # problemType definition
     conv = Convolution(z, 'ConvolutionForward',
               config={'TensorAFormat': 'NCHW',
-                      'Filter': '1x1',
-                      'Stride': '1x1',
+                      'Filter': '2x2',
                       'Dilation': '2x1',
-                      'Spatial': '17x31',
                       })
     log.debug(conv.printUsage(z))
     run_convolution_vs_contraction(conv)
 
-@pytest.mark.skip(reason="dilationY breaks conv reference model")
 def test_dilation2x3(run_convolution_vs_contraction):
     z={} # problemType definition
     conv = Convolution(z, 'ConvolutionForward',
               config={'TensorAFormat': 'NCHW',
-                      'Filter': '1x1',
-                      'Stride': '1x1',
+                      'Filter': '2x2',
                       'Dilation': '2x3',
-                      'Spatial': '17x31',
                       })
     log.debug(conv.printUsage(z))
     run_convolution_vs_contraction(conv)
+
+def test_pad1x0(run_convolution_vs_contraction):
+    z={} # problemType definition
+    conv = Convolution(z, 'ConvolutionForward',
+              config={'TensorAFormat': 'NCHW',
+                      'Filter': '2x2',
+                      'PadStart': '1x0',
+                      'PadEnd': '1x0',
+                      })
+    log.debug(conv.printUsage(z))
+    run_convolution_vs_contraction(conv)
+
+def test_pad0x1(run_convolution_vs_contraction):
+    z={} # problemType definition
+    conv = Convolution(z, 'ConvolutionForward',
+              config={'TensorAFormat': 'NCHW',
+                      'Filter': '2x2',
+                      'PadStart': '0x1',
+                      'PadEnd': '0x1',
+                      })
+    log.debug(conv.printUsage(z))
+    run_convolution_vs_contraction(conv)
+
+def test_pad2x3(run_convolution_vs_contraction):
+    z={} # problemType definition
+    conv = Convolution(z, 'ConvolutionForward',
+              config={'TensorAFormat': 'NCHW',
+                      'Filter': '2x2',
+                      'PadStart': '2x3',
+                      'PadEnd': '2x3',
+                      })
+    log.debug(conv.printUsage(z))
+    run_convolution_vs_contraction(conv)
+
 
 def test_filter_stride_dilation_0(run_convolution_vs_contraction):
     z={} # problemType definition
@@ -143,7 +145,6 @@ def test_filter_stride_dilation_0(run_convolution_vs_contraction):
                       'Filter': '2x3',
                       'Stride': '2x3',
                       'Dilation': '2x3',
-                      'Spatial': '17x31',
                       })
     assert(z['NumIndicesC']==4)
     assert(z['IndexAssignmentsA']==[6,5, 0,1, 4,3])

--- a/Tensile/Tests/unit/test_conv_problem.py
+++ b/Tensile/Tests/unit/test_conv_problem.py
@@ -12,7 +12,7 @@ def test_stride2x3():
     e= { 'n':64, 'c':256, 'h':20, 'w':14, 'k':1024, 'x':1, 'y':1, 'u':2, 'v':3 }
     ec = ConvProblem(e, conv)
     assert (ec.sizes == (5, 10, e['k'], e['n'], e['c']))
-    assert (ec.stridesA == (3, 28, -1, 71680))
+    assert (ec.stridesA == (3, 28, e['h'] * e['w'], 71680))
 
 def test_stride2x3_defaults():
     z={} # problemType definition
@@ -24,7 +24,7 @@ def test_stride2x3_defaults():
     e= { 'n':64, 'c':256, 'h':20, 'w':14, 'k':1024}
     ec = ConvProblem(e, conv)
     assert (ec.sizes == (5, 10, e['k'], e['n'], e['c']))
-    assert (ec.stridesA == (3, 28, -1, 71680))
+    assert (ec.stridesA == (3, 28, e['h'] * e['w'], 71680))
 
 @pytest.mark.skip(reason="no X filter, ZeroPadA has one entry and it is for Y filter")
 def test_pad_4x1():

--- a/Tensile/Tests/unit/test_makeProblem.py
+++ b/Tensile/Tests/unit/test_makeProblem.py
@@ -12,7 +12,7 @@ def test_spatial_in():
     pcc = ConvolutionConfig(spatial=[14,15])
     p = conv.makeProblem(n=64, c=1024, k=256, pcc=pcc)
     assert(p[0] == [210, 256, 64, 1024])
-    assert(p[1] == [1, -1, 215040])
+    assert(p[1] == [1, 210, 215040])
     assert(p[2] == [-1, -1, 0])
 
 def test_spatial_parm():
@@ -26,7 +26,7 @@ def test_spatial_parm():
     pcc = ConvolutionConfig()
     p = conv.makeProblem(n=64, c=1024, k=256, pcc=pcc)
     assert(p[0] == [182, 256, 64, 1024])
-    assert(p[1] == [1, -1, 186368])
+    assert(p[1] == [1, 182, 186368])
     assert(p[2] == [-1, -1, 0])
 
 
@@ -41,7 +41,7 @@ def test_stride():
     log.debug(conv.printUsage(z))
     p = conv.makeProblem(n=64, c=1024, k=256, pcc=conv.cc)
     assert(p[0] == [5, 7, 256, 64, 1024])
-    assert(p[1] == [3, 28, -1, 186368])
+    assert(p[1] == [3, 28, 182, 186368])
     assert(p[2] == [-1, -1, 0])
 
 
@@ -57,7 +57,7 @@ def test_stride_filter():
     log.debug(conv.printUsage(z))
     p = conv.makeProblem(n=64, c=1024, k=256, pcc=conv.cc)
     assert(p[0] == [4, 6, 256, 64, 3, 4, 1024])
-    assert(p[1] == [1, 14, 3, 28, -1, 186368])
+    assert(p[1] == [1, 14, 3, 28, 182, 186368])
     assert(p[2] == [-1, -1, -1, -1, 0])
 
 def test_stride_filter_dilated():
@@ -73,7 +73,7 @@ def test_stride_filter_dilated():
     log.debug(conv.printUsage(z))
     p = conv.makeProblem(n=64, c=1024, k=256, pcc=conv.cc)
     assert(p[0] == [2, 5, 256, 64, 3, 4, 1024])
-    assert(p[1] == [3, 28, 3, 28, -1, 186368])
+    assert(p[1] == [3, 28, 3, 28, 182, 186368])
     assert(p[2] == [-1, -1, -1, -1, 0])
 
 def test_spatial_unspecified():


### PR DESCRIPTION
**Refactor ConvolutionVsContraction:**

> The original design of **ConvolutionVsContraction** needs to specify the convolution problem size  exactly into convolution config of yaml. Then the convolution config would be translated into "convolution-identifier" of client parameter. It means that only 1 conv problem size is allowed since all conv problem sizes of this yaml must be exactly identical with conv config.

> This patch refactor the design to store each convolution problem sizes into another client parameter "convolution-problem" along with each problems. It allows user to set different problem sizes into same yaml for ConvolutionVsContraction validation. 

> With this patch, we are able to enable ConvolutionVsContraction for all NCHW conv forward tests.

**support zeropad in CPU convolution validation**

**Fix bug: the channel stride is incorrect when convert conv problem into tensor contraction problem.**

**CI tests: Extend the test scope of conv_vs_contraction CI tests**
  

> With the new design, we are able to test multiple problem sizes in one convolution configs. This commit set the problemLevel = 2 for test_conv_vs_contraction CI tests. It would test 28 problem sizes for each convolution config. This commit also removes all pytest.mark.skip() from test_conv_vs_contraction and add testing for zero padding. 

example: new parameter "convolution-problem" of ClientParameter.ini
![image](https://user-images.githubusercontent.com/40224768/106119720-78837c80-6190-11eb-9959-19a6386391d9.png)
