### PR TITLE
Expanded solution filtering

### DIFF
--- a/Tensile/BenchmarkProblems.py
+++ b/Tensile/BenchmarkProblems.py
@@ -376,8 +376,8 @@ def benchmarkProblemType( problemTypeConfig, problemSizeGroupConfig, \
         elapsedTime = currentTime - startTime
         print1("# Finish GetResults - %.3fs\n" % (elapsedTime))
         print2("CSV Results: %s" % results)
-        winners.addResults(benchmarkStep.hardcodedParameters, \
-            benchmarkPermutations, solutions, results)
+        #winners.addResults(benchmarkStep.hardcodedParameters, \
+            #benchmarkPermutations, solutions, results)
         currentTime = time.time()
         elapsedTime = currentTime - startTime
         print1("# Finish Adding Results - %.3fs\n" % (elapsedTime))
@@ -460,11 +460,11 @@ def getResults(resultsFileName, solutions, enableTileSelection, newResultsFileNa
 
   if globalParameters["CSVExportWinner"]:
     # in both old/new clients, csv files always output "GFlops" ,...., "LDD" "LDC" "LDA" "LDB" "TotalFlops" "WinnerGFlops" "WinnerTimeUS" "WinnerIdx" "WinnerName" columns
-    startIdx = numColForProblemSize + 10
+    startIdx = numColForProblemSize + 11
   else:
     # in both old/new clients, csv files always output "GFlops" ,...., "LDD" "LDC" "LDA" "LDB"columns
     # old client, non-GEMM csv files don't contain "LDD" "LDC" "LDA" "LDB", so we output an "N/A" text (in csv only) for alignment purpose (-diff.csv)
-    startIdx = numColForProblemSize + 5
+    startIdx = numColForProblemSize + 6
 
   rowLength = startIdx + numSolutions
 

--- a/Tensile/BenchmarkProblems.py
+++ b/Tensile/BenchmarkProblems.py
@@ -370,6 +370,7 @@ def benchmarkProblemType( problemTypeConfig, problemSizeGroupConfig, \
     ############################################################################
     # Winners -> Determined Parameters
     ############################################################################
+    # This code is not currently needed; updates to CSV format have broken, so commenting out for now
     # if not enableTileSelection:
     #     results = getResults(resultsFileName, solutions, enableTileSelection, newResultsFileName)
     #     currentTime = time.time()

--- a/Tensile/BenchmarkProblems.py
+++ b/Tensile/BenchmarkProblems.py
@@ -370,17 +370,17 @@ def benchmarkProblemType( problemTypeConfig, problemSizeGroupConfig, \
     ############################################################################
     # Winners -> Determined Parameters
     ############################################################################
-    if not enableTileSelection:
-        results = getResults(resultsFileName, solutions, enableTileSelection, newResultsFileName)
-        currentTime = time.time()
-        elapsedTime = currentTime - startTime
-        print1("# Finish GetResults - %.3fs\n" % (elapsedTime))
-        print2("CSV Results: %s" % results)
-        #winners.addResults(benchmarkStep.hardcodedParameters, \
-            #benchmarkPermutations, solutions, results)
-        currentTime = time.time()
-        elapsedTime = currentTime - startTime
-        print1("# Finish Adding Results - %.3fs\n" % (elapsedTime))
+    # if not enableTileSelection:
+    #     results = getResults(resultsFileName, solutions, enableTileSelection, newResultsFileName)
+    #     currentTime = time.time()
+    #     elapsedTime = currentTime - startTime
+    #     print1("# Finish GetResults - %.3fs\n" % (elapsedTime))
+    #     print2("CSV Results: %s" % results)
+    #     winners.addResults(benchmarkStep.hardcodedParameters, \
+    #         benchmarkPermutations, solutions, results)
+    #     currentTime = time.time()
+    #     elapsedTime = currentTime - startTime
+    #     print1("# Finish Adding Results - %.3fs\n" % (elapsedTime))
 
     ############################################################################
     # Write Solutions YAML

--- a/Tensile/BenchmarkStructs.py
+++ b/Tensile/BenchmarkStructs.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright 2016-2020 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright 2016-2021 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -222,6 +222,8 @@ class BenchmarkProcess:
     ############################################################################
     # Ensure only valid solution parameters were requested
     validParameterNames = set(validParameters.keys())
+    globalParameters["IsMFMA"] = False
+
     for paramDictList in [configBenchmarkCommonParameters, \
         configForkParameters, configBenchmarkForkParameters, \
         configBenchmarkJoinParameters]:
@@ -231,6 +233,9 @@ class BenchmarkProcess:
             if paramName in ["ProblemSizes"]:
               continue
             else:
+              if paramName == "MatrixInstruction":
+                globalParameters["IsMFMA"] = True
+
               if paramName not in validParameterNames:
                 printExit("Invalid parameter name: %s\nValid parameters are %s." \
                     % (paramName, sorted(validParameterNames)))
@@ -711,6 +716,3 @@ class BenchmarkStep:
 
   def __repr__(self):
     return self.__str__()
-
-
-

--- a/Tensile/ClientWriter.py
+++ b/Tensile/ClientWriter.py
@@ -701,6 +701,7 @@ def writeClientConfigIni(problemSizes, problemType, sourceDir, codeObjectFiles, 
         param("run-criteria-verify",      globalParameters["RunCriteriaVerify"])
         param("granularity-threshold",    globalParameters["GranularityThreshold"])
         param("mem-throughput-threshold", globalParameters["MemThroughputThreshold"])
+        param("run-criteria-min-size",    globalParameters["RunCriteriaMinSize"])
 
         param("pristine-on-gpu",          globalParameters["PristineOnGPU"])
         param("library-update-file",      globalParameters["LibraryUpdateFile"])

--- a/Tensile/ClientWriter.py
+++ b/Tensile/ClientWriter.py
@@ -707,6 +707,12 @@ def writeClientConfigIni(problemSizes, problemType, sourceDir, codeObjectFiles, 
         param("library-update-comment",   globalParameters["LibraryUpdateComment"])
 
 
+        mfmaKey = "mfma" if globalParameters["IsMFMA"] else "non_mfma"
+        typeKey = problemType.aType.toChar()
+
+        param("alu-rate",                 globalParameters["ALURates"][mfmaKey][typeKey])
+        param("l2-speed",                 globalParameters["L2Speed"])
+
 def writeClientConfig(forBenchmark, solutions, problemSizes, stepName, stepBaseDir, newLibrary, codeObjectFiles, tileAwareSelection, configBase = "ClientParameters", libraryFile = None):
 
     if tileAwareSelection:

--- a/Tensile/ClientWriter.py
+++ b/Tensile/ClientWriter.py
@@ -698,11 +698,14 @@ def writeClientConfigIni(problemSizes, problemType, sourceDir, codeObjectFiles, 
         param("csv-merge-same-problems",  globalParameters["CSVMergeSameProblemID"])
         param("log-level",                ClientLogLevel(globalParameters["ClientLogLevel"]).name)
         param("max-workspace-size",       globalParameters["MaxWorkspaceSize"])
+        param("run-criteria-verify",      globalParameters["RunCriteriaVerify"])
         param("granularity-threshold",    globalParameters["GranularityThreshold"])
+        param("mem-throughput-threshold", globalParameters["MemThroughputThreshold"])
+        param("min-lds-utilization",      globalParameters["MinLDSUtilization"])
         param("pristine-on-gpu",          globalParameters["PristineOnGPU"])
-
         param("library-update-file",      globalParameters["LibraryUpdateFile"])
         param("library-update-comment",   globalParameters["LibraryUpdateComment"])
+
 
 def writeClientConfig(forBenchmark, solutions, problemSizes, stepName, stepBaseDir, newLibrary, codeObjectFiles, tileAwareSelection, configBase = "ClientParameters", libraryFile = None):
 

--- a/Tensile/ClientWriter.py
+++ b/Tensile/ClientWriter.py
@@ -701,7 +701,7 @@ def writeClientConfigIni(problemSizes, problemType, sourceDir, codeObjectFiles, 
         param("run-criteria-verify",      globalParameters["RunCriteriaVerify"])
         param("granularity-threshold",    globalParameters["GranularityThreshold"])
         param("mem-throughput-threshold", globalParameters["MemThroughputThreshold"])
-        param("min-lds-utilization",      globalParameters["MinLDSUtilization"])
+
         param("pristine-on-gpu",          globalParameters["PristineOnGPU"])
         param("library-update-file",      globalParameters["LibraryUpdateFile"])
         param("library-update-comment",   globalParameters["LibraryUpdateComment"])
@@ -710,8 +710,12 @@ def writeClientConfigIni(problemSizes, problemType, sourceDir, codeObjectFiles, 
         mfmaKey = "mfma" if globalParameters["IsMFMA"] else "non_mfma"
         typeKey = problemType.aType.toChar()
 
-        param("alu-rate",                 globalParameters["ALURates"][mfmaKey][typeKey])
-        param("l2-speed",                 globalParameters["L2Speed"])
+        if (globalParameters["MemThroughputThreshold"] > 0.0):
+          try:
+            param("alu-rate",                 globalParameters["ALURates"][mfmaKey][typeKey])
+            param("l2-speed",                 globalParameters["L2Speed"])
+          except Exception as e:
+            printExit("Exception when setting alu-rate or l2-speed: {}".format(e))
 
 def writeClientConfig(forBenchmark, solutions, problemSizes, stepName, stepBaseDir, newLibrary, codeObjectFiles, tileAwareSelection, configBase = "ClientParameters", libraryFile = None):
 

--- a/Tensile/ClientWriter.py
+++ b/Tensile/ClientWriter.py
@@ -707,12 +707,10 @@ def writeClientConfigIni(problemSizes, problemType, sourceDir, codeObjectFiles, 
         param("library-update-file",      globalParameters["LibraryUpdateFile"])
         param("library-update-comment",   globalParameters["LibraryUpdateComment"])
 
-
-        mfmaKey = "mfma" if globalParameters["IsMFMA"] else "non_mfma"
-        typeKey = problemType.aType.toChar()
-
         if (globalParameters["MemThroughputThreshold"] > 0.0):
           try:
+            mfmaKey = "mfma" if globalParameters["IsMFMA"] else "non_mfma"
+            typeKey = problemType.aType.toChar()
             param("alu-rate",                 globalParameters["ALURates"][mfmaKey][typeKey])
             param("l2-speed",                 globalParameters["L2Speed"])
           except Exception as e:

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -251,8 +251,11 @@ globalParameters["PerfModelReadEfficiency"] = 0.85
 globalParameters["MaxWorkspaceSize"] = 32 * 1024 * 1024 # max workspace for training (32M)
 globalParameters["MinKForGSU"] = 256 # min K size to use GlobalSplitU algorithm (only for HPA now)
 
-# control if a solution is run for a given problem
+# controls for if a solution is run for a given problem
+globalParameters["RunCriteriaVerify"] = False
 globalParameters["GranularityThreshold"] = 0.0
+globalParameters["MemThroughputThreshold"] = 0.0
+globalParameters["MinLDSUtilization"] = 0.0
 
 globalParameters["PristineOnGPU"] = True # use Pristine memory on Tensile trainning verification or not
 

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -256,7 +256,7 @@ globalParameters["RunCriteriaVerify"] = False
 globalParameters["GranularityThreshold"] = 0.0
 globalParameters["MemThroughputThreshold"] = 0.0
 globalParameters["MinLDSUtilization"] = 0.0
-globalParameters["HardwareSpecsPath"] = "hardware_specs.yaml"
+globalParameters["HardwareSpecsPath"] = None
 
 globalParameters["PristineOnGPU"] = True # use Pristine memory on Tensile trainning verification or not
 

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -255,7 +255,6 @@ globalParameters["MinKForGSU"] = 256 # min K size to use GlobalSplitU algorithm 
 globalParameters["RunCriteriaVerify"] = False
 globalParameters["GranularityThreshold"] = 0.0
 globalParameters["MemThroughputThreshold"] = 0.0
-globalParameters["MinLDSUtilization"] = 0.0
 globalParameters["HardwareSpecsPath"] = None
 
 globalParameters["PristineOnGPU"] = True # use Pristine memory on Tensile trainning verification or not

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -256,6 +256,7 @@ globalParameters["RunCriteriaVerify"] = False
 globalParameters["GranularityThreshold"] = 0.0
 globalParameters["MemThroughputThreshold"] = 0.0
 globalParameters["MinLDSUtilization"] = 0.0
+globalParameters["HardwareSpecsPath"] = "hardware_specs.yaml"
 
 globalParameters["PristineOnGPU"] = True # use Pristine memory on Tensile trainning verification or not
 

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -255,6 +255,7 @@ globalParameters["MinKForGSU"] = 256 # min K size to use GlobalSplitU algorithm 
 globalParameters["RunCriteriaVerify"] = False
 globalParameters["GranularityThreshold"] = 0.0
 globalParameters["MemThroughputThreshold"] = 0.0
+globalParameters["RunCriteriaMinSize"] = 1000 # minimum size of each dimension (except batch) to enable filtering
 globalParameters["HardwareSpecsPath"] = None
 
 globalParameters["PristineOnGPU"] = True # use Pristine memory on Tensile trainning verification or not

--- a/Tensile/LibraryLogic.py
+++ b/Tensile/LibraryLogic.py
@@ -206,9 +206,11 @@ def analyzeProblemType( problemType, problemSizeGroups, inputParameters ):
 
   for key, value in logicAnalyzer.wouldSkipWinner.items():
     if value:
-      printWarning("Winning solution would have been skipped by solution filtering criteria for problem size {}:\n\t"
-                  "{} vs {} (idx, GFlops)".format(key, logicAnalyzer.exactWinners[key], logicAnalyzer.winnersNotSkipped[key]))
-
+      if key in logicAnalyzer.winnersNotSkipped:
+        printWarning("Winning solution would have been skipped by solution filtering criteria for problem size {}:\n\t"
+                     "{} vs {} (idx, GFlops)".format(key, logicAnalyzer.exactWinners[key], logicAnalyzer.winnersNotSkipped[key]))
+      else:
+        printWarning("All solutions would have been skipped by solution filtering criteria for problem size {}".format(key))
 
   return (problemType, logicAnalyzer.solutions, logicAnalyzer.indexOrder, \
        exactLogic, rangeLogic, selectionSolutions, selectionSolutionsIdsList, logicAnalyzer.perfMetric)
@@ -462,12 +464,17 @@ class LogicAnalyzer:
           if problemSize in self.exactWinners:
             if winnerGFlops > self.exactWinners[problemSize][1]:
               self.exactWinners[problemSize] = [solutionMap[winnerIdx], winnerGFlops]
-              self.winnersNotSkipped[problemSize] = [solutionMap[winnerIdxNotSkipped], winnerGFlopsNotSkipped]
           else:
             self.exactWinners[problemSize] = [solutionMap[winnerIdx], winnerGFlops]
-            self.winnersNotSkipped[problemSize] = [solutionMap[winnerIdxNotSkipped], winnerGFlopsNotSkipped]
 
           self.wouldSkipWinner[problemSize] = wouldSkipWinner
+
+        if winnerIdxNotSkipped != -1:
+          if problemSize in self.winnersNotSkipped:
+            if winnerGFlopsNotSkipped > self.winnersNotSkipped[problemSize][1]:
+              self.winnersNotSkipped[problemSize] = [solutionMap[winnerIdxNotSkipped], winnerGFlopsNotSkipped]
+          else:
+            self.winnersNotSkipped[problemSize] = [solutionMap[winnerIdxNotSkipped], winnerGFlopsNotSkipped]
 
 
       # Range Problem Size

--- a/Tensile/LibraryLogic.py
+++ b/Tensile/LibraryLogic.py
@@ -207,10 +207,10 @@ def analyzeProblemType( problemType, problemSizeGroups, inputParameters ):
   for key, value in logicAnalyzer.wouldSkipWinner.items():
     if value:
       if key in logicAnalyzer.winnersNotSkipped:
-        printWarning("Winning solution would have been skipped by solution filtering criteria for problem size {}:\n\t"
-                     "{} vs {} (idx, GFlops)".format(key, logicAnalyzer.exactWinners[key], logicAnalyzer.winnersNotSkipped[key]))
+        printWarning("Winning solution would have been skipped by solution filtering criteria for problem size {} because of {}---"
+                     "{} vs {} (idx, GFlops)".format(key, logicAnalyzer.winnerSkipReason[key], logicAnalyzer.exactWinners[key], logicAnalyzer.winnersNotSkipped[key]))
       else:
-        printWarning("All solutions would have been skipped by solution filtering criteria for problem size {}".format(key))
+        printWarning("All solutions would have been skipped by solution filtering criteria for problem size {}. Winner skipped because of {}".format(key, logicAnalyzer.winnerSkipReason[key]))
 
   return (problemType, logicAnalyzer.solutions, logicAnalyzer.indexOrder, \
        exactLogic, rangeLogic, selectionSolutions, selectionSolutionsIdsList, logicAnalyzer.perfMetric)
@@ -361,6 +361,7 @@ class LogicAnalyzer:
     # Each entry in exactWinners is a 2D array [solutionIdx, perf]
     self.exactWinners = {}
     self.wouldSkipWinner = {}
+    self.winnerSkipReason = {}
     self.winnersNotSkipped = {}
 
     """
@@ -443,6 +444,7 @@ class LogicAnalyzer:
           winnerGFlops = -1
           winnerGFlopsNotSkipped = -1
           wouldSkipWinner = False
+          wouldSkipReason = ("", 0)
           for i in range(solutionStartIdx, rowLength):
 
             gflops_ws = row[i].strip().split(":")
@@ -453,6 +455,8 @@ class LogicAnalyzer:
               winnerIdx = solutionIdx
               winnerGFlops = gflops
               wouldSkipWinner = wouldSkip
+              if wouldSkip:
+                wouldSkipReason = (gflops_ws[1], gflops_ws[2])
 
             if gflops > winnerGFlopsNotSkipped and not wouldSkip:
               winnerGFlopsNotSkipped = gflops
@@ -468,6 +472,7 @@ class LogicAnalyzer:
             self.exactWinners[problemSize] = [solutionMap[winnerIdx], winnerGFlops]
 
           self.wouldSkipWinner[problemSize] = wouldSkipWinner
+          self.winnerSkipReason[problemSize] = wouldSkipReason
 
         if winnerIdxNotSkipped != -1:
           if problemSize in self.winnersNotSkipped:

--- a/Tensile/Source/client/include/ResultFileReporter.hpp
+++ b/Tensile/Source/client/include/ResultFileReporter.hpp
@@ -72,6 +72,8 @@ namespace Tensile
             bool              m_invalidSolution = false;
             bool              m_extraCol;
             bool              m_mergeSameProblems;
+            bool              m_wouldSkip       = false;
+            std::string       m_wouldSkipReason = "";
             PerformanceMetric m_performanceMetric;
             // for extra columns
             std::string m_winnerSolution;

--- a/Tensile/Source/client/include/ResultReporter.hpp
+++ b/Tensile/Source/client/include/ResultReporter.hpp
@@ -87,6 +87,7 @@ namespace Tensile
             const std::string SolutionWinner       = "solution-winner";
 
             // Performance-related
+            const std::string WouldSkip        = "would-skip";
             const std::string Validation       = "validation";
             const std::string TimeUS           = "time-us";
             const std::string SpeedGFlops      = "gflops";

--- a/Tensile/Source/client/include/ResultReporter.hpp
+++ b/Tensile/Source/client/include/ResultReporter.hpp
@@ -75,6 +75,7 @@ namespace Tensile
             const std::string LDD = "ldd";
 
             const std::string TotalFlops   = "total-flops";
+            const std::string SolutionsRun = "solutions-run";
             const std::string ProblemSizes = "problem-sizes";
 
             // Solution information

--- a/Tensile/Source/client/include/SolutionIterator.hpp
+++ b/Tensile/Source/client/include/SolutionIterator.hpp
@@ -129,12 +129,19 @@ namespace Tensile
         class AllSolutionsIterator : public SolutionIterator
         {
         public:
-            enum class FilterResult : int
+            enum class TestResult : int
             {
                 Run,
                 LowGranularity,
                 LowMemoryThroughput
             };
+            struct FilterResult
+            {
+                TestResult reason;
+                double     value;
+                double     thresh;
+            };
+            using TR = TestResult;
             using FR = FilterResult;
 
             using RunCriteria = std::vector<std::function<FR(
@@ -173,9 +180,9 @@ namespace Tensile
             RunCriteria m_runCriteria;
         };
 
-        std::string   ToString(AllSolutionsIterator::FR fr);
-        std::string   TypeAbbrev(AllSolutionsIterator::FR fr);
-        std::ostream& operator<<(std::ostream& stream, AllSolutionsIterator::FR const& fr);
+        std::string   ToString(AllSolutionsIterator::TR tr);
+        std::string   TypeAbbrev(AllSolutionsIterator::TR tr);
+        std::ostream& operator<<(std::ostream& stream, AllSolutionsIterator::TR const& tr);
 
         class BestSolutionIterator : public SolutionIterator
         {

--- a/Tensile/Source/client/include/SolutionIterator.hpp
+++ b/Tensile/Source/client/include/SolutionIterator.hpp
@@ -129,22 +129,19 @@ namespace Tensile
         class AllSolutionsIterator : public SolutionIterator
         {
         public:
-            enum class TestResult : int
+            enum class FilterTest : int
             {
-                Run,
-                LowGranularity,
-                LowMemoryThroughput
+                Granularity,
+                MemoryThroughput
             };
             struct FilterResult
             {
-                TestResult reason;
-                double     value;
-                double     thresh;
+                FilterTest  test;
+                bool        passed;
+                std::string msg;
             };
-            using TR = TestResult;
-            using FR = FilterResult;
 
-            using RunCriteria = std::vector<std::function<FR(
+            using RunCriteria = std::vector<std::function<FilterResult(
                 ContractionProblem const&, Hardware const&, ContractionSolution const&)>>;
 
             static RunCriteria
@@ -179,10 +176,6 @@ namespace Tensile
             bool        m_criteriaVerify;
             RunCriteria m_runCriteria;
         };
-
-        std::string   ToString(AllSolutionsIterator::TR tr);
-        std::string   TypeAbbrev(AllSolutionsIterator::TR tr);
-        std::ostream& operator<<(std::ostream& stream, AllSolutionsIterator::TR const& tr);
 
         class BestSolutionIterator : public SolutionIterator
         {

--- a/Tensile/Source/client/include/SolutionIterator.hpp
+++ b/Tensile/Source/client/include/SolutionIterator.hpp
@@ -42,9 +42,9 @@ namespace Tensile
         namespace po = boost::program_options;
 
         /**
- * Not an iterator by the traditional definition but I can't think of a better
- * name
- */
+         * Not an iterator by the traditional definition but I can't think of a better
+         * name
+        */
         class SolutionIterator : public RunListener
         {
         public:
@@ -129,7 +129,15 @@ namespace Tensile
         class AllSolutionsIterator : public SolutionIterator
         {
         public:
-            using RunCriteria = std::vector<std::function<bool(
+            enum class FilterResult : int
+            {
+                Run,
+                LowGranularity,
+                LowMemoryThroughput
+            };
+            using FR = FilterResult;
+
+            using RunCriteria = std::vector<std::function<FR(
                 ContractionProblem const&, Hardware const&, ContractionSolution const&)>>;
 
             static RunCriteria
@@ -141,7 +149,8 @@ namespace Tensile
                                  std::shared_ptr<Hardware> hardware,
                                  int                       firstSolutionIdx,
                                  int                       numSolutions,
-                                 RunCriteria               runCriteria = RunCriteria());
+                                 RunCriteria               runCriteria    = RunCriteria(),
+                                 bool                      criteriaVerify = false);
 
             virtual void preProblem(ContractionProblem const& problem) override;
             virtual void postProblem() override;
@@ -160,8 +169,13 @@ namespace Tensile
             int m_currentSolutionIdx;
             int m_numSolutionsSkipped;
 
+            bool        m_criteriaVerify;
             RunCriteria m_runCriteria;
         };
+
+        std::string   ToString(AllSolutionsIterator::FR fr);
+        std::string   TypeAbbrev(AllSolutionsIterator::FR fr);
+        std::ostream& operator<<(std::ostream& stream, AllSolutionsIterator::FR const& fr);
 
         class BestSolutionIterator : public SolutionIterator
         {

--- a/Tensile/Source/client/include/SolutionIterator.hpp
+++ b/Tensile/Source/client/include/SolutionIterator.hpp
@@ -153,8 +153,9 @@ namespace Tensile
                                  std::shared_ptr<Hardware> hardware,
                                  int                       firstSolutionIdx,
                                  int                       numSolutions,
-                                 RunCriteria               runCriteria    = RunCriteria(),
-                                 bool                      criteriaVerify = false);
+                                 RunCriteria               runCriteria     = RunCriteria(),
+                                 bool                      criteriaVerify  = false,
+                                 int                       criteriaMinSize = 0);
 
             virtual void preProblem(ContractionProblem const& problem) override;
             virtual void postProblem() override;
@@ -174,6 +175,7 @@ namespace Tensile
             int m_numSolutionsSkipped;
 
             bool        m_criteriaVerify;
+            int         m_criteriaMinSize;
             RunCriteria m_runCriteria;
         };
 

--- a/Tensile/Source/client/include/SolutionIterator.hpp
+++ b/Tensile/Source/client/include/SolutionIterator.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright 2020 Advanced Micro Devices, Inc.
+ * Copyright 2020-2021 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -158,6 +158,7 @@ namespace Tensile
             int m_lastSolutionIdx;
 
             int m_currentSolutionIdx;
+            int m_numSolutionsSkipped;
 
             RunCriteria m_runCriteria;
         };

--- a/Tensile/Source/client/main.cpp
+++ b/Tensile/Source/client/main.cpp
@@ -240,7 +240,6 @@ namespace Tensile
                 ("run-criteria-verify",      po::value<bool>()->default_value(false), "Benchmark skipped solutions and verify they aren't winners")
                 ("granularity-threshold",    po::value<double>()->default_value(0.0), "Don't run a solution if total granularity is below")
                 ("mem-throughput-threshold", po::value<double>()->default_value(0.0), "Don't run a solution if mem throughput is below")
-                ("min-lds-utilization",      po::value<double>()->default_value(0.0), "Don't run a solution if LDS utilization is below")
 
                 ("alu-rate",                 po::value<int>()->default_value(0), "ALU rate in flops / cu / cycle. Used for mem throughput solution filtering")
                 ("l2-speed",                 po::value<int>()->default_value(0), "L2 cache speed in bytes / cycle. Used for mem throughput solution filtering")

--- a/Tensile/Source/client/main.cpp
+++ b/Tensile/Source/client/main.cpp
@@ -241,6 +241,9 @@ namespace Tensile
                 ("granularity-threshold",    po::value<double>()->default_value(0.0), "Don't run a solution if total granularity is below")
                 ("mem-throughput-threshold", po::value<double>()->default_value(0.0), "Don't run a solution if mem throughput is below")
                 ("min-lds-utilization",      po::value<double>()->default_value(0.0), "Don't run a solution if LDS utilization is below")
+
+                ("alu-rate",                 po::value<int>()->default_value(0), "ALU rate in flops / cu / cycle. Used for mem throughput solution filtering")
+                ("l2-speed",                 po::value<int>()->default_value(0), "L2 cache speed in bytes / cycle. Used for mem throughput solution filtering")
                 ;
             // clang-format on
 

--- a/Tensile/Source/client/main.cpp
+++ b/Tensile/Source/client/main.cpp
@@ -240,6 +240,7 @@ namespace Tensile
                 ("run-criteria-verify",      po::value<bool>()->default_value(false), "Benchmark skipped solutions and verify they aren't winners")
                 ("granularity-threshold",    po::value<double>()->default_value(0.0), "Don't run a solution if total granularity is below")
                 ("mem-throughput-threshold", po::value<double>()->default_value(0.0), "Don't run a solution if mem throughput is below")
+                ("run-criteria-min-size",    po::value<int>()->default_value(0),      "Minimum size of each dimension (except batch) to enable filtering")
 
                 ("alu-rate",                 po::value<int>()->default_value(0), "ALU rate in flops / cu / cycle. Used for mem throughput solution filtering")
                 ("l2-speed",                 po::value<int>()->default_value(0), "L2 cache speed in bytes / cycle. Used for mem throughput solution filtering")
@@ -533,14 +534,6 @@ int main(int argc, const char* argv[])
         listeners.addListener(std::make_shared<BenchmarkTimer>(args, *hardware));
         listeners.addListener(std::make_shared<HardwareMonitorListener>(args));
     }
-
-    auto reporters = std::make_shared<MetaResultReporter>();
-    reporters->addReporter(PerformanceReporter::Default(args));
-
-    // PerformanceReporter needs to be called before these two, or else values
-    // will be missing
-    reporters->addReporter(LogReporter::Default(args));
-    reporters->addReporter(ResultFileReporter::Default(args));
 
     if(args.count("log-file"))
     {

--- a/Tensile/Source/client/main.cpp
+++ b/Tensile/Source/client/main.cpp
@@ -236,7 +236,11 @@ namespace Tensile
                 ("exit-on-error",            po::value<bool>()->default_value(false), "Exit run early on failed kernels or other errors.")
                 ("selection-only",           po::value<bool>()->default_value(false), "Don't run any solutions, only print kernel selections.")
                 ("max-workspace-size",       po::value<size_t>()->default_value(32*1024*1024), "Max workspace for training")
+
+                ("run-criteria-verify",      po::value<bool>()->default_value(false), "Benchmark skipped solutions and verify they aren't winners")
                 ("granularity-threshold",    po::value<double>()->default_value(0.0), "Don't run a solution if total granularity is below")
+                ("mem-throughput-threshold", po::value<double>()->default_value(0.0), "Don't run a solution if mem throughput is below")
+                ("min-lds-utilization",      po::value<double>()->default_value(0.0), "Don't run a solution if LDS utilization is below")
                 ;
             // clang-format on
 

--- a/Tensile/Source/client/main.cpp
+++ b/Tensile/Source/client/main.cpp
@@ -496,6 +496,17 @@ int main(int argc, const char* argv[])
         lastSolutionIdx = firstSolutionIdx + numSolutions - 1;
     }
 
+    auto reporters = std::make_shared<MetaResultReporter>();
+    reporters->addReporter(PerformanceReporter::Default(args));
+
+    // PerformanceReporter needs to be called before these two, or else values
+    // will be missing
+    reporters->addReporter(LogReporter::Default(args));
+    reporters->addReporter(ResultFileReporter::Default(args));
+    reporters->addReporter(LibraryUpdateReporter::Default(args));
+
+    // PerformanceReported called before getting max workspace size so
+    // AllSolutionIterator has the data it needs (e.g. numCUs)
     size_t maxWorkspaceSizeLimit = args["max-workspace-size"].as<size_t>();
     size_t maxWorkspaceSize
         = getMaxWorkspace(library, hardware, args, problems, firstProblemIdx, lastProblemIdx);
@@ -524,7 +535,6 @@ int main(int argc, const char* argv[])
     // will be missing
     reporters->addReporter(LogReporter::Default(args));
     reporters->addReporter(ResultFileReporter::Default(args));
-    reporters->addReporter(LibraryUpdateReporter::Default(args));
 
     if(args.count("log-file"))
     {
@@ -536,10 +546,6 @@ int main(int argc, const char* argv[])
     }
 
     listeners.setReporter(reporters);
-
-    // ReferenceValidator validator(args, dataInit);
-    // BenchmarkTimer timer(args);
-
     reporters->report(ResultKey::ProblemCount, problemFactory.problems().size());
 
     while(listeners.needMoreBenchmarkRuns())

--- a/Tensile/Source/client/source/BenchmarkTimer.cpp
+++ b/Tensile/Source/client/source/BenchmarkTimer.cpp
@@ -99,6 +99,15 @@ namespace Tensile
 
         void BenchmarkTimer::postSolution()
         {
+            std::cout << m_numEnqueuesInSolution << std::endl;
+            if(m_timeInSolution == double_millis::zero())
+            {
+                m_reporter->report(ResultKey::Validation, "SKIPPED");
+                m_reporter->report(ResultKey::TimeUS, 0);
+                m_reporter->report(ResultKey::SpeedGFlops, -1);
+                return;
+            }
+
             double timePerEnqueue_us
                 = double_micros(m_timeInSolution).count() / m_numEnqueuesInSolution;
 

--- a/Tensile/Source/client/source/BenchmarkTimer.cpp
+++ b/Tensile/Source/client/source/BenchmarkTimer.cpp
@@ -99,15 +99,6 @@ namespace Tensile
 
         void BenchmarkTimer::postSolution()
         {
-            std::cout << m_numEnqueuesInSolution << std::endl;
-            if(m_timeInSolution == double_millis::zero())
-            {
-                m_reporter->report(ResultKey::Validation, "SKIPPED");
-                m_reporter->report(ResultKey::TimeUS, 0);
-                m_reporter->report(ResultKey::SpeedGFlops, -1);
-                return;
-            }
-
             double timePerEnqueue_us
                 = double_micros(m_timeInSolution).count() / m_numEnqueuesInSolution;
 

--- a/Tensile/Source/client/source/ResultFileReporter.cpp
+++ b/Tensile/Source/client/source/ResultFileReporter.cpp
@@ -151,7 +151,9 @@ namespace Tensile
                 m_output.setHeaderForKey(ResultKey::LDC, "LDC");
                 m_output.setHeaderForKey(ResultKey::LDA, "LDA");
                 m_output.setHeaderForKey(ResultKey::LDB, "LDB");
+                m_output.setHeaderForKey(ResultKey::SolutionsRun, "Solutions Run");
                 m_output.setHeaderForKey(ResultKey::TotalFlops, "TotalFlops");
+
                 if(m_extraCol)
                 {
                     m_output.setHeaderForKey(ResultKey::FastestGFlops, "WinnerGFlops");

--- a/Tensile/Source/client/source/ResultFileReporter.cpp
+++ b/Tensile/Source/client/source/ResultFileReporter.cpp
@@ -70,6 +70,11 @@ namespace Tensile
                     m_invalidSolution = true;
                 }
             }
+            else if(key == ResultKey::WouldSkip)
+            {
+                m_wouldSkip       = true;
+                m_wouldSkipReason = value;
+            }
             else if(key == ResultKey::SolutionName)
             {
                 m_solutionName = valueStr;
@@ -96,7 +101,14 @@ namespace Tensile
                 // cascade from BenchmarkTimer, SpeedGFlops or SpeedGFlopsPerCU second
                 if(!m_invalidSolution)
                 {
-                    m_output.setValueForKey(m_solutionName, value);
+                    if(m_wouldSkip)
+                    {
+                        m_output.setValueForKey(m_solutionName, valueStr + ":" + m_wouldSkipReason);
+                    }
+                    else
+                    {
+                        m_output.setValueForKey(m_solutionName, value);
+                    }
 
                     int64_t gflops = std::stoull(valueStr);
                     if(m_fastestGflops < gflops)
@@ -257,6 +269,7 @@ namespace Tensile
         {
             m_solutionName    = "";
             m_invalidSolution = false;
+            m_wouldSkip       = false;
         }
 
         void ResultFileReporter::finalizeReport()

--- a/Tensile/Source/client/source/SolutionIterator.cpp
+++ b/Tensile/Source/client/source/SolutionIterator.cpp
@@ -116,7 +116,6 @@ namespace Tensile
         {
             double granThresh = args["granularity-threshold"].as<double>();
             double memThresh  = args["mem-throughput-threshold"].as<double>();
-            double minLDSUtil = args["min-lds-utilization"].as<double>();
             int    l2Speed    = args["l2-speed"].as<int>();
             int    aluRate    = args["alu-rate"].as<int>();
 

--- a/Tensile/Tensile.py
+++ b/Tensile/Tensile.py
@@ -34,10 +34,7 @@ from . import LibraryIO
 from . import LibraryLogic
 from . import __version__
 
-try:
-  import yaml
-except ImportError:
-  printExit("You must install PyYAML to use Tensile (to parse config files). See http://pyyaml.org/wiki/PyYAML for installation instructions.")
+import yaml
 
 ###############################################################################
 # Execute Steps in Config
@@ -179,30 +176,27 @@ def argUpdatedGlobalParameters(args):
 
 def processHardwareSpecsFile(config):
   print1("MemThroughputThreshold {} > 0: getting hardware specs from {}".format( \
-    globalParameters["MemThroughputThreshold"], globalParameters["HardwareSpecsPath"]) \
-  )
+      globalParameters["MemThroughputThreshold"], globalParameters["HardwareSpecsPath"]))
 
   error = True
   try:
     schedule = config["LibraryLogic"]["ScheduleName"]
-
     try:
-      f = open(globalParameters["HardwareSpecsPath"])
-      specs = yaml.safe_load(f)
+      specs = LibraryIO.readYAML(globalParameters["HardwareSpecsPath"])
 
       globalParameters["ALURates"] = specs[schedule]["ALU"]
       globalParameters["L2Speed"] = specs[schedule]["L2Speed"]
       error = False
 
     except OSError as e:
-      printWarning("Error reading hardware specs yaml file: {}".format(e))
+      printExit("Error reading hardware specs yaml file: {}".format(e))
     except yaml.YAMLError as e:
-      printWarning("YAML error: {}".format(e))
+      printExit("YAML error in hardware specs yaml file: {}".format(e))
     except KeyError as e:
-      printWarning("Key error in hardware specs yaml file: {}".format(e))
+      printExit("Key error in hardware specs yaml file: {}".format(e))
 
   except KeyError as e:
-    printWarning("Could not get schedule from config file")
+    printExit("Could not get schedule from config file")
 
   if error:
     print1("Setting MemThroughputThreshold to 0")

--- a/Tensile/Tensile.py
+++ b/Tensile/Tensile.py
@@ -27,7 +27,7 @@ import os
 import sys
 import argparse
 from .Common import globalParameters, print1, ensurePath, \
-    assignGlobalParameters, restoreDefaultGlobalParameters, HR, printWarning
+    assignGlobalParameters, restoreDefaultGlobalParameters, HR, printWarning, printExit
 from . import BenchmarkProblems
 from . import ClientWriter
 from . import LibraryIO

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -28,7 +28,7 @@ from . import Common
 from . import EmbeddedData
 from . import LibraryIO
 from . import Utils
-from .Common import globalParameters, HR, print1, print2, printExit, ensurePath, \
+from .Common import globalParameters, HR, print1, print2, printWarning, printExit, ensurePath, \
                     CHeader, CMakeHeader, assignGlobalParameters, \
                     listToInitializer, gfxName, architectureMap
 from .KernelWriterAssembly import KernelWriterAssembly
@@ -729,7 +729,7 @@ def writeLogic(outputPath, logicData, solutionWriter ):
                                     solutionsForSchedule, exactLogic, \
                                     solutionNamesForSchedule, True)
     if rangeLogic != None:
-      print("** warning: ignored ranges in logic file, these should have been expanded with ExpandRanges=1 during Tensile phase 3")
+      printWarning("Ignored ranges in logic file; these should have been expanded with ExpandRanges=1 during Tensile phase 3")
     s += "  /* exact mappings */\n"
     s += exactLogicStr
     s += "\n  return nullptr;\n"

--- a/tuning/automation/ConvertToEfficiency.py
+++ b/tuning/automation/ConvertToEfficiency.py
@@ -87,7 +87,7 @@ def main():
 
                 sched = data[1]
                 type = typeIndexToName[data[4]["DataType"]]
-                alu = specs[sched][mfmaKey][type]
+                alu = specs["ALU"][sched][mfmaKey][type]
 
                 # get CU count
                 if args.per_cu:


### PR DESCRIPTION
### Overview
This draft expands the barebone functionality introduced in PR #1245 by adding an additional filtering criteria (MemThroughput) and adding a verify mode for testing if winning solutions would be skipped by filtering criteria. Nvidia has a [good page](https://docs.nvidia.com/deeplearning/performance/dl-performance-matrix-multiplication/index.html) with information on some GEMM performance factors which these filtering criteria work based off of. Translating the language in this PR to terms on that page: MemThroughput -> Math and Memory Bounds; Granularity -> Quantization.

### Usage and New GlobalParameters
In Common.py:
```Python
globalParameters["RunCriteriaVerify"] = False
globalParameters["GranularityThreshold"] = 0.0
globalParameters["MemThroughputThreshold"] = 0.0
globalParameters["HardwareSpecsPath"] = None
```
- **GranularityThreshold:** unchanged from PR #1245; only run solutions with total granularity greater than this 
- **MemThroughputThreshold:** only run solutions with a ratio of memory throughput to computational throughput greater than this
- **RunCriteriaVerify:** if enabled, solutions are not actually skipped, but report if they would have been skipped. This is used to verify the correctness of filtering criteria by checking if they skip winning solutions
- **HardwareSpecsPath:** the MemThroughput criteria requires specifications about the hardware; this is a path to a yaml file with said specs.

### Verify Mode Reporting
A typical Tensile Client run outputs a CSV file with a table that compares performance (GFlops or GFlops/CU) of each problem size--solution combination. Verify mode works by adding additional information to these entries: problem size--solution combinations that would be skipped have the form `Performance:SkipReason:Value`
- **Performance:** the normally reported GFlops or GFlops/CU (depending on the performance metric used)
- **SkipReason:** a short string representing the filtering test that failed (currently "gran" or "mem")
- **Value:** value calculated by the criteria that caused rejection

When parsing this CSV file, the existence of SkipReason and Value indicate a solution would have been skipped and why. This information is used to check if the winning solution would have been skipped, or worse, if all solutions would have been skipped. It is worth noting that only the first filtering test to fail is reported. For example, a solution that would be rejected for low granularity _and_ low memory throughput will only report the first one tested (granularity in the current implementation).

An alternative---and more elegant---way to report this information is in a separate CSV (or other format) file. Doing so would allow the current CSV format and parsing to go unchanged while also providing more flexibility in how verify mode reporting is done. This could be implemented as a separate class that extends `ResultReporter` and is only added to the list of reporters when verify mode is turned on.

Finally, a summary entry for each problem size has been added to the CSV file which indicates how many solutions were run vs skipped in both verify and non-verify modes.

### Getting ALU Rate and L2Speed
The new filtering criteria for MemThroughput requires information about the hardware. To allow for applying solution filtering on unreleased hardware, these specs are read in from an external yaml file---the same one used by ConvertToEfficiency.py. The path to this file is a global parameter, and any errors in reading, parsing, or getting the required information causes Tensile to exit. However, this process only occurs is MemThroughputThreshold > 0 (i.e. the information is actually needed). 

This process is cumbersome and I believe the current implementation violates some properties we like to maintain, such as each global parameter always having a value; suggestions for improvements and/or alternate workflows would be appreciated. 

### Ongoing and Future Work
I've been doing some experiments and validation to determine the correctness and effectiveness of these two filtering criteria. For small sizes (M, N, or K < 1000), the correctness often fails. To address this, we can add an additional condition to solution filtering that ensures it is only done if the minimum matrix dimension is greater than some value. For large enough sizes, an initial test for F32 on MI100 indicates ~50% of solutions can be skipped---without violating correctness---with GranularityThreshold = 0.75 and MemThroughputThreshold = 1.25.

To find good threshold values, the current plan is to perform an analysis of existing rocBLAS library logic to determine the values of GranularityThreshold and MemThroughputThreshold that would have ensured none of the winners would have been skipped. These values would be different for each hardware and data type combination. 