### PR TITLE
Per CU benchmarking and Tensile library support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [(Unreleased) Tensile 4.27.0 for ROCm 4.2.0]
 ### Added
+- Benchmarking and library support for CU efficiency vs. overall speed
 - support general batch GEMM
 - Support offset for each input/output buffer in Tensile
 - support support ldc != ldd for all GEMM kernel

--- a/HostLibraryTests/CMakeLists.txt
+++ b/HostLibraryTests/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright 2019-2020 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright 2019-2021 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -133,6 +133,7 @@ if(TENSILE_USE_LLVM)
         ContractionLibraryLoading_test.cpp
         ContractionFitness_test.cpp
         llvm/ArithmeticUnitPredicate_test.cpp
+        llvm/CUEfficiencyPredicate_test.cpp
         llvm/DeterministicModePredicate_test.cpp
         llvm/KernelLanguagePredicate_test.cpp
         llvm/LLVMYAMLContraction_test.cpp
@@ -192,4 +193,3 @@ endif()
 if(TENSILE_USE_OPENMP)
     target_link_libraries(TensileTests PRIVATE "${OpenMP_EXE_LINKER_FLAGS}")
 endif()
-

--- a/HostLibraryTests/llvm/CUEfficiencyPredicate_test.cpp
+++ b/HostLibraryTests/llvm/CUEfficiencyPredicate_test.cpp
@@ -1,0 +1,118 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright 2019-2021 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include <Tensile/ContractionLibrary.hpp>
+#include <Tensile/Serialization.hpp>
+#include <Tensile/llvm/YAML.hpp>
+
+using namespace Tensile;
+
+TEST(CUEfficiencyPredicate, CUEfficiency)
+{
+    std::string mydoc = "type: And\n"
+                        "value: [{type: TruePred}, \n"
+                        "        {type: CUEfficiency}]";
+
+    llvm::yaml::Input yin(mydoc);
+
+    std::shared_ptr<Predicates::Predicate<ContractionProblem>> p;
+
+    yin >> p;
+    ASSERT_FALSE(yin.error());
+    EXPECT_NE(p, nullptr);
+
+    ContractionProblem small
+        = ContractionProblem::GEMM(false, false, 4, 4, 4, 4, 4, 4, 1, false, 1);
+
+    ContractionProblem large = ContractionProblem::GEMM(
+        false, false, 10'000, 10'000, 10'000, 10'000, 10'000, 10'000, 1, false, 1);
+
+    small.setBenchmarkMetric(BenchmarkMetric::CUEfficiency);
+    large.setBenchmarkMetric(BenchmarkMetric::CUEfficiency);
+
+    EXPECT_EQ((*p)(small), true);
+    EXPECT_EQ((*p)(large), true);
+}
+
+TEST(CUEfficiencyPredicate, Overall)
+{
+    std::string mydoc = "type: And\n"
+                        "value: [{type: TruePred}, \n"
+                        "        {type: CUEfficiency}]";
+
+    llvm::yaml::Input yin(mydoc);
+
+    std::shared_ptr<Predicates::Predicate<ContractionProblem>> p;
+
+    yin >> p;
+    ASSERT_FALSE(yin.error());
+    EXPECT_NE(p, nullptr);
+
+    ContractionProblem small
+        = ContractionProblem::GEMM(false, false, 4, 4, 4, 4, 4, 4, 1, false, 1);
+
+    ContractionProblem large = ContractionProblem::GEMM(
+        false, false, 10'000, 10'000, 10'000, 10'000, 10'000, 10'000, 1, false, 1);
+
+    small.setBenchmarkMetric(BenchmarkMetric::Overall);
+    large.setBenchmarkMetric(BenchmarkMetric::Overall);
+
+    EXPECT_EQ((*p)(small), false);
+    EXPECT_EQ((*p)(large), false);
+}
+
+TEST(CUEfficiencyPredicate, Best)
+{
+    std::string mydoc = "type: And\n"
+                        "value: [{type: TruePred}, \n"
+                        "        {type: CUEfficiency}]";
+
+    llvm::yaml::Input yin(mydoc);
+
+    std::shared_ptr<Predicates::Predicate<ContractionProblem>> p;
+
+    yin >> p;
+    ASSERT_FALSE(yin.error());
+    EXPECT_NE(p, nullptr);
+
+    // Small enough that 'Best' should always return true for CUEfficiency,
+    // even if exact logic changes
+    ContractionProblem small
+        = ContractionProblem::GEMM(false, false, 4, 4, 4, 4, 4, 4, 1, false, 1);
+
+    // Large enough that 'Best' should always return false for CUEfficiency,
+    // even if exact logic changes
+    ContractionProblem large = ContractionProblem::GEMM(
+        false, false, 10'000, 10'000, 10'000, 10'000, 10'000, 10'000, 1, false, 1);
+
+    small.setBenchmarkMetric(BenchmarkMetric::Best);
+    large.setBenchmarkMetric(BenchmarkMetric::Best);
+
+    EXPECT_EQ((*p)(small), true);
+    EXPECT_EQ((*p)(large), false);
+}

--- a/HostLibraryTests/llvm/CUEfficiencyPredicate_test.cpp
+++ b/HostLibraryTests/llvm/CUEfficiencyPredicate_test.cpp
@@ -52,8 +52,8 @@ TEST(CUEfficiencyPredicate, CUEfficiency)
     ContractionProblem large = ContractionProblem::GEMM(
         false, false, 10'000, 10'000, 10'000, 10'000, 10'000, 10'000, 1, false, 1);
 
-    small.setBenchmarkMetric(BenchmarkMetric::CUEfficiency);
-    large.setBenchmarkMetric(BenchmarkMetric::CUEfficiency);
+    small.setPerformanceMetric(PerformanceMetric::CUEfficiency);
+    large.setPerformanceMetric(PerformanceMetric::CUEfficiency);
 
     EXPECT_EQ((*p)(small), true);
     EXPECT_EQ((*p)(large), true);
@@ -79,8 +79,8 @@ TEST(CUEfficiencyPredicate, Overall)
     ContractionProblem large = ContractionProblem::GEMM(
         false, false, 10'000, 10'000, 10'000, 10'000, 10'000, 10'000, 1, false, 1);
 
-    small.setBenchmarkMetric(BenchmarkMetric::Overall);
-    large.setBenchmarkMetric(BenchmarkMetric::Overall);
+    small.setPerformanceMetric(PerformanceMetric::Overall);
+    large.setPerformanceMetric(PerformanceMetric::Overall);
 
     EXPECT_EQ((*p)(small), false);
     EXPECT_EQ((*p)(large), false);
@@ -110,8 +110,8 @@ TEST(CUEfficiencyPredicate, Best)
     ContractionProblem large = ContractionProblem::GEMM(
         false, false, 10'000, 10'000, 10'000, 10'000, 10'000, 10'000, 1, false, 1);
 
-    small.setBenchmarkMetric(BenchmarkMetric::Best);
-    large.setBenchmarkMetric(BenchmarkMetric::Best);
+    small.setPerformanceMetric(PerformanceMetric::Best);
+    large.setPerformanceMetric(PerformanceMetric::Best);
 
     EXPECT_EQ((*p)(small), true);
     EXPECT_EQ((*p)(large), false);

