### PR TITLE
Enable ccache on CI by default

### DIFF
--- a/.jenkins/debug.groovy
+++ b/.jenkins/debug.groovy
@@ -14,6 +14,7 @@ def runCI =
     nodeDetails, jobName ->
 
     def prj = new rocProject('Tensile', 'Debug')
+    prj.defaults.ccache = true
 
     // Define test architectures, optional rocm version argument is available
     def nodes = new dockerNodes(nodeDetails, jobName, prj)

--- a/.jenkins/extended.groovy
+++ b/.jenkins/extended.groovy
@@ -14,6 +14,7 @@ def runCI =
     nodeDetails, jobName ->
 
     def prj = new rocProject('Tensile', 'Extended')
+    prj.defaults.ccache = true
 
     // Define test architectures, optional rocm version argument is available
     def nodes = new dockerNodes(nodeDetails, jobName, prj)

--- a/.jenkins/integration.groovy
+++ b/.jenkins/integration.groovy
@@ -14,6 +14,7 @@ def runCI =
     nodeDetails, jobName ->
 
     def prj = new rocProject('Tensile', 'Integration')
+    prj.defaults.ccache = true
 
     // Define test architectures, optional rocm version argument is available
     def nodes = new dockerNodes(nodeDetails, jobName, prj)

--- a/.jenkins/precheckin.groovy
+++ b/.jenkins/precheckin.groovy
@@ -14,6 +14,7 @@ def runCI =
     nodeDetails, jobName ->
 
     def prj = new rocProject('Tensile', 'PreCheckin')
+    prj.defaults.ccache = true
 
     // Define test architectures, optional rocm version argument is available
     def nodes = new dockerNodes(nodeDetails, jobName, prj)

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,10 @@ envlist = py35,py36,py27,lint
 # Some versions of Pytest versions have a bug:
 # https://github.com/pytest-dev/pytest/issues/5971 which causes the whole test
 # process to crash if a multiprocessing job has an exception. Fixed in 5.3.3.
+passenv =
+    CMAKE_CXX_COMPILER_LAUNCHER
+    Tensile_CXX_COMPILER_LAUNCHER
+    Tensile_ASM_COMPILER_LAUNCHER
 deps =
     -r{toxinidir}/requirements.txt
     pytest>=5.4.1


### PR DESCRIPTION
This PR enables ccache on Tensile builds by default.

It's currently a draft, as I'm testing a few improvements to the robustness of our ccache configuration. When I'm done, I'll mark it ready for review.