### PR TITLE
cherry-pick hot-fix #1307 back to develop

### DIFF
--- a/Tensile/KernelWriterSource.py
+++ b/Tensile/KernelWriterSource.py
@@ -825,7 +825,8 @@ class KernelWriterSource(KernelWriter):
     else:
       s += "extern \"C\"\n"
       s += "__global__ "
-    s += "void %s" % ( kernelName )
+    # the new default of 1024 degrades HGEMM performance too much
+    s += "void\n__launch_bounds__(256)\n%s" % ( kernelName )
     s += "(" + self.endLine
     # pointers
     globalStr = "__global "


### PR DESCRIPTION
Standard "git merge origin/master" back to develop wouldn't work due to the reverted PR; cherry-pick 3438af228dc812768b20a068b0285122f327fa5b from hot-fix #1307 directly instead.