--- a/Tensile/ClientWriter.py
+++ b/Tensile/ClientWriter.py
@@ -634,7 +634,7 @@ def writeClientConfigIni(problemSizes, problemType, sourceDir, codeObjectFiles, 
 
         if problemType.convolution and globalParameters["ConvolutionVsContraction"]:
             param('convolution-identifier', problemType.convolution.identifier())
-        param('benchmark-per-cu', globalParameters["BenchmarkPerCU"])
+        param('benchmark-metric', globalParameters["BenchmarkMetric"])
         param('problem-identifier', problemType.operationIdentifier)
         param('a-type',     problemType.aType.toEnum())
         param('b-type',     problemType.bType.toEnum())

--- a/Tensile/ClientWriter.py
+++ b/Tensile/ClientWriter.py
@@ -634,7 +634,7 @@ def writeClientConfigIni(problemSizes, problemType, sourceDir, codeObjectFiles, 
 
         if problemType.convolution and globalParameters["ConvolutionVsContraction"]:
             param('convolution-identifier', problemType.convolution.identifier())
-        param('benchmark-metric', globalParameters["BenchmarkMetric"])
+        param('performance-metric', globalParameters["PerformanceMetric"])
         param('problem-identifier', problemType.operationIdentifier)
         param('a-type',     problemType.aType.toEnum())
         param('b-type',     problemType.bType.toEnum())

--- a/Tensile/ClientWriter.py
+++ b/Tensile/ClientWriter.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright 2016-2020 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright 2016-2021 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -634,6 +634,7 @@ def writeClientConfigIni(problemSizes, problemType, sourceDir, codeObjectFiles, 
 
         if problemType.convolution and globalParameters["ConvolutionVsContraction"]:
             param('convolution-identifier', problemType.convolution.identifier())
+        param('benchmark-per-cu', globalParameters["BenchmarkPerCU"])
         param('problem-identifier', problemType.operationIdentifier)
         param('a-type',     problemType.aType.toEnum())
         param('b-type',     problemType.bType.toEnum())

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -51,7 +51,7 @@ workingDirectoryStack = []
 # common
 ########################################
 globalParameters["MinimumRequiredVersion"] = "0.0.0"  # which version of tensile is required to handle all the features required by this configuration file
-globalParameters["BenchmarkPerCU"] = False        # if True, benchmark speed will be reported per CU instead of overall speed
+globalParameters["BenchmarkMetric"] = "Overall"   # metric for benchmarking results; one of {Overall, CUEfficiency}
 globalParameters["PrintLevel"] = 1                # how much info to print in generator. 0=none, 1=standard, 2=verbose
 globalParameters["ClientLogLevel"] = 3            # the log level of client. 0=Error, 1=Terse, 2=Verbose, 3=Debug (Aligned with ResultReporter.hpp)
 # benchmarking

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -50,8 +50,8 @@ workingDirectoryStack = []
 ########################################
 # common
 ########################################
-globalParameters["MinimumRequiredVersion"] = "0.0.0"  # which version of tensile is required to handle all the features required by this configuration file
-globalParameters["BenchmarkMetric"] = "Overall"   # metric for benchmarking results; one of {Overall, CUEfficiency}
+globalParameters["MinimumRequiredVersion"] = "0.0.0" # which version of tensile is required to handle all the features required by this configuration file
+globalParameters["PerformanceMetric"] = "Overall"    # performance metric for benchmarking; one of {Overall, CUEfficiency}
 globalParameters["PrintLevel"] = 1                # how much info to print in generator. 0=none, 1=standard, 2=verbose
 globalParameters["ClientLogLevel"] = 3            # the log level of client. 0=Error, 1=Terse, 2=Verbose, 3=Debug (Aligned with ResultReporter.hpp)
 # benchmarking

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright 2016-2020 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright 2016-2021 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -51,6 +51,7 @@ workingDirectoryStack = []
 # common
 ########################################
 globalParameters["MinimumRequiredVersion"] = "0.0.0"  # which version of tensile is required to handle all the features required by this configuration file
+globalParameters["BenchmarkPerCU"] = False        # if True, benchmark speed will be reported per CU instead of overall speed
 globalParameters["PrintLevel"] = 1                # how much info to print in generator. 0=none, 1=standard, 2=verbose
 globalParameters["ClientLogLevel"] = 3            # the log level of client. 0=Error, 1=Terse, 2=Verbose, 3=Debug (Aligned with ResultReporter.hpp)
 # benchmarking

--- a/Tensile/Hardware.py
+++ b/Tensile/Hardware.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright 2019-2021 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright 2019-2020 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +20,6 @@
 ################################################################################
 
 from . import Properties
-import copy
 
 class HardwarePredicate(Properties.Predicate):
     @classmethod
@@ -69,10 +68,8 @@ class HardwarePredicate(Properties.Predicate):
             assert myProcPred.tag == otherProcPred.tag == "Processor", "Invalid processor predicate"
 
             # Downgrade to base class so that we don't recurse
-            myProcPredCopy = copy.deepcopy(myProcPred)
-            otherProcPredCopy = copy.deepcopy(otherProcPred)
-            myProcPredCopy.__class__ = otherProcPredCopy.__class__ = Properties.Predicate
-            return myProcPredCopy < otherProcPredCopy
+            myProcPred.__class__ = otherProcPred.__class__ = Properties.Predicate
+            return myProcPred < otherProcPred
 
         # Higher priority given to higher CU count
         return myCUCount > otherCUCount

--- a/Tensile/Hardware.py
+++ b/Tensile/Hardware.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright 2019-2020 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright 2019-2021 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,6 +20,7 @@
 ################################################################################
 
 from . import Properties
+import copy
 
 class HardwarePredicate(Properties.Predicate):
     @classmethod
@@ -68,8 +69,10 @@ class HardwarePredicate(Properties.Predicate):
             assert myProcPred.tag == otherProcPred.tag == "Processor", "Invalid processor predicate"
 
             # Downgrade to base class so that we don't recurse
-            myProcPred.__class__ = otherProcPred.__class__ = Properties.Predicate
-            return myProcPred < otherProcPred
+            myProcPredCopy = copy.deepcopy(myProcPred)
+            otherProcPredCopy = copy.deepcopy(otherProcPred)
+            myProcPredCopy.__class__ = otherProcPredCopy.__class__ = Properties.Predicate
+            return myProcPredCopy < otherProcPredCopy
 
         # Higher priority given to higher CU count
         return myCUCount > otherCUCount

--- a/Tensile/LibraryIO.py
+++ b/Tensile/LibraryIO.py
@@ -130,9 +130,9 @@ def readLibraryLogicForSchedule( filename ):
   data = yaml.load(stream, yaml.SafeLoader)
   stream.close()
 
-  # verify
-  if len(data) < 6:
-    printExit("len(%s) %u < 6" % (filename, len(data)))
+  # verify data has all the fields we need
+  if len(data) < 9:
+    printExit("Library logic file %s is missing required fields (len = %u < 9)" % (filename, len(data)))
 
   # parse out objects
   versionString     = data[0]["MinimumRequiredVersion"]

--- a/Tensile/LibraryIO.py
+++ b/Tensile/LibraryIO.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright 2016-2020 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright 2016-2021 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -132,7 +132,7 @@ def readLibraryLogicForSchedule( filename ):
 
   # verify
   if len(data) < 6:
-    printExit("len(%s) %u < 7" % (filename, len(data)))
+    printExit("len(%s) %u < 6" % (filename, len(data)))
 
   # parse out objects
   versionString     = data[0]["MinimumRequiredVersion"]
@@ -264,7 +264,10 @@ class Writer:
       tileSelectionIndices = logicTuple[6]
       tileSelectionLogic["TileSelectionIndices"] = tileSelectionIndices
       data.append(tileSelectionLogic)
+    else:
+      data.append(None)
 
+    data.append(logicTuple[7])
     return data
 
 class YAMLWriter(Writer):
@@ -295,7 +298,7 @@ class MessagePackWriter(Writer):
       try:
         msgpack.pack(data, f)
       except NameError:
-        printExit("You must install MessagePack for Python to use Tensile (to parse config files). See https://github.com/msgpack/msgpack-python for installation instructions.") 
+        printExit("You must install MessagePack for Python to use Tensile (to parse config files). See https://github.com/msgpack/msgpack-python for installation instructions.")
 
 
   def writeLibraryLogicForSchedule(self, filePath, schedulePrefix, architectureName, \
@@ -315,4 +318,4 @@ class MessagePackWriter(Writer):
     except IOError:
       printExit("Cannot open file: %s" % filename)
     except NameError:
-      printExit("You must install MessagePack for Python to use Tensile (to parse config files). See https://github.com/msgpack/msgpack-python for installation instructions.") 
+      printExit("You must install MessagePack for Python to use Tensile (to parse config files). See https://github.com/msgpack/msgpack-python for installation instructions.")

--- a/Tensile/LibraryLogic.py
+++ b/Tensile/LibraryLogic.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright 2016-2020 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright 2016-2021 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -207,7 +207,7 @@ def analyzeProblemType( problemType, problemSizeGroups, inputParameters ):
 
   #selectionSolutionsIdsList = list(selectionSolutionsIds)
   return (problemType, logicAnalyzer.solutions, logicAnalyzer.indexOrder, \
-       exactLogic, rangeLogic, selectionSolutions, selectionSolutionsIdsList)
+       exactLogic, rangeLogic, selectionSolutions, selectionSolutionsIdsList, logicAnalyzer.perCU)
 
 
 
@@ -438,6 +438,16 @@ class LogicAnalyzer:
     for row in csvFile:
       rowIdx+=1
       if rowIdx == 1:
+        # get unit (gflops or gflops/cu) of benchmark data
+        perfUnit = row[0]
+        if perfUnit == "GFlops":
+          self.perCU = False
+        elif perfUnit == "GFlopsPerCU":
+          self.perCU = True
+        else:
+          printWarning("Performance unit %s in %s is unrecognized: assuming GFlops" % (perfUnit, dataFileName))
+          self.perCU = False
+
         # get the length of each row, and derive the first column of the solution instead of using wrong "solutionStartIdx = totalSizeIdx + 1"
         rowLength = len(row)
         solutionStartIdx = rowLength - numSolutions
@@ -1468,5 +1478,3 @@ def main(  config ):
       globalParameters["LibraryLogicPath"])
 
   generateLogic(config, benchmarkDataPath, libraryLogicPath)
-
-

--- a/Tensile/LibraryLogic.py
+++ b/Tensile/LibraryLogic.py
@@ -207,7 +207,7 @@ def analyzeProblemType( problemType, problemSizeGroups, inputParameters ):
 
   #selectionSolutionsIdsList = list(selectionSolutionsIds)
   return (problemType, logicAnalyzer.solutions, logicAnalyzer.indexOrder, \
-       exactLogic, rangeLogic, selectionSolutions, selectionSolutionsIdsList, logicAnalyzer.perCU)
+       exactLogic, rangeLogic, selectionSolutions, selectionSolutionsIdsList, logicAnalyzer.perfMetric)
 
 
 
@@ -441,12 +441,12 @@ class LogicAnalyzer:
         # get unit (gflops or gflops/cu) of benchmark data
         perfUnit = row[0]
         if perfUnit == "GFlops":
-          self.perCU = False
+          self.perfMetric = "Overall"
         elif perfUnit == "GFlopsPerCU":
-          self.perCU = True
+          self.perfMetric = "CUEfficiency"
         else:
-          printWarning("Performance unit %s in %s is unrecognized: assuming GFlops" % (perfUnit, dataFileName))
-          self.perCU = False
+          printWarning("Performance unit %s in %s is unrecognized: assuming GFlops (overall)" % (perfUnit, dataFileName))
+          self.perfMetric = "Overall"
 
         # get the length of each row, and derive the first column of the solution instead of using wrong "solutionStartIdx = totalSizeIdx + 1"
         rowLength = len(row)

--- a/Tensile/Properties.py
+++ b/Tensile/Properties.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright 2019-2020 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright 2019-2021 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -87,4 +87,3 @@ class Predicate(Property):
 
         # If neither is a TruePred then just use the default comparison.
         return (self.tag, self.index, self.value) < (other.tag, other.index, other.value)
-

--- a/Tensile/SolutionLibrary.py
+++ b/Tensile/SolutionLibrary.py
@@ -51,7 +51,7 @@ class GranularitySelectionLibrary:
     @classmethod
     def FromOriginalState(cls, d, indices):
         origTable = d[1]
-        #indices = d[9]["TileSelectionIndices"]
+        #indices = d[9]['TileSelectionIndices']
         #  entry = {'key': key, 'value': value, 'speed': row[1][1]}
         entries = []
         for row in origTable:
@@ -218,24 +218,23 @@ class MasterSolutionLibrary:
     @classmethod
     def FromOriginalState(cls, d, origSolutions, solutionClass=Contractions.Solution, libraryOrder = None):
         if libraryOrder is None:
-            libraryOrder = ['Hardware', 'OperationIdentifier', 'PerCU', 'Predicates', 'Matching']
+            libraryOrder = ['Hardware', 'OperationIdentifier', 'BenchmarkMetric', 'Predicates', 'Matching']
 
         deviceSection = d[1:4]
         origProblemType = d[4]
         #origSolutions = d[5]
         origLibrary = d[6:8]
 
-        perCU = False
+        benchMetric = 'Overall'
         if len(d) > 10:
-            perCU = d[10]
-            print(perCU)
+            benchMetric = d[10]
 
         problemType = Contractions.ProblemType.FromOriginalState(origProblemType)
 
         if len(d) > 9 and d[9]:
             # It's a Granularity library
-            assert libraryOrder[-1] == "Matching"
-            libraryOrder[-1] = "Granularity"
+            assert libraryOrder[-1] == 'Matching'
+            libraryOrder[-1] = 'Granularity'
 
         allSolutions = [solutionClass.FromSolutionStruct(s, deviceSection) for s in origSolutions]
         cls.FixSolutionIndices(allSolutions)
@@ -248,24 +247,24 @@ class MasterSolutionLibrary:
                 library = matchingLibrary
 
             elif libName == 'Granularity':
-                selectionIndices = d[9]["TileSelectionIndices"]
+                selectionIndices = d[9]['TileSelectionIndices']
                 library = GranularitySelectionLibrary.FromOriginalState(origLibrary, selectionIndices)
 
             elif libName == 'Hardware':
 
                 if isinstance(deviceSection[1], dict):
                     architectureProps = deviceSection[1]
-                    assert "Architecture" in architectureProps, "Invalid device section [1]"
-                    assert "CUCount" in architectureProps, "Invalid device section [1]"
-                    devicePart = architectureProps["Architecture"]
-                    cuCount = architectureProps["CUCount"]
+                    assert 'Architecture' in architectureProps, 'Invalid device section [1]'
+                    assert 'CUCount' in architectureProps, 'Invalid device section [1]'
+                    devicePart = architectureProps['Architecture']
+                    cuCount = architectureProps['CUCount']
                 else:
                     devicePart = deviceSection[1]
                     cuCount = None
 
                 newLib = PredicateLibrary(tag='Hardware')
                 if devicePart == 'fallback':
-                    pred = Hardware.HardwarePredicate("TruePred")
+                    pred = Hardware.HardwarePredicate('TruePred')
                 else:
                     pred = Hardware.HardwarePredicate.FromHardware(Common.gfxArch(devicePart), cuCount)
 
@@ -288,17 +287,17 @@ class MasterSolutionLibrary:
                 newLib = ProblemMapLibrary(prop, mapping)
                 library = newLib
 
-            elif libName == 'PerCU':
-                if perCU:
-                    predicate = Properties.Predicate(tag='PerCU')
+            elif libName == 'BenchmarkMetric':
+                if benchMetric != 'Overall':
+                    predicate = Properties.Predicate(tag=benchMetric)
                 else:
                     predicate = Properties.Predicate(tag='TruePred')
-                newLib = PredicateLibrary(tag='PerCUorOverall')
+                newLib = PredicateLibrary(tag='Problem')
                 newLib.rows.append({'predicate': predicate, 'library': library})
                 library = newLib
 
             else:
-                raise ValueError("Unknown value " + libName)
+                raise ValueError('Unknown value ' + libName)
 
         rv = cls(solutions, library)
         return rv
@@ -355,8 +354,8 @@ class MasterSolutionLibrary:
 
     @property
     def cpp_base_class(self):
-        return "SolutionLibrary<ContractionProblem, ContractionSolution>"
+        return 'SolutionLibrary<ContractionProblem, ContractionSolution>'
 
     @property
     def cpp_class(self):
-        return "MasterSolutionLibrary<ContractionProblem, ContractionSolution>"
+        return 'MasterSolutionLibrary<ContractionProblem, ContractionSolution>'

--- a/Tensile/SolutionLibrary.py
+++ b/Tensile/SolutionLibrary.py
@@ -218,16 +218,16 @@ class MasterSolutionLibrary:
     @classmethod
     def FromOriginalState(cls, d, origSolutions, solutionClass=Contractions.Solution, libraryOrder = None):
         if libraryOrder is None:
-            libraryOrder = ['Hardware', 'OperationIdentifier', 'BenchmarkMetric', 'Predicates', 'Matching']
+            libraryOrder = ['Hardware', 'OperationIdentifier', 'PerformanceMetric', 'Predicates', 'Matching']
 
         deviceSection = d[1:4]
         origProblemType = d[4]
         #origSolutions = d[5]
         origLibrary = d[6:8]
 
-        benchMetric = 'Overall'
+        perfMetric = 'Overall'
         if len(d) > 10:
-            benchMetric = d[10]
+            perfMetric = d[10]
 
         problemType = Contractions.ProblemType.FromOriginalState(origProblemType)
 
@@ -287,9 +287,9 @@ class MasterSolutionLibrary:
                 newLib = ProblemMapLibrary(prop, mapping)
                 library = newLib
 
-            elif libName == 'BenchmarkMetric':
-                if benchMetric != 'Overall':
-                    predicate = Properties.Predicate(tag=benchMetric)
+            elif libName == 'PerformanceMetric':
+                if perfMetric != 'Overall':
+                    predicate = Properties.Predicate(tag=perfMetric)
                 else:
                     predicate = Properties.Predicate(tag='TruePred')
                 newLib = PredicateLibrary(tag='Problem')

--- a/Tensile/SolutionLibrary.py
+++ b/Tensile/SolutionLibrary.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright 2019-2020 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright 2019-2021 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -218,12 +218,17 @@ class MasterSolutionLibrary:
     @classmethod
     def FromOriginalState(cls, d, origSolutions, solutionClass=Contractions.Solution, libraryOrder = None):
         if libraryOrder is None:
-            libraryOrder = ['Hardware', 'OperationIdentifier', 'Predicates', 'Matching']
+            libraryOrder = ['Hardware', 'OperationIdentifier', 'PerCU', 'Predicates', 'Matching']
 
         deviceSection = d[1:4]
         origProblemType = d[4]
         #origSolutions = d[5]
         origLibrary = d[6:8]
+
+        perCU = False
+        if len(d) > 10:
+            perCU = d[10]
+            print(perCU)
 
         problemType = Contractions.ProblemType.FromOriginalState(origProblemType)
 
@@ -282,6 +287,16 @@ class MasterSolutionLibrary:
 
                 newLib = ProblemMapLibrary(prop, mapping)
                 library = newLib
+
+            elif libName == 'PerCU':
+                if perCU:
+                    predicate = Properties.Predicate(tag='PerCU')
+                else:
+                    predicate = Properties.Predicate(tag='TruePred')
+                newLib = PredicateLibrary(tag='PerCUorOverall')
+                newLib.rows.append({'predicate': predicate, 'library': library})
+                library = newLib
+
             else:
                 raise ValueError("Unknown value " + libName)
 
@@ -345,4 +360,3 @@ class MasterSolutionLibrary:
     @property
     def cpp_class(self):
         return "MasterSolutionLibrary<ContractionProblem, ContractionSolution>"
-

--- a/Tensile/Source/SolutionHelper.h
+++ b/Tensile/Source/SolutionHelper.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -75,7 +75,7 @@ struct SolutionLock
 #ifdef WIN32
 __declspec(thread) extern KernelMap kernelMap;
 #else
-extern thread_local KernelMap kernelMap;
+extern thread_local KernelMap                 kernelMap;
 #endif
 
 /*******************************************************************************

--- a/Tensile/Source/client/include/ClientProblemFactory.hpp
+++ b/Tensile/Source/client/include/ClientProblemFactory.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright 2019-2020 Advanced Micro Devices, Inc.
+ * Copyright 2019-2021 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -70,17 +70,18 @@ namespace Tensile
             ContractionProblem::BatchIndices m_batchIndices;
             ContractionProblem::BoundIndices m_boundIndices;
 
-            DataType       m_aType;
-            DataType       m_bType;
-            DataType       m_cType;
-            DataType       m_dType;
-            DataType       m_alphaType;
-            DataType       m_betaType;
-            bool           m_stridedBatched;
-            bool           m_highPrecisionAccumulate;
-            bool           m_deterministicMode;
-            ArithmeticUnit m_arithmeticUnit;
-            KernelLanguage m_kernelLanguage;
+            DataType        m_aType;
+            DataType        m_bType;
+            DataType        m_cType;
+            DataType        m_dType;
+            DataType        m_alphaType;
+            DataType        m_betaType;
+            bool            m_stridedBatched;
+            bool            m_highPrecisionAccumulate;
+            bool            m_deterministicMode;
+            ArithmeticUnit  m_arithmeticUnit;
+            BenchmarkMetric m_benchmarkMetric;
+            KernelLanguage  m_kernelLanguage;
 
             std::vector<std::vector<size_t>> m_problemSizes;
             std::vector<std::vector<size_t>> m_aStrides;

--- a/Tensile/Source/client/include/ClientProblemFactory.hpp
+++ b/Tensile/Source/client/include/ClientProblemFactory.hpp
@@ -70,18 +70,18 @@ namespace Tensile
             ContractionProblem::BatchIndices m_batchIndices;
             ContractionProblem::BoundIndices m_boundIndices;
 
-            DataType        m_aType;
-            DataType        m_bType;
-            DataType        m_cType;
-            DataType        m_dType;
-            DataType        m_alphaType;
-            DataType        m_betaType;
-            bool            m_stridedBatched;
-            bool            m_highPrecisionAccumulate;
-            bool            m_deterministicMode;
-            ArithmeticUnit  m_arithmeticUnit;
-            BenchmarkMetric m_benchmarkMetric;
-            KernelLanguage  m_kernelLanguage;
+            DataType          m_aType;
+            DataType          m_bType;
+            DataType          m_cType;
+            DataType          m_dType;
+            DataType          m_alphaType;
+            DataType          m_betaType;
+            bool              m_stridedBatched;
+            bool              m_highPrecisionAccumulate;
+            bool              m_deterministicMode;
+            ArithmeticUnit    m_arithmeticUnit;
+            KernelLanguage    m_kernelLanguage;
+            PerformanceMetric m_performanceMetric;
 
             std::vector<std::vector<size_t>> m_problemSizes;
             std::vector<std::vector<size_t>> m_aStrides;

--- a/Tensile/Source/client/include/LogReporter.hpp
+++ b/Tensile/Source/client/include/LogReporter.hpp
@@ -94,9 +94,9 @@ namespace Tensile
                 auto logLevel = args["log-level"].as<LogLevel>();
                 std::cout << "Log level: " << logLevel << std::endl;
 
-                BenchmarkMetric   metric = args["benchmark-metric"].as<BenchmarkMetric>();
+                PerformanceMetric metric = args["performance-metric"].as<PerformanceMetric>();
                 const std::string perfUnit
-                    = (metric == BenchmarkMetric::CUEfficiency ? SpeedGFlopsPerCu : SpeedGFlops);
+                    = (metric == PerformanceMetric::CUEfficiency ? SpeedGFlopsPerCu : SpeedGFlops);
 
                 return std::shared_ptr<LogReporter>(new LogReporter(logLevel,
                                                                     {BenchmarkRunNumber,

--- a/Tensile/Source/client/include/LogReporter.hpp
+++ b/Tensile/Source/client/include/LogReporter.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright 2019-2020 Advanced Micro Devices, Inc.
+ * Copyright 2019-2021 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -93,6 +93,10 @@ namespace Tensile
                 using namespace ResultKey;
                 auto logLevel = args["log-level"].as<LogLevel>();
                 std::cout << "Log level: " << logLevel << std::endl;
+
+                const std::string perfMetric
+                    = (args["benchmark-per-cu"].as<bool>()) ? SpeedGFlopsPerCu : SpeedGFlops;
+
                 return std::shared_ptr<LogReporter>(new LogReporter(logLevel,
                                                                     {BenchmarkRunNumber,
                                                                      ProblemProgress,
@@ -102,7 +106,7 @@ namespace Tensile
                                                                      SolutionName,
                                                                      Validation,
                                                                      TimeUS,
-                                                                     SpeedGFlops,
+                                                                     perfMetric,
                                                                      Empty,
                                                                      TotalGranularity,
                                                                      TilesPerCu,

--- a/Tensile/Source/client/include/LogReporter.hpp
+++ b/Tensile/Source/client/include/LogReporter.hpp
@@ -94,8 +94,9 @@ namespace Tensile
                 auto logLevel = args["log-level"].as<LogLevel>();
                 std::cout << "Log level: " << logLevel << std::endl;
 
-                const std::string perfMetric
-                    = (args["benchmark-per-cu"].as<bool>()) ? SpeedGFlopsPerCu : SpeedGFlops;
+                BenchmarkMetric   metric = args["benchmark-metric"].as<BenchmarkMetric>();
+                const std::string perfUnit
+                    = (metric == BenchmarkMetric::CUEfficiency ? SpeedGFlopsPerCu : SpeedGFlops);
 
                 return std::shared_ptr<LogReporter>(new LogReporter(logLevel,
                                                                     {BenchmarkRunNumber,
@@ -106,7 +107,7 @@ namespace Tensile
                                                                      SolutionName,
                                                                      Validation,
                                                                      TimeUS,
-                                                                     perfMetric,
+                                                                     perfUnit,
                                                                      Empty,
                                                                      TotalGranularity,
                                                                      TilesPerCu,

--- a/Tensile/Source/client/include/LogReporter.hpp
+++ b/Tensile/Source/client/include/LogReporter.hpp
@@ -95,6 +95,7 @@ namespace Tensile
                 std::cout << "Log level: " << logLevel << std::endl;
 
                 PerformanceMetric metric = args["performance-metric"].as<PerformanceMetric>();
+                // Default to 'Overall' benchmarking if CUEfficiency not specified
                 const std::string perfUnit
                     = (metric == PerformanceMetric::CUEfficiency ? SpeedGFlopsPerCu : SpeedGFlops);
 

--- a/Tensile/Source/client/include/ResultFileReporter.hpp
+++ b/Tensile/Source/client/include/ResultFileReporter.hpp
@@ -47,7 +47,7 @@ namespace Tensile
             ResultFileReporter(std::string const& filename,
                                bool               exportExtraCols,
                                bool               mergeSameProblems,
-                               BenchmarkMetric    benchmarkMetric);
+                               PerformanceMetric  performanceMetric);
 
             virtual void reportValue_string(std::string const& key,
                                             std::string const& value) override;
@@ -67,12 +67,12 @@ namespace Tensile
             void reportValue(std::string const& key, T const& value);
             void mergeRow(std::unordered_map<std::string, std::string>& newRow);
 
-            CSVStackFile    m_output;
-            std::string     m_solutionName;
-            bool            m_invalidSolution = false;
-            bool            m_extraCol;
-            bool            m_mergeSameProblems;
-            BenchmarkMetric m_benchmarkMetric;
+            CSVStackFile      m_output;
+            std::string       m_solutionName;
+            bool              m_invalidSolution = false;
+            bool              m_extraCol;
+            bool              m_mergeSameProblems;
+            PerformanceMetric m_performanceMetric;
             // for extra columns
             std::string m_winnerSolution;
             int64_t     m_currSolutionIdx   = -1;

--- a/Tensile/Source/client/include/ResultFileReporter.hpp
+++ b/Tensile/Source/client/include/ResultFileReporter.hpp
@@ -47,7 +47,7 @@ namespace Tensile
             ResultFileReporter(std::string const& filename,
                                bool               exportExtraCols,
                                bool               mergeSameProblems,
-                               bool               gflopsPerCu);
+                               BenchmarkMetric    benchmarkMetric);
 
             virtual void reportValue_string(std::string const& key,
                                             std::string const& value) override;
@@ -67,12 +67,12 @@ namespace Tensile
             void reportValue(std::string const& key, T const& value);
             void mergeRow(std::unordered_map<std::string, std::string>& newRow);
 
-            CSVStackFile m_output;
-            std::string  m_solutionName;
-            bool         m_invalidSolution = false;
-            bool         m_extraCol;
-            bool         m_mergeSameProblems;
-            bool         m_gflopsPerCu;
+            CSVStackFile    m_output;
+            std::string     m_solutionName;
+            bool            m_invalidSolution = false;
+            bool            m_extraCol;
+            bool            m_mergeSameProblems;
+            BenchmarkMetric m_benchmarkMetric;
             // for extra columns
             std::string m_winnerSolution;
             int64_t     m_currSolutionIdx   = -1;

--- a/Tensile/Source/client/include/ResultFileReporter.hpp
+++ b/Tensile/Source/client/include/ResultFileReporter.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright 2019-2020 Advanced Micro Devices, Inc.
+ * Copyright 2019-2021 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -46,7 +46,8 @@ namespace Tensile
 
             ResultFileReporter(std::string const& filename,
                                bool               exportExtraCols,
-                               bool               mergeSameProblems);
+                               bool               mergeSameProblems,
+                               bool               gflopsPerCu);
 
             virtual void reportValue_string(std::string const& key,
                                             std::string const& value) override;
@@ -71,6 +72,7 @@ namespace Tensile
             bool         m_invalidSolution = false;
             bool         m_extraCol;
             bool         m_mergeSameProblems;
+            bool         m_gflopsPerCu;
             // for extra columns
             std::string m_winnerSolution;
             int64_t     m_currSolutionIdx   = -1;

--- a/Tensile/Source/client/include/ResultReporter.hpp
+++ b/Tensile/Source/client/include/ResultReporter.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright 2019-2020 Advanced Micro Devices, Inc.
+ * Copyright 2019-2021 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -84,11 +84,12 @@ namespace Tensile
             const std::string SolutionWinner    = "solution-winner";
 
             // Performance-related
-            const std::string Validation    = "validation";
-            const std::string TimeUS        = "time-us";
-            const std::string SpeedGFlops   = "gflops";
-            const std::string EnqueueTime   = "enqueue-time";
-            const std::string FastestGFlops = "fastest-gflops";
+            const std::string Validation       = "validation";
+            const std::string TimeUS           = "time-us";
+            const std::string SpeedGFlops      = "gflops";
+            const std::string SpeedGFlopsPerCu = "gflops-per-cu";
+            const std::string EnqueueTime      = "enqueue-time";
+            const std::string FastestGFlops    = "fastest-gflops";
 
             // Performance estimation and granularity
             const std::string Tile0Granularity = "tile0-gran";

--- a/Tensile/Source/client/main.cpp
+++ b/Tensile/Source/client/main.cpp
@@ -96,7 +96,7 @@ namespace Tensile
                                                                                   "specified, we will use the embedded code "
                                                                                   "object(s) if available.")
 
-                ("benchmark-metric",         po::value<BenchmarkMetric>()->default_value(BenchmarkMetric::Overall), "Metric for benchmarking results")
+                ("performance-metric",       po::value<PerformanceMetric>()->default_value(PerformanceMetric::Overall), "Metric for benchmarking results")
 
                 ("problem-identifier",       po::value<std::string>(), "Problem identifer (Einstein notation). Either "
                                                                        "this or free/batch/bound must be specified.")

--- a/Tensile/Source/client/main.cpp
+++ b/Tensile/Source/client/main.cpp
@@ -96,7 +96,7 @@ namespace Tensile
                                                                                   "specified, we will use the embedded code "
                                                                                   "object(s) if available.")
 
-                ("benchmark-per-cu",         po::value<bool>()->default_value(false), "Benchmark speed per CU instead of overall speed")
+                ("benchmark-metric",         po::value<BenchmarkMetric>()->default_value(BenchmarkMetric::Overall), "Metric for benchmarking results")
 
                 ("problem-identifier",       po::value<std::string>(), "Problem identifer (Einstein notation). Either "
                                                                        "this or free/batch/bound must be specified.")

--- a/Tensile/Source/client/main.cpp
+++ b/Tensile/Source/client/main.cpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright 2019-2020 Advanced Micro Devices, Inc.
+ * Copyright 2019-2021 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -95,6 +95,8 @@ namespace Tensile
                 ("code-object,c",            vector_default_empty<std::string>(), "Code object file with kernel(s).  If none are "
                                                                                   "specified, we will use the embedded code "
                                                                                   "object(s) if available.")
+
+                ("benchmark-per-cu",         po::value<bool>()->default_value(false), "Benchmark speed per CU instead of overall speed")
 
                 ("problem-identifier",       po::value<std::string>(), "Problem identifer (Einstein notation). Either "
                                                                        "this or free/batch/bound must be specified.")

--- a/Tensile/Source/client/source/BenchmarkTimer.cpp
+++ b/Tensile/Source/client/source/BenchmarkTimer.cpp
@@ -104,7 +104,7 @@ namespace Tensile
                 = m_solution.projectedPerformance(m_problem, m_hardware);
 
             double gflops      = m_problem.flopCount() / (timePerEnqueue_us) / 1000.0;
-            double tiles       = pp.tilesPerCu * perf.CUs;
+            int    tiles       = pp.tilesPerCu * perf.CUs;
             int    usedCus     = std::min(tiles, perf.CUs);
             double gflopsPerCu = gflops / usedCus;
 

--- a/Tensile/Source/client/source/BenchmarkTimer.cpp
+++ b/Tensile/Source/client/source/BenchmarkTimer.cpp
@@ -108,19 +108,15 @@ namespace Tensile
             int    usedCus     = (tiles > perf.CUs) ? perf.CUs : tiles;
             double gflopsPerCu = gflops / usedCus;
 
-            uint64_t gflopsUint      = static_cast<uint64_t>(round(gflops));
-            uint64_t gflopsPerCuUint = static_cast<uint64_t>(round(gflopsPerCu));
+            uint64_t gflopsUint = static_cast<uint64_t>(round(gflops));
 
             m_reporter->report(ResultKey::TimeUS, timePerEnqueue_us);
+            m_reporter->report(ResultKey::SpeedGFlopsPerCu, gflopsPerCu);
+
             if(gflopsUint)
                 m_reporter->report(ResultKey::SpeedGFlops, gflopsUint);
             else
                 m_reporter->report(ResultKey::SpeedGFlops, gflops);
-
-            if(gflopsPerCuUint)
-                m_reporter->report(ResultKey::SpeedGFlopsPerCu, gflopsPerCuUint);
-            else
-                m_reporter->report(ResultKey::SpeedGFlopsPerCu, gflopsPerCu);
 
             m_timeInSolution        = double_millis::zero();
             m_numEnqueuesInSolution = 0;

--- a/Tensile/Source/client/source/BenchmarkTimer.cpp
+++ b/Tensile/Source/client/source/BenchmarkTimer.cpp
@@ -105,7 +105,7 @@ namespace Tensile
 
             double gflops      = m_problem.flopCount() / (timePerEnqueue_us) / 1000.0;
             double tiles       = pp.tilesPerCu * perf.CUs;
-            int    usedCus     = (tiles > perf.CUs) ? perf.CUs : tiles;
+            int    usedCus     = std::min(tiles, perf.CUs);
             double gflopsPerCu = gflops / usedCus;
 
             uint64_t gflopsUint = static_cast<uint64_t>(round(gflops));

--- a/Tensile/Source/client/source/ClientProblemFactory.cpp
+++ b/Tensile/Source/client/source/ClientProblemFactory.cpp
@@ -48,8 +48,8 @@ namespace Tensile
             , m_betaType(DataType::Float)
             , m_stridedBatched(args["strided-batched"].as<bool>())
             , m_highPrecisionAccumulate(args["high-precision-accumulate"].as<bool>())
-            , m_benchmarkMetric(args["benchmark-metric"].as<BenchmarkMetric>())
             , m_kernelLanguage(args["kernel-language"].as<KernelLanguage>())
+            , m_performanceMetric(args["performance-metric"].as<PerformanceMetric>())
             , m_deterministicMode(args["deterministic-mode"].as<bool>())
             , m_arithmeticUnit(args["arithmetic-unit"].as<ArithmeticUnit>())
             , m_aStrides(args["a-strides"].as<std::vector<std::vector<size_t>>>())
@@ -190,7 +190,7 @@ namespace Tensile
                 rv.back().setStridedBatched(m_stridedBatched);
                 rv.back().setHighPrecisionAccumulate(m_highPrecisionAccumulate);
                 rv.back().setKernelLanguage(m_kernelLanguage);
-                rv.back().setBenchmarkMetric(m_benchmarkMetric);
+                rv.back().setPerformanceMetric(m_performanceMetric);
                 rv.back().setDeterministicMode(m_deterministicMode);
                 rv.back().setArithmeticUnit(m_arithmeticUnit);
             }

--- a/Tensile/Source/client/source/ClientProblemFactory.cpp
+++ b/Tensile/Source/client/source/ClientProblemFactory.cpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright 2019-2020 Advanced Micro Devices, Inc.
+ * Copyright 2019-2021 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -48,7 +48,8 @@ namespace Tensile
             , m_betaType(DataType::Float)
             , m_stridedBatched(args["strided-batched"].as<bool>())
             , m_highPrecisionAccumulate(args["high-precision-accumulate"].as<bool>())
-            , m_kernelLanguage(args["kernel-language"].as<Tensile::KernelLanguage>())
+            , m_benchmarkMetric(args["benchmark-metric"].as<BenchmarkMetric>())
+            , m_kernelLanguage(args["kernel-language"].as<KernelLanguage>())
             , m_deterministicMode(args["deterministic-mode"].as<bool>())
             , m_arithmeticUnit(args["arithmetic-unit"].as<ArithmeticUnit>())
             , m_aStrides(args["a-strides"].as<std::vector<std::vector<size_t>>>())
@@ -189,6 +190,7 @@ namespace Tensile
                 rv.back().setStridedBatched(m_stridedBatched);
                 rv.back().setHighPrecisionAccumulate(m_highPrecisionAccumulate);
                 rv.back().setKernelLanguage(m_kernelLanguage);
+                rv.back().setBenchmarkMetric(m_benchmarkMetric);
                 rv.back().setDeterministicMode(m_deterministicMode);
                 rv.back().setArithmeticUnit(m_arithmeticUnit);
             }

--- a/Tensile/Source/client/source/ResultFileReporter.cpp
+++ b/Tensile/Source/client/source/ResultFileReporter.cpp
@@ -39,21 +39,21 @@ namespace Tensile
                 args["results-file"].as<std::string>(),
                 args["csv-export-extra-cols"].as<bool>(),
                 args["csv-merge-same-problems"].as<bool>(),
-                args["benchmark-metric"].as<BenchmarkMetric>());
+                args["performance-metric"].as<PerformanceMetric>());
         }
 
         ResultFileReporter::ResultFileReporter(std::string const& filename,
                                                bool               exportExtraCols,
                                                bool               mergeSameProblems,
-                                               BenchmarkMetric    benchmarkMetric)
+                                               PerformanceMetric  performanceMetric)
             : m_output(filename)
             , m_extraCol(exportExtraCols)
             , m_mergeSameProblems(mergeSameProblems)
-            , m_benchmarkMetric(benchmarkMetric)
+            , m_performanceMetric(performanceMetric)
         {
-            if(m_benchmarkMetric == BenchmarkMetric::CUEfficiency)
+            if(m_performanceMetric == PerformanceMetric::CUEfficiency)
                 m_output.setHeaderForKey(ResultKey::ProblemIndex, "GFlopsPerCU");
-            else // (m_benchmarkMetric == BenchmarkMetric::Overall)
+            else // (m_performanceMetric == PerformanceMetric::Overall)
                 m_output.setHeaderForKey(ResultKey::ProblemIndex, "GFlops");
         }
 
@@ -88,9 +88,10 @@ namespace Tensile
                     }
                 }
             }
-            else if((key == ResultKey::SpeedGFlops && m_benchmarkMetric == BenchmarkMetric::Overall)
+            else if((key == ResultKey::SpeedGFlops
+                     && m_performanceMetric == PerformanceMetric::Overall)
                     || (key == ResultKey::SpeedGFlopsPerCu
-                        && m_benchmarkMetric == BenchmarkMetric::CUEfficiency))
+                        && m_performanceMetric == PerformanceMetric::CUEfficiency))
             {
                 // cascade from BenchmarkTimer, SpeedGFlops or SpeedGFlopsPerCU second
                 if(!m_invalidSolution)

--- a/Tensile/Source/client/source/ResultFileReporter.cpp
+++ b/Tensile/Source/client/source/ResultFileReporter.cpp
@@ -53,7 +53,7 @@ namespace Tensile
         {
             if(m_performanceMetric == PerformanceMetric::CUEfficiency)
                 m_output.setHeaderForKey(ResultKey::ProblemIndex, "GFlopsPerCU");
-            else // (m_performanceMetric == PerformanceMetric::Overall)
+            else // Default to 'Overall' benchmarking if CUEfficiency not specified
                 m_output.setHeaderForKey(ResultKey::ProblemIndex, "GFlops");
         }
 

--- a/Tensile/Source/lib/CMakeLists.txt
+++ b/Tensile/Source/lib/CMakeLists.txt
@@ -33,7 +33,6 @@ endif()
 set(tensile_sources  ${tensile_sources}
     source/AMDGPU.cpp
     source/ArithmeticUnitTypes.cpp
-    source/BenchmarkMetricTypes.cpp
     source/ContractionProblem.cpp
     source/ContractionSolution.cpp
     source/DataTypes.cpp
@@ -41,6 +40,7 @@ set(tensile_sources  ${tensile_sources}
     source/EmbeddedLibrary.cpp
     source/KernelArguments.cpp
     source/KernelLanguageTypes.cpp
+    source/PerformanceMetricTypes.cpp
     source/TensorDescriptor.cpp
     source/TensorOps.cpp
     source/Tensile.cpp

--- a/Tensile/Source/lib/CMakeLists.txt
+++ b/Tensile/Source/lib/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright 2019-2020 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright 2019-2021 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -33,6 +33,7 @@ endif()
 set(tensile_sources  ${tensile_sources}
     source/AMDGPU.cpp
     source/ArithmeticUnitTypes.cpp
+    source/BenchmarkMetricTypes.cpp
     source/ContractionProblem.cpp
     source/ContractionSolution.cpp
     source/DataTypes.cpp
@@ -131,4 +132,3 @@ foreach (_variableName ${_variableNames})
     message(STATUS "${_variableName}=${${_variableName}}")
 endforeach()
 endif()
-

--- a/Tensile/Source/lib/include/Tensile/ArithmeticUnitTypes.hpp
+++ b/Tensile/Source/lib/include/Tensile/ArithmeticUnitTypes.hpp
@@ -93,9 +93,7 @@ namespace Tensile
  * \brief Compile-time accessible arithmetic unit type metadata.
  */
     template <ArithmeticUnit T_Enum>
-    struct ArithmeticUnitInfo
-    {
-    };
+    struct ArithmeticUnitInfo;
 
     template <ArithmeticUnit T_Enum>
     struct BaseArithmeticUnitInfo

--- a/Tensile/Source/lib/include/Tensile/BenchmarkMetricTypes.hpp
+++ b/Tensile/Source/lib/include/Tensile/BenchmarkMetricTypes.hpp
@@ -94,9 +94,7 @@ namespace Tensile
  * \brief Compile-time accessible benchmark metric type metadata.
  */
     template <BenchmarkMetric T_Enum>
-    struct BenchmarkMetricInfo
-    {
-    };
+    struct BenchmarkMetricInfo;
 
     template <BenchmarkMetric T_Enum>
     struct BaseBenchmarkMetricInfo

--- a/Tensile/Source/lib/include/Tensile/BenchmarkMetricTypes.hpp
+++ b/Tensile/Source/lib/include/Tensile/BenchmarkMetricTypes.hpp
@@ -36,71 +36,72 @@ namespace Tensile
 {
     /**
  * \ingroup Tensile
- * \defgroup ArithmeticUnits Arithmetic unit type Info
+ * \defgroup BenchmarkMetrics Benchmark metric type Info
  *
- * @brief Definitions and metadata on supported arithmetic unit types.
+ * @brief Definitions and metadata on supported benchmark metric types.
  */
 
     /**
- * \ingroup ArithmeticUnits
+ * \ingroup BenchmarkMetrics
  * @{
  */
 
     /**
- * Arithmetic Unit
+ * Benchmark Metric
  */
-    enum class ArithmeticUnit : int
+    enum class BenchmarkMetric : int
     {
-        Any,
-        MFMA,
-        VALU,
+        Best,
+        CUEfficiency,
+        Overall,
         Count
     };
 
-    std::string   ToString(ArithmeticUnit d);
-    std::string   TypeAbbrev(ArithmeticUnit d);
-    std::ostream& operator<<(std::ostream& stream, ArithmeticUnit const& t);
-    std::istream& operator>>(std::istream& stream, ArithmeticUnit& t);
+    std::string   ToString(BenchmarkMetric d);
+    std::string   TypeAbbrev(BenchmarkMetric d);
+    std::ostream& operator<<(std::ostream& stream, BenchmarkMetric const& t);
+    std::istream& operator>>(std::istream& stream, BenchmarkMetric& t);
 
     /**
- * \ingroup ArithmeticUnits
- * \brief Runtime accessible arithmetic unit type metadata
+ * \ingroup BenchmarkMetrics
+ * \brief Runtime accessible benchmark metric type metadata
  */
-    struct ArithmeticUnitTypeInfo
+    struct BenchmarkMetricTypeInfo
     {
-        static ArithmeticUnitTypeInfo const& Get(int index);
-        static ArithmeticUnitTypeInfo const& Get(ArithmeticUnit t);
-        static ArithmeticUnitTypeInfo const& Get(std::string const& str);
+        static BenchmarkMetricTypeInfo const& Get(int index);
+        static BenchmarkMetricTypeInfo const& Get(BenchmarkMetric t);
+        static BenchmarkMetricTypeInfo const& Get(std::string const& str);
 
-        ArithmeticUnit m_arithmeticUnit;
-        std::string    name;
+        BenchmarkMetric m_benchmarkMetric;
+        std::string     name;
+        std::string     abbrev;
 
     private:
         static void registerAllTypeInfo();
         static void registerAllTypeInfoOnce();
 
-        template <ArithmeticUnit T_Enum>
+        template <BenchmarkMetric T_Enum>
         static void registerTypeInfo();
 
-        static void addInfoObject(ArithmeticUnitTypeInfo const& info);
+        static void addInfoObject(BenchmarkMetricTypeInfo const& info);
 
-        static std::map<ArithmeticUnit, ArithmeticUnitTypeInfo> data;
-        static std::map<std::string, ArithmeticUnit>            typeNames;
+        static std::map<BenchmarkMetric, BenchmarkMetricTypeInfo> data;
+        static std::map<std::string, BenchmarkMetric>             typeNames;
     };
 
     /**
- * \ingroup ArithmeticUnits
- * \brief Compile-time accessible arithmetic unit type metadata.
+ * \ingroup BenchmarkMetrics
+ * \brief Compile-time accessible benchmark metric type metadata.
  */
-    template <ArithmeticUnit T_Enum>
-    struct ArithmeticUnitInfo
+    template <BenchmarkMetric T_Enum>
+    struct BenchmarkMetricInfo
     {
     };
 
-    template <ArithmeticUnit T_Enum>
-    struct BaseArithmeticUnitInfo
+    template <BenchmarkMetric T_Enum>
+    struct BaseBenchmarkMetricInfo
     {
-        constexpr static ArithmeticUnit Enum = T_Enum;
+        constexpr static BenchmarkMetric Enum = T_Enum;
 
         static inline std::string Name()
         {
@@ -112,22 +113,22 @@ namespace Tensile
         }
     };
 
-    template <ArithmeticUnit T_Enum>
-    constexpr ArithmeticUnit BaseArithmeticUnitInfo<T_Enum>::Enum;
+    template <BenchmarkMetric T_Enum>
+    constexpr BenchmarkMetric BaseBenchmarkMetricInfo<T_Enum>::Enum;
 
     template <>
-    struct ArithmeticUnitInfo<ArithmeticUnit::Any>
-        : public BaseArithmeticUnitInfo<ArithmeticUnit::Any>
+    struct BenchmarkMetricInfo<BenchmarkMetric::Best>
+        : public BaseBenchmarkMetricInfo<BenchmarkMetric::Best>
     {
     };
     template <>
-    struct ArithmeticUnitInfo<ArithmeticUnit::MFMA>
-        : public BaseArithmeticUnitInfo<ArithmeticUnit::MFMA>
+    struct BenchmarkMetricInfo<BenchmarkMetric::CUEfficiency>
+        : public BaseBenchmarkMetricInfo<BenchmarkMetric::CUEfficiency>
     {
     };
     template <>
-    struct ArithmeticUnitInfo<ArithmeticUnit::VALU>
-        : public BaseArithmeticUnitInfo<ArithmeticUnit::VALU>
+    struct BenchmarkMetricInfo<BenchmarkMetric::Overall>
+        : public BaseBenchmarkMetricInfo<BenchmarkMetric::Overall>
     {
     };
 
@@ -139,9 +140,9 @@ namespace Tensile
 namespace std
 {
     template <>
-    struct hash<Tensile::ArithmeticUnit>
+    struct hash<Tensile::BenchmarkMetric>
     {
-        inline size_t operator()(Tensile::ArithmeticUnit const& val) const
+        inline size_t operator()(Tensile::BenchmarkMetric const& val) const
         {
             return hash<int>()(static_cast<int>(val));
         }

--- a/Tensile/Source/lib/include/Tensile/ContractionProblem.hpp
+++ b/Tensile/Source/lib/include/Tensile/ContractionProblem.hpp
@@ -1,7 +1,7 @@
 /**
  * MIT License
  *
- * Copyright 2019-2020 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright 2019-2021 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <Tensile/ArithmeticUnitTypes.hpp>
+#include <Tensile/BenchmarkMetricTypes.hpp>
 #include <Tensile/KernelLanguageTypes.hpp>
 #include <Tensile/Tensile.hpp>
 
@@ -543,6 +544,16 @@ namespace Tensile
             return m_kernelLanguage;
         }
 
+        void setBenchmarkMetric(BenchmarkMetric value)
+        {
+            m_benchmarkMetric = value;
+        }
+
+        BenchmarkMetric benchmarkMetric() const
+        {
+            return m_benchmarkMetric;
+        }
+
         void setDeterministicMode(bool value)
         {
             m_deterministicMode = value;
@@ -725,14 +736,15 @@ namespace Tensile
         std::string m_sumNames;
         std::string m_operationIdentifier;
 
-        bool           m_transA;
-        bool           m_transB;
-        bool           m_stridedBatched          = true;
-        bool           m_highPrecisionAccumulate = false;
-        bool           m_deterministicMode       = false;
-        bool           m_eligibleForPK           = true;
-        ArithmeticUnit m_arithmeticUnit          = ArithmeticUnit::Any;
-        KernelLanguage m_kernelLanguage          = KernelLanguage::Any;
+        bool            m_transA;
+        bool            m_transB;
+        bool            m_stridedBatched          = true;
+        bool            m_highPrecisionAccumulate = false;
+        bool            m_deterministicMode       = false;
+        bool            m_eligibleForPK           = true;
+        ArithmeticUnit  m_arithmeticUnit          = ArithmeticUnit::Any;
+        BenchmarkMetric m_benchmarkMetric         = BenchmarkMetric::Overall;
+        KernelLanguage  m_kernelLanguage          = KernelLanguage::Any;
 
         DataType m_alphaType = DataType::None; // if not assigned, will follow d-type
         DataType m_betaType  = DataType::None; // for bwd-compatible

--- a/Tensile/Source/lib/include/Tensile/ContractionProblem.hpp
+++ b/Tensile/Source/lib/include/Tensile/ContractionProblem.hpp
@@ -25,8 +25,8 @@
 #pragma once
 
 #include <Tensile/ArithmeticUnitTypes.hpp>
-#include <Tensile/BenchmarkMetricTypes.hpp>
 #include <Tensile/KernelLanguageTypes.hpp>
+#include <Tensile/PerformanceMetricTypes.hpp>
 #include <Tensile/Tensile.hpp>
 
 #include <Tensile/ContractionProblem_fwd.hpp>
@@ -544,14 +544,14 @@ namespace Tensile
             return m_kernelLanguage;
         }
 
-        void setBenchmarkMetric(BenchmarkMetric value)
+        void setPerformanceMetric(PerformanceMetric value)
         {
-            m_benchmarkMetric = value;
+            m_performanceMetric = value;
         }
 
-        BenchmarkMetric benchmarkMetric() const
+        PerformanceMetric performanceMetric() const
         {
-            return m_benchmarkMetric;
+            return m_performanceMetric;
         }
 
         void setDeterministicMode(bool value)
@@ -736,15 +736,15 @@ namespace Tensile
         std::string m_sumNames;
         std::string m_operationIdentifier;
 
-        bool            m_transA;
-        bool            m_transB;
-        bool            m_stridedBatched          = true;
-        bool            m_highPrecisionAccumulate = false;
-        bool            m_deterministicMode       = false;
-        bool            m_eligibleForPK           = true;
-        ArithmeticUnit  m_arithmeticUnit          = ArithmeticUnit::Any;
-        BenchmarkMetric m_benchmarkMetric         = BenchmarkMetric::Overall;
-        KernelLanguage  m_kernelLanguage          = KernelLanguage::Any;
+        bool              m_transA;
+        bool              m_transB;
+        bool              m_stridedBatched          = true;
+        bool              m_highPrecisionAccumulate = false;
+        bool              m_deterministicMode       = false;
+        bool              m_eligibleForPK           = true;
+        ArithmeticUnit    m_arithmeticUnit          = ArithmeticUnit::Any;
+        KernelLanguage    m_kernelLanguage          = KernelLanguage::Any;
+        PerformanceMetric m_performanceMetric       = PerformanceMetric::Overall;
 
         DataType m_alphaType = DataType::None; // if not assigned, will follow d-type
         DataType m_betaType  = DataType::None; // for bwd-compatible

--- a/Tensile/Source/lib/include/Tensile/ContractionProblemPredicates.hpp
+++ b/Tensile/Source/lib/include/Tensile/ContractionProblemPredicates.hpp
@@ -1079,9 +1079,10 @@ namespace Tensile
                     }
                     else if(problem.benchmarkMetric() == BenchmarkMetric::Best)
                     {
-                        // TODO logic to determine if should use or not this metric or not
-                        // based on problem sizes and/or number of flops
-                        return false;
+                        // True if total flops below a constant threshold
+                        // Current threshold chosen naively as the flops for a
+                        // 1500x1500 square matrix multiply
+                        return problem.flopCount() < size_t(1500ll * 1500ll * 1500ll * 2);
                     }
                     else
                     {

--- a/Tensile/Source/lib/include/Tensile/ContractionProblemPredicates.hpp
+++ b/Tensile/Source/lib/include/Tensile/ContractionProblemPredicates.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright 2019-2020 Advanced Micro Devices, Inc.
+ * Copyright 2019-2021 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -1053,6 +1053,29 @@ namespace Tensile
                 virtual bool operator()(ContractionProblem const& problem) const override
                 {
                     return problem.stridedBatched() == value;
+                }
+            };
+
+            struct PerCU : public Predicate_CRTP<PerCU, ContractionProblem>
+            {
+                enum
+                {
+                    HasIndex = false,
+                    HasValue = false
+                };
+                bool value;
+
+                PerCU() = default;
+
+                static std::string Type()
+                {
+                    return "PerCU";
+                }
+
+                virtual bool operator()(ContractionProblem const& problem) const override
+                {
+                    return true; // TODO - logic for determining to use per CU or not
+                    //return problem.flopCount() <= some_value;
                 }
             };
         } // namespace Contraction

--- a/Tensile/Source/lib/include/Tensile/ContractionProblemPredicates.hpp
+++ b/Tensile/Source/lib/include/Tensile/ContractionProblemPredicates.hpp
@@ -1063,7 +1063,6 @@ namespace Tensile
                     HasIndex = false,
                     HasValue = false
                 };
-                bool value;
 
                 CUEfficiency() = default;
 

--- a/Tensile/Source/lib/include/Tensile/ContractionProblemPredicates.hpp
+++ b/Tensile/Source/lib/include/Tensile/ContractionProblemPredicates.hpp
@@ -1056,7 +1056,7 @@ namespace Tensile
                 }
             };
 
-            struct PerCU : public Predicate_CRTP<PerCU, ContractionProblem>
+            struct CUEfficiency : public Predicate_CRTP<CUEfficiency, ContractionProblem>
             {
                 enum
                 {
@@ -1065,17 +1065,29 @@ namespace Tensile
                 };
                 bool value;
 
-                PerCU() = default;
+                CUEfficiency() = default;
 
                 static std::string Type()
                 {
-                    return "PerCU";
+                    return "CUEfficiency";
                 }
 
                 virtual bool operator()(ContractionProblem const& problem) const override
                 {
-                    return true; // TODO - logic for determining to use per CU or not
-                    //return problem.flopCount() <= some_value;
+                    if(problem.benchmarkMetric() == BenchmarkMetric::CUEfficiency)
+                    {
+                        return true;
+                    }
+                    else if(problem.benchmarkMetric() == BenchmarkMetric::Best)
+                    {
+                        // TODO logic to determine if should use or not this metric or not
+                        // based on problem sizes and/or number of flops
+                        return false;
+                    }
+                    else
+                    {
+                        return false;
+                    }
                 }
             };
         } // namespace Contraction

--- a/Tensile/Source/lib/include/Tensile/ContractionProblemPredicates.hpp
+++ b/Tensile/Source/lib/include/Tensile/ContractionProblemPredicates.hpp
@@ -1073,11 +1073,11 @@ namespace Tensile
 
                 virtual bool operator()(ContractionProblem const& problem) const override
                 {
-                    if(problem.benchmarkMetric() == BenchmarkMetric::CUEfficiency)
+                    if(problem.performanceMetric() == PerformanceMetric::CUEfficiency)
                     {
                         return true;
                     }
-                    else if(problem.benchmarkMetric() == BenchmarkMetric::Best)
+                    else if(problem.performanceMetric() == PerformanceMetric::Best)
                     {
                         // True if total flops below a constant threshold
                         // Current threshold chosen naively as the flops for a

--- a/Tensile/Source/lib/include/Tensile/DataTypes_BFloat16.hpp
+++ b/Tensile/Source/lib/include/Tensile/DataTypes_BFloat16.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright 2019-2020 Advanced Micro Devices, Inc.
+ * Copyright 2019-2021 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -99,7 +99,7 @@ namespace Tensile
 #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
             q[0] = v.data;
 #else
-            q[1] = v.data;
+            q[1]      = v.data;
 #endif
             return fp32;
         }

--- a/Tensile/Source/lib/include/Tensile/ExactLogicLibrary.hpp
+++ b/Tensile/Source/lib/include/Tensile/ExactLogicLibrary.hpp
@@ -213,33 +213,6 @@ namespace Tensile
         }
     };
 
-    template <typename MyProblem, typename MySolution>
-    struct PerCUorOverallLibrary
-        : public ExactLogicLibrary<MyProblem, MySolution, ProblemPredicate<MyProblem>>
-    {
-        using Base = ExactLogicLibrary<MyProblem, MySolution, ProblemPredicate<MyProblem>>;
-
-        PerCUorOverallLibrary() = default;
-        PerCUorOverallLibrary(std::initializer_list<typename Base::Row> init)
-            : Base(init)
-        {
-        }
-
-        PerCUorOverallLibrary(std::vector<typename Base::Row> const& init)
-            : Base(init)
-        {
-        }
-
-        static std::string Type()
-        {
-            return "PerCUorOverall";
-        }
-        virtual std::string type() const
-        {
-            return Type();
-        }
-    };
-
     /**
  * @}
  */

--- a/Tensile/Source/lib/include/Tensile/ExactLogicLibrary.hpp
+++ b/Tensile/Source/lib/include/Tensile/ExactLogicLibrary.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright 2019-2020 Advanced Micro Devices, Inc.
+ * Copyright 2019-2021 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -206,6 +206,33 @@ namespace Tensile
         static std::string Type()
         {
             return "Problem";
+        }
+        virtual std::string type() const
+        {
+            return Type();
+        }
+    };
+
+    template <typename MyProblem, typename MySolution>
+    struct PerCUorOverallLibrary
+        : public ExactLogicLibrary<MyProblem, MySolution, ProblemPredicate<MyProblem>>
+    {
+        using Base = ExactLogicLibrary<MyProblem, MySolution, ProblemPredicate<MyProblem>>;
+
+        PerCUorOverallLibrary() = default;
+        PerCUorOverallLibrary(std::initializer_list<typename Base::Row> init)
+            : Base(init)
+        {
+        }
+
+        PerCUorOverallLibrary(std::vector<typename Base::Row> const& init)
+            : Base(init)
+        {
+        }
+
+        static std::string Type()
+        {
+            return "PerCUorOverall";
         }
         virtual std::string type() const
         {

--- a/Tensile/Source/lib/include/Tensile/KernelLanguageTypes.hpp
+++ b/Tensile/Source/lib/include/Tensile/KernelLanguageTypes.hpp
@@ -94,9 +94,7 @@ namespace Tensile
  * \brief Compile-time accessible kernel language type metadata.
  */
     template <KernelLanguage T_Enum>
-    struct KernelLanguageInfo
-    {
-    };
+    struct KernelLanguageInfo;
 
     template <KernelLanguage T_Enum>
     struct BaseKernelLanguageInfo

--- a/Tensile/Source/lib/include/Tensile/PerformanceMetricTypes.hpp
+++ b/Tensile/Source/lib/include/Tensile/PerformanceMetricTypes.hpp
@@ -36,20 +36,20 @@ namespace Tensile
 {
     /**
  * \ingroup Tensile
- * \defgroup BenchmarkMetrics Benchmark metric type Info
+ * \defgroup PerformanceMetrics Performance metric type Info
  *
- * @brief Definitions and metadata on supported benchmark metric types.
+ * @brief Definitions and metadata on supported performance metric types.
  */
 
     /**
- * \ingroup BenchmarkMetrics
+ * \ingroup PerformanceMetrics
  * @{
  */
 
     /**
- * Benchmark Metric
+ * Performance Metric
  */
-    enum class BenchmarkMetric : int
+    enum class PerformanceMetric : int
     {
         Best,
         CUEfficiency,
@@ -57,49 +57,49 @@ namespace Tensile
         Count
     };
 
-    std::string   ToString(BenchmarkMetric d);
-    std::string   TypeAbbrev(BenchmarkMetric d);
-    std::ostream& operator<<(std::ostream& stream, BenchmarkMetric const& t);
-    std::istream& operator>>(std::istream& stream, BenchmarkMetric& t);
+    std::string   ToString(PerformanceMetric d);
+    std::string   TypeAbbrev(PerformanceMetric d);
+    std::ostream& operator<<(std::ostream& stream, PerformanceMetric const& t);
+    std::istream& operator>>(std::istream& stream, PerformanceMetric& t);
 
     /**
- * \ingroup BenchmarkMetrics
- * \brief Runtime accessible benchmark metric type metadata
+ * \ingroup PerformanceMetrics
+ * \brief Runtime accessible performance metric type metadata
  */
-    struct BenchmarkMetricTypeInfo
+    struct PerformanceMetricTypeInfo
     {
-        static BenchmarkMetricTypeInfo const& Get(int index);
-        static BenchmarkMetricTypeInfo const& Get(BenchmarkMetric t);
-        static BenchmarkMetricTypeInfo const& Get(std::string const& str);
+        static PerformanceMetricTypeInfo const& Get(int index);
+        static PerformanceMetricTypeInfo const& Get(PerformanceMetric t);
+        static PerformanceMetricTypeInfo const& Get(std::string const& str);
 
-        BenchmarkMetric m_benchmarkMetric;
-        std::string     name;
-        std::string     abbrev;
+        PerformanceMetric m_performanceMetric;
+        std::string       name;
+        std::string       abbrev;
 
     private:
         static void registerAllTypeInfo();
         static void registerAllTypeInfoOnce();
 
-        template <BenchmarkMetric T_Enum>
+        template <PerformanceMetric T_Enum>
         static void registerTypeInfo();
 
-        static void addInfoObject(BenchmarkMetricTypeInfo const& info);
+        static void addInfoObject(PerformanceMetricTypeInfo const& info);
 
-        static std::map<BenchmarkMetric, BenchmarkMetricTypeInfo> data;
-        static std::map<std::string, BenchmarkMetric>             typeNames;
+        static std::map<PerformanceMetric, PerformanceMetricTypeInfo> data;
+        static std::map<std::string, PerformanceMetric>               typeNames;
     };
 
     /**
- * \ingroup BenchmarkMetrics
- * \brief Compile-time accessible benchmark metric type metadata.
+ * \ingroup PerformanceMetrics
+ * \brief Compile-time accessible performance metric type metadata.
  */
-    template <BenchmarkMetric T_Enum>
-    struct BenchmarkMetricInfo;
+    template <PerformanceMetric T_Enum>
+    struct PerformanceMetricInfo;
 
-    template <BenchmarkMetric T_Enum>
-    struct BaseBenchmarkMetricInfo
+    template <PerformanceMetric T_Enum>
+    struct BasePerformanceMetricInfo
     {
-        constexpr static BenchmarkMetric Enum = T_Enum;
+        constexpr static PerformanceMetric Enum = T_Enum;
 
         static inline std::string Name()
         {
@@ -111,22 +111,22 @@ namespace Tensile
         }
     };
 
-    template <BenchmarkMetric T_Enum>
-    constexpr BenchmarkMetric BaseBenchmarkMetricInfo<T_Enum>::Enum;
+    template <PerformanceMetric T_Enum>
+    constexpr PerformanceMetric BasePerformanceMetricInfo<T_Enum>::Enum;
 
     template <>
-    struct BenchmarkMetricInfo<BenchmarkMetric::Best>
-        : public BaseBenchmarkMetricInfo<BenchmarkMetric::Best>
+    struct PerformanceMetricInfo<PerformanceMetric::Best>
+        : public BasePerformanceMetricInfo<PerformanceMetric::Best>
     {
     };
     template <>
-    struct BenchmarkMetricInfo<BenchmarkMetric::CUEfficiency>
-        : public BaseBenchmarkMetricInfo<BenchmarkMetric::CUEfficiency>
+    struct PerformanceMetricInfo<PerformanceMetric::CUEfficiency>
+        : public BasePerformanceMetricInfo<PerformanceMetric::CUEfficiency>
     {
     };
     template <>
-    struct BenchmarkMetricInfo<BenchmarkMetric::Overall>
-        : public BaseBenchmarkMetricInfo<BenchmarkMetric::Overall>
+    struct PerformanceMetricInfo<PerformanceMetric::Overall>
+        : public BasePerformanceMetricInfo<PerformanceMetric::Overall>
     {
     };
 
@@ -138,9 +138,9 @@ namespace Tensile
 namespace std
 {
     template <>
-    struct hash<Tensile::BenchmarkMetric>
+    struct hash<Tensile::PerformanceMetric>
     {
-        inline size_t operator()(Tensile::BenchmarkMetric const& val) const
+        inline size_t operator()(Tensile::PerformanceMetric const& val) const
         {
             return hash<int>()(static_cast<int>(val));
         }

--- a/Tensile/Source/lib/include/Tensile/Serialization/ContractionPredicates.hpp
+++ b/Tensile/Source/lib/include/Tensile/Serialization/ContractionPredicates.hpp
@@ -85,7 +85,7 @@ namespace Tensile
                     Base::template Pair<Predicates::Contraction::GlobalSplitUCheckMinK>(),
                     Base::template Pair<Predicates::Contraction::CDStridesEqual>(),
                     Base::template Pair<Predicates::Contraction::StridedBatchedEqual>(),
-                    Base::template Pair<Predicates::Contraction::PerCU>(),
+                    Base::template Pair<Predicates::Contraction::CUEfficiency>(),
                 });
 
                 auto gmap = Generic::GetSubclasses();
@@ -279,8 +279,8 @@ namespace Tensile
         };
 
         template <typename IO>
-        struct MappingTraits<Predicates::Contraction::PerCU, IO>
-            : public AutoMappingTraits<Predicates::Contraction::PerCU, IO>
+        struct MappingTraits<Predicates::Contraction::CUEfficiency, IO>
+            : public AutoMappingTraits<Predicates::Contraction::CUEfficiency, IO>
         {
         };
     } // namespace Serialization

--- a/Tensile/Source/lib/include/Tensile/Serialization/ContractionPredicates.hpp
+++ b/Tensile/Source/lib/include/Tensile/Serialization/ContractionPredicates.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright 2019-2020 Advanced Micro Devices, Inc.
+ * Copyright 2019-2021 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -85,6 +85,7 @@ namespace Tensile
                     Base::template Pair<Predicates::Contraction::GlobalSplitUCheckMinK>(),
                     Base::template Pair<Predicates::Contraction::CDStridesEqual>(),
                     Base::template Pair<Predicates::Contraction::StridedBatchedEqual>(),
+                    Base::template Pair<Predicates::Contraction::PerCU>(),
                 });
 
                 auto gmap = Generic::GetSubclasses();
@@ -274,6 +275,12 @@ namespace Tensile
         template <typename IO>
         struct MappingTraits<Predicates::Contraction::StridedBatchedEqual, IO>
             : public AutoMappingTraits<Predicates::Contraction::StridedBatchedEqual, IO>
+        {
+        };
+
+        template <typename IO>
+        struct MappingTraits<Predicates::Contraction::PerCU, IO>
+            : public AutoMappingTraits<Predicates::Contraction::PerCU, IO>
         {
         };
     } // namespace Serialization

--- a/Tensile/Source/lib/include/Tensile/Serialization/ExactLogicLibrary.hpp
+++ b/Tensile/Source/lib/include/Tensile/Serialization/ExactLogicLibrary.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright 2019-2020 Advanced Micro Devices, Inc.
+ * Copyright 2019-2021 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -53,6 +53,20 @@ namespace Tensile
         struct MappingTraits<ProblemSelectionLibrary<MyProblem, MySolution>, IO>
         {
             using Library = ProblemSelectionLibrary<MyProblem, MySolution>;
+            using iot     = IOTraits<IO>;
+
+            static void mapping(IO& io, Library& lib)
+            {
+                iot::mapRequired(io, "rows", lib.rows);
+            }
+
+            const static bool flow = false;
+        };
+
+        template <typename MyProblem, typename MySolution, typename IO>
+        struct MappingTraits<PerCUorOverallLibrary<MyProblem, MySolution>, IO>
+        {
+            using Library = PerCUorOverallLibrary<MyProblem, MySolution>;
             using iot     = IOTraits<IO>;
 
             static void mapping(IO& io, Library& lib)

--- a/Tensile/Source/lib/include/Tensile/Serialization/ExactLogicLibrary.hpp
+++ b/Tensile/Source/lib/include/Tensile/Serialization/ExactLogicLibrary.hpp
@@ -63,20 +63,6 @@ namespace Tensile
             const static bool flow = false;
         };
 
-        template <typename MyProblem, typename MySolution, typename IO>
-        struct MappingTraits<PerCUorOverallLibrary<MyProblem, MySolution>, IO>
-        {
-            using Library = PerCUorOverallLibrary<MyProblem, MySolution>;
-            using iot     = IOTraits<IO>;
-
-            static void mapping(IO& io, Library& lib)
-            {
-                iot::mapRequired(io, "rows", lib.rows);
-            }
-
-            const static bool flow = false;
-        };
-
         template <typename MyProblem, typename MySolution, typename MyPredicate, typename IO>
         struct MappingTraits<LibraryRow<MyProblem, MySolution, MyPredicate>, IO>
         {

--- a/Tensile/Source/lib/include/Tensile/Serialization/SolutionLibrary.hpp
+++ b/Tensile/Source/lib/include/Tensile/Serialization/SolutionLibrary.hpp
@@ -72,7 +72,6 @@ namespace Tensile
                     {Base::template Pair<SingleSolutionLibrary<MyProblem, MySolution>>(),
                      Base::template Pair<HardwareSelectionLibrary<MyProblem, MySolution>>(),
                      Base::template Pair<ProblemSelectionLibrary<MyProblem, MySolution>>(),
-                     Base::template Pair<PerCUorOverallLibrary<MyProblem, MySolution>>(),
                      Base::template Pair<ProblemMapLibrary<MyProblem, MySolution>>(),
                      Base::template Pair<ProblemMatchingLibrary<MyProblem, MySolution>>(),
                      Base::template Pair<GranularitySelectionLibrary<MyProblem, MySolution>>()});

--- a/Tensile/Source/lib/include/Tensile/Serialization/SolutionLibrary.hpp
+++ b/Tensile/Source/lib/include/Tensile/Serialization/SolutionLibrary.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright 2019-2020 Advanced Micro Devices, Inc.
+ * Copyright 2019-2021 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -72,6 +72,7 @@ namespace Tensile
                     {Base::template Pair<SingleSolutionLibrary<MyProblem, MySolution>>(),
                      Base::template Pair<HardwareSelectionLibrary<MyProblem, MySolution>>(),
                      Base::template Pair<ProblemSelectionLibrary<MyProblem, MySolution>>(),
+                     Base::template Pair<PerCUorOverallLibrary<MyProblem, MySolution>>(),
                      Base::template Pair<ProblemMapLibrary<MyProblem, MySolution>>(),
                      Base::template Pair<ProblemMatchingLibrary<MyProblem, MySolution>>(),
                      Base::template Pair<GranularitySelectionLibrary<MyProblem, MySolution>>()});

