### PR TITLE
resolves SWDEV-269618; recovers HGEMM source kernel performance

### DIFF
--- a/Tensile/KernelWriterSource.py
+++ b/Tensile/KernelWriterSource.py
@@ -825,7 +825,8 @@ class KernelWriterSource(KernelWriter):
     else:
       s += "extern \"C\"\n"
       s += "__global__ "
-    s += "void %s" % ( kernelName )
+    # the new default of 1024 degrades HGEMM performance too much
+    s += "void\n__launch_bounds__(256)\n%s" % ( kernelName )
     s += "(" + self.endLine
     # pointers
     globalStr = "__global "


### PR DESCRIPTION
Forces the old max-threads-per-block via \_\_launch_bounds\_\_(256); the new default of 1024 slows down HGEMM source kernel performance too much.