### PR TITLE
Instruction Scheduling

### DIFF
--- a/Tensile/Code.py
+++ b/Tensile/Code.py
@@ -320,7 +320,9 @@ class WaitCnt (Module):
     main_args = []
     wait_store = False
     if self.lgkmcnt != -1:
-      main_args += ["lgkmcnt(%u)" % self.lgkmcnt]
+      currentIsa = globalParameters["CurrentISA"]
+      maxLgkmcnt = globalParameters["AsmCaps"][currentIsa]["MaxLgkmcnt"]
+      main_args += ["lgkmcnt(%u)" % (min(self.lgkmcnt,maxLgkmcnt))]
       wait_store = True
 
     if self.vmcnt != -1:
@@ -351,8 +353,9 @@ class LocalWriteInst (Inst):
 
 # uniq type that can be used in Module.countType
 class LocalReadInst (Inst):
-  def __init__(self,issuelatency,*args):
+  def __init__(self,issuelatency,readToTempVgpr,*args):
     self.IssueLatency = issuelatency
+    self.readToTempVgpr = readToTempVgpr
     Inst.__init__(self,*args)
 
 ################################################################################

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -500,7 +500,7 @@ validParameters = {
     # Range from 0.01 to 5
     #         0.1 means 1 GR per 10 mfma
     #           5 means 5 GR per 1 mfma
-    "GlobalReadPerMfma":       [ i/100 for i in range(1,500)] + [ -2 ],
+    "GlobalReadPerMfma":       [ i/100 for i in range(1,3200)] + [ -2 ],
 
     # For MatrixInstruction and SIA3, number of LocalWriteInstruction between mfma
     # the purpose of this parameter is to control density of local write instruction scheduling
@@ -513,7 +513,7 @@ validParameters = {
     #         0.1 means 1 LW per 10 mfma
     #           5 means 5 LW per 1 mfma
     # -1 will use an optimized setting
-    "LocalWritePerMfma":       [ i/100 for i in range(1,500)] + [ -1, -2 ],
+    "LocalWritePerMfma":       [ i/100 for i in range(1,3200)] + [ -1, -2, -3 ],
 
     # LDD Support
     # Allow LDD and StrideD to != LDC and StrideC for LDD <= LDC and LDD == M

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -513,8 +513,7 @@ validParameters = {
     #         0.1 means 1 LW per 10 mfma
     #           5 means 5 LW per 1 mfma
     # -1 will derived an optimized value internally
-    # -2 is used to support old logic yaml
-    # -3 will derived an optimized value and override LWPM silently
+    # -2 will derived an optimized value and override LWPM silently (debug only, not recommended)
     "LocalWritePerMfma":       [ i/100 for i in range(1,3200)] + [ -1 ],
 
     # LDD Support

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -500,7 +500,7 @@ validParameters = {
     # Range from 0.01 to 5
     #         0.1 means 1 GR per 10 mfma
     #           5 means 5 GR per 1 mfma
-    "GlobalReadPerMfma":       [ i/100 for i in range(1,500)],
+    "GlobalReadPerMfma":       [ i/100 for i in range(1,500)] + [ -2 ],
 
     # For MatrixInstruction and SIA3, number of LocalWriteInstruction between mfma
     # the purpose of this parameter is to control density of local write instruction scheduling
@@ -513,7 +513,7 @@ validParameters = {
     #         0.1 means 1 LW per 10 mfma
     #           5 means 5 LW per 1 mfma
     # -1 will use an optimized setting
-    "LocalWritePerMfma":       [ i/100 for i in range(1,500)] + [ -1 ],
+    "LocalWritePerMfma":       [ i/100 for i in range(1,500)] + [ -1, -2 ],
 
     # LDD Support
     # Allow LDD and StrideD to != LDC and StrideC for LDD <= LDC and LDD == M
@@ -1188,8 +1188,8 @@ defaultBenchmarkCommonParameters = [
 
     {"LdcEqualsLdd":              [ False ] },
 
-    {"GlobalReadPerMfma":         [ 1 ] },
-    {"LocalWritePerMfma":         [ 1 ] },
+    {"GlobalReadPerMfma":         [ -2 ] },
+    {"LocalWritePerMfma":         [ -2 ] },
 
     {"InterleaveAlpha":           [ 0 ] },
     {"OptNoLoadLoop":             [ 1 ] },

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -493,6 +493,28 @@ validParameters = {
     # Can always be True, set to False for debugging or comparison
     "OptPreLoopVmcnt":            [False, True],
 
+    # For MatrixInstruction and SIA3, number of GlobalReadInstruction between mfma
+    # the purpose of this parameter is to control density of global read instruction scheduling
+    # Scheduling global read back to back can have better memory efficiency
+    # However, when full of vmem FIFO, it will block other instruction to be issued
+    # Range from 0.01 to 5
+    #         0.1 means 1 GR per 10 mfma
+    #           5 means 5 GR per 1 mfma
+    "GlobalReadPerMfma":       [ i/100 for i in range(1,500)],
+
+    # For MatrixInstruction and SIA3, number of LocalWriteInstruction between mfma
+    # the purpose of this parameter is to control density of local write instruction scheduling
+    # In PGR1, we want to schedule local write more denser, so we can have more
+    #          latency to hide global read
+    # In PGR2, since LW is followed by GR, every LW has same whole loop latecy
+    #          to hide global read. We want to schedule LW less denser, can
+    #          avoid full of vmem FIFO.
+    # Range from 0.01 to 5
+    #         0.1 means 1 LW per 10 mfma
+    #           5 means 5 LW per 1 mfma
+    # -1 will use an optimized setting
+    "LocalWritePerMfma":       [ i/100 for i in range(1,500)] + [ -1 ],
+
     # LDD Support
     # Allow LDD and StrideD to != LDC and StrideC for LDD <= LDC and LDD == M
     # TODO: remove. legacy logic yaml in rocblas contains true and false for this parameter
@@ -1159,6 +1181,10 @@ defaultBenchmarkCommonParameters = [
     {"OptPreLoopVmcnt":           [ True ] },
 
     {"LdcEqualsLdd":              [ False ] },
+
+    {"GlobalReadPerMfma":         [ 1 ] },
+    {"LocalWritePerMfma":         [ 1 ] },
+
     {"InterleaveAlpha":           [ 0 ] },
     {"OptNoLoadLoop":             [ 1 ] },
     {"PrefetchAcrossPersistent":  [ 0 ] },

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -877,6 +877,12 @@ validParameters = {
     # 0 means issue instructions as many as possible if VGPR available
     "NumElementsPerBatchStore":   list(range(0, 256)),
     #
+    # add sync after per batch store in order to store contiguous elements
+    # add sleep after per batch store in order to distribute store over whole loops
+    # NOTE: this parameter is highly depends on size_k
+    # 0 means no sync and sleep
+    "StoreSyncOpt":               list(range(0, 256)),
+    #
     # There are index or address calculation between global instructions.
     # issue global instruction b2b has better performance
     "GroupLoadStore":             [False, True],
@@ -1263,6 +1269,7 @@ defaultBenchmarkCommonParameters = [
     {"AtomicAddC":                [ False ] },
     {"StorePriorityOpt":          [ False ] },
     {"NumElementsPerBatchStore":  [ 0 ] },
+    {"StoreSyncOpt":              [ 0 ] },
     {"GroupLoadStore":            [ False ] },
     ]
 # benchmark these solution independently

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -500,7 +500,7 @@ validParameters = {
     # Range from 0.01 to 32
     #         0.1 means 1 GR per 10 mfma
     #           5 means 5 GR per 1 mfma
-    "GlobalReadPerMfma":       [ i/100 for i in range(1,3200)] + [ -2 ],
+    "GlobalReadPerMfma":       [ i/100 for i in range(1,3200)],
     #
     # For MatrixInstruction and SIA3, number of LocalWriteInstruction between mfma
     # the purpose of this parameter is to control density of local write instruction scheduling
@@ -512,10 +512,10 @@ validParameters = {
     # Range from 0.01 to 32
     #         0.1 means 1 LW per 10 mfma
     #           5 means 5 LW per 1 mfma
-    # -1 will derived an optimized value and override LWPM silently
+    # -1 will derived an optimized value internally
     # -2 is used to support old logic yaml
-    # -3 will derived an optimized value internally
-    "LocalWritePerMfma":       [ i/100 for i in range(1,3200)] + [ -1, -2, -3 ],
+    # -3 will derived an optimized value and override LWPM silently
+    "LocalWritePerMfma":       [ i/100 for i in range(1,3200)] + [ -1 ],
 
     # LDD Support
     # Allow LDD and StrideD to != LDC and StrideC for LDD <= LDC and LDD == M
@@ -1190,8 +1190,8 @@ defaultBenchmarkCommonParameters = [
 
     {"LdcEqualsLdd":              [ False ] },
 
-    {"GlobalReadPerMfma":         [ -2 ] },
-    {"LocalWritePerMfma":         [ -2 ] },
+    {"GlobalReadPerMfma":         [ 1 ] },
+    {"LocalWritePerMfma":         [ -1 ] },
 
     {"InterleaveAlpha":           [ 0 ] },
     {"OptNoLoadLoop":             [ 1 ] },

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -497,11 +497,11 @@ validParameters = {
     # the purpose of this parameter is to control density of global read instruction scheduling
     # Scheduling global read back to back can have better memory efficiency
     # However, when full of vmem FIFO, it will block other instruction to be issued
-    # Range from 0.01 to 5
+    # Range from 0.01 to 32
     #         0.1 means 1 GR per 10 mfma
     #           5 means 5 GR per 1 mfma
     "GlobalReadPerMfma":       [ i/100 for i in range(1,3200)] + [ -2 ],
-
+    #
     # For MatrixInstruction and SIA3, number of LocalWriteInstruction between mfma
     # the purpose of this parameter is to control density of local write instruction scheduling
     # In PGR1, we want to schedule local write more denser, so we can have more
@@ -509,10 +509,12 @@ validParameters = {
     # In PGR2, since LW is followed by GR, every LW has same whole loop latecy
     #          to hide global read. We want to schedule LW less denser, can
     #          avoid full of vmem FIFO.
-    # Range from 0.01 to 5
+    # Range from 0.01 to 32
     #         0.1 means 1 LW per 10 mfma
     #           5 means 5 LW per 1 mfma
-    # -1 will use an optimized setting
+    # -1 will derived an optimized value and override LWPM silently
+    # -2 is used to support old logic yaml
+    # -3 will derived an optimized value internally
     "LocalWritePerMfma":       [ i/100 for i in range(1,3200)] + [ -1, -2, -3 ],
 
     # LDD Support

--- a/Tensile/Components/LocalRead.py
+++ b/Tensile/Components/LocalRead.py
@@ -70,7 +70,7 @@ class LocalReadVALU(LocalRead):
                 paramTuple = tuple(paramList)
                 comment = "L -> Reg lro=%d swapByteOffset=%u ti=%u vIdx=%u rIdx=%u oIdx=%u buffer=%u iui=%u"\
                     %(tP["localReadOffset"],tP["localReadSwapByteOffset"],kernel["SubGroup%u"%tile01], vIdx, rIdx, oIdx, bufferIdx, iui)
-                localReadCode.addCode(Code.LocalReadInst(instruction.IssueLatency,instruction.toCodeInst(paramTuple), comment))
+                localReadCode.addCode(Code.LocalReadInst(instruction.IssueLatency,False,instruction.toCodeInst(paramTuple), comment))
                 valuIdx += blockWidth
 
                 # TODO - handle vector-load
@@ -173,7 +173,6 @@ class LocalReadMFMA(LocalRead):
                 localReadCode = imod.addCode (Code.Module("LocalRead%s Valu%u"%(tc,valuiIdx)))
                 if needPack:
                     packCode = pack.addCode (Code.Module("packCode"))
-
                 for rIdx in range(0, numReadsPerUnroll):
                     valuiIdx = int(valufIdx)
                     baseLRVgpr = vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, valuiIdx), numVgpr)
@@ -222,7 +221,8 @@ class LocalReadMFMA(LocalRead):
                             % (tP["localReadOffset"], tP["localReadSwapByteOffset"], MIWaveGroupShape[tile01], vIdx, rIdx, oIdx, bufferIdx, iui)
 
                     highBits = highBitsForHalf or isHigh16Bits
-                    localReadCode.addCode(Code.LocalReadInst(instruction.IssueLatency,instruction.toCodeInst(paramTuple, 0, highBits), comment))
+                    readToTempVgpr = highBitsForHalf or isHigh8Bits or isHigh16Bits
+                    localReadCode.addCode(Code.LocalReadInst(instruction.IssueLatency,readToTempVgpr,instruction.toCodeInst(paramTuple, 0, highBits), comment))
 
                     # TODO - handle vector-load
                     tmpSgpr = writer.getTmpSgpr(1).idx()

--- a/Tensile/KernelWriter.py
+++ b/Tensile/KernelWriter.py
@@ -295,10 +295,9 @@ class KernelWriter(metaclass=abc.ABCMeta):
       #   Ex. GRPM = 0.5
       #        GR ---------99--------- GR --------99---------- GR
       #   mfma --49-- mfma --49-- mfma --49-- mfma --49-- mfma --49--
-      if kernel["GlobalReadPerMfma"] == -2:
-        self.numGlobalReadInsPerMfma = 200 if kernel["MatrixInstM"] == 32 and not kernel["ProblemType"]["TLUA"] and not kernel["ProblemType"]["TLUB"] and kernel["TransposeLDS"] and not kernel["1LDSBuffer"] else 100
-      else:
-        self.numGlobalReadInsPerMfma = roundUp(kernel["GlobalReadPerMfma"]*100)
+      self.numGlobalReadInsPerMfma = roundUp(kernel["GlobalReadPerMfma"]*100)
+      # if kernel["GlobalReadPerMfma"] == -2:
+      #   self.numGlobalReadInsPerMfma = 200 if kernel["MatrixInstM"] == 32 and not kernel["ProblemType"]["TLUA"] and not kernel["ProblemType"]["TLUB"] and kernel["TransposeLDS"] and not kernel["1LDSBuffer"] else 100
 
       # HOW THIS WORK
       # padding each globalReadInstruction to 100 with empty instruction, 
@@ -311,15 +310,15 @@ class KernelWriter(metaclass=abc.ABCMeta):
           self.numLocalWriteModPerMfma = max(numLocalWriteModPerMfma,100)
         else:
           self.numLocalWriteModPerMfma = numLocalWriteModPerMfma
-      # elif kernel["LocalWritePerMfma"] == -2:
+      else:
+        self.numLocalWriteModPerMfma = roundUp(kernel["LocalWritePerMfma"]*100)
+      # if kernel["LocalWritePerMfma"] == -2:
       #   readsLatencyA = self.numReadsPerIterA/numMfmaPerIter if self.numReadsIterCoalescedA == 1 else 0
       #   readsLatencyB = self.numReadsPerIterB/numMfmaPerIter if self.numReadsIterCoalescedB == 1 else 0
       #   readsLatency = roundUp(readsLatencyA+readsLatencyB)*2
       #   if kernel["1LDSBuffer"] and self.numVgprBuffer >= kernel["LoopIters"]:
       #     readsLatency = 0
       #   self.numLocalWriteModPerMfma = max((self.miLatencyLeft - readsLatency)//(self.tPA["localWriteInstruction"].IssueLatency*2),1)*100
-      else:
-        self.numLocalWriteModPerMfma = roundUp(kernel["LocalWritePerMfma"]*100)
 
       ##################################
       numGlobalReadInsPerIter = numMfmaPerIter * self.numGlobalReadInsPerMfma

--- a/Tensile/KernelWriter.py
+++ b/Tensile/KernelWriter.py
@@ -182,7 +182,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
       #########
       # strategy is to distribute LW/GR as wide as possible to avoid hitting vmem FIFO
       # LWPM = (LW_End - LW_Start) / numLW
-      if kernel["LocalWritePerMfma"] == -3 and kernel["PrefetchGlobalRead"] == 2:
+      if kernel["LocalWritePerMfma"] == -3:
         #########
         # Get localWriteStart
         #########
@@ -314,7 +314,10 @@ class KernelWriter(metaclass=abc.ABCMeta):
           readsLatency = 0
         self.numLocalWriteModPerMfma = max((self.miLatencyLeft - readsLatency)//(self.tPA["localWriteInstruction"].IssueLatency*2),1)*100
       elif kernel["LocalWritePerMfma"] == -3:
-        self.numLocalWriteModPerMfma = numLocalWriteModPerMfma if kernel["PrefetchGlobalRead"] == 2 else 100
+        if kernel["PrefetchGlobalRead"] == 1 and kernel["1LDSBuffer"]:
+          self.numLocalWriteModPerMfma = max(numLocalWriteModPerMfma,100)
+        else:
+          self.numLocalWriteModPerMfma = numLocalWriteModPerMfma
       else:
         self.numLocalWriteModPerMfma = roundUp(kernel["LocalWritePerMfma"]*100)
 

--- a/Tensile/KernelWriter.py
+++ b/Tensile/KernelWriter.py
@@ -182,7 +182,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
       #########
       # strategy is to distribute LW/GR as wide as possible to avoid hitting vmem FIFO
       # LWPM = (LW_End - LW_Start) / numLW
-      if kernel["LocalWritePerMfma"] == -3:
+      if kernel["LocalWritePerMfma"] == -1:
         #########
         # Get localWriteStart
         #########
@@ -306,18 +306,18 @@ class KernelWriter(metaclass=abc.ABCMeta):
       #   Ex. LWPM = 0.5
       #        LW ---------99--------- LW --------99---------- LW
       #   mfma --49-- mfma --49-- mfma --49-- mfma --49-- mfma --49--
-      if kernel["LocalWritePerMfma"] == -2:
-        readsLatencyA = self.numReadsPerIterA/numMfmaPerIter if self.numReadsIterCoalescedA == 1 else 0
-        readsLatencyB = self.numReadsPerIterB/numMfmaPerIter if self.numReadsIterCoalescedB == 1 else 0
-        readsLatency = roundUp(readsLatencyA+readsLatencyB)*2
-        if kernel["1LDSBuffer"] and self.numVgprBuffer >= kernel["LoopIters"]:
-          readsLatency = 0
-        self.numLocalWriteModPerMfma = max((self.miLatencyLeft - readsLatency)//(self.tPA["localWriteInstruction"].IssueLatency*2),1)*100
-      elif kernel["LocalWritePerMfma"] == -3:
+      if kernel["LocalWritePerMfma"] == -1:
         if kernel["PrefetchGlobalRead"] == 1 and kernel["1LDSBuffer"]:
           self.numLocalWriteModPerMfma = max(numLocalWriteModPerMfma,100)
         else:
           self.numLocalWriteModPerMfma = numLocalWriteModPerMfma
+      # elif kernel["LocalWritePerMfma"] == -2:
+      #   readsLatencyA = self.numReadsPerIterA/numMfmaPerIter if self.numReadsIterCoalescedA == 1 else 0
+      #   readsLatencyB = self.numReadsPerIterB/numMfmaPerIter if self.numReadsIterCoalescedB == 1 else 0
+      #   readsLatency = roundUp(readsLatencyA+readsLatencyB)*2
+      #   if kernel["1LDSBuffer"] and self.numVgprBuffer >= kernel["LoopIters"]:
+      #     readsLatency = 0
+      #   self.numLocalWriteModPerMfma = max((self.miLatencyLeft - readsLatency)//(self.tPA["localWriteInstruction"].IssueLatency*2),1)*100
       else:
         self.numLocalWriteModPerMfma = roundUp(kernel["LocalWritePerMfma"]*100)
 

--- a/Tensile/KernelWriter.py
+++ b/Tensile/KernelWriter.py
@@ -198,7 +198,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
             # be scheduled in the front of loop.
             # localwrite have to start after last read-to-tempVgpr.
             if self.numReadPerVectorA != 1 or self.numReadPerVectorB !=1:
-              numHalfReads = (self.numReadPerVectorA//2)*kernel["InnerUnroll"]*kernel["MIWaveTile"][0] + (self.numReadPerVectorB//2)*kernel["InnerUnroll"]*kernel["MIWaveTile"][1]
+              numHalfReads = (self.numReadPerVectorA//2)*kernel["InnerUnroll"]*kernel["MIWaveTileA"] + (self.numReadPerVectorB//2)*kernel["InnerUnroll"]*kernel["MIWaveTileB"]
               numMfmaForHalfRead = 1
               latencyLeft = self.miLatencyLeft
               for i in range(numHalfReads):
@@ -216,7 +216,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
                 if latencyLeft < 0:
                   numMfmaForCurrentLoopLR += 1
                   latencyLeft = max(self.miLatencyLeft - tensorParametersB["localReadInstruction"].IssueLatency*2,0)
-              if kernel["MIWaveTile"][0] * kernel["MIWaveTile"][1] > 1:
+              if kernel["MIWaveTileA"] * kernel["MIWaveTileB"] > 1:
                 numMfmaForCurrentLoopLR += 1
               lwStartMfmaIndex = numMfmaForCurrentLoopLR
           else:
@@ -234,8 +234,8 @@ class KernelWriter(metaclass=abc.ABCMeta):
         if lwStartMfmaIndex > self.lwEndMfmaIndex:
           lwStartMfmaIndex = self.lwEndMfmaIndex
         numMfmaCanSched = self.lwEndMfmaIndex - lwStartMfmaIndex + 1
-        numLoadsA = kernel["DepthU"]*kernel["MacroTile0"]//kernel["GlobalLoadVectorWidthA"]//kernel["NumThreads"]
-        numLoadsB = kernel["DepthU"]*kernel["MacroTile1"]//kernel["GlobalLoadVectorWidthB"]//kernel["NumThreads"]
+        numLoadsA = kernel["DepthU"]*kernel["MacroTileA"]//kernel["GlobalLoadVectorWidthA"]//kernel["NumThreads"]
+        numLoadsB = kernel["DepthU"]*kernel["MacroTileB"]//kernel["GlobalLoadVectorWidthB"]//kernel["NumThreads"]
         writesToSched = (numLoadsA + numLoadsB - 1) * 100
         temp1 = 0
         temp2 = 100

--- a/Tensile/KernelWriter.py
+++ b/Tensile/KernelWriter.py
@@ -93,9 +93,6 @@ class KernelWriter(metaclass=abc.ABCMeta):
   #   self.lwStartMfmaIndex
   #   self.lwEndMfmaIndex
   #   self.barrierMfmaIndex
-  #   self.perIterLocalWriteCanSkip
-  #   self.numGlobalReadInsPerMfma
-  #   self.numReadsIterCoalescedB
   #   self.numMfmaForNextLoopLR
   # This routine is responsible for setting the schedule including determining
   # that all necessary dependency are met.  The driver code in kernelBody
@@ -134,7 +131,11 @@ class KernelWriter(metaclass=abc.ABCMeta):
       readsLatencyA = self.numReadsPerIterA/numMfmaPerIter if self.numReadsIterCoalescedA == 1 else 0
       readsLatencyB = self.numReadsPerIterB/numMfmaPerIter if self.numReadsIterCoalescedB == 1 else 0
       readsLatency = roundUp(readsLatencyA+readsLatencyB)*2
-      self.numLocalWriteModPerMfma = max((self.miLatency - readsLatency)//(self.tPA["localWriteInstruction"].IssueLatency*2+1),1)
+      # when numVgprBuffer > LoopIters, we can schedule localreads that not using tempVgpr to the front of loops
+      # so we can schedule localwrites tighter, and can have more chance to enable 1LDSBuffer
+      if kernel["1LDSBuffer"] and self.numVgprBuffer >= kernel["LoopIters"]:
+        readsLatency = 0
+      self.numLocalWriteModPerMfma = max((self.miLatencyLeft - readsLatency)//(self.tPA["localWriteInstruction"].IssueLatency*2),1)
       ##################################
       numGlobalReadInsPerIter = numMfmaPerIter * self.numGlobalReadInsPerMfma
       numLocalWriteModPerIter = numMfmaPerIter * self.numLocalWriteModPerMfma
@@ -149,43 +150,42 @@ class KernelWriter(metaclass=abc.ABCMeta):
       # localReads followed following sequence to be scheduled
       # ds_read[A][0], ds_read[B][0], ds_read[A][1:], ds_read[B][1:]
       self.numMfmaForNextLoopLR = 1
-      latencyLeft = self.miLatency
+      latencyLeft = self.miLatencyLeft
       # ds_read[A][0]
       for i in range(self.numReadPerVectorA):
         latencyLeft -= tensorParametersA["localReadInstruction"].IssueLatency*2
         if latencyLeft < 0:
           self.numMfmaForNextLoopLR += 1
-          latencyLeft = self.miLatency - tensorParametersA["localReadInstruction"].IssueLatency*2
+          latencyLeft = max(self.miLatencyLeft - tensorParametersA["localReadInstruction"].IssueLatency*2,0)
       # ds_read[B][0]
       for i in range(self.numReadPerVectorB):
         latencyLeft -= tensorParametersB["localReadInstruction"].IssueLatency*2
         if latencyLeft < 0:
           self.numMfmaForNextLoopLR += 1
-          latencyLeft = self.miLatency - tensorParametersB["localReadInstruction"].IssueLatency*2
+          latencyLeft = max(self.miLatencyLeft - tensorParametersB["localReadInstruction"].IssueLatency*2,0)
       # ds_read[A][1:]
       for i in range(self.numReadsPerIterA-self.numReadPerVectorA):
         latencyLeft -= tensorParametersA["localReadInstruction"].IssueLatency*2
         if latencyLeft < 0:
           self.numMfmaForNextLoopLR += 1
-          latencyLeft = self.miLatency - tensorParametersA["localReadInstruction"].IssueLatency*2
+          latencyLeft = max(self.miLatencyLeft - tensorParametersA["localReadInstruction"].IssueLatency*2,0)
       # ds_read[B][1:]
       for i in range(self.numReadsPerIterB-self.numReadPerVectorB):
         latencyLeft -= tensorParametersB["localReadInstruction"].IssueLatency*2
         if latencyLeft < 0:
           self.numMfmaForNextLoopLR += 1
-          latencyLeft = self.miLatency - tensorParametersB["localReadInstruction"].IssueLatency*2
+          latencyLeft = max(self.miLatencyLeft - tensorParametersB["localReadInstruction"].IssueLatency*2,0)
       # to calculate number of mfma we need to wait before data arrive from lds to vgpr.
-      # TODO: latency: 40 quad-cycle for 4 word, 22 quad-cycle for 2 word, 10 quad-cycle for 1 word
-      latencyForLR = tensorParametersB["localReadInstruction"].IssueLatency*18
-      latencyForLR -= latencyLeft # remaining latency in mfma
-      latencyForLR -= (self.miLatency+self.miLatencyBuffer+2) # last LR will have 1 mfma latency
+      # latency: 40 quad-cycle for 4 word, 20 quad-cycle for 2 word, 10 quad-cycle for 1 word / half word
+      latencyForLR = roundUp(tensorParametersB["localReadInstruction"].blockWidth)*10
+      latencyForLR -= max(latencyLeft,0) # remaining latency in mfma
+      latencyForLR -= self.miLatency # last LR will have 1 mfma latency
       while latencyForLR > 0:
-        latencyForLR -= (self.miLatency+self.miLatencyBuffer+2)
+        latencyForLR -= self.miLatency
         self.numMfmaForNextLoopLR += 1
       # final index definition
       self.numMfmaForNextLoopLR = min(self.numMfmaForNextLoopLR,numMfmaPerIter-1)
       self.barrierMfmaIndex = numMfmaPerIter*(kernel["LoopIters"]-self.numItersPLR+1) - self.numMfmaForNextLoopLR - 1 if self.numItersPLR else 0
-      self.nextLoopLRMfmaIndex = self.barrierMfmaIndex if self.numItersPLR else numMfmaPerIter*kernel["LoopIters"] - self.numMfmaForNextLoopLR - 1
       self.lwEndMfmaIndex = max(self.barrierMfmaIndex - numMfmaBetweenLWandBarrier,0) if self.numItersPLR else numMfmaPerIter*kernel["LoopIters"] - 1
       if kernel["DepthULdsDivisor"] > 1:
         # SplitLDS's schedule looks like: # (LW/GR) x N -> (GR address increment) x 2
@@ -665,11 +665,14 @@ class KernelWriter(metaclass=abc.ABCMeta):
       #####
       # Prepare and Assign parameter
       ####
+      if iteration == 0:
+        self.localReadsVacancy = []
+        self.localReadsWait = [ [] for j in range(kernel["LoopIters"])]
+      self.localReadsWait[iteration] = waitCode
       numMfmaPerIter = self.numMfmaPerIter
       isBarrier = kernel["LoopIters"] - self.numItersPLR
       writeItems = list(localWriteCode.items())
       macIterItems = macIterCode.flatitems()
-      readsPerIter = localReadCode.countType(Code.LocalReadInst)
       skipLocalWriteWaitcnt = 0
       localReadsWaitcnt = 0
       curPackIdx = 0
@@ -703,8 +706,8 @@ class KernelWriter(metaclass=abc.ABCMeta):
       localReadItemsNextLoop = localReadItems if iteration >= isBarrier else []
 
       #####
-      # Prepare pack Code                for A:
-      # since the mfma reuse B first =>    for B: mfma[A][B]
+      # Prepare pack Code                for B:
+      # since the mfma reuse B first =>    for A: mfma[A][B]
       # we need 1 vector A and 1 vector B for first mfma
       # then we prepare remaining A, then remaining B
       ####
@@ -747,6 +750,29 @@ class KernelWriter(metaclass=abc.ABCMeta):
       if macIterItems:
         macIterItems.pop(0)
 
+      ####
+      # scheduled local read to previous iterations
+      ####
+      if self.numVgprBuffer >= kernel["LoopIters"]:
+        for vacancy in self.localReadsVacancy:
+          # {"items","letencyLeft","atIter","atMfmaIndex","noReadsAtThisIter"}
+          for localRead in list(localReadItemsThisLoop):
+            if vacancy["letencyLeft"] > localRead.IssueLatency * 2:
+              if not localRead.readToTempVgpr:
+                vacancy["letencyLeft"] -= localRead.IssueLatency * 2
+                vacancy["items"].addCode(localRead)
+                localReadItemsThisLoop.remove(localRead)
+                # update waitCnt
+                if self.numItersPLR:
+                  for readsIter in range(vacancy["atIter"], iteration + self.numItersPLR):
+                    if (vacancy["atMfmaIndex"] % numMfmaPerIter == 0 or readsIter != vacancy["atIter"]) and \
+                        (vacancy["noReadsAtThisIter"] or readsIter <= vacancy["atIter"] + self.numItersPLR):
+                      self.localReadsWait[readsIter].lgkmcnt += 1
+            else:
+              # make sure the localread sequence remain the same
+              vacancy["letencyLeft"] = 0
+      numReadsInst = len(localReadItemsThisLoop) if iteration < isBarrier else len(localReadItemsNextLoop)
+
       for i in range(numMfmaPerIter):
         mfmaIndex = iteration * numMfmaPerIter + i
         iterCode.addComment0(" mfmaIndex:%u " %(mfmaIndex))
@@ -754,54 +780,63 @@ class KernelWriter(metaclass=abc.ABCMeta):
         ####
         # scheduled local read
         ####
-        readLeft = readsPerIter
+        readLeft = numReadsInst
+        latencyLeft = self.miLatencyLeft
         # with PrefetchLocalRead, localreads can interleave with mfma
-        if self.numItersPLR:
-          latencyLeft = self.miLatency
+        if self.numItersPLR and iteration < isBarrier:
           # take ds_write into account to schedule ds_read, assume A and B localwrite have same width (TLDS=1)
           if (mfmaIndex >= self.lwStartMfmaIndex) and not globalReadCode.countType(Code.GlobalReadInst):
             for j in range(len(writeItems)):
               latencyLeft -= (self.tPA["localWriteInstruction"].IssueLatency*2+1)
           readLeftLROPT = 0
-          for j in range(len(localReadItems)):
-            latencyLeft -= localReadItems[j].IssueLatency*2
+          for j in range(len(localReadItemsThisLoop)):
+            latencyLeft -= localReadItemsThisLoop[j].IssueLatency*2
             readLeftLROPT += 1 if latencyLeft >= 0 else 0
+          # at least 1 instruction
+          readLeftLROPT = max(readLeftLROPT,1)
           # evenly schedule localread with each mfma
-          readLeftLREven = readsPerIter // numMfmaPerIter
-          if (readsPerIter % (numMfmaPerIter)) > i:
+          readLeftLREven = numReadsInst // numMfmaPerIter
+          if (numReadsInst % (numMfmaPerIter)) > i:
             readLeftLREven += 1
-          # we want no localreads at first and barrier mfma
-          if (iteration == 0 or iteration == isBarrier):
+          # we want no localreads at first mfma
+          if (iteration == 0) and numMfmaPerIter != 1:
             numMfmaForLR = numMfmaPerIter - 1
-            if iteration == isBarrier:
-              numMfmaForLR = self.numMfmaForNextLoopLR
-            if i < numMfmaPerIter - numMfmaForLR or numMfmaPerIter == 1:
+            if i < numMfmaPerIter - numMfmaForLR:
               readLeftLREven = 0
               readLeftLROPT = 0
             # rest mfma help to schedule those localReads
             else:
-              readLeftLREven = readsPerIter // (numMfmaPerIter-1)
-              if (readsPerIter % (numMfmaPerIter-1)) >= i:
+              readLeftLREven = numReadsInst // (numMfmaPerIter-1)
+              if (numReadsInst % (numMfmaPerIter-1)) >= i:
                 readLeftLREven += 1
           # if there are too many localreads, change strategy to even.
           readLeft = max(readLeftLREven,readLeftLROPT)
+        if not self.numItersPLR and iteration < isBarrier:
+          for j in range(len(localReadItemsThisLoop)):
+            latencyLeft -= localReadItemsThisLoop[j].IssueLatency*2
         # if start to schedule localwrite, but still have localreads not scheduled yet,
         # reject to use 1LDSB, since it will write and read same lds buffer at same time.
         # TODO: force to schedule all remaining localreads before start to schedule localwrite.
-        if mfmaIndex >= self.lwStartMfmaIndex and mfmaIndex <= max(self.lwEndMfmaIndex,self.barrierMfmaIndex) and \
+        if mfmaIndex > self.lwStartMfmaIndex and mfmaIndex <= max(self.lwEndMfmaIndex,self.barrierMfmaIndex) and \
           localReadItemsThisLoop and kernel["1LDSBuffer"]:
           self.overflowedResources = 5
-        while localReadItemsThisLoop:
-          if readLeft == 0 and (i != numMfmaPerIter - 1):
-            break
-          item = localReadItemsThisLoop.pop(0)
-          iterCode.addCode(item)
-          readsThisItem = item.countType(Code.LocalReadInst)
-          if readsThisItem:
-            readLeft = readLeft - 1
-            # because waitCode is scheduled at first mfma, we only need to skip localreads at first mfma.
+        for j in range(readLeft):
+          if localReadItemsThisLoop:
+            item = localReadItemsThisLoop.pop(0)
+            iterCode.addCode(item)
             if (i == 0):
               localReadsWaitcnt += 1
+        if not localReadItemsThisLoop and latencyLeft > 0 and iteration < isBarrier and \
+            not(mfmaIndex > self.lwStartMfmaIndex and kernel["1LDSBuffer"]):
+          item = Code.Module()
+          item.addComment0("localReadsVacancy: letencyLeft %d"%(latencyLeft))
+          iterCode.addCode(item)
+          self.localReadsVacancy.append({ "items": item, \
+                                          "letencyLeft": latencyLeft, \
+                                          "atIter": iteration, \
+                                          "atMfmaIndex": mfmaIndex, \
+                                          "noReadsAtThisIter": numReadsInst == 0, \
+                                        })
 
         ####
         # scheduled global read
@@ -843,6 +878,9 @@ class KernelWriter(metaclass=abc.ABCMeta):
             if not localReadItemsThisLoop:
               self.perIterLocalWriteCanSkip[iteration] += writeItem.countType(Code.LocalWriteInst)
 
+        ####
+        # scheduled pointer
+        ####
         if mfmaIndex == self.lwEndMfmaIndex:
           iterCode.addCode(pointerLWCode)
         if i == numMfmaPerIter - 1:
@@ -859,17 +897,41 @@ class KernelWriter(metaclass=abc.ABCMeta):
         # scheduled local read for next loop
         # localReads for next loop should after barrier
         ####
-        while localReadItemsNextLoop:
-          if readLeft == 0 and (i != numMfmaPerIter - 1):
-            break
-          item = localReadItemsNextLoop.pop(0)
-          iterCode.addCode(item)
-          readsThisItem = item.countType(Code.LocalReadInst)
-          if readsThisItem:
-            readLeft = readLeft - 1
+        latencyLeft = self.miLatencyLeft
+        if self.numItersPLR and iteration >= isBarrier:
+          readLeftLROPT = 0
+          for j in range(len(localReadItemsNextLoop)):
+            latencyLeft -= localReadItemsNextLoop[j].IssueLatency*2
+            readLeftLROPT += 1 if latencyLeft >= 0 else 0
+          # at least 1 instruction
+          readLeftLROPT = max(readLeftLROPT,1)
+          # evenly schedule localread with each mfma
+          readLeftLREven = numReadsInst // numMfmaPerIter
+          if (numReadsInst % (numMfmaPerIter)) > i:
+            readLeftLREven += 1
+          # we want no localreads at barrier mfma
+          if (iteration == isBarrier) and numMfmaPerIter != 1:
+            numMfmaForLR = self.numMfmaForNextLoopLR
+            if i < numMfmaPerIter - numMfmaForLR:
+              readLeftLREven = 0
+              readLeftLROPT = 0
+            # rest mfma help to schedule those localReads
+            else:
+              readLeftLREven = numReadsInst // (numMfmaPerIter-1)
+              if (numReadsInst % (numMfmaPerIter-1)) >= i:
+                readLeftLREven += 1
+          # if there are too many localreads, change strategy to even.
+          readLeft = max(readLeftLREven,readLeftLROPT)
+        for j in range(readLeft):
+          if localReadItemsNextLoop:
+            item = localReadItemsNextLoop.pop(0)
+            iterCode.addCode(item)
             if (i == 0):
               localReadsWaitcnt += 1
 
+        ####
+        # scheduled wait localReads
+        ####
         if i == 0:
           iterCode.addCode(waitCode)
 
@@ -920,10 +982,9 @@ class KernelWriter(metaclass=abc.ABCMeta):
 
     if isinstance(waitCode, Code.WaitCnt):
       currentIsa = globalParameters["CurrentISA"]
-      maxLgkmcnt = globalParameters["AsmCaps"][currentIsa]["MaxLgkmcnt"]
 
       # Set the waitCount, based on the new iter schedule
-      lgkmcnt = 0 # most conservative
+      lgkmcnt = waitCode.lgkmcnt
       localReads = 0
       localWrites = 0
       if kernel["EnableMatrixInstruction"]:
@@ -947,7 +1008,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
         # how many localreads can skip is based on how many iterations we prefetch.
         localReads += self.numReadsPerIterA * skipReadsIterA + localReads + self.numReadsPerIterB * skipReadsIterB
         # some of localReads is interleaved after waitcnt in SIA3
-        if kernel["ScheduleIterAlg"] == 3 and \
+        if kernel["ScheduleIterAlg"] == 3 and self.numItersPLR and\
           (iteration < numReadsIterA or iteration < numReadsIterB or numPrefetchIter) and \
           self.enable["LocalRead"]:
           if (iteration < numReadsIterA and not dataAtIterA < max(dataAtIterA,dataAtIterB)) or numPrefetchIter:
@@ -1002,7 +1063,6 @@ class KernelWriter(metaclass=abc.ABCMeta):
               else:
                 lgkmcnt = localWrites  # this only survives if writes are at the end
 
-      lgkmcnt = min(lgkmcnt, maxLgkmcnt)
       waitCode.comment += " old=%u, new=%u newLW=%u newLR=%u" % (waitCode.lgkmcnt, lgkmcnt,localWrites,localReads)
       waitCode.lgkmcnt = lgkmcnt
 
@@ -1326,7 +1386,6 @@ class KernelWriter(metaclass=abc.ABCMeta):
       isSwapAndResetLwoIter = isResetLroIter
       isSwapLroIter = isResetLroIter
       if kernel["ScheduleIterAlg"] == 3:
-          # isSwapLroIter = (u == self.nextLoopLRMfmaIndex//(self.numMfmaPerIter))
           isSwapAndResetLwoIter = (u == self.lwEndMfmaIndex//(self.numMfmaPerIter))
 
       extraComment = ""
@@ -1415,13 +1474,12 @@ class KernelWriter(metaclass=abc.ABCMeta):
             pointerLRCode.addText(self.comment("local read init pointers b"))
             pointerLRCode.addText(self.localReadInitPointers(kernel, tensorParametersB))
 
+      # we initiate lgkmcnt to 0, then assigning it correct value in makeSubIterSchedule()
       if self.enable["Wait"]:
-        dataAtIter = u - self.numItersPLR
-        numReadsIter = min(u+1,kernel["LoopIters"] - self.numItersPLR)
-        skipReadsIter = numReadsIter - dataAtIter - 1
-        waitCode = self.wait(kernel, tensorParametersA, tensorParametersB, -1, -1, \
-            skipReadsIter, \
-            "7wait for local read")
+        waitCode = self.wait(kernel, tensorParametersA, tensorParametersB, \
+            -1, 0, 0, \
+            "wait for prior local read local write")
+
       luIdx = (u) % (self.numVgprBuffer+1) # local to use for MACs
       if self.enable["MAC"]:
         if kernel["EnableMatrixInstruction"]:
@@ -1781,7 +1839,6 @@ class KernelWriter(metaclass=abc.ABCMeta):
         isSwapAndResetLwoIter = isResetLroIter
         isSwapLroIter = isResetLroIter
         if kernel["ScheduleIterAlg"] == 3:
-          # isSwapLroIter = (u == self.nextLoopLRMfmaIndex//(self.numMfmaPerIter))
           isSwapAndResetLwoIter = (u == self.lwEndMfmaIndex//(self.numMfmaPerIter))
         extraComment = ""
         if isResetLroIter:
@@ -1872,23 +1929,10 @@ class KernelWriter(metaclass=abc.ABCMeta):
             pointerLRCode.addText(self.comment("local read init pointers b"))
             pointerLRCode.addText(self.localReadInitPointers(kernel, tensorParametersB))
 
-          waitGlobalRead = -1
-          if kernel["PrefetchGlobalRead"] and isSwapAndResetLwoIter:
-            waitLocalWrite = 1
-          else:
-            waitLocalWrite = -1
-
-        else: # not isResetLroIter
-          waitGlobalRead = 1 if u==0 and kernel["PrefetchGlobalRead"] and self.numVgprBuffer else -1
-          waitLocalWrite = -1
-
+        # we initiate lgkmcnt to 0, then assigning it correct value in makeSubIterSchedule()
         if self.enable["Wait"]:
-          dataAtIter = u - self.numItersPLR
-          numReadsIter = min(u+1,kernel["LoopIters"] - self.numItersPLR)
-          numPrefetchIter = (u//(kernel["LoopIters"]-self.numItersPLR))*((u+1)-(kernel["LoopIters"]-self.numItersPLR)) if kernel["PrefetchGlobalRead"] else 0
-          skipReadsIter = numReadsIter + numPrefetchIter - dataAtIter - 1
           waitCode = self.wait(kernel, tensorParametersA, tensorParametersB, \
-              waitGlobalRead, waitLocalWrite, skipReadsIter, \
+              -1, 0, 0, \
               "wait for prior local read local write")
 
         luIdx = (u) % (self.numVgprBuffer+1) # local to use for MACs
@@ -2561,7 +2605,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
     vwb = kernel["GlobalLoadVectorWidthB"]
 
     self.numItersPLR = kernel["PrefetchLocalRead"]%kernel["LoopIters"]
-    self.numVgprBuffer = kernel["PrefetchLocalRead"]
+    self.numVgprBuffer = kernel["LoopIters"] if kernel["PrefetchLocalRead"] > kernel["LoopIters"] else kernel["PrefetchLocalRead"]
     # merge N iteration's read into 1 iteration if can't coalesce read
     # ex, A can coalesce read, B can't
     # MergeRead 0: ds_readAx1 ds_readBx1 mfma | ds_readAx1 ds_readBx1 mfma | => ds_readAx2 ds_readBx1 mfma | ds_readBx1 mfma |

--- a/Tensile/KernelWriter.py
+++ b/Tensile/KernelWriter.py
@@ -297,8 +297,6 @@ class KernelWriter(metaclass=abc.ABCMeta):
       #        GR ---------99--------- GR --------99---------- GR
       #   mfma --49-- mfma --49-- mfma --49-- mfma --49-- mfma --49--
       self.numGlobalReadInsPerMfma = roundUp(kernel["GlobalReadPerMfma"]*PRECISION)
-      # if kernel["GlobalReadPerMfma"] == -2:
-      #   self.numGlobalReadInsPerMfma = 200 if kernel["MatrixInstM"] == 32 and not kernel["ProblemType"]["TLUA"] and not kernel["ProblemType"]["TLUB"] and kernel["TransposeLDS"] and not kernel["1LDSBuffer"] else 100
 
       # HOW THIS WORK
       # padding each globalReadInstruction to 100 with empty instruction, 
@@ -313,13 +311,6 @@ class KernelWriter(metaclass=abc.ABCMeta):
           self.numLocalWriteModPerMfma = numLocalWriteModPerMfma
       else:
         self.numLocalWriteModPerMfma = roundUp(kernel["LocalWritePerMfma"]*PRECISION)
-      # if kernel["LocalWritePerMfma"] == -2:
-      #   readsLatencyA = self.numReadsPerIterA/numMfmaPerIter if self.numReadsIterCoalescedA == 1 else 0
-      #   readsLatencyB = self.numReadsPerIterB/numMfmaPerIter if self.numReadsIterCoalescedB == 1 else 0
-      #   readsLatency = roundUp(readsLatencyA+readsLatencyB)*2
-      #   if kernel["1LDSBuffer"] and self.numVgprBuffer >= kernel["LoopIters"]:
-      #     readsLatency = 0
-      #   self.numLocalWriteModPerMfma = max((self.miLatencyLeft - readsLatency)//(self.tPA["localWriteInstruction"].IssueLatency*2),1)*100
 
       ##################################
       numGlobalReadInsPerIter = numMfmaPerIter * self.numGlobalReadInsPerMfma

--- a/Tensile/KernelWriter.py
+++ b/Tensile/KernelWriter.py
@@ -893,6 +893,10 @@ class KernelWriter(metaclass=abc.ABCMeta):
           barrier.addInst("s_barrier","")
           iterCode.addCode(barrier)
 
+        if kernel["StorePriorityOpt"] and kernel["PrefetchGlobalRead"] == 2 and \
+            mfmaIndex == self.lwStartMfmaIndex:
+          iterCode.addInst("s_setprio 3","store optimization")
+
         if (mfmaIndex >= self.lwStartMfmaIndex):
           for j in range(self.numLocalWriteModPerMfma):
             # in case there are localWrite and globalread in same iteration
@@ -928,6 +932,10 @@ class KernelWriter(metaclass=abc.ABCMeta):
         if mfmaIndex == self.barrierMfmaIndex and self.numItersPLR:
           iterCode.addCode(waitLWCode)
           iterCode.addCode(syncCode)
+
+        if kernel["StorePriorityOpt"] and kernel["PrefetchGlobalRead"] == 2 and \
+            mfmaIndex == self.barrierMfmaIndex and self.numItersPLR:
+          iterCode.addInst("s_setprio 0","store optimization")
 
         ####
         # scheduled local read for next loop

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -2140,10 +2140,11 @@ class KernelWriterAssembly(KernelWriter):
     self.localReadDoCntB   = 0
 
     if kernel["EnableMatrixInstruction"]:
-      self.miLatency = kernel["MatrixInstM"] // 2 - 2
+      self.miLatency = kernel["MatrixInstM"] // 2
+      miIssueLatency = 2
       # give 1 quad-cycle buffer to prevend bubble from sync
-      self.miLatencyBuffer = 1
-      self.miLatency -= self.miLatencyBuffer
+      miLatencyBuffer = 1
+      self.miLatencyLeft = max(self.miLatency - miLatencyBuffer - miIssueLatency,0)
 
     # pre-determine labels in order
     unrollChar = self.indexChars[ \

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -10984,6 +10984,11 @@ class KernelWriterAssembly(KernelWriter):
 
     kStr += self.comment1("optSingleColVgpr=%u optSharedColVgpr=%u optSGPRUsage=%s optSrdIncForRow=%u" % \
               (ss.optSingleColVgpr, ss.optSharedColVgpr, ss.optSGPRUsage, ss.optSrdIncForRow))
+
+    if kernel["StoreSyncOpt"]:
+      kStr += "s_sleep %d // optimization: sync and wait\n" %(kernel["StoreSyncOpt"]-1)
+      kStr += "s_barrier\n"
+
     if atomic:
       # all kinds of code relies on this assumption:
       assert(atomicW <= gwvw)
@@ -11104,6 +11109,10 @@ class KernelWriterAssembly(KernelWriter):
           kStr += inst("s_mov_b{}".format(kernel["WavefrontSize"]), self.exec, -1, "full mask -1 -> exec" )
 
     kStr += loadCInputCode
+
+    if beta and kernel["StoreSyncOpt"]:
+      kStr += "s_sleep %d // optimization: sync and wait\n" %(kernel["StoreSyncOpt"]-1)
+      kStr += "s_barrier\n"
 
     ########################################
     # AccVgpr read

--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -3511,7 +3511,7 @@ class Solution:
         reject(state, "SplitLDS requires wider GlobalReadVectorWidth (assert RegisterPerElem (%f) * GRVW (%u) // DepthULdsDivisor (%u) >= 1"%
           (state["ProblemType"]["DataType"].numRegisters(),state["GlobalReadVectorWidth"],state["DepthULdsDivisor"]))
 
-    if state["LocalWritePerMfma"] == -3:
+    if state["LocalWritePerMfma"] == -2:
       # Get optmizaed LWPM for PGR2
       # optmized value is as wide as possible to avoid hitting vmem FIFO
       numLoadsA = state["DepthU"]*state["MacroTileA"]//state["GlobalLoadVectorWidthA"]//state["NumThreads"]

--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -3565,8 +3565,11 @@ class Solution:
           if latencyLeft < 0:
             numMfmaForNextLoopLR += 1
             latencyLeft = max(miLatencyLeft - issueLatencyB*2,0)
-        # in PGR2, we need 2 mfma for global read increments
-        lwStartMfmaIndex = 2
+        # In PGR2, localWrites should be scheduled after globalReadInc
+        numGRIncInst = 12 if not state["StaggerU"] else 18
+        numInstPerMfma = max(roundUp(miLatencyLeft/2),1)
+        numMfmaToSched = roundUp(numGRIncInst/numInstPerMfma)
+        lwStartMfmaIndex = 1 + numMfmaToSched
         # for 1LDSB, we have to issue localwrites after localreads
         if state["1LDSBuffer"] and numVgprBuffer >= state["LoopIters"]:
           if numReadPerVectorA != 1 or numReadPerVectorB !=1:

--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -3511,7 +3511,7 @@ class Solution:
         reject(state, "SplitLDS requires wider GlobalReadVectorWidth (assert RegisterPerElem (%f) * GRVW (%u) // DepthULdsDivisor (%u) >= 1"%
           (state["ProblemType"]["DataType"].numRegisters(),state["GlobalReadVectorWidth"],state["DepthULdsDivisor"]))
 
-    if state["LocalWritePerMfma"] == -1:
+    if state["LocalWritePerMfma"] == -3:
       # Get optmizaed LWPM for PGR2
       # optmized value is as wide as possible to avoid hitting vmem FIFO
       numLoadsA = state["DepthU"]*state["MacroTileA"]//state["GlobalLoadVectorWidthA"]//state["NumThreads"]

--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -3272,7 +3272,8 @@ class Solution:
       if not math.log(state["MacroTile0"],2).is_integer() or \
           ldsSize > globalParameters["MaxLDS"] or \
           state["SourceSwap"] or \
-          (state["GlobalSplitU"] > 1) and (state["_GlobalAccumulation"] != 'MultipleBuffer'):
+          (state["GlobalSplitU"] > 1) and (state["_GlobalAccumulation"] != 'MultipleBuffer') or \
+          state["MatrixInstBN"] > 1 and state["MatrixInstN"] == 4:
         state["StoreRemapVectorWidth"] = 0
       else:
         state["StoreRemapVectorWidth"] = defaultRemap

--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -2639,7 +2639,6 @@ class Solution:
                                state["PrefetchAcrossPersistent"] and \
                                bufferLoad
 
-
     #print("PackedC0IdxChars", state["PackedC0IdxChars"])
     #print("PackedC1IdxChars", state["PackedC1IdxChars"])
 
@@ -3871,6 +3870,11 @@ class Solution:
       return abbrev
     elif isinstance(value, dict):
       s =  "_".join(["%d%d"%(pos,k) for pos,k in value.items()])
+      return s
+    elif isinstance(value, float):
+      val1 = int(value)
+      val2 = int(value*100) - int(value)*100
+      s =  "%dp%d" % (val1,val2)
       return s
     else:
       printExit('Parameter {key}={value} is new object type ({t})'.format(key=key, value=value, t=type(value)))

--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -3514,164 +3514,165 @@ class Solution:
     if state["LocalWritePerMfma"] == -1:
       # Get optmizaed LWPM for PGR2
       # optmized value is as wide as possible to avoid hitting vmem FIFO
-      if state["PrefetchGlobalRead"] == 2:
-        numLoadsA = state["DepthU"]*state["MacroTileA"]//state["GlobalLoadVectorWidthA"]//state["NumThreads"]
-        numLoadsB = state["DepthU"]*state["MacroTileB"]//state["GlobalLoadVectorWidthB"]//state["NumThreads"]
-        numMfmaPerIter = state["MIWaveTileA"] * state["MIWaveTileB"] * state["InnerUnroll"]
-        lrvwA = state["LocalReadVectorWidth"] if not state["ProblemType"]["TLUA"] else state["MIInputPerThread"]
-        lrvwB = state["LocalReadVectorWidth"] if not state["ProblemType"]["TLUB"] else state["MIInputPerThread"]
-        numReadsIterCoalescedA = lrvwA // state["MIInputPerThread"]
-        numReadsIterCoalescedB = lrvwB // state["MIInputPerThread"]
-        numIterPerCoalescedReadA = max(1,numReadsIterCoalescedA//state["InnerUnroll"])
-        numIterPerCoalescedReadB = max(1,numReadsIterCoalescedB//state["InnerUnroll"])
-        blockWidthA = state["LocalReadVectorWidth"]/(4/bpeAB) if state["TransposeLDS"] and not state["ProblemType"]["TLUA"] else bpeAB/4
-        blockWidthB = state["LocalReadVectorWidth"]/(4/bpeAB) if state["TransposeLDS"] and not state["ProblemType"]["TLUB"] else bpeAB/4
+      numLoadsA = state["DepthU"]*state["MacroTileA"]//state["GlobalLoadVectorWidthA"]//state["NumThreads"]
+      numLoadsB = state["DepthU"]*state["MacroTileB"]//state["GlobalLoadVectorWidthB"]//state["NumThreads"]
+      numMfmaPerIter = state["MIWaveTileA"] * state["MIWaveTileB"] * state["InnerUnroll"]
+      lrvwA = state["LocalReadVectorWidth"] if not state["ProblemType"]["TLUA"] else state["MIInputPerThread"]
+      lrvwB = state["LocalReadVectorWidth"] if not state["ProblemType"]["TLUB"] else state["MIInputPerThread"]
+      numReadsIterCoalescedA = lrvwA // state["MIInputPerThread"]
+      numReadsIterCoalescedB = lrvwB // state["MIInputPerThread"]
+      numIterPerCoalescedReadA = max(1,numReadsIterCoalescedA//state["InnerUnroll"])
+      numIterPerCoalescedReadB = max(1,numReadsIterCoalescedB//state["InnerUnroll"])
+      blockWidthA = state["LocalReadVectorWidth"]/(4/bpeAB) if state["TransposeLDS"] and not state["ProblemType"]["TLUA"] else bpeAB/4
+      blockWidthB = state["LocalReadVectorWidth"]/(4/bpeAB) if state["TransposeLDS"] and not state["ProblemType"]["TLUB"] else bpeAB/4
 
-        numReadPerVectorA = bpeAB * lrvwA // int(blockWidthA * 4)
-        numReadsPerIterA = state["InnerUnroll"]*(state["MIWaveTileA"] * numReadPerVectorA)
-        numReadPerVectorB = bpeAB * lrvwB // int(blockWidthB * 4)
-        numReadsPerIterB = state["InnerUnroll"]*(state["MIWaveTileB"] * numReadPerVectorB)
+      numReadPerVectorA = bpeAB * lrvwA // int(blockWidthA * 4)
+      numReadsPerIterA = state["InnerUnroll"]*(state["MIWaveTileA"] * numReadPerVectorA)
+      numReadPerVectorB = bpeAB * lrvwB // int(blockWidthB * 4)
+      numReadsPerIterB = state["InnerUnroll"]*(state["MIWaveTileB"] * numReadPerVectorB)
 
-        numItersPLR = state["PrefetchLocalRead"]%state["LoopIters"]
-        numVgprBuffer = state["LoopIters"] if state["PrefetchLocalRead"] > state["LoopIters"] else state["PrefetchLocalRead"]
-        issueLatencyA = 2 if state["TransposeLDS"] and not state["ProblemType"]["TLUA"] and state["LocalReadVectorWidth"]*bpeAB == 16 else 1
-        issueLatencyB = 2 if state["TransposeLDS"] and not state["ProblemType"]["TLUB"] and state["LocalReadVectorWidth"]*bpeAB == 16 else 1
+      numItersPLR = state["PrefetchLocalRead"]%state["LoopIters"]
+      numVgprBuffer = state["LoopIters"] if state["PrefetchLocalRead"] > state["LoopIters"] else state["PrefetchLocalRead"]
+      issueLatencyA = 2 if state["TransposeLDS"] and not state["ProblemType"]["TLUA"] and state["LocalReadVectorWidth"]*bpeAB == 16 else 1
+      issueLatencyB = 2 if state["TransposeLDS"] and not state["ProblemType"]["TLUB"] and state["LocalReadVectorWidth"]*bpeAB == 16 else 1
 
-        miLatency = state["MatrixInstM"] // 2
-        miIssueLatency = 2
-        # give 1 quad-cycle buffer to prevend bubble from sync
-        miLatencyBuffer = 1
-        miLatencyLeft = max(miLatency - miLatencyBuffer - miIssueLatency,0)
-        #########
-        # Get localWriteEnd
-        #########
-        numMfmaForLR = 1
-        latencyLeft = miLatencyLeft
-        # ds_read[A][0]
-        for i in range(numReadPerVectorA):
-          latencyLeft -= issueLatencyA*2
-          if latencyLeft < 0:
-            numMfmaForLR += 1
-            latencyLeft = max(miLatencyLeft - issueLatencyA*2,0)
-        # ds_read[B][0]
-        for i in range(numReadPerVectorB):
-          latencyLeft -= issueLatencyB*2
-          if latencyLeft < 0:
-            numMfmaForLR += 1
-            latencyLeft = max(miLatencyLeft - issueLatencyB*2,0)
-        # ds_read[A][1:]
-        for i in range(numReadsPerIterA-numReadPerVectorA):
-          latencyLeft -= issueLatencyA*2
-          if latencyLeft < 0:
-            numMfmaForLR += 1
-            latencyLeft = max(miLatencyLeft - issueLatencyA*2,0)
-        # ds_read[B][1:]
-        for i in range(numReadsPerIterB-numReadPerVectorB):
-          latencyLeft -= issueLatencyB*2
-          if latencyLeft < 0:
-            numMfmaForLR += 1
-            latencyLeft = max(miLatencyLeft - issueLatencyB*2,0)
+      miLatency = state["MatrixInstM"] // 2
+      miIssueLatency = 2
+      # give 1 quad-cycle buffer to prevend bubble from sync
+      miLatencyBuffer = 1
+      miLatencyLeft = max(miLatency - miLatencyBuffer - miIssueLatency,0)
+      #########
+      # Get localWriteEnd
+      #########
+      numMfmaForLR = 1
+      latencyLeft = miLatencyLeft
+      # ds_read[A][0]
+      for i in range(numReadPerVectorA):
+        latencyLeft -= issueLatencyA*2
+        if latencyLeft < 0:
+          numMfmaForLR += 1
+          latencyLeft = max(miLatencyLeft - issueLatencyA*2,0)
+      # ds_read[B][0]
+      for i in range(numReadPerVectorB):
+        latencyLeft -= issueLatencyB*2
+        if latencyLeft < 0:
+          numMfmaForLR += 1
+          latencyLeft = max(miLatencyLeft - issueLatencyB*2,0)
+      # ds_read[A][1:]
+      for i in range(numReadsPerIterA-numReadPerVectorA):
+        latencyLeft -= issueLatencyA*2
+        if latencyLeft < 0:
+          numMfmaForLR += 1
+          latencyLeft = max(miLatencyLeft - issueLatencyA*2,0)
+      # ds_read[B][1:]
+      for i in range(numReadsPerIterB-numReadPerVectorB):
+        latencyLeft -= issueLatencyB*2
+        if latencyLeft < 0:
+          numMfmaForLR += 1
+          latencyLeft = max(miLatencyLeft - issueLatencyB*2,0)
+      # to calculate number of mfma we need to wait before data arrive from lds to vgpr.
+      # latency: 40 quad-cycle for 4 word, 20 quad-cycle for 2 word, 10 quad-cycle for 1 word / half word
+      numMfmaForNextLoopLR = numMfmaForLR
+      latencyForLR = roundUp(blockWidthB)*10
+      latencyForLR -= max(latencyLeft,0) # remaining latency in mfma
+      latencyForLR -= miLatency # last LR will have 1 mfma latency
+      while latencyForLR > 0:
+        latencyForLR -= miLatency
+        numMfmaForNextLoopLR += 1
+      # final index definition
+      numMfmaForNextLoopLR = min(numMfmaForNextLoopLR, numMfmaPerIter - 1)
+      barrierMfmaIndex = numMfmaPerIter*(state["LoopIters"]-numItersPLR+1) - numMfmaForNextLoopLR - 1 if numItersPLR else 0
+      numMfmaBetweenLWandBarrier = 2 if state["MatrixInstM"] == 32 else 3
+      lwEndMfmaIndex = max(barrierMfmaIndex - numMfmaBetweenLWandBarrier,0) if numItersPLR else numMfmaPerIter*state["LoopIters"] - 1
+      #########
+      # Get localWriteStart
+      #########
+      if not state["1LDSBuffer"]:
+        # In PGR2, localWrites should be scheduled after globalReadInc
+        numGRIncInst = 12 if not state["StaggerU"] else 18
+        numInstPerMfma = max(roundUp(miLatencyLeft/2),1)
+        numMfmaToSched = roundUp(numGRIncInst/numInstPerMfma)
+        lwStartMfmaIndex = 1 + numMfmaToSched
+      else:
+        # for 1LDSB, we have to issue localwrites after localreads
+        # we have enough vgprBuffer to schedule localRead in the front of loop
+        if numVgprBuffer == state["LoopIters"]:
+          # fp16 or bf16, we read 1 element to vgprBuffer the other element to tempVgpr.
+          # since each iteration shares same tempVgpr, only read-to-vgprBuffer can
+          # be scheduled in the front of loop.
+          # localwrite have to start after last read-to-tempVgpr.
+          if numReadPerVectorA != 1 or numReadPerVectorB !=1:
+            numHalfReads = (numReadPerVectorA//2)*state["InnerUnroll"]*state["MIWaveTileA"] + (numReadPerVectorB//2)*state["InnerUnroll"]*state["MIWaveTileB"]
+            numMfmaForHalfRead = 1
+            latencyLeft = miLatencyLeft
+            for i in range(numHalfReads):
+              latencyLeft -= 2
+              if latencyLeft < 0:
+                numMfmaForHalfRead += 1
+                latencyLeft = max(miLatencyLeft - 2, 0)
+            lwStartMfmaIndex = numMfmaPerIter * (state["LoopIters"] - 1 - numItersPLR) + numMfmaForHalfRead
+          else:
+            numMfmaForCurrentLoopLR = 1
+            latencyLeft = miLatencyLeft
+            for u in range(state["LoopIters"] - numItersPLR):
+              doReadA = (u < state["LoopIters"]//numIterPerCoalescedReadA - numItersPLR)
+              doReadB = (u < state["LoopIters"]//numIterPerCoalescedReadB - numItersPLR)
+              # ds_read[A][0]
+              for i in range(numReadPerVectorA * doReadA):
+                latencyLeft -= issueLatencyA*2
+                if latencyLeft < 0:
+                  numMfmaForCurrentLoopLR += 1
+                  latencyLeft = max(miLatencyLeft - issueLatencyA*2,0)
+              # ds_read[B][0]
+              for i in range(numReadPerVectorB * doReadB):
+                latencyLeft -= issueLatencyB*2
+                if latencyLeft < 0:
+                  numMfmaForCurrentLoopLR += 1
+                  latencyLeft = max(miLatencyLeft - issueLatencyB*2,0)
+              # ds_read[A][1:]
+              for i in range((numReadsPerIterA - numReadPerVectorA) * doReadA):
+                latencyLeft -= issueLatencyA*2
+                if latencyLeft < 0:
+                  numMfmaForCurrentLoopLR += 1
+                  latencyLeft = max(miLatencyLeft - issueLatencyA*2,0)
+              # ds_read[B][1:]
+              for i in range((numReadsPerIterB - numReadPerVectorB) * doReadB):
+                latencyLeft -= issueLatencyB*2
+                if latencyLeft < 0:
+                  numMfmaForCurrentLoopLR += 1
+                  latencyLeft = max(miLatencyLeft - issueLatencyB*2,0)
+            lwStartMfmaIndex = numMfmaForCurrentLoopLR
+        else:
+          lwStartMfmaIndex = numMfmaPerIter * (state["LoopIters"] - 1 - numItersPLR) + numMfmaForLR
         # to calculate number of mfma we need to wait before data arrive from lds to vgpr.
         # latency: 40 quad-cycle for 4 word, 20 quad-cycle for 2 word, 10 quad-cycle for 1 word / half word
-        numMfmaForNextLoopLR = numMfmaForLR
-        latencyForLR = roundUp(blockWidthB)*10
+        if numIterPerCoalescedReadB > numIterPerCoalescedReadA:
+          latencyForLR = roundUp(blockWidthA) * 10
+        else:
+          latencyForLR = roundUp(blockWidthB) * 10
         latencyForLR -= max(latencyLeft,0) # remaining latency in mfma
-        latencyForLR -= miLatency # last LR will have 1 mfma latency
         while latencyForLR > 0:
           latencyForLR -= miLatency
-          numMfmaForNextLoopLR += 1
-        # final index definition
-        numMfmaForNextLoopLR = min(numMfmaForNextLoopLR, numMfmaPerIter - 1)
-        barrierMfmaIndex = numMfmaPerIter*(state["LoopIters"]-numItersPLR+1) - numMfmaForNextLoopLR - 1 if numItersPLR else 0
-        numMfmaBetweenLWandBarrier = 2 if state["MatrixInstM"] == 32 else 3
-        lwEndMfmaIndex = max(barrierMfmaIndex - numMfmaBetweenLWandBarrier,0) if numItersPLR else numMfmaPerIter*state["LoopIters"] - 1
-        #########
-        # Get localWriteStart
-        #########
-        if not state["1LDSBuffer"]:
-          # In PGR2, localWrites should be scheduled after globalReadInc
-          numGRIncInst = 12 if not state["StaggerU"] else 18
-          numInstPerMfma = max(roundUp(miLatencyLeft/2),1)
-          numMfmaToSched = roundUp(numGRIncInst/numInstPerMfma)
-          lwStartMfmaIndex = 1 + numMfmaToSched
-        else:
-          # for 1LDSB, we have to issue localwrites after localreads
-          # we have enough vgprBuffer to schedule localRead in the front of loop
-          if numVgprBuffer == state["LoopIters"]:
-            # fp16 or bf16, we read 1 element to vgprBuffer the other element to tempVgpr.
-            # since each iteration shares same tempVgpr, only read-to-vgprBuffer can 
-            # be scheduled in the front of loop.
-            # localwrite have to start after last read-to-tempVgpr.
-            if numReadPerVectorA != 1 or numReadPerVectorB !=1:
-              numHalfReads = (numReadPerVectorA//2)*state["InnerUnroll"]*state["MIWaveTileA"] + (numReadPerVectorB//2)*state["InnerUnroll"]*state["MIWaveTileB"]
-              numMfmaForHalfRead = 1
-              latencyLeft = miLatencyLeft
-              for i in range(numHalfReads):
-                latencyLeft -= 2
-                if latencyLeft < 0:
-                  numMfmaForHalfRead += 1
-                  latencyLeft = max(miLatencyLeft - 2, 0)
-              lwStartMfmaIndex = numMfmaPerIter * (state["LoopIters"] - 1 - numItersPLR) + numMfmaForHalfRead
-            else:
-              numMfmaForCurrentLoopLR = 1
-              latencyLeft = miLatencyLeft
-              for u in range(state["LoopIters"] - numItersPLR):
-                doReadA = (u < state["LoopIters"]//numIterPerCoalescedReadA - numItersPLR)
-                doReadB = (u < state["LoopIters"]//numIterPerCoalescedReadB - numItersPLR)
-                # ds_read[A][0]
-                for i in range(numReadPerVectorA * doReadA):
-                  latencyLeft -= issueLatencyA*2
-                  if latencyLeft < 0:
-                    numMfmaForCurrentLoopLR += 1
-                    latencyLeft = max(miLatencyLeft - issueLatencyA*2,0)
-                # ds_read[B][0]
-                for i in range(numReadPerVectorB * doReadB):
-                  latencyLeft -= issueLatencyB*2
-                  if latencyLeft < 0:
-                    numMfmaForCurrentLoopLR += 1
-                    latencyLeft = max(miLatencyLeft - issueLatencyB*2,0)
-                # ds_read[A][1:]
-                for i in range((numReadsPerIterA - numReadPerVectorA) * doReadA):
-                  latencyLeft -= issueLatencyA*2
-                  if latencyLeft < 0:
-                    numMfmaForCurrentLoopLR += 1
-                    latencyLeft = max(miLatencyLeft - issueLatencyA*2,0)
-                # ds_read[B][1:]
-                for i in range((numReadsPerIterB - numReadPerVectorB) * doReadB):
-                  latencyLeft -= issueLatencyB*2
-                  if latencyLeft < 0:
-                    numMfmaForCurrentLoopLR += 1
-                    latencyLeft = max(miLatencyLeft - issueLatencyB*2,0)
-              lwStartMfmaIndex = numMfmaForCurrentLoopLR
-          else:
-            lwStartMfmaIndex = numMfmaPerIter * (state["LoopIters"] - 1 - numItersPLR) + numMfmaForLR
-          # to calculate number of mfma we need to wait before data arrive from lds to vgpr.
-          # latency: 40 quad-cycle for 4 word, 20 quad-cycle for 2 word, 10 quad-cycle for 1 word / half word
-          if numIterPerCoalescedReadB > numIterPerCoalescedReadA:
-            latencyForLR = roundUp(blockWidthA) * 10
-          else:
-            latencyForLR = roundUp(blockWidthB) * 10
-          latencyForLR -= max(latencyLeft,0) # remaining latency in mfma
-          while latencyForLR > 0:
-            latencyForLR -= miLatency
-            lwStartMfmaIndex += 1
-        #########
-        # Get localWritePerMfma
-        #########
-        oldValue = 0
-        newValue = 100
-        writesToSched = (numLoadsA+numLoadsB-1)*100
-        loop = 0
-        if lwStartMfmaIndex > lwEndMfmaIndex:
-          lwStartMfmaIndex = lwEndMfmaIndex
-        numMfmaCanSched = lwEndMfmaIndex - lwStartMfmaIndex + 1
-        while oldValue != newValue and loop < 10:
-          loop += 1
-          oldValue = newValue
-          newValue = roundUp((writesToSched+1 + oldValue + oldValue%100 - (writesToSched+1) % oldValue)/numMfmaCanSched)
-        state["LocalWritePerMfma"] = newValue/100
+          lwStartMfmaIndex += 1
+      #########
+      # Get localWritePerMfma
+      #########
+      oldValue = 0
+      newValue = 100
+      writesToSched = (numLoadsA+numLoadsB-1)*100
+      loop = 0
+      if lwStartMfmaIndex > lwEndMfmaIndex:
+        lwStartMfmaIndex = lwEndMfmaIndex
+      numMfmaCanSched = lwEndMfmaIndex - lwStartMfmaIndex + 1
+      while oldValue != newValue and loop < 10:
+        loop += 1
+        oldValue = newValue
+        newValue = roundUp((writesToSched+1 + (oldValue - (writesToSched+1) % oldValue) + oldValue%100)/numMfmaCanSched)
+      localWritePerMfma = newValue/100
+      if state["PrefetchGlobalRead"] == 1 and state["1LDSBuffer"]:
+        state["LocalWritePerMfma"] = max(localWritePerMfma,1)
       else:
-        state["LocalWritePerMfma"] = 1
+        state["LocalWritePerMfma"] = localWritePerMfma
 
     if state["GlobalReadPerMfma"] > 1 and state["PrefetchGlobalRead"] == 2:
       reject(state, "GlobalReadPerMfma need to be 1 if PGR2")


### PR DESCRIPTION
## Reduce MFMA Bubbles
1. schedule globalReadInc code
2. schedule sync for 1LDSB

## Increase Memory Performance for PGR2
1. can schedule localread in the front of loop if vgprBuffer = iterations
2. widely distribute global read and localwrite in the loop with new parameters GRPM, LWPM

## New Parameters
### GlobalReadPerMfma (range from 0.01 to 5.00)
Example:
2 denotes to 2 globalReadInst per mfma
0.5 denotes to 0.5 globalReadInst per mfma, means 1 globalReadInst per 2 mfma
### LocalWritePerMfma (range from 0.01 to 5.00)
Example:
2 denotes to 2 localwrite per mfma
0.5 denotes to 0.5 localwrite per mfma, means 1 localwrite per 2 mfma