### PR TITLE
Report GFlops with 6 digits precision

### DIFF
--- a/Tensile/Source/client/include/LibraryUpdateReporter.hpp
+++ b/Tensile/Source/client/include/LibraryUpdateReporter.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright 2019-2020 Advanced Micro Devices, Inc.
+ * Copyright 2019-2021 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -78,12 +78,12 @@ namespace Tensile
 
             int64_t     m_curSolutionIdx = -1;
             std::string m_curSolutionName;
-            int64_t     m_curSolutionSpeed  = -1;
+            double      m_curSolutionSpeed  = -1.0;
             bool        m_curSolutionPassed = false;
 
             int64_t     m_fastestSolutionIdx = -1;
             std::string m_fastestSolutionName;
-            int64_t     m_fastestSolutionSpeed = -1;
+            double      m_fastestSolutionSpeed = -1.0;
         };
     } // namespace Client
 } // namespace Tensile

--- a/Tensile/Source/client/include/ResultFileReporter.hpp
+++ b/Tensile/Source/client/include/ResultFileReporter.hpp
@@ -77,8 +77,8 @@ namespace Tensile
             std::string m_winnerSolution;
             int64_t     m_currSolutionIdx   = -1;
             int64_t     m_winnerSolutionIdx = -1;
-            int64_t     m_fastestGflops     = -1;
-            double      m_fasterTimeUS      = -1;
+            double      m_fastestGflops     = -1.0;
+            double      m_fasterTimeUS      = -1.0;
             // for merge rows
             int64_t                                                         m_currProbID = -1;
             std::map<int64_t, std::unordered_map<std::string, std::string>> m_probMap;

--- a/Tensile/Source/client/source/BenchmarkTimer.cpp
+++ b/Tensile/Source/client/source/BenchmarkTimer.cpp
@@ -110,15 +110,9 @@ namespace Tensile
             int    usedCus     = std::min(tiles, perf.CUs);
             double gflopsPerCu = gflops / usedCus;
 
-            uint64_t gflopsUint = static_cast<uint64_t>(round(gflops));
-
             m_reporter->report(ResultKey::TimeUS, timePerEnqueue_us);
             m_reporter->report(ResultKey::SpeedGFlopsPerCu, gflopsPerCu);
-
-            if(gflopsUint)
-                m_reporter->report(ResultKey::SpeedGFlops, gflopsUint);
-            else
-                m_reporter->report(ResultKey::SpeedGFlops, gflops);
+            m_reporter->report(ResultKey::SpeedGFlops, gflops);
 
             m_timeInSolution        = double_millis::zero();
             m_numEnqueuesInSolution = 0;

--- a/Tensile/Source/client/source/CSVStackFile.cpp
+++ b/Tensile/Source/client/source/CSVStackFile.cpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright 2019-2020 Advanced Micro Devices, Inc.
+ * Copyright 2019-2021 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -186,14 +186,10 @@ namespace Tensile
 
         void CSVStackFile::setValueForKey(std::string const& key, double const& value)
         {
-            if(value > 0.01)
-            {
-                std::ostringstream ss;
-                ss << std::fixed << std::setprecision(2) << value;
-                setValueForKey(key, ss.str());
-            }
-            else
-                setValueForKey(key, boost::lexical_cast<std::string>(value));
+
+            std::ostringstream ss;
+            ss << std::setprecision(6) << value;
+            setValueForKey(key, ss.str());
         }
     } // namespace Client
 } // namespace Tensile

--- a/Tensile/Source/client/source/LibraryUpdateReporter.cpp
+++ b/Tensile/Source/client/source/LibraryUpdateReporter.cpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright 2019-2020 Advanced Micro Devices, Inc.
+ * Copyright 2019-2021 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -89,7 +89,7 @@ namespace Tensile
             {
                 try
                 {
-                    int64_t speed      = std::stoll(valueStr);
+                    double speed       = std::stod(valueStr);
                     m_curSolutionSpeed = speed;
                     //m_stream << "Fastest: " << m_fastestSolutionSpeed << std::endl;
                 }
@@ -154,7 +154,7 @@ namespace Tensile
             // reset
             m_fastestSolutionIdx   = -1;
             m_fastestSolutionName  = "";
-            m_fastestSolutionSpeed = -1;
+            m_fastestSolutionSpeed = -1.0;
         }
 
         void LibraryUpdateReporter::postSolution()
@@ -169,7 +169,7 @@ namespace Tensile
 
             m_curSolutionName   = "";
             m_curSolutionIdx    = -1;
-            m_curSolutionSpeed  = -1;
+            m_curSolutionSpeed  = -1.0;
             m_curSolutionPassed = false;
         }
 

--- a/Tensile/Source/client/source/ResultFileReporter.cpp
+++ b/Tensile/Source/client/source/ResultFileReporter.cpp
@@ -98,7 +98,7 @@ namespace Tensile
                 {
                     m_output.setValueForKey(m_solutionName, value);
 
-                    int64_t gflops = std::stoull(valueStr);
+                    double gflops = std::stod(valueStr);
                     if(m_fastestGflops < gflops)
                     {
                         m_winnerSolution    = m_solutionName;
@@ -233,8 +233,8 @@ namespace Tensile
             m_winnerSolution    = "";
             m_currSolutionIdx   = -1;
             m_winnerSolutionIdx = -1;
-            m_fastestGflops     = -1;
-            m_fasterTimeUS      = -1;
+            m_fastestGflops     = -1.0;
+            m_fasterTimeUS      = -1.0;
 
             if(!m_mergeSameProblems)
             {


### PR DESCRIPTION
These changes also make all other double values report with 6 digits of precision; however, I don't think this will cause any issues.