### PR TITLE
New Python unit tests for predicates and predicate libraries

### DIFF
--- a/Tensile/Tests/unit/test_HardwarePredicates.py
+++ b/Tensile/Tests/unit/test_HardwarePredicates.py
@@ -101,3 +101,12 @@ def test_hardware_library_merge_dups(libraries):
         lib.merge(lib2)
 
     assert len(lib.rows) == 4
+
+    def getPred(row):
+        return row['predicate']
+    rowPreds = map(getPred, lib.rows)
+
+    assert HardwarePredicate.FromISA((9,0,0)) in rowPreds
+    assert HardwarePredicate.FromISA((9,0,6)) in rowPreds
+    assert HardwarePredicate.FromISA((9,0,8)) in rowPreds
+    assert HardwarePredicate('TruePred') in rowPreds

--- a/Tensile/Tests/unit/test_HardwarePredicates.py
+++ b/Tensile/Tests/unit/test_HardwarePredicates.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright 2020 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright 2020-2021 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -24,6 +24,7 @@ import itertools
 import copy
 from Tensile.Hardware import HardwarePredicate
 from Tensile.SolutionLibrary import PredicateLibrary
+
 
 def test_hardware_predicate_comparison():
     a = HardwarePredicate.FromISA((9,0,0))
@@ -59,7 +60,7 @@ def test_hardware_predicate_comparison():
     assert not d < d
     assert not e < e
 
-def predicate_library_objects():
+def hardware_library_objects_order():
     objs = [PredicateLibrary('Hardware', [{'predicate': HardwarePredicate.FromISA((9,0,0))}]),
             PredicateLibrary('Hardware', [{'predicate': HardwarePredicate.FromISA((9,0,6))}]),
             PredicateLibrary('Hardware', [{'predicate': HardwarePredicate.FromISA((9,0,8))}]),
@@ -71,8 +72,8 @@ def predicate_library_objects():
 
     return [copy.deepcopy(libs) for libs in itertools.permutations(objs)]
 
-@pytest.mark.parametrize("libraries", predicate_library_objects())
-def test_predicate_library_merge(libraries):
+@pytest.mark.parametrize("libraries", hardware_library_objects_order())
+def test_hardware_library_merge_order(libraries):
     lib = libraries[0]
     for lib2 in libraries[1:]:
         lib.merge(lib2)
@@ -82,3 +83,21 @@ def test_predicate_library_merge(libraries):
     assert lib.rows[1]['predicate'] == HardwarePredicate.FromHardware((9,0,8), 60)
     for r in lib.rows[:-1]:
         assert r['predicate'] != HardwarePredicate('TruePred')
+
+def hardware_library_objects_dups():
+    objs = [PredicateLibrary('Hardware', [{'predicate': HardwarePredicate.FromISA((9,0,0)), 'library': PredicateLibrary()}]),
+            PredicateLibrary('Hardware', [{'predicate': HardwarePredicate.FromISA((9,0,6)), 'library': PredicateLibrary()}]),
+            PredicateLibrary('Hardware', [{'predicate': HardwarePredicate.FromISA((9,0,6)), 'library': PredicateLibrary()}]),
+            PredicateLibrary('Hardware', [{'predicate': HardwarePredicate.FromISA((9,0,8)), 'library': PredicateLibrary()}]),
+            PredicateLibrary('Hardware', [{'predicate': HardwarePredicate('TruePred'),      'library': PredicateLibrary()}])
+    ]
+
+    return [copy.deepcopy(libs) for libs in itertools.permutations(objs)]
+
+@pytest.mark.parametrize("libraries", hardware_library_objects_dups())
+def test_hardware_library_merge_dups(libraries):
+    lib = libraries[0]
+    for lib2 in libraries[1:]:
+        lib.merge(lib2)
+
+    assert len(lib.rows) == 4

--- a/Tensile/Tests/unit/test_PerfMetricPredicates.py
+++ b/Tensile/Tests/unit/test_PerfMetricPredicates.py
@@ -1,0 +1,67 @@
+################################################################################
+# Copyright 2020-2021 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell cop-
+# ies of the Software, and to permit persons to whom the Software is furnished
+# to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM-
+# PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNE-
+# CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+################################################################################
+
+import pytest
+import itertools
+import copy
+from Tensile.Properties import Predicate
+from Tensile.SolutionLibrary import PredicateLibrary
+
+
+def test_perf_metric_predicate_comparison():
+    cu = Predicate('CUEfficiency')
+    dv = Predicate('TruePred')
+
+    assert cu < dv
+    assert not dv < cu
+
+def perf_metric_library_objects_order():
+    objs = [PredicateLibrary('Problem', [{'predicate': Predicate('CUEfficiency')}]),
+            PredicateLibrary('Problem', [{'predicate': Predicate('TruePred')}])
+    ]
+
+    return [copy.deepcopy(libs) for libs in itertools.permutations(objs)]
+
+@pytest.mark.parametrize("libraries", perf_metric_library_objects_order())
+def test_perf_metric_library_merge_order(libraries):
+    lib = libraries[0]
+    for lib2 in libraries[1:]:
+        lib.merge(lib2)
+
+    assert lib.rows[0]['predicate'] == Predicate('CUEfficiency')
+    assert lib.rows[1]['predicate'] == Predicate('TruePred')
+
+def perf_metric_library_objects_dups():
+    objs = [PredicateLibrary('Problem', [{'predicate': Predicate('CUEfficiency'), 'library': PredicateLibrary()}]),
+            PredicateLibrary('Problem', [{'predicate': Predicate('CUEfficiency'), 'library': PredicateLibrary()}]),
+            PredicateLibrary('Problem', [{'predicate': Predicate('TruePred'),     'library': PredicateLibrary()}]),
+            PredicateLibrary('Problem', [{'predicate': Predicate('TruePred'),     'library': PredicateLibrary()}])
+    ]
+
+    return [copy.deepcopy(libs) for libs in itertools.permutations(objs)]
+
+@pytest.mark.parametrize("libraries", perf_metric_library_objects_dups())
+def test_perf_metric_library_merge_dups(libraries):
+    lib = libraries[0]
+    for lib2 in libraries[1:]:
+        lib.merge(lib2)
+
+    assert len(lib.rows) == 2

--- a/Tensile/Tests/unit/test_PerfMetricPredicates.py
+++ b/Tensile/Tests/unit/test_PerfMetricPredicates.py
@@ -65,3 +65,10 @@ def test_perf_metric_library_merge_dups(libraries):
         lib.merge(lib2)
 
     assert len(lib.rows) == 2
+
+    def getPred(row):
+        return row['predicate']
+    rowPreds = map(getPred, lib.rows)
+
+    assert Predicate('CUEfficiency') in rowPreds
+    assert Predicate('TruePred') in rowPreds


### PR DESCRIPTION
`test_hardware_library_merge_dups` motivated by #1280.

Other tests added to help ensure fallback to Device Efficiency kernels when a CU efficiency kernel cannot be found happens correctly (see #1279).