--- a/Tensile/Source/lib/source/BenchmarkMetricTypes.cpp
+++ b/Tensile/Source/lib/source/BenchmarkMetricTypes.cpp
@@ -1,0 +1,156 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright 2019-2021 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <Tensile/BenchmarkMetricTypes.hpp>
+#include <Tensile/Utils.hpp>
+
+#include <algorithm>
+
+namespace Tensile
+{
+    std::map<BenchmarkMetric, BenchmarkMetricTypeInfo> BenchmarkMetricTypeInfo::data;
+    std::map<std::string, BenchmarkMetric>             BenchmarkMetricTypeInfo::typeNames;
+
+    std::string ToString(BenchmarkMetric d)
+    {
+        switch(d)
+        {
+        case BenchmarkMetric::Best:
+            return "Best";
+        case BenchmarkMetric::CUEfficiency:
+            return "CUEfficiency";
+        case BenchmarkMetric::Overall:
+            return "Overall";
+
+        case BenchmarkMetric::Count:
+        default:;
+        }
+        return "Invalid";
+    }
+
+    std::string TypeAbbrev(BenchmarkMetric d)
+    {
+        switch(d)
+        {
+        case BenchmarkMetric::Best:
+            return "Best";
+        case BenchmarkMetric::CUEfficiency:
+            return "CUEff";
+        case BenchmarkMetric::Overall:
+            return "Ovrl";
+
+        case BenchmarkMetric::Count:
+        default:;
+        }
+        return "Invalid";
+    }
+
+    template <BenchmarkMetric T>
+    void BenchmarkMetricTypeInfo::registerTypeInfo()
+    {
+        using T_Info = BenchmarkMetricInfo<T>;
+
+        BenchmarkMetricTypeInfo info;
+
+        info.m_benchmarkMetric = T_Info::Enum;
+        info.name              = T_Info::Name();
+        info.abbrev            = T_Info::Abbrev();
+
+        addInfoObject(info);
+    }
+
+    void BenchmarkMetricTypeInfo::registerAllTypeInfo()
+    {
+        registerTypeInfo<BenchmarkMetric::Best>();
+        registerTypeInfo<BenchmarkMetric::CUEfficiency>();
+        registerTypeInfo<BenchmarkMetric::Overall>();
+    }
+
+    void BenchmarkMetricTypeInfo::registerAllTypeInfoOnce()
+    {
+        static int call_once = (registerAllTypeInfo(), 0);
+    }
+
+    void BenchmarkMetricTypeInfo::addInfoObject(BenchmarkMetricTypeInfo const& info)
+    {
+        auto toLower = [](std::string tmp) {
+            std::transform(tmp.begin(), tmp.end(), tmp.begin(), ::tolower);
+            return tmp;
+        };
+
+        data[info.m_benchmarkMetric] = info;
+
+        // Add some flexibility to names registry. Accept abbreviations and
+        // lower case versions of the strings
+        typeNames[info.name]            = info.m_benchmarkMetric;
+        typeNames[toLower(info.name)]   = info.m_benchmarkMetric;
+        typeNames[info.abbrev]          = info.m_benchmarkMetric;
+        typeNames[toLower(info.abbrev)] = info.m_benchmarkMetric;
+    }
+
+    BenchmarkMetricTypeInfo const& BenchmarkMetricTypeInfo::Get(int index)
+    {
+        return Get(static_cast<BenchmarkMetric>(index));
+    }
+
+    BenchmarkMetricTypeInfo const& BenchmarkMetricTypeInfo::Get(BenchmarkMetric t)
+    {
+        registerAllTypeInfoOnce();
+
+        auto iter = data.find(t);
+        if(iter == data.end())
+            throw std::runtime_error(
+                concatenate("Invalid benchmark metric: ", static_cast<int>(t)));
+
+        return iter->second;
+    }
+
+    BenchmarkMetricTypeInfo const& BenchmarkMetricTypeInfo::Get(std::string const& str)
+    {
+        registerAllTypeInfoOnce();
+
+        auto iter = typeNames.find(str);
+        if(iter == typeNames.end())
+            throw std::runtime_error(concatenate("Invalid benchmark metric: ", str));
+
+        return Get(iter->second);
+    }
+
+    std::ostream& operator<<(std::ostream& stream, const BenchmarkMetric& t)
+    {
+        return stream << ToString(t);
+    }
+
+    std::istream& operator>>(std::istream& stream, BenchmarkMetric& t)
+    {
+        std::string strValue;
+        stream >> strValue;
+
+        t = BenchmarkMetricTypeInfo::Get(strValue).m_benchmarkMetric;
+
+        return stream;
+    }
+} // namespace Tensile

