### PR TITLE
Rename PerformanceMetric enum values

### DIFF
--- a/HostLibraryTests/llvm/CUEfficiencyPredicate_test.cpp
+++ b/HostLibraryTests/llvm/CUEfficiencyPredicate_test.cpp
@@ -59,7 +59,7 @@ TEST(CUEfficiencyPredicate, CUEfficiency)
     EXPECT_EQ((*p)(large), true);
 }
 
-TEST(CUEfficiencyPredicate, Overall)
+TEST(CUEfficiencyPredicate, DeviceEfficiency)
 {
     std::string mydoc = "type: And\n"
                         "value: [{type: TruePred}, \n"
@@ -79,8 +79,8 @@ TEST(CUEfficiencyPredicate, Overall)
     ContractionProblem large = ContractionProblem::GEMM(
         false, false, 10'000, 10'000, 10'000, 10'000, 10'000, 10'000, 1, false, 1);
 
-    small.setPerformanceMetric(PerformanceMetric::Overall);
-    large.setPerformanceMetric(PerformanceMetric::Overall);
+    small.setPerformanceMetric(PerformanceMetric::DeviceEfficiency);
+    large.setPerformanceMetric(PerformanceMetric::DeviceEfficiency);
 
     EXPECT_EQ((*p)(small), false);
     EXPECT_EQ((*p)(large), false);

--- a/HostLibraryTests/llvm/CUEfficiencyPredicate_test.cpp
+++ b/HostLibraryTests/llvm/CUEfficiencyPredicate_test.cpp
@@ -110,8 +110,8 @@ TEST(CUEfficiencyPredicate, Best)
     ContractionProblem large = ContractionProblem::GEMM(
         false, false, 10'000, 10'000, 10'000, 10'000, 10'000, 10'000, 1, false, 1);
 
-    small.setPerformanceMetric(PerformanceMetric::Best);
-    large.setPerformanceMetric(PerformanceMetric::Best);
+    small.setPerformanceMetric(PerformanceMetric::Auto);
+    large.setPerformanceMetric(PerformanceMetric::Auto);
 
     EXPECT_EQ((*p)(small), true);
     EXPECT_EQ((*p)(large), false);

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -51,12 +51,12 @@ workingDirectoryStack = []
 # common
 ########################################
 globalParameters["MinimumRequiredVersion"] = "0.0.0" # which version of tensile is required to handle all the features required by this configuration file
-globalParameters["PerformanceMetric"] = "Overall"    # performance metric for benchmarking; one of {Overall, CUEfficiency}
+globalParameters["PerformanceMetric"] = "DeviceEfficiency" # performance metric for benchmarking; one of {DeviceEfficiency, CUEfficiency}
 globalParameters["PrintLevel"] = 1                # how much info to print in generator. 0=none, 1=standard, 2=verbose
 globalParameters["ClientLogLevel"] = 3            # the log level of client. 0=Error, 1=Terse, 2=Verbose, 3=Debug (Aligned with ResultReporter.hpp)
 # benchmarking
 globalParameters["KernelTime"] = False            # T=use device timers, F=use host timers
-globalParameters["PreciseKernelTime"] = True     # T=On hip, use the timestamps for kernel start and stop rather than separate events.  Can provide more accurate kernel timing.  For GlobalSplitU kernels, recommend disabling this to provide consistent
+globalParameters["PreciseKernelTime"] = True      # T=On hip, use the timestamps for kernel start and stop rather than separate events.  Can provide more accurate kernel timing.  For GlobalSplitU kernels, recommend disabling this to provide consistent
 # timing between GSU / non-GSU kernels
 globalParameters["CodeFromFiles"] = True          # if False byte arrays will be generated during Benchmarking phase as before
 globalParameters["SortProblems"] = False          # sort problems by size; else use order in YAML file

--- a/Tensile/LibraryLogic.py
+++ b/Tensile/LibraryLogic.py
@@ -442,12 +442,12 @@ class LogicAnalyzer:
         # get unit (gflops or gflops/cu) of benchmark data
         perfUnit = row[0]
         if perfUnit == "GFlops":
-          self.perfMetric = "Overall"
+          self.perfMetric = "DeviceEfficiency"
         elif perfUnit == "GFlopsPerCU":
           self.perfMetric = "CUEfficiency"
         else:
-          printWarning("Performance unit %s in %s is unrecognized: assuming GFlops (overall)" % (perfUnit, dataFileName))
-          self.perfMetric = "Overall"
+          printWarning("Performance unit %s in %s is unrecognized: assuming GFlops (device efficiency)" % (perfUnit, dataFileName))
+          self.perfMetric = "DeviceEfficiency"
 
         # get the length of each row, and derive the first column of the solution instead of using wrong "solutionStartIdx = totalSizeIdx + 1"
         rowLength = len(row)

--- a/Tensile/SolutionLibrary.py
+++ b/Tensile/SolutionLibrary.py
@@ -225,7 +225,7 @@ class MasterSolutionLibrary:
         #origSolutions = d[5]
         origLibrary = d[6:8]
 
-        perfMetric = 'Overall'
+        perfMetric = 'DeviceEfficiency'
         if len(d) > 10:
             perfMetric = d[10]
 
@@ -288,7 +288,7 @@ class MasterSolutionLibrary:
                 library = newLib
 
             elif libName == 'PerformanceMetric':
-                if perfMetric != 'Overall':
+                if perfMetric != 'DeviceEfficiency':
                     predicate = Properties.Predicate(tag=perfMetric)
                 else:
                     predicate = Properties.Predicate(tag='TruePred')

--- a/Tensile/Source/client/include/LogReporter.hpp
+++ b/Tensile/Source/client/include/LogReporter.hpp
@@ -95,7 +95,7 @@ namespace Tensile
                 std::cout << "Log level: " << logLevel << std::endl;
 
                 PerformanceMetric metric = args["performance-metric"].as<PerformanceMetric>();
-                // Default to 'Overall' benchmarking if CUEfficiency not specified
+                // Default to 'DeviceEfficiency' benchmarking if CUEfficiency not specified
                 const std::string perfUnit
                     = (metric == PerformanceMetric::CUEfficiency ? SpeedGFlopsPerCu : SpeedGFlops);
 

--- a/Tensile/Source/client/main.cpp
+++ b/Tensile/Source/client/main.cpp
@@ -96,7 +96,7 @@ namespace Tensile
                                                                                   "specified, we will use the embedded code "
                                                                                   "object(s) if available.")
 
