### PR TITLE
MasterSolutionLibrary duplicated hardware rows fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Support offset for each input/output buffer in Tensile
 - support support ldc != ldd for all GEMM kernel
 
+### Fixed
+- Fixed MasterSolutionLibrary having duplicated hardware rows
 
 ## [Tensile 4.26.0 for ROCm 4.1.0]
 ### Added

--- a/Tensile/Hardware.py
+++ b/Tensile/Hardware.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright 2019-2020 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright 2019-2021 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,6 +20,7 @@
 ################################################################################
 
 from . import Properties
+import copy
 
 class HardwarePredicate(Properties.Predicate):
     @classmethod
@@ -68,8 +69,10 @@ class HardwarePredicate(Properties.Predicate):
             assert myProcPred.tag == otherProcPred.tag == "Processor", "Invalid processor predicate"
 
             # Downgrade to base class so that we don't recurse
-            myProcPred.__class__ = otherProcPred.__class__ = Properties.Predicate
-            return myProcPred < otherProcPred
+            myProcPredCopy = copy.deepcopy(myProcPred)
+            otherProcPredCopy = copy.deepcopy(otherProcPred)
+            myProcPredCopy.__class__ = otherProcPredCopy.__class__ = Properties.Predicate
+            return myProcPredCopy < otherProcPredCopy
 
         # Higher priority given to higher CU count
         return myCUCount > otherCUCount

--- a/Tensile/Source/SolutionHelper.h
+++ b/Tensile/Source/SolutionHelper.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -75,7 +75,7 @@ struct SolutionLock
 #ifdef WIN32
 __declspec(thread) extern KernelMap kernelMap;
 #else
-extern thread_local KernelMap kernelMap;
+extern thread_local KernelMap                 kernelMap;
 #endif
 
 /*******************************************************************************

--- a/Tensile/Source/lib/include/Tensile/DataTypes_BFloat16.hpp
+++ b/Tensile/Source/lib/include/Tensile/DataTypes_BFloat16.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright 2019-2020 Advanced Micro Devices, Inc.
+ * Copyright 2019-2021 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -99,7 +99,7 @@ namespace Tensile
 #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
             q[0] = v.data;
 #else
-            q[1] = v.data;
+            q[1]      = v.data;
 #endif
             return fp32;
         }


### PR DESCRIPTION
Fixed a bug where the master solution library would have multiple rows for the same hardware. This was caused by the less than operator of HardwarePredicate modifying its own `__class__`, which caused later equality checks with other HardwarePredicates to return false negatives due to differing `__class__` values.

Originally fixed in a draft of #1279, this change has been isolated for idependent tracking. 