--- a/Tensile/Source/lib/source/PerformanceMetricTypes.cpp
+++ b/Tensile/Source/lib/source/PerformanceMetricTypes.cpp
@@ -24,132 +24,132 @@
  *
  *******************************************************************************/
 
-#include <Tensile/BenchmarkMetricTypes.hpp>
+#include <Tensile/PerformanceMetricTypes.hpp>
 #include <Tensile/Utils.hpp>
 
 #include <algorithm>
 
 namespace Tensile
 {
-    std::map<BenchmarkMetric, BenchmarkMetricTypeInfo> BenchmarkMetricTypeInfo::data;
-    std::map<std::string, BenchmarkMetric>             BenchmarkMetricTypeInfo::typeNames;
+    std::map<PerformanceMetric, PerformanceMetricTypeInfo> PerformanceMetricTypeInfo::data;
+    std::map<std::string, PerformanceMetric>               PerformanceMetricTypeInfo::typeNames;
 
-    std::string ToString(BenchmarkMetric d)
+    std::string ToString(PerformanceMetric d)
     {
         switch(d)
         {
-        case BenchmarkMetric::Best:
+        case PerformanceMetric::Best:
             return "Best";
-        case BenchmarkMetric::CUEfficiency:
+        case PerformanceMetric::CUEfficiency:
             return "CUEfficiency";
-        case BenchmarkMetric::Overall:
+        case PerformanceMetric::Overall:
             return "Overall";
 
-        case BenchmarkMetric::Count:
+        case PerformanceMetric::Count:
         default:;
         }
         return "Invalid";
     }
 
-    std::string TypeAbbrev(BenchmarkMetric d)
+    std::string TypeAbbrev(PerformanceMetric d)
     {
         switch(d)
         {
-        case BenchmarkMetric::Best:
+        case PerformanceMetric::Best:
             return "Best";
-        case BenchmarkMetric::CUEfficiency:
+        case PerformanceMetric::CUEfficiency:
             return "CUEff";
-        case BenchmarkMetric::Overall:
+        case PerformanceMetric::Overall:
             return "Ovrl";
 
-        case BenchmarkMetric::Count:
+        case PerformanceMetric::Count:
         default:;
         }
         return "Invalid";
     }
 
-    template <BenchmarkMetric T>
-    void BenchmarkMetricTypeInfo::registerTypeInfo()
+    template <PerformanceMetric T>
+    void PerformanceMetricTypeInfo::registerTypeInfo()
     {
-        using T_Info = BenchmarkMetricInfo<T>;
+        using T_Info = PerformanceMetricInfo<T>;
 
-        BenchmarkMetricTypeInfo info;
+        PerformanceMetricTypeInfo info;
 
-        info.m_benchmarkMetric = T_Info::Enum;
-        info.name              = T_Info::Name();
-        info.abbrev            = T_Info::Abbrev();
+        info.m_performanceMetric = T_Info::Enum;
+        info.name                = T_Info::Name();
+        info.abbrev              = T_Info::Abbrev();
 
         addInfoObject(info);
     }
 
-    void BenchmarkMetricTypeInfo::registerAllTypeInfo()
+    void PerformanceMetricTypeInfo::registerAllTypeInfo()
     {
-        registerTypeInfo<BenchmarkMetric::Best>();
-        registerTypeInfo<BenchmarkMetric::CUEfficiency>();
-        registerTypeInfo<BenchmarkMetric::Overall>();
+        registerTypeInfo<PerformanceMetric::Best>();
+        registerTypeInfo<PerformanceMetric::CUEfficiency>();
+        registerTypeInfo<PerformanceMetric::Overall>();
     }
 
-    void BenchmarkMetricTypeInfo::registerAllTypeInfoOnce()
+    void PerformanceMetricTypeInfo::registerAllTypeInfoOnce()
     {
         static int call_once = (registerAllTypeInfo(), 0);
     }
 
-    void BenchmarkMetricTypeInfo::addInfoObject(BenchmarkMetricTypeInfo const& info)
+    void PerformanceMetricTypeInfo::addInfoObject(PerformanceMetricTypeInfo const& info)
     {
         auto toLower = [](std::string tmp) {
             std::transform(tmp.begin(), tmp.end(), tmp.begin(), ::tolower);
             return tmp;
         };
 
-        data[info.m_benchmarkMetric] = info;
+        data[info.m_performanceMetric] = info;
 
         // Add some flexibility to names registry. Accept abbreviations and
         // lower case versions of the strings
-        typeNames[info.name]            = info.m_benchmarkMetric;
-        typeNames[toLower(info.name)]   = info.m_benchmarkMetric;
-        typeNames[info.abbrev]          = info.m_benchmarkMetric;
-        typeNames[toLower(info.abbrev)] = info.m_benchmarkMetric;
+        typeNames[info.name]            = info.m_performanceMetric;
+        typeNames[toLower(info.name)]   = info.m_performanceMetric;
+        typeNames[info.abbrev]          = info.m_performanceMetric;
+        typeNames[toLower(info.abbrev)] = info.m_performanceMetric;
     }
 
-    BenchmarkMetricTypeInfo const& BenchmarkMetricTypeInfo::Get(int index)
+    PerformanceMetricTypeInfo const& PerformanceMetricTypeInfo::Get(int index)
     {
-        return Get(static_cast<BenchmarkMetric>(index));
+        return Get(static_cast<PerformanceMetric>(index));
     }
 
-    BenchmarkMetricTypeInfo const& BenchmarkMetricTypeInfo::Get(BenchmarkMetric t)
+    PerformanceMetricTypeInfo const& PerformanceMetricTypeInfo::Get(PerformanceMetric t)
     {
         registerAllTypeInfoOnce();
 
         auto iter = data.find(t);
         if(iter == data.end())
             throw std::runtime_error(
-                concatenate("Invalid benchmark metric: ", static_cast<int>(t)));
+                concatenate("Invalid performance metric: ", static_cast<int>(t)));
 
         return iter->second;
     }
 