-                ("performance-metric",       po::value<PerformanceMetric>()->default_value(PerformanceMetric::Overall), "Metric for benchmarking results")
+                ("performance-metric",       po::value<PerformanceMetric>()->default_value(PerformanceMetric::DeviceEfficiency), "Metric for benchmarking results")
 
                 ("problem-identifier",       po::value<std::string>(), "Problem identifer (Einstein notation). Either "
                                                                        "this or free/batch/bound must be specified.")

--- a/Tensile/Source/client/source/ResultFileReporter.cpp
+++ b/Tensile/Source/client/source/ResultFileReporter.cpp
@@ -53,7 +53,7 @@ namespace Tensile
         {
             if(m_performanceMetric == PerformanceMetric::CUEfficiency)
                 m_output.setHeaderForKey(ResultKey::ProblemIndex, "GFlopsPerCU");
-            else // Default to 'Overall' benchmarking if CUEfficiency not specified
+            else // Default to 'DeviceEfficiency' benchmarking if CUEfficiency not specified
                 m_output.setHeaderForKey(ResultKey::ProblemIndex, "GFlops");
         }
 
@@ -89,7 +89,7 @@ namespace Tensile
                 }
             }
             else if((key == ResultKey::SpeedGFlops
-                     && m_performanceMetric == PerformanceMetric::Overall)
+                     && m_performanceMetric == PerformanceMetric::DeviceEfficiency)
                     || (key == ResultKey::SpeedGFlopsPerCu
                         && m_performanceMetric == PerformanceMetric::CUEfficiency))
             {

--- a/Tensile/Source/lib/include/Tensile/ContractionProblem.hpp
+++ b/Tensile/Source/lib/include/Tensile/ContractionProblem.hpp
@@ -753,7 +753,7 @@ namespace Tensile
         bool              m_eligibleForPK           = true;
         ArithmeticUnit    m_arithmeticUnit          = ArithmeticUnit::Any;
         KernelLanguage    m_kernelLanguage          = KernelLanguage::Any;
-        PerformanceMetric m_performanceMetric       = PerformanceMetric::Overall;
+        PerformanceMetric m_performanceMetric       = PerformanceMetric::DeviceEfficiency;
 
         DataType m_alphaType = DataType::None; // if not assigned, will follow d-type
         DataType m_betaType  = DataType::None; // for bwd-compatible

--- a/Tensile/Source/lib/include/Tensile/ContractionProblemPredicates.hpp
+++ b/Tensile/Source/lib/include/Tensile/ContractionProblemPredicates.hpp
@@ -1077,7 +1077,7 @@ namespace Tensile
                     {
                         return true;
                     }
-                    else if(problem.performanceMetric() == PerformanceMetric::Best)
+                    else if(problem.performanceMetric() == PerformanceMetric::Auto)
                     {
                         // True if total flops below a constant threshold
                         // Current threshold chosen naively as the flops for a

--- a/Tensile/Source/lib/include/Tensile/PerformanceMetricTypes.hpp
+++ b/Tensile/Source/lib/include/Tensile/PerformanceMetricTypes.hpp
@@ -53,7 +53,7 @@ namespace Tensile
     {
         Best,
         CUEfficiency,
-        Overall,
+        DeviceEfficiency,
         Count
     };
 
@@ -125,8 +125,8 @@ namespace Tensile
     {
     };
     template <>
-    struct PerformanceMetricInfo<PerformanceMetric::Overall>
-        : public BasePerformanceMetricInfo<PerformanceMetric::Overall>
+    struct PerformanceMetricInfo<PerformanceMetric::DeviceEfficiency>
+        : public BasePerformanceMetricInfo<PerformanceMetric::DeviceEfficiency>
     {
     };
 

--- a/Tensile/Source/lib/include/Tensile/PerformanceMetricTypes.hpp
+++ b/Tensile/Source/lib/include/Tensile/PerformanceMetricTypes.hpp
@@ -51,7 +51,7 @@ namespace Tensile
  */
     enum class PerformanceMetric : int
     {
-        Best,
+        Auto,
         CUEfficiency,
         DeviceEfficiency,
         Count
@@ -115,8 +115,8 @@ namespace Tensile
     constexpr PerformanceMetric BasePerformanceMetricInfo<T_Enum>::Enum;
 
     template <>
-    struct PerformanceMetricInfo<PerformanceMetric::Best>
-        : public BasePerformanceMetricInfo<PerformanceMetric::Best>
+    struct PerformanceMetricInfo<PerformanceMetric::Auto>
+        : public BasePerformanceMetricInfo<PerformanceMetric::Auto>
     {
     };
     template <>

--- a/Tensile/Source/lib/source/PerformanceMetricTypes.cpp
+++ b/Tensile/Source/lib/source/PerformanceMetricTypes.cpp
@@ -42,8 +42,8 @@ namespace Tensile
             return "Best";
         case PerformanceMetric::CUEfficiency:
             return "CUEfficiency";
-        case PerformanceMetric::Overall:
-            return "Overall";
+        case PerformanceMetric::DeviceEfficiency:
+            return "DeviceEfficiency";
 
         case PerformanceMetric::Count:
         default:;
@@ -59,8 +59,8 @@ namespace Tensile
             return "Best";
         case PerformanceMetric::CUEfficiency:
             return "CUEff";
-        case PerformanceMetric::Overall:
-            return "Ovrl";
+        case PerformanceMetric::DeviceEfficiency:
+            return "DvEff";
 
         case PerformanceMetric::Count:
         default:;
@@ -86,7 +86,7 @@ namespace Tensile
     {
         registerTypeInfo<PerformanceMetric::Best>();
         registerTypeInfo<PerformanceMetric::CUEfficiency>();
-        registerTypeInfo<PerformanceMetric::Overall>();
+        registerTypeInfo<PerformanceMetric::DeviceEfficiency>();
     }
 
     void PerformanceMetricTypeInfo::registerAllTypeInfoOnce()

--- a/Tensile/Source/lib/source/PerformanceMetricTypes.cpp
+++ b/Tensile/Source/lib/source/PerformanceMetricTypes.cpp
@@ -38,8 +38,8 @@ namespace Tensile
     {
         switch(d)
         {
-        case PerformanceMetric::Best:
-            return "Best";
+        case PerformanceMetric::Auto:
+            return "Auto";
         case PerformanceMetric::CUEfficiency:
             return "CUEfficiency";
         case PerformanceMetric::DeviceEfficiency:
@@ -55,8 +55,8 @@ namespace Tensile
     {
         switch(d)
         {
-        case PerformanceMetric::Best:
-            return "Best";
+        case PerformanceMetric::Auto:
+            return "Auto";
         case PerformanceMetric::CUEfficiency:
             return "CUEff";
         case PerformanceMetric::DeviceEfficiency:
@@ -84,7 +84,7 @@ namespace Tensile
 
     void PerformanceMetricTypeInfo::registerAllTypeInfo()
     {
-        registerTypeInfo<PerformanceMetric::Best>();
+        registerTypeInfo<PerformanceMetric::Auto>();
         registerTypeInfo<PerformanceMetric::CUEfficiency>();
         registerTypeInfo<PerformanceMetric::DeviceEfficiency>();
     }


### PR DESCRIPTION
Renamed `PerformanceMetric` enums: Best -> Auto and Overall -> DeviceEfficiency.
This was done to keep the names consistent between Tensile and rocBLAS (see [rocBLAS-internal #587](https://github.com/ROCmSoftwarePlatform/rocBLAS-internal/pull/578)).

Since no CUEfficiency solution files are in rocBLAS yet, this change should have no effect. 