### PR TITLE
Few fixes for PAP - waitcnt optimize, last tile, and StaggerU=0

### DIFF
--- a/Tensile/KernelWriter.py
+++ b/Tensile/KernelWriter.py
@@ -1210,7 +1210,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
     if kernel["PrefetchGlobalRead"]:
       pfi = 1
       kl.append(self.comment("prefetch: global -> local"))
-      kl.append(self.openSumAtLeastUnroll(kernel, prefetch=True, isPap=isPap, isOptNLL=isOptNLL))
+      kl.append(self.openSumAtLeastUnroll(kernel, prefetch=True, isOptNLL=isOptNLL, isPap=isPap))
       if isPap and isOptNLL:
         if self.enable["GlobalRead"]:
           self.dtlsM0UpdateACode = self.directToLdsM0Update(kernel, 0, tensorParametersA)
@@ -1249,7 +1249,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
   #
   # isOptNLL : the NLL is to be optimized for the alpha=1 and non-edge case
   ##############################################################################
-  def noLoadLoop( self, kernel, tensorParametersA, tensorParametersB, isOptNLL, isNGLL, pack ):
+  def noLoadLoop( self, kernel, tensorParametersA, tensorParametersB, isOptNLL, isPap, isNGLL, pack ):
     kl = []
     pflr     = self.numItersPLR
     localWriteEndIter = kernel["LoopIters"] - self.numItersPLR - 1
@@ -1259,7 +1259,10 @@ class KernelWriter(metaclass=abc.ABCMeta):
       self.perIterLocalWriteCode = self.perIterLocalWriteCodeNGLL
       self.perIterLocalWriteCanSkip = [ 0 for i in range (kernel["LoopIters"]) ]
     else:
-      kl.append(self.comment3("%s NoLoadLoop - Begin") % ("Opt." if isOptNLL else "Ord."))
+      if not isOptNLL:
+        kl.append(self.comment3("Ord. NoLoadLoop - Begin"))
+      else:
+        kl.append(self.comment3("Opt. NoLoadLoop %s PAP - Begin") % ("With" if isPap else "Without"))
       self.dtlsM0UpdateACode = Code.StructuredModule()
       self.globalReadACode = Code.StructuredModule() # empty
       self.dtlsM0UpdateBCode = Code.StructuredModule()
@@ -1271,7 +1274,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
       self.localWriteBCode = Code.Module()
 
     # the scheduled GlobalRead,Inc code of PAP is inside openSumAtLeastUnroll (if PAP=on)
-    kl.append(self.openSumAtLeastUnroll(kernel, prefetch=False, isPap=False, isOptNLL=isOptNLL))
+    kl.append(self.openSumAtLeastUnroll(kernel, prefetch=False, isOptNLL=isOptNLL, isPap=isPap))
 
     if not self.numItersPLR:
       if self.enable["Wait"]:
@@ -1437,7 +1440,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
           item.tempVgpr = None
       pack[luIdx] = Code.Module()
 
-    kl.append(self.closeSumAtLeastUnroll(kernel, prefetch=False, isOptNLL=isOptNLL, isNGLL=isNGLL))
+    kl.append(self.closeSumAtLeastUnroll(kernel, prefetch=False, isOptNLL=isOptNLL, isPap=isPap, isNGLL=isNGLL))
 
     return kl
 
@@ -1595,7 +1598,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
                 if iui*self.numReadsIterCoalescedB < kernel["InnerUnroll"]:
                   kl.append(self.comment("local read inc b"))
                   kl.append(self.localReadInc(kernel, iui, tensorParametersB))
-      kl.append(self.closeSumAtLeastUnroll(kernel, prefetch=True, isOptNLL=False, isNGLL=False))
+      kl.append(self.closeSumAtLeastUnroll(kernel, prefetch=True, isOptNLL=False, isPap=False, isNGLL=False))
 
     # open unrolled summation loop
     kl.append(self.comment3("Unrolled Loop(s) - Begin"))
@@ -2098,7 +2101,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
     self.tmpCheckedOutLWVgprs = []
 
     if kernel["PrefetchGlobalRead"] == 2:
