### PR TITLE
TensileRetuneLibrary updates

### DIFF
--- a/Tensile/LibraryLogic.py
+++ b/Tensile/LibraryLogic.py
@@ -1463,7 +1463,7 @@ def generateLogic(config, benchmarkDataPath, libraryLogicPath):
 
   currentTime = time.time()
   elapsedTime = currentTime - startTime
-  print1("%s\n# Finish Analysing data to in %s - %.3fs\n%s" % (HR, os.path.split(libraryLogicPath)[0], elapsedTime, HR) )
+  print1("%s\n# Finish Analysing data to %s in %.3fs\n%s" % (HR, os.path.split(libraryLogicPath)[0], elapsedTime, HR) )
   popWorkingPath()
 
 

--- a/Tensile/LibraryLogic.py
+++ b/Tensile/LibraryLogic.py
@@ -1459,7 +1459,7 @@ def generateLogic(config, benchmarkDataPath, libraryLogicPath):
     data = LibraryIO.createLibraryLogic(analysisParameters["ScheduleName"], \
         analysisParameters["ArchitectureName"], analysisParameters["DeviceNames"], logicTuple)
 
-    LibraryIO.writeYAML(filename, data)
+    LibraryIO.writeYAML(filename, data, explicit_start=False, explicit_end=False)
 
   currentTime = time.time()
   elapsedTime = currentTime - startTime

--- a/Tensile/TensileRetuneLibrary.py
+++ b/Tensile/TensileRetuneLibrary.py
@@ -60,6 +60,8 @@ def parseCurrentLibrary(libPath, skipRK):
 
     if skipRK:
         solutions = [s for s in solutions if not s["ReplacementKernel"]]
+        for i, s in enumerate(solutions):
+            s["SolutionIndex"] = i
 
     problemSizes = ProblemSizes(problemType, sizes)
 

--- a/Tensile/TensileRetuneLibrary.py
+++ b/Tensile/TensileRetuneLibrary.py
@@ -134,7 +134,7 @@ def runBenchmarking(solutions, problemSizes, outPath, update):
     # TODO make this work with TileAware selection
     returncode = ClientWriter.runClient(libraryLogicPath, forBenchmark, False)
     if returncode:
-        printWarning("BenchmarkProblems: Benchmark Process exited with code {}".format(returncode))
+        printWarning("Benchmarking Client exited with code {}. Trying to continue".format(returncode))
 
     # write solutions yaml file
     for sol in solutions:
@@ -204,7 +204,7 @@ def TensileRetuneLibrary(userArgs):
 
     overrideParameters = argUpdatedGlobalParameters(args)
     for key, value in overrideParameters.items():
-        print("Overriding {0}={1}".format(key, value))
+        print1("Overriding {0}={1}".format(key, value))
         Common.globalParameters[key] = value
 
     # parse library logic then setup and run benchmarks


### PR DESCRIPTION
In addition to a bit of cleaning up, this PR adds two new features to the retuning client:
1) Option to fully remake the resulting library logic file instead of---or in addition to---using the previous update method
2) Option to skip replacement kernels and sizes that map to replacement kernels. This option only works when fully remaking the output logic