### PR TITLE
don't allocate vgpr in globalWriteBatch

### DIFF
--- a/Tensile/Tests/extended/bufferload_offset/rocblas_dgemm_bufferload_limit.yaml
+++ b/Tensile/Tests/extended/bufferload_offset/rocblas_dgemm_bufferload_limit.yaml
@@ -129,7 +129,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [250, 250, 1, 8000000]
+          - Exact: [80, 80, 1, 8000000]
 
   ########################################
   # TT / TLUA = 0, TLUB = 1


### PR DESCRIPTION
globalWriteBatch will allocate most of vgpr in order to do batch write.
So allocate vgpr in globalWriteBatch is easily to met vpgr overflow.
We should allocate all needed vgpr outside of globalWriteBatch.