-      kl += self.noLoadLoop(kernel, tensorParametersA, tensorParametersB, isOptNLL=False, isNGLL=True, pack=pack)
+      kl += self.noLoadLoop(kernel, tensorParametersA, tensorParametersB, isOptNLL=False, isPap=False, isNGLL=True, pack=pack)
 
     # This "NoLoad" loop is a copy of the unroll loop but with global loads + LDS writes removed
     # doShadowInit is required since this pushes up the store SRD initialization before the NLL
@@ -2111,14 +2114,25 @@ class KernelWriter(metaclass=abc.ABCMeta):
            kernel["BufferLoad"] and kernel["BufferStore"] and self.doShadowInit and \
            kernel["LocalSplitU"]==1 and kernel["GlobalSplitU"] == 1 and \
            self.actualSummationLoops==1:
-          self.saveLocalPointers(kernel)
 
+          # three different noLoadLoops:
+          # 1. OptNLL & PAP global-read interleaved (only for PAP=ON)
+          # 2. OptNLL : No PAP global-read (For PAP=OFF, or PAP=ON but the last tile)
+          # 3. OrdinaryNLL (Not Opt.)
+          if self.prefetchAcrossPersistent:
+            self.saveLocalPointers(kernel)
+            # deepCopy packCode for OptNLL noLoadLoop
+            deepCopyPack = copy.deepcopy(pack)
+            kl += self.noLoadLoop(kernel, tensorParametersA, tensorParametersB, isOptNLL=True, isPap=True, isNGLL=False, pack=deepCopyPack)
+            self.restoreLocalPointers(kernel)
+
+          self.saveLocalPointers(kernel)
           # deepCopy packCode for OptNLL noLoadLoop
           deepCopyPack = copy.deepcopy(pack)
-          kl += self.noLoadLoop(kernel, tensorParametersA, tensorParametersB, isOptNLL=True, isNGLL=False, pack=deepCopyPack)
+          kl += self.noLoadLoop(kernel, tensorParametersA, tensorParametersB, isOptNLL=True, isPap=False, isNGLL=False, pack=deepCopyPack)
           self.restoreLocalPointers(kernel)
 
-        kl += self.noLoadLoop(kernel, tensorParametersA, tensorParametersB, isOptNLL=False, isNGLL=False, pack=pack)
+        kl += self.noLoadLoop(kernel, tensorParametersA, tensorParametersB, isOptNLL=False, isPap=False, isNGLL=False, pack=pack)
       # if PGR, last few iterations will have PLR,
       # and those PLR will not be used(register not checkIn) if without NoLoadLoop
       else:
@@ -3319,11 +3333,11 @@ class KernelWriter(metaclass=abc.ABCMeta):
   # At Least 1 Unroll
   ##############################################################################
   @abc.abstractmethod
-  def openSumAtLeastUnroll(self, kernel, prefetch, isPap, isOptNLL):
+  def openSumAtLeastUnroll(self, kernel, prefetch, isOptNLL, isPap):
     return ""
 
   @abc.abstractmethod
-  def closeSumAtLeastUnroll(self, kernel, prefetch, isOptNLL, isNGLL):
+  def closeSumAtLeastUnroll(self, kernel, prefetch, isOptNLL, isPap, isNGLL):
     return ""
 
   ##############################################################################

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -10229,7 +10229,10 @@ class KernelWriterAssembly(KernelWriter):
             self.currPreLoopVmcntCase = PreLoopVmcntCase.OptNLL_Store
           kStr += inst("s_mov_b32", sgpr("PreLoopLWVmcntCase"), hex(self.currPreLoopVmcntCase.value), \
             "for optimizing next PreLoop LW vmcnt, set to Case%u"%self.currPreLoopVmcntCase.value)
-          self.preLoopVmcntDict[self.currPreLoopVmcntCase] = 0 #reset vmcnt
+          # reset vmcnt if the dict has this key (OptNLL_Store, OrdNLL_E1_Store),
+          # OrdNLL_B1_Store is excluded
+          if self.currPreLoopVmcntCase in self.preLoopVmcntDict:
+            self.preLoopVmcntDict[self.currPreLoopVmcntCase] = 0
 
         # for storeRemap edge case, non-beta still can enable vector stores
         if kernel["StoreRemapVectorWidth"] and not beta:

--- a/Tensile/KernelWriterSource.py
+++ b/Tensile/KernelWriterSource.py
@@ -2149,7 +2149,7 @@ class KernelWriterSource(KernelWriter):
   ##############################################################################
   # At Least 1 Unroll
   ##############################################################################
