### PR TITLE
propagate hip error code from Tensile to rocBlas

### DIFF
--- a/Tensile/Source/client/main.cpp
+++ b/Tensile/Source/client/main.cpp
@@ -301,12 +301,26 @@ namespace Tensile
             }
             else
             {
+                //only trigger exception when failed to load all code objects.
+                bool       loaded   = false;
+                hipError_t retError = hipSuccess;
+
                 for(auto const& filename : filenames)
                 {
+                    hipError_t ret;
+
                     if(logLevel >= LogLevel::Verbose)
                         std::cout << "Loading " << filename << std::endl;
-                    HIP_CHECK_EXC(adapter.loadCodeObjectFile(filename));
+                    ret = adapter.loadCodeObjectFile(filename);
+
+                    if(ret == hipSuccess)
+                        loaded = true;
+                    else
+                        retError = ret;
                 }
+
+                if(!loaded)
+                    HIP_CHECK_EXC(retError);
             }
         }
 

--- a/Tensile/Source/client/main.cpp
+++ b/Tensile/Source/client/main.cpp
@@ -305,7 +305,7 @@ namespace Tensile
                 {
                     if(logLevel >= LogLevel::Verbose)
                         std::cout << "Loading " << filename << std::endl;
-                    adapter.loadCodeObjectFile(filename);
+                    HIP_CHECK_EXC(adapter.loadCodeObjectFile(filename));
                 }
             }
         }
@@ -587,10 +587,13 @@ int main(int argc, const char* argv[])
                             {
                                 listeners.preWarmup();
                                 if(gpuTimer)
-                                    adapter.launchKernels(
-                                        kernels, stream, warmupStartEvents[i], warmupStopEvents[i]);
+                                    HIP_CHECK_EXC(adapter.launchKernels(kernels,
+                                                                        stream,
+                                                                        warmupStartEvents[i],
+                                                                        warmupStopEvents[i]));
                                 else
-                                    adapter.launchKernels(kernels, stream, nullptr, nullptr);
+                                    HIP_CHECK_EXC(
+                                        adapter.launchKernels(kernels, stream, nullptr, nullptr));
                                 listeners.postWarmup();
                             }
 
@@ -611,10 +614,11 @@ int main(int argc, const char* argv[])
                                 for(int j = 0; j < enq; j++)
                                 {
                                     if(gpuTimer)
-                                        adapter.launchKernels(
-                                            kernels, stream, startEvents[j], stopEvents[j]);
+                                        HIP_CHECK_EXC(adapter.launchKernels(
+                                            kernels, stream, startEvents[j], stopEvents[j]));
                                     else
-                                        adapter.launchKernels(kernels, stream, nullptr, nullptr);
+                                        HIP_CHECK_EXC(adapter.launchKernels(
+                                            kernels, stream, nullptr, nullptr));
                                 }
 
                                 listeners.postEnqueues(startEvents, stopEvents);

--- a/Tensile/Source/lib/include/Tensile/hip/HipSolutionAdapter.hpp
+++ b/Tensile/Source/lib/include/Tensile/hip/HipSolutionAdapter.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright 2019-2020 Advanced Micro Devices, Inc.
+ * Copyright 2019-2021 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -48,37 +48,37 @@ namespace Tensile
                 return m_name;
             }
 
-            void loadCodeObjectFile(std::string const& path);
+            hipError_t loadCodeObjectFile(std::string const& path);
 
-            void loadCodeObject(const void* image);
+            hipError_t loadCodeObject(const void* image);
 
-            void loadCodeObjectBytes(std::vector<uint8_t> const& bytes);
+            hipError_t loadCodeObjectBytes(std::vector<uint8_t> const& bytes);
 
             void loadEmbeddedCodeObjects();
             void loadEmbeddedCodeObjects(std::string const& key);
 
-            void launchKernel(KernelInvocation const& kernel);
-            void launchKernel(KernelInvocation const& kernel,
-                              hipStream_t             stream,
-                              hipEvent_t              startEvent,
-                              hipEvent_t              stopEvent);
+            hipError_t launchKernel(KernelInvocation const& kernel);
+            hipError_t launchKernel(KernelInvocation const& kernel,
+                                    hipStream_t             stream,
+                                    hipEvent_t              startEvent,
+                                    hipEvent_t              stopEvent);
 
-            void launchKernels(std::vector<KernelInvocation> const& kernels);
+            hipError_t launchKernels(std::vector<KernelInvocation> const& kernels);
 
-            void launchKernels(std::vector<KernelInvocation> const& kernels,
-                               hipStream_t                          stream,
-                               hipEvent_t                           startEvent,
-                               hipEvent_t                           stopEvent);
+            hipError_t launchKernels(std::vector<KernelInvocation> const& kernels,
+                                     hipStream_t                          stream,
+                                     hipEvent_t                           startEvent,
+                                     hipEvent_t                           stopEvent);
 
-            void launchKernels(std::vector<KernelInvocation> const& kernels,
-                               hipStream_t                          stream,
-                               std::vector<hipEvent_t> const&       startEvents,
-                               std::vector<hipEvent_t> const&       stopEvents);
+            hipError_t launchKernels(std::vector<KernelInvocation> const& kernels,
+                                     hipStream_t                          stream,
+                                     std::vector<hipEvent_t> const&       startEvents,
+                                     std::vector<hipEvent_t> const&       stopEvents);
 
-            void initKernel(std::string const& name);
+            hipError_t initKernel(std::string const& name);
 
         private:
-            hipFunction_t getKernel(std::string const& name);
+            hipError_t getKernel(hipFunction_t& rv, std::string const& name);
 
             std::mutex m_access;
 

--- a/Tensile/Source/lib/include/Tensile/hip/HipUtils.hpp
+++ b/Tensile/Source/lib/include/Tensile/hip/HipUtils.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright 2019-2020 Advanced Micro Devices, Inc.
+ * Copyright 2019-2021 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -67,6 +67,14 @@
                 << (message) << std::endl;                                                        \
             throw std::runtime_error(msg.str());                                                  \
         }                                                                                         \
+    } while(0)
+
+#define HIP_CHECK_RETURN(expr) \
+    do                         \
+    {                          \
+        hipError_t e = (expr); \
+        if(e)                  \
+            return e;          \
     } while(0)
 
 namespace Tensile


### PR DESCRIPTION
SWDEV-279840 mentioned that rocblas/tensile don't propagate hip return code properly but just swallow the actual error by trigger exception.
This PR add the hip return code into some APIs of SolutionAdapter:: called by rocblas.
rocblas part can be added as well after this PR merged accordingly. 