### PR TITLE
fix large K correctness issue

### DIFF
--- a/Tensile/Tests/extended/bufferload_offset/rocblas_dgemm_bufferload_limit.yaml
+++ b/Tensile/Tests/extended/bufferload_offset/rocblas_dgemm_bufferload_limit.yaml
@@ -115,6 +115,22 @@ BenchmarkProblems:
         - ProblemSizes:
           - Range: [ [16], [16], [1], [16777216] ]  # strideA = 16777216, should fail on MT0 >= 32 (For tensorA-T)  # strideB = 16777216, should fail on MT1 >= 32 (For tensorB-N)
 
+    - BenchmarkCommonParameters:
+      BenchmarkFinalParameters:
+      ForkParameters:
+        - EdgeType: [ShiftPtr]
+        - KernelLanguage: [Assembly]
+        - ThreadTile:
+          - [4, 4]
+        - WorkGroup:
+          - [16, 16, 1]
+        - DepthU: [4]
+        - GlobalSplitU: [1, 10]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [250, 250, 1, 8000000]
+
   ########################################
   # TT / TLUA = 0, TLUB = 1
   ########################################


### PR DESCRIPTION
1. non-power-of-2 GSU
  non-power-2 of GSU need divide operation.
  LargeK will make salu divide overflow
  use valu to handle non-power-2 of GSU case.

2. set buffer limit to ffffffff