### PR TITLE
Use LLVM bundled with rocm for Tensile

### DIFF
--- a/HostLibraryTests/CMakeLists.txt
+++ b/HostLibraryTests/CMakeLists.txt
@@ -127,7 +127,7 @@ set(test_sources ${test_sources}
 )
 
 if(TENSILE_USE_LLVM)
-    find_package(LLVM 6.0 REQUIRED CONFIG)
+    find_package(LLVM 12.0 REQUIRED CONFIG)
 
     set(test_sources ${test_sources}
         ContractionLibraryLoading_test.cpp

--- a/HostLibraryTests/CMakeLists.txt
+++ b/HostLibraryTests/CMakeLists.txt
@@ -26,6 +26,8 @@ project(TensileHostLibraryTest)
 set( CMAKE_CXX_STANDARD 14 )
 set( CMAKE_CXX_EXTENSIONS OFF )
 
+list(APPEND CMAKE_PREFIX_PATH $ENV{ROCM_PATH} /opt/rocm)
+
 option(TENSILE_USE_HIP       "Use the Hip runtime." ON)
 option(TENSILE_USE_LLVM      "Use LLVM for parsing config files." ON)
 option(TENSILE_USE_MSGPACK   "Use msgpack for parsing config files." ON)
@@ -127,7 +129,13 @@ set(test_sources ${test_sources}
 )
 
 if(TENSILE_USE_LLVM)
-    find_package(LLVM 12.0 REQUIRED CONFIG)
+    find_package(LLVM 13.0 QUIET CONFIG)
+    if(NOT LLVM_FOUND)
+        find_package(LLVM 12.0 QUIET CONFIG)
+        if(NOT LLVM_FOUND)
+            find_package(LLVM REQUIRED CONFIG)
+        endif()
+    endif()
 
     set(test_sources ${test_sources}
         ContractionLibraryLoading_test.cpp

--- a/Tensile/Source/lib/CMakeLists.txt
+++ b/Tensile/Source/lib/CMakeLists.txt
@@ -48,7 +48,14 @@ set(tensile_sources  ${tensile_sources}
     )
 
 if(TENSILE_USE_LLVM)
-	find_package(LLVM 12.0 REQUIRED QUIET CONFIG)
+    find_package(LLVM 13.0 QUIET CONFIG)
+    if(NOT LLVM_FOUND)
+        find_package(LLVM 12.0 QUIET CONFIG)
+        if(NOT LLVM_FOUND)
+            find_package(LLVM REQUIRED CONFIG)
+        endif()
+    endif()
+
     set(tensile_sources ${tensile_sources}
         source/llvm/YAML.cpp
         source/llvm/Loading.cpp

--- a/Tensile/Source/lib/CMakeLists.txt
+++ b/Tensile/Source/lib/CMakeLists.txt
@@ -48,16 +48,7 @@ set(tensile_sources  ${tensile_sources}
     )
 
 if(TENSILE_USE_LLVM)
-    find_package(LLVM 6.0 QUIET CONFIG)
-    if(NOT LLVM_FOUND)
-        find_package(LLVM 7.0 QUIET CONFIG)
-        if(NOT LLVM_FOUND)
-            find_package(LLVM 9.0 QUIET CONFIG)
-            if(NOT LLVM_FOUND)
-                find_package(LLVM REQUIRED CONFIG)
-            endif()
-        endif()
-    endif()
+	find_package(LLVM 12.0 REQUIRED QUIET CONFIG)
     set(tensile_sources ${tensile_sources}
         source/llvm/YAML.cpp
         source/llvm/Loading.cpp

--- a/docker/dockerfile-build-ubuntu-rock
+++ b/docker/dockerfile-build-ubuntu-rock
@@ -45,7 +45,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     python3-setuptools \
     python3-yaml \
     libnuma1 \
-    llvm-6.0-dev \
     libboost-all-dev \
     zlib1g-dev \
     libomp-dev \

--- a/docker/dockerfile-tensile-tuning-slurm
+++ b/docker/dockerfile-tensile-tuning-slurm
@@ -27,7 +27,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     python3-setuptools \
     python3-yaml \
     libnuma1 \
-    llvm-6.0-dev \
     libboost-all-dev \
     zlib1g-dev \
     libomp-dev \


### PR DESCRIPTION
ROCm comes packaged with llvm-12.0, however Tensile requires llvm-6.0 for the HostLibraryTests. The library however can already build with just llvm-12.0 installed. To eliminate the need to have multiple versions of llvm installed for the tests, they now require llvm 12.0 (Which should always be present), and I propagated the same change over to the library to prevent conflicts when the library finds llvm-6.0 first.