-    BenchmarkMetricTypeInfo const& BenchmarkMetricTypeInfo::Get(std::string const& str)
+    PerformanceMetricTypeInfo const& PerformanceMetricTypeInfo::Get(std::string const& str)
     {
         registerAllTypeInfoOnce();
 
         auto iter = typeNames.find(str);
         if(iter == typeNames.end())
-            throw std::runtime_error(concatenate("Invalid benchmark metric: ", str));
+            throw std::runtime_error(concatenate("Invalid performance metric: ", str));
 
         return Get(iter->second);
     }
 
-    std::ostream& operator<<(std::ostream& stream, const BenchmarkMetric& t)
+    std::ostream& operator<<(std::ostream& stream, const PerformanceMetric& t)
     {
         return stream << ToString(t);
     }
 
-    std::istream& operator>>(std::istream& stream, BenchmarkMetric& t)
+    std::istream& operator>>(std::istream& stream, PerformanceMetric& t)
     {
         std::string strValue;
         stream >> strValue;
 
-        t = BenchmarkMetricTypeInfo::Get(strValue).m_benchmarkMetric;
+        t = PerformanceMetricTypeInfo::Get(strValue).m_performanceMetric;
 
         return stream;
     }

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright 2016-2020 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright 2016-2021 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -1594,4 +1594,3 @@ def TensileCreateLibrary():
   print1("# Tensile Library Writer DONE")
   print1(HR)
   print1("")
