### PR TITLE
Fix calling dpkg

### DIFF
--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -1693,18 +1693,17 @@ def assignGlobalParameters( config ):
   # See https://docs.python.org/3.7/library/platform.html#platform.linux_distribution
   try:
     if globalParameters["CxxCompiler"] == "hipcc":
-      output = subprocess.run(["dpkg", "-l", "hip-rocclr"], check=True, stdout=subprocess.PIPE).stdout.decode()
+      output = subprocess.run(["hipcc", "--version"], check=True, stdout=subprocess.PIPE).stdout.decode()
     elif globalParameters["CxxCompiler"] == "hcc":
-      output = subprocess.run(["dpkg", "-l", "hcc"], check=True, stdout=subprocess.PIPE).stdout.decode()
+      printWarning("Error: hcc is deprecated")
 
     for line in output.split('\n'):
-      if 'hipcc' in line:
+      if 'HIP' in line:
         globalParameters['HipClangVersion'] = line.split()[2]
-      elif 'hcc' in line:
-        globalParameters['HccVersion'] = line.split()[2]
+        print1("# Found  hipcc version " + globalParameters['HipClangVersion'])
 
   except (subprocess.CalledProcessError, OSError) as e:
-      printWarning("Error: {} looking for package {}: {}".format('dpkg', 'hip-rocclr', e))
+      printWarning("Error: {} running {} {} ".format('hipcc', '--version',  e))
 
   for key in config:
     value = config[key]


### PR DESCRIPTION
Remove dpkg dependency so you can point to AOMP etc
Remove hcc as it is deprecated.

Fixes:https://github.com/ROCmSoftwarePlatform/Tensile/issues/1172

TEST: Build with latest hipcc from AOMP. Tensile will report:
Found  hipcc version 4.0.20496-4f163c68