### PR TITLE
Fix: TensileCreateLibrary relative output path crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Change Log for Tensile
+## [(Unreleased) Tensile 4.28.0 for ROCm 4.3.0]
+### Fixed
+- TensileCreateLibrary crash with relative output and --merge-files
 
 ## [Tensile 4.27.0 for ROCm 4.2.0]
 ### Added

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -1340,6 +1340,7 @@ def TensileCreateLibrary():
   libraryFormat = args.LibraryFormat
   print2("OutputPath: %s" % outputPath)
   ensurePath(outputPath)
+  outputPath = os.path.abspath(outputPath)
   arguments = {}
   arguments["RuntimeLanguage"] = args.RuntimeLanguage
   arguments["CodeObjectVersion"] = args.CodeObjectVersion


### PR DESCRIPTION
Using a relative output path with TensileCreateLibrary would crash if `--merge-files` was set to true.