-

--- a/tuning/automation/ConvertToEfficiency.py
+++ b/tuning/automation/ConvertToEfficiency.py
@@ -60,6 +60,8 @@ def allFiles(startDir):
             files.append(fullPath)
     return files
 
+# sclk: MHz
+# alu: flops/cycle/CU
 def peakGFlops(sclk, alu, numCUs):
     return (sclk / 1000) * alu * numCUs
 

--- a/tuning/automation/ConvertToEfficiency.py
+++ b/tuning/automation/ConvertToEfficiency.py
@@ -1,0 +1,116 @@
+################################################################################
+# Copyright 2016-2021 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell cop-
+# ies of the Software, and to permit persons to whom the Software is furnished
+# to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM-
+# PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNE-
+# CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+################################################################################
+
+import argparse
+import os
+import yaml
+
+typeIndexToName = {0: "S", 1: "D", 4: "H", 7: "B"}
+
+def parseArgs():
+    argParser = argparse.ArgumentParser()
+
+    h = {"inDir"   : "Directory containing input logic files", \
+         "outDir"  : "Output directory for modified logic files", \
+         "sclk"    : "SCLK frequency in MHz tuning was done at", \
+         "specs"   : ".yaml file containing hardware specifications", \
+         "per-cu"  : "If tuning was done per CU", \
+         "name"    : "Name substring to filter which files are modified", \
+         "mfma"    : "If MFMA instructions were used for tuning", \
+         "mi50"    : "For vega20, if tuning was done on mi50"
+    }
+
+    argParser.add_argument("inDir", metavar="input-dir", type=str, help=h["inDir"])
+    argParser.add_argument("outDir", metavar="output-dir", type=str, help=h["outDir"])
+    argParser.add_argument("sclk", type=int, help=h["sclk"])
+    argParser.add_argument("specs", metavar="hardware-specs", nargs="?", type=str, default="default_specs.yaml", help=h["specs"])
+    argParser.add_argument("-p", "--per-cu", action="store_true", help=h["per-cu"])
+    argParser.add_argument("-n", "--name", type=str, help=h["name"])
+    argParser.add_argument("-m", "--mfma", action="store_true", help=h["mfma"])
+    argParser.add_argument("--mi50", action="store_true", help=h["mi50"])
+
+    return argParser.parse_args()
+
+def allFiles(startDir):
+    current = os.listdir(startDir)
+    files = []
+    for filename in current:
+        fullPath = os.path.join(startDir, filename)
+        if os.path.isdir(fullPath):
+            files = files + allFiles(fullPath)
+        else:
+            files.append(fullPath)
+    return files
+
+def peakGFlops(sclk, alu, numCUs):
+    return (sclk / 1000) * alu * numCUs
+
+def main():
+    args = parseArgs()
+    mfmaKey = "mfma" if args.mfma else "non_mfma"
+
+    with open(args.specs) as y:
+        specs = yaml.safe_load(y)
+
+    try:
+        os.makedirs(args.outDir)
+    except OSError:
+        pass
+
+    files = allFiles(args.inDir)
+    for f in files:
+        if not args.name or args.name in f:
+            print(f)
+            with open(f) as y:
+
+                data = yaml.safe_load(y)
+
+                sched = data[1]
+                type = typeIndexToName[data[4]["DataType"]]
+                alu = specs[sched][mfmaKey][type]
+
+                # get CU count
+                if args.per_cu:
+                    numCUs = 1
+                elif sched == "vega20":
+                    gpu = "mi50" if args.mi50 else "mi60"
+                    numCUs = specs[sched]["numCUs"][gpu]
+                else:
+                    numCUs = specs[sched]["numCUs"]
+
+                peak = peakGFlops(args.sclk, alu, numCUs)
+
+                # update each entry
+                for entry in data[7]:
+                    print("Size: ", entry[0])
+                    eff = entry[1][1] / peak
+                    entry[1][1] = round (100 * eff, 3)
+                    print("Efficiency: ", entry[1][1])
+                    print()
+
+            fName = os.path.basename(f)
+            outFile = os.path.join(args.outDir, fName)
+
+            with open(outFile, "w") as y:
+                yaml.safe_dump(data, y, default_flow_style=None)
+
+if __name__ == "__main__":
+    main()

