### PR TITLE
TensileRetuneLibrary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log for Tensile
 ## [(Unreleased) Tensile 4.28.0 for ROCm 4.3.0]
+### Added
+- TensileRetuneLibrary for updating existing library logic files
+
 ### Fixed
 - TensileCreateLibrary crash with relative output and --merge-files
 

--- a/Tensile/ClientWriter.py
+++ b/Tensile/ClientWriter.py
@@ -701,6 +701,9 @@ def writeClientConfigIni(problemSizes, problemType, sourceDir, codeObjectFiles, 
         param("granularity-threshold",    globalParameters["GranularityThreshold"])
         param("pristine-on-gpu",          globalParameters["PristineOnGPU"])
 
+        param("library-update-file",      globalParameters["LibraryUpdateFile"])
+        param("library-update-comment",   globalParameters["LibraryUpdateComment"])
+
 def writeClientConfig(forBenchmark, solutions, problemSizes, stepName, stepBaseDir, newLibrary, codeObjectFiles, tileAwareSelection, configBase = "ClientParameters", libraryFile = None):
 
     if tileAwareSelection:

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -203,16 +203,15 @@ globalParameters["MaxFileName"] = 64              # If a file name would be long
 globalParameters["SupportedISA"] = [(8,0,3), (9,0,0), (9,0,6), (9,0,8), (9,0,10), (10,1,0), (10,1,1), (10,1,2), (10,3,0)] # assembly kernels writer supports these architectures
 
 globalParameters["GenerateManifestAndExit"] = False               # Output manifest file with list of expected library objects and exit
-globalParameters["ClientBuildPath"] = "0_Build"                   # subdirectory for host code build directory.
+globalParameters["ClientBuildPath"] = "0_Build"                   # subdirectory for host code build directory
 globalParameters["NewClient"] = 2                                 # 1=Run old+new client, 2=run new client only (All In)
 globalParameters["BenchmarkProblemsPath"] = "1_BenchmarkProblems" # subdirectory for benchmarking phases
 globalParameters["BenchmarkDataPath"] = "2_BenchmarkData"         # subdirectory for storing final benchmarking data
 globalParameters["LibraryLogicPath"] = "3_LibraryLogic"           # subdirectory for library logic produced by analysis
 globalParameters["LibraryClientPath"] = "4_LibraryClient"         # subdirectory for building example library client
-#globalParameters["BenchmarkClientVersion"] = "Both"               # Old, New, Both
-globalParameters["ClientExecutionLockPath"] = None # Path for a file lock to ensure only one client is executed at once.  filelock module is required if this is enabled.
-globalParameters["LibraryUpdateFile"] = "" # File for outputing indices and speeds for updating a library logic file
-globalParameters["LibraryUpdateComment"] = False # Include comment in library update file
+globalParameters["ClientExecutionLockPath"] = None                # Path for a file lock to ensure only one client is executed at once.  filelock module is required if this is enabled.
+globalParameters["LibraryUpdateFile"] =                           # File name for writing indices and speeds suitable for updating an existing library logic file
+globalParameters["LibraryUpdateComment"] = False                  # Include solution name as a comment in the library update file
 
 # internal, i.e., gets set during startup
 globalParameters["CurrentISA"] = (0,0,0)

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -210,7 +210,7 @@ globalParameters["BenchmarkDataPath"] = "2_BenchmarkData"         # subdirectory
 globalParameters["LibraryLogicPath"] = "3_LibraryLogic"           # subdirectory for library logic produced by analysis
 globalParameters["LibraryClientPath"] = "4_LibraryClient"         # subdirectory for building example library client
 globalParameters["ClientExecutionLockPath"] = None                # Path for a file lock to ensure only one client is executed at once.  filelock module is required if this is enabled.
-globalParameters["LibraryUpdateFile"] =                           # File name for writing indices and speeds suitable for updating an existing library logic file
+globalParameters["LibraryUpdateFile"] = ""                        # File name for writing indices and speeds suitable for updating an existing library logic file
 globalParameters["LibraryUpdateComment"] = False                  # Include solution name as a comment in the library update file
 
 # internal, i.e., gets set during startup

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -209,8 +209,10 @@ globalParameters["BenchmarkProblemsPath"] = "1_BenchmarkProblems" # subdirectory
 globalParameters["BenchmarkDataPath"] = "2_BenchmarkData"         # subdirectory for storing final benchmarking data
 globalParameters["LibraryLogicPath"] = "3_LibraryLogic"           # subdirectory for library logic produced by analysis
 globalParameters["LibraryClientPath"] = "4_LibraryClient"         # subdirectory for building example library client
-globalParameters["BenchmarkClientVersion"] = "Both"               # Old, New, Both
+#globalParameters["BenchmarkClientVersion"] = "Both"               # Old, New, Both
 globalParameters["ClientExecutionLockPath"] = None # Path for a file lock to ensure only one client is executed at once.  filelock module is required if this is enabled.
+globalParameters["LibraryUpdateFile"] = "" # File for outputing indices and speeds for updating a library logic file
+globalParameters["LibraryUpdateComment"] = False # Include comment in library update file
 
 # internal, i.e., gets set during startup
 globalParameters["CurrentISA"] = (0,0,0)

--- a/Tensile/LibraryIO.py
+++ b/Tensile/LibraryIO.py
@@ -48,18 +48,18 @@ def write(filename_noExt, data, format="yaml"):
     else:
         printExit("Unrecognized format {}".format(format))
 
-def writeYAML(filename, data, **kwags):
+def writeYAML(filename, data, **kwargs):
     """Writes data to file in YAML format."""
     # set default kwags for yaml dump
-    if "explicit_start" not in kwags:
-        kwags["explicit_start"] = True
-    if "explicit_end" not in kwags:
-        kwags["explicit_end"] = True
-    if "default_flow_style" not in kwags:
-        kwags["default_flow_style"] = None
+    if "explicit_start" not in kwargs:
+        kwargs["explicit_start"] = True
+    if "explicit_end" not in kwargs:
+        kwargs["explicit_end"] = True
+    if "default_flow_style" not in kwargs:
+        kwargs["default_flow_style"] = None
 
     with open(filename, "w") as f:
-        yaml.dump(data, f, **kwags)
+        yaml.dump(data, f, **kwargs)
 
 def writeMsgPack(filename, data):
     """Writes data to file in Message Pack format."""

--- a/Tensile/LibraryIO.py
+++ b/Tensile/LibraryIO.py
@@ -19,7 +19,6 @@
 # CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ################################################################################
 
-import copy
 from .Common import printExit, printWarning, versionIsCompatible
 from .SolutionStructs import Solution, ProblemSizes, ProblemType
 from . import __version__

--- a/Tensile/LibraryIO.py
+++ b/Tensile/LibraryIO.py
@@ -148,16 +148,15 @@ def parseLibraryLogicData(data, srcFile="?"):
     if len(data) < 9:
         printExit("Library logic file {} is missing required fields (len = {} < 9)".format(srcFile, len(data)))
 
-    dataCpy = copy.deepcopy(data)
-    versionString     = dataCpy[0]["MinimumRequiredVersion"]
-    scheduleName      = dataCpy[1]
-    architectureName  = dataCpy[2] if isinstance(dataCpy[2], str) else dataCpy[2]["Architecture"]
-    deviceNames       = dataCpy[3]
-    problemTypeState  = dataCpy[4]
-    solutionStates    = dataCpy[5]
-    indexOrder        = dataCpy[6]
-    exactLogic        = dataCpy[7]
-    rangeLogic        = dataCpy[8]
+    versionString     = data[0]["MinimumRequiredVersion"]
+    scheduleName      = data[1]
+    architectureName  = data[2] if isinstance(data[2], str) else data[2]["Architecture"]
+    deviceNames       = data[3]
+    problemTypeState  = data[4]
+    solutionStates    = data[5]
+    indexOrder        = data[6]
+    exactLogic        = data[7]
+    rangeLogic        = data[8]
 
     if not versionIsCompatible(versionString):
         printWarning("Version = {} in library logic file {} does not match Tensile version = {}" \
@@ -183,7 +182,7 @@ def parseLibraryLogicData(data, srcFile="?"):
                     .format(srcFile, problemType, solutionObject["ProblemType"]))
         solutions.append(solutionObject)
 
-    newLibrary = SolutionLibrary.MasterSolutionLibrary.FromOriginalState(dataCpy, solutions)
+    newLibrary = SolutionLibrary.MasterSolutionLibrary.FromOriginalState(data, solutions)
 
     return (scheduleName, deviceNames, problemType, solutions, indexOrder, \
             exactLogic, rangeLogic, newLibrary, architectureName)

--- a/Tensile/Source/client/main.cpp
+++ b/Tensile/Source/client/main.cpp
@@ -225,9 +225,9 @@ namespace Tensile
                 ("log-file-append",          po::value<bool>()->default_value(false),                "Append to log file.")
                 ("log-level",                po::value<LogLevel>()->default_value(LogLevel::Debug),  "Log level")
 
-                ("library-update-file",      po::value<std::string>()->default_value(""), "File name which will have indices "
-                                                                       "and speeds suitable for updating "
-                                                                       "an existing library logic file.")
+                ("library-update-file",      po::value<std::string>()->default_value(""), "File name for writing indices "
+                                                                                          "and speeds suitable for updating "
+                                                                                          "an existing library logic file.")
                 ("library-update-comment",   po::value<bool>()->default_value(false), "Include solution name as a "
                                                                                       "comment in library update "
                                                                                       "file.")

--- a/Tensile/TensileBenchmarkCluster.py
+++ b/Tensile/TensileBenchmarkCluster.py
@@ -1,3 +1,24 @@
+################################################################################
+# Copyright 2016-2021 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell cop-
+# ies of the Software, and to permit persons to whom the Software is furnished
+# to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM-
+# PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNE-
+# CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+################################################################################
+
 import shlex, subprocess
 import sys
 import os

--- a/Tensile/TensileBenchmarkCluster.py
+++ b/Tensile/TensileBenchmarkCluster.py
@@ -1,24 +1,3 @@
-################################################################################
-# Copyright 2016-2021 Advanced Micro Devices, Inc. All rights reserved.
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell cop-
-# ies of the Software, and to permit persons to whom the Software is furnished
-# to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM-
-# PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNE-
-# CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-################################################################################
-
 import shlex, subprocess
 import sys
 import os

--- a/Tensile/TensileRetuneLibrary.py
+++ b/Tensile/TensileRetuneLibrary.py
@@ -30,6 +30,7 @@ from .SolutionStructs import ProblemSizes
 from . import __version__
 
 import argparse
+import copy
 import os
 import shutil
 import sys
@@ -39,7 +40,8 @@ def parseCurrentLibrary(libPath):
     global globalParameters
 
     libYaml = LibraryIO.readYAML(libPath)
-    fields = LibraryIO.parseLibraryLogicData(libYaml, libPath)
+    # parseLibraryLogicData mutates the original data, so make a copy
+    fields = LibraryIO.parseLibraryLogicData(copy.deepcopy(libYaml), libPath)
     (_, _, problemType, solutions, _, exactLogic, _, _, _) = fields
 
     # get performance metric

--- a/Tensile/TensileRetuneLibrary.py
+++ b/Tensile/TensileRetuneLibrary.py
@@ -23,6 +23,7 @@ from . import BenchmarkProblems
 from . import ClientExecutable
 from . import ClientWriter
 from . import LibraryIO
+from . import Common
 from .Common import globalParameters, print1, printExit, ensurePath, assignGlobalParameters, \
                     pushWorkingPath, popWorkingPath, restoreDefaultGlobalParameters, HR
 from .Tensile import addCommonArguments
@@ -37,8 +38,6 @@ import sys
 
 
 def parseCurrentLibrary(libPath):
-    global globalParameters
-
     libYaml = LibraryIO.readYAML(libPath)
     # parseLibraryLogicData mutates the original data, so make a copy
     fields = LibraryIO.parseLibraryLogicData(copy.deepcopy(libYaml), libPath)
@@ -46,7 +45,7 @@ def parseCurrentLibrary(libPath):
 
     # get performance metric
     if len(libYaml) > 10:
-        globalParameters["PerformanceMetric"] = libYaml[10]
+        Common.globalParameters["PerformanceMetric"] = libYaml[10]
 
     # process exactLogic into ProblemSizes
     sizes = []
@@ -60,8 +59,6 @@ def parseCurrentLibrary(libPath):
 def runBenchmarking(solutions, problemSizes, outPath):
     # TODO some copy-pasting from BenchmarkProblems.benchmarkProblemType
     # could use a refactor to elimate duplicated code
-    global globalParameters
-
     ClientExecutable.getClientExecutable()
 
     shortName = "benchmark"
@@ -108,7 +105,7 @@ def runBenchmarking(solutions, problemSizes, outPath):
     resultsDir = os.path.normpath(os.path.join(globalParameters["WorkingPath"], "../../Data"))
     ensurePath(resultsDir)
     updateFile = os.path.join(resultsDir, "update.yaml")
-    globalParameters["LibraryUpdateFile"] = updateFile
+    Common.globalParameters["LibraryUpdateFile"] = updateFile
 
     BenchmarkProblems.writeBenchmarkFiles(benchmarkDir, solutions, problemSizes, shortName, filesToCopy, [])
 
@@ -126,8 +123,6 @@ def runBenchmarking(solutions, problemSizes, outPath):
 
 
 def TensileRetuneLibrary(userArgs):
-    global globalParameters
-
     print1("")
     print1(HR)
     print1("#")

--- a/Tensile/TensileRetuneLibrary.py
+++ b/Tensile/TensileRetuneLibrary.py
@@ -1,0 +1,156 @@
+###############################################################################
+# Copyright 2016-2021 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell cop-
+# ies of the Software, and to permit persons to whom the Software is furnished
+# to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM-
+# PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNE-
+# CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+################################################################################
+
+from Tensile import BenchmarkProblems, ClientExecutable, SolutionLibrary
+import os
+import sys
+import filecmp
+import argparse
+import shutil
+from .Common import globalParameters, print1, printExit, ensurePath, \
+    assignGlobalParameters, pushWorkingPath, popWorkingPath, restoreDefaultGlobalParameters, HR
+from .Tensile import addCommonArguments
+from .SolutionStructs import ProblemSizes
+from . import ClientWriter
+from . import LibraryIO
+from . import __version__
+
+
+def TensileReturnLibrary(userArgs):
+    global globalParameters
+
+    print1("")
+    print1(HR)
+    print1("#")
+    print1("#  Tensile Retune Library v{}".format(__version__))
+
+    # setup argument parsing
+    argParser = argparse.ArgumentParser()
+    argParser.add_argument("library_file", type=os.path.realpath, help="library logic file to retune")
+    argParser.add_argument("output_path", help="path where to conduct benchmark")
+    addCommonArguments(argParser)
+    args = argParser.parse_args(userArgs)
+
+    libPath = args.library_file
+
+    print1("#  Library Logic: {}".format(libPath))
+    print1("#")
+    print1(HR)
+    print1("")
+
+    # setup global parameters
+    outPath = ensurePath(os.path.abspath(args.output_path))
+    restoreDefaultGlobalParameters()
+    assignGlobalParameters({"LibraryFormat": "msgpack",
+                            "OutputPath": outPath,
+                            "WorkingPath": outPath})
+
+    # read and parse library logic file
+    libYaml = LibraryIO.readYAML(libPath)
+    fields = LibraryIO.parseLibraryLogicData(libYaml, libPath)
+    (_, _, problemType, solutions, _, exactLogic, _, _, _) = fields
+
+    # get performance metric
+    if len(libYaml) > 10:
+        globalParameters["PerformanceMetric"] = libYaml[10]
+
+    # process exactLogic into ProblemSizes
+    sizes = []
+    for (size, _) in exactLogic:
+        sizes.append({"Exact": size})
+    problemSizes = ProblemSizes(problemType, sizes)
+
+    ############################################################################
+    # setup and run benchmarking
+    # TODO mostly copy-pasted from BenchmarkProblems.benchmarkProblemType
+    # could use a refactor to elimate duplicated code
+    ############################################################################
+    ClientExecutable.getClientExecutable()
+
+    shortName = "benchmark"
+    benchmarkDir = os.path.join(outPath, shortName)
+    sourceDir = os.path.join(benchmarkDir, "source")
+    ensurePath(sourceDir)
+
+    pushWorkingPath(shortName)
+    pushWorkingPath("source")
+
+    filesToCopy = [
+        "SolutionMapper.h",
+        "Client.cpp",
+        "Client.h",
+        "CMakeLists.txt",
+        "DeviceStats.h",
+        "TensorUtils.h",
+        "MathTemplates.cpp",
+        "MathTemplates.h",
+        "TensileTypes.h",
+        "tensile_bfloat16.h",
+        "KernelHeader.h",
+        "ReferenceCPU.h",
+        "SolutionHelper.cpp",
+        "SolutionHelper.h",
+        "Tools.cpp",
+        "Tools.h",
+        ]
+
+    for f in filesToCopy:
+        shutil.copy(
+            os.path.join(globalParameters["SourcePath"], f),
+            globalParameters["WorkingPath"] )
+    if globalParameters["RuntimeLanguage"] == "OCL":
+        shutil.copy(
+            os.path.join(globalParameters["SourcePath"], "FindOpenCL.cmake"),
+            globalParameters["WorkingPath"] )
+    else:
+        shutil.copy(
+            os.path.join(globalParameters["SourcePath"], "FindHIP.cmake"),
+            globalParameters["WorkingPath"] )
+
+    # make directory for results and set update yaml file
+    resultsDir = os.path.normpath(os.path.join(globalParameters["WorkingPath"], "../../Data"))
+    ensurePath(resultsDir)
+    updateFile = os.path.join(resultsDir, "update.yaml")
+    globalParameters["LibraryUpdateFile"] = updateFile
+
+    BenchmarkProblems.writeBenchmarkFiles(benchmarkDir, solutions, problemSizes, shortName, filesToCopy, [])
+
+    popWorkingPath() # source
+
+    libraryLogicPath = None
+    forBenchmark = True
+    # TODO make this work with TileAware selection
+    returncode = ClientWriter.runClient(libraryLogicPath, forBenchmark, False)
+
+    if returncode:
+        printExit("BenchmarkProblems: Benchmark Process exited with code %u" % returncode)
+
+    # read update yaml from benchmark client and update logic
+    updateLogic = LibraryIO.readYAML(updateFile)
+    libYaml[7] = updateLogic
+
+    # write updated yaml (does not overwrite original)
+    libName = os.path.basename(libPath)
+    outFile = os.path.join(outPath, libName)
+    LibraryIO.writeYAML(outFile, libYaml, explicit_start=False, explicit_end=False)
+
+def main():
+    TensileReturnLibrary(sys.argv[1:])

--- a/Tensile/bin/TensileRetuneLibrary
+++ b/Tensile/bin/TensileRetuneLibrary
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+################################################################################
+# Copyright 2016-2021 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell cop-
+# ies of the Software, and to permit persons to whom the Software is furnished
+# to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM-
+# PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNE-
+# CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+################################################################################
+
+
+try:
+    from Tensile import TensileRetuneLibrary
+except ImportError:
+    import os.path
+    import sys
+    parentdir = os.path.normpath(os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", ".."))
+    sys.path.append(parentdir)
+
+    from Tensile import TensileRetuneLibrary
+
+# script run from commandline
+if __name__ == "__main__":
+    TensileRetuneLibrary.main()

--- a/setup.py
+++ b/setup.py
@@ -50,5 +50,7 @@ setup(
     "tensile_sgemm = Tensile.Tensile:TensileSGEMM5760",
     # Run tensile benchmark from cluster
     "TensileBenchmarkCluster = Tensile.TensileBenchmarkCluster:main",
+    # Retune library logic file
+    "TensileRetuneLibrary = Tensile.TensileRetuneLibrary:main"
     ]}
   )


### PR DESCRIPTION
### Motivation
Through updates to Tensile and rocBLAS, it is possible that the size mappings in rocBLAS become out of date and do not necessarily map each size to the best performing kernel in the library. We have evidence this is happening for F32 on MI100, and it's likely that other data types and hardware have a similar issue. 

This PR adds the TensileRetuneLibrary script, which updates the size mappings in an existing library logic file, thus "retuning" the library.

### Usage
TensileRetuneLibrary takes a single library logic file and a directory to output the results. After executing successfully, the output directory will contain the updated library logic file. This file is identical to the input one except for the size mapping portion, which will have been updated so that each size maps to the _true_ best performing solution.

### Future work and limitations
The current usage of TensileRetuneLibrary is pretty rigid to accommodate a narrow intended use case. A more general type of library based tuning---which allows tuning arbitrary sizes with the solutions present in a library logic file---is planned, but should be added as an expansion of the main Tensile tuning client, not TensileRetuneLibrary.