### PR TITLE
let mfma half and i8 use vectorwidth 1

### DIFF
--- a/Tensile/Configs/mfma/mfma_igemm_lite_test.yaml
+++ b/Tensile/Configs/mfma/mfma_igemm_lite_test.yaml
@@ -65,7 +65,6 @@ BenchmarkProblems:
           - [ 4, 4 ]
         - WorkGroup:
           - [ 16, 16, 1 ]
-
         - PrefetchGlobalRead: [1,2]
         - PrefetchLocalRead: [1,5,9]
         - DepthU: [32,64]


### PR DESCRIPTION
let fp16/BF16/i* run with vectorwidth 1, so we can use 32x32 MT for MFMA SourceSwap.
MFMA non-SourceSwap doesn's use vectorwidth.
MFMA SourceSwap use vectorwidth only in M dimension.