--- a/tuning/scripts/stage_tuning.sh
+++ b/tuning/scripts/stage_tuning.sh
@@ -17,7 +17,7 @@ function make_tensile_tuning() {
     echo "#!/bin/sh"
     echo "if [ ! -d 3_LibraryLogic ] || [ -z \"\$(ls -A 3_LibraryLogic)\" ]; then"
     echo "  touch time.begin"
-    echo "  ${TENSILE}/Tensile/bin/Tensile ${FILE_NAME} ./ > make.out 2>&1"
+    echo "  ${TENSILE}/Tensile/bin/Tensile ${FILE_NAME} ./ > tuning.out 2>&1"
     echo "  touch time.end"
     echo "fi"
   } > runTensileTuning.sh
@@ -79,7 +79,7 @@ done
   echo "for dir in${DIRS}"
   echo "do"
   echo "  cd build-\${dir} || exit"
-  echo "  ./doit.sh > doit-errs 2>&1"
+  echo "  ./runTensileTuning.sh > tuning-errs.out 2>&1"
   echo "  cd .."
   echo "done"
 } >> "${DOIT}"


### PR DESCRIPTION
This PR is a prototype for adding support in Tensile for kernels with performace reported per CU. There are two main components of this:
1) At the benchmarking phase, reporting either GFlops/CU _or_ raw GFlops as determined by the `BenchmarkPerCU` global parameter and reflecting this in the generated library logic yaml file
2) Adding an additional layer to the Master Solution Library (currently, between the Problem Map and Predicate layers) which decides between picking kernels with per CU or overall performance data