-  def openSumAtLeastUnroll(self, kernel, prefetch, isPap, isOptNLL):
+  def openSumAtLeastUnroll(self, kernel, prefetch, isOptNLL, isPap):
     kStr = ""
     if kernel["GlobalSplitU"] > 1:
       kStr += "%sif (numIterMyWg >= 1) {%s" \
@@ -2160,7 +2160,7 @@ class KernelWriterSource(KernelWriter):
     self.indent += "  "
     return kStr
 
-  def closeSumAtLeastUnroll(self, kernel, prefetch, isOptNLL, isNGLL):
+  def closeSumAtLeastUnroll(self, kernel, prefetch, isOptNLL, isPap, isNGLL):
     kStr = ""
     self.indent = self.indent[2:]
     kStr += "%s} // end %s%s" % \

--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -2520,11 +2520,6 @@ class Solution:
         print2("PAP requires Assembly, PK!=0, PGR==1, SuppressNoLoadLoop=True, forcing PAP=False")
         state["PrefetchAcrossPersistent"] = False
 
-    # TODO- fix this, avoid the bug for now
-    if state["PrefetchAcrossPersistent"] and state["StaggerU"] == 0:
-        print2("PAP has some defects so far and would cause error when SU=0, disable PAP temporarily")
-        state["PrefetchAcrossPersistent"] = False
-
     problemType = state["ProblemType"]
     if not problemType["UseInitialStridesAB"]:
       for (tc) in ('A','B'):
@@ -3080,7 +3075,7 @@ class Solution:
       if state["EnableMatrixInstruction"]:
         state["LocalReadVectorWidth"] = state["MIInputPerThread"]
       else:
-        state["LocalReadVectorWidth"] = state["VectorWidth"]    
+        state["LocalReadVectorWidth"] = state["VectorWidth"]
     else:
       if state["EnableMatrixInstruction"]:
         if state["LocalReadVectorWidth"] < state["MIInputPerThread"]:

--- a/Tensile/Tests/pre_checkin/mfma/hpa_hgemm_split_lds.yaml
+++ b/Tensile/Tests/pre_checkin/mfma/hpa_hgemm_split_lds.yaml
@@ -43,6 +43,7 @@ BenchmarkProblems:
         - ScheduleIterAlg: [3]
         - VectorWidth: [4, 8]
         - 1LDSBuffer: [0, 1]
+        - StaggerU: [0,32]
         - PersistentKernel: [0, 1]
         - PersistentKernelAlongBatch: [False]
         - PrefetchAcrossPersistent: [0, 1]

--- a/Tensile/Tests/pre_checkin/mfma/sgemm_split_lds.yaml
+++ b/Tensile/Tests/pre_checkin/mfma/sgemm_split_lds.yaml
@@ -42,6 +42,7 @@ BenchmarkProblems:
         - ScheduleIterAlg: [3]
         - VectorWidth: [4, 8]
         - 1LDSBuffer: [0, 1]
+        - StaggerU: [0,32]
         - PersistentKernel: [0, 1]
         - PersistentKernelAlongBatch: [False]
         - PrefetchAcrossPersistent: [0, 1]

--- a/Tensile/Tests/pre_checkin/regression/persistent_kernel.yaml
+++ b/Tensile/Tests/pre_checkin/regression/persistent_kernel.yaml
@@ -33,6 +33,7 @@ BenchmarkProblems:
           - [ 8, 8, 1 ]
           - [ 32, 32, 1 ]
         - DepthU: [8]
+        - StaggerU: [0,32]
         - PersistentKernel: [1,2]
         - PersistentKernelAlongBatch: [False,True]
         - PrefetchAcrossPersistent: [False,True]


### PR DESCRIPTION
- Bug fix for PreLoopVmcnt optimization:
  - Need to consider edge case (collaborated with @jichangjichang )
- Remove some redundant PAP In the last persistent loop (the last tile):
  - No need to do PAP, so the OptNLL shouldn't have any interleaved PAP global-fetch instruction.
  - Two OptNLLs:
    - One is OptNLL + interleaved PAP
    - The other is pure OptNLL 
  - This can also fix the potential segFault when staggerU=0, since the last unnecessary PAP read from invalid global memory