### PR TITLE
Add compiler launcher environment variables

### DIFF
--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -30,6 +30,8 @@ from .AsmUtils import inst, vgpr, sgpr, log2, vectorStaticDivideAndRemainder, ve
 from math import ceil, trunc, modf
 from copy import deepcopy
 import collections
+import os
+import shlex
 import traceback
 from enum import Enum
 
@@ -598,7 +600,9 @@ class KernelWriterAssembly(KernelWriter):
 
     archHasV3 = globalParameters["AsmCaps"][isa]["HasCodeObjectV3"]
 
-    rv = [globalParameters['AssemblerPath'],
+    launcher = shlex.split(os.environ.get('Tensile_ASM_COMPILER_LAUNCHER', ''))
+
+    rv = launcher + [globalParameters['AssemblerPath'],
           '-x', 'assembler',
           '-target', 'amdgcn-amd-amdhsa']
 

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -42,6 +42,7 @@ import collections
 import itertools
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -156,7 +157,9 @@ def buildSourceCodeObjectFile(CxxCompiler, outputPath, kernelFile):
 
       hipFlags += ['-I', outputPath]
 
-      compileArgs = [which('hipcc')] + hipFlags + archFlags + [kernelFile, '-c', '-o', os.path.join(buildPath, objectFilename)]
+      launcher = shlex.split(os.environ.get('Tensile_CXX_COMPILER_LAUNCHER', ''))
+
+      compileArgs = launcher + [which('hipcc')] + hipFlags + archFlags + [kernelFile, '-c', '-o', os.path.join(buildPath, objectFilename)]
 
       if globalParameters["PrintCodeCommands"]:
         print('hipcc:', ' '.join(compileArgs))


### PR DESCRIPTION
This change adds support for two environment variables: `Tensile_ASM_COMPILER_LAUNCHER` and `Tensile_CXX_COMPILER_LAUNCHER`, which serve a similar purpose as the [`CMAKE_<LANG>_COMPILER_LAUNCHER`](https://cmake.org/cmake/help/latest/envvar/CMAKE_LANG_COMPILER_LAUNCHER.html) variable in CMake.

With this change and `export Tensile_ASM_COMPILER_LAUNCHER=/usr/local/bin/ccache`, the cached assembly kernels are retreived almost instantly when building rocBLAS. The source kernels remain a major cause of slow builds, however.

With `export Tensile_CXX_COMPILER_LAUNCHER=/usr/local/bin/ccache`, Tensile will invoke ccache when building `/src/rocBLAS/build/release/Tensile/Kernels.cpp`, though the result always seems to be a cache miss. That said, I don't think the miss has anything to do with my implementation of this feature. The Kernels.cpp file is 46 MB and preprocessing with -E results in 514 MB of output, so it's a bit difficult to debug. In any case, perhaps another compiler launcher (like sccache) will be able to handle that beast.