Below are some notes on the implementation of these features that I would like some feedback on:
- Each library logic file will have either overall or per CU tuned kernels, not both
  - This is indicated by a boolean at [10] in the library logic file: true for per CU and false for overall
  - For backwards compatibility, if [10] in the logic file doesn't exist, the file is treated as having overall results
- The `PerCUorOverall` layer of the Master Solution Library is an `ExactSolutionLibrary` and is placed above the normal Predicate layer
  - Allows quickly filtering out all per CU kernels if overall speed is desired and vice versa
  - Allows falling back to overall speed kernels (all existing ones in rocBLAS) if a per CU one is requested but cannot be provided
  - Currently its own class, but could be implemented with the existing `ProblemSelectionLibrary` at the cost of not having a unique name for the layer.  
- Currently, the predicate for determining if per CU kernels should be selected is hardcoded to return true
  - For the short term, some metric for choosing per CU or overall is needed. This could either be determined by the problem sizes or the total flop count of the problem
  - Eventually, user control can be added so that per CU or overall speed can be requested specifically

Other things yet to do/add:
- New tests?
- Buckets in tuning scripts for tuning per CU
- Update changelog once ready for review

Also, this PR fixes a bug which resulted in the Master Solution Library having multiple rows for the same hardware (changes in Hardware.py).