### PR TITLE
Reduce extended test count for RunGEMMKernelTests

### DIFF
--- a/HostLibraryTests/testlib/include/RunGEMMKernelTest_impl.hpp
+++ b/HostLibraryTests/testlib/include/RunGEMMKernelTest_impl.hpp
@@ -145,10 +145,6 @@ template <typename DeviceBackend>
 auto RunGEMMKernelTestParams<DeviceBackend>::TestProblemsExtended() -> std::vector<ProblemParams>
 {
     return std::vector<ProblemParams>{
-
-        TestInterface::RandomGEMMParams,
-        TestInterface::RandomGEMMParams,
-        TestInterface::RandomGEMMParams,
         TestInterface::RandomGEMMParams,
         TestInterface::RandomGEMMParams,
         TestInterface::RandomGEMMParams,


### PR DESCRIPTION
- CI is hovering around 7.5 to 8 hrs for extended tests, which tends to time out randomly. 
- Goal is to reduce them to ~ 7hrs