### PR TITLE
Aldebaran dgemm misc optimization

### DIFF
--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -1658,7 +1658,7 @@ def GetArchCaps(isaVersion):
   rv["SeparateVscnt"]    = isaVersion[0] == 10
   rv["CMPXWritesSGPR"]   = isaVersion[0] != 10
   rv["HasWave32"]        = isaVersion[0] == 10
-  rv["HasVmAcc"]         = (isaVersion==(9,0,10))
+  rv["HasAccCD"]         = (isaVersion==(9,0,10))
 
   return rv
 

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -887,6 +887,10 @@ validParameters = {
     # There are index or address calculation between global instructions.
     # issue global instruction b2b has better performance
     "GroupLoadStore":             [False, True],
+    #
+    # In order to remove the copying from Acc vgpr to Arch vgpr, only use Arch vgprs for v_mfma_xxx.
+    # Only support for kernel whose totalVgpr counts less than 256 and gcn that has control bit ACC_CD.
+    "MIArchVgpr":               [False, True],
 
     # Disable overlapping AB-tile vgpr and read/write addr vgprs with C-tile vgprs
     # Valid only for MatrixInstruction enabled kernels, which by default overlaps
@@ -1272,6 +1276,7 @@ defaultBenchmarkCommonParameters = [
     {"NumElementsPerBatchStore":  [ 0 ] },
     {"StoreSyncOpt":              [ 0 ] },
     {"GroupLoadStore":            [ False ] },
+    {"MIArchVgpr":                [ False ] },
     ]
 # benchmark these solution independently
 defaultForkParameters = []

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -1653,6 +1653,7 @@ def GetArchCaps(isaVersion):
   rv["SeparateVscnt"]    = isaVersion[0] == 10
   rv["CMPXWritesSGPR"]   = isaVersion[0] != 10
   rv["HasWave32"]        = isaVersion[0] == 10
+  rv["HasVmAcc"]         = (isaVersion==(9,0,10))
 
   return rv
 

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -6478,6 +6478,8 @@ class KernelWriterAssembly(KernelWriter):
     if prefetch:
       kStr += self.checkLastIter(kernel)
       if not isPap:
+        if kernel["StorePriorityOpt"]:
+          kStr += inst("s_setprio 0", "optimization store")
         if self.doShadowInit:
           kStr += inst("s_cbranch_scc1 %s"\
               % self.getNamedLabel("ShadowInitStart"), \

--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -3299,6 +3299,13 @@ class Solution:
         reject(state, "SourceSwap not compatibile with StoreRemap")
         return
 
+    # check if need to use lds init Acc vgprs
+    state["LdsInitCVgprs"] = False
+    if globalParameters["ArchCaps"][globalParameters["CurrentISA"]]["HasVmAcc"] and \
+         state["EnableMatrixInstruction"] and state["StorePriorityOpt"] and \
+         state["ProblemType"]["DataType"].isDouble():
+      state["LdsInitCVgprs"] = True
+
     if state["AtomicAddC"]:
       if not state["ProblemType"]["DataType"].isDouble():
         reject(state, "AtomicAddC currently only available for dgemm")

--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -3293,15 +3293,21 @@ class Solution:
 
     # check if need to use lds init Acc vgprs
     state["LdsInitCVgprs"] = False
-    if globalParameters["ArchCaps"][globalParameters["CurrentISA"]]["HasVmAcc"] and \
+    if globalParameters["ArchCaps"][globalParameters["CurrentISA"]]["HasAccCD"] and \
          state["EnableMatrixInstruction"] and state["StorePriorityOpt"] and \
          state["ProblemType"]["DataType"].isDouble():
       state["LdsInitCVgprs"] = True
 
     if state["MIArchVgpr"]:
-      if not globalParameters["ArchCaps"][globalParameters["CurrentISA"]]["HasVmAcc"] or \
+      if not globalParameters["ArchCaps"][globalParameters["CurrentISA"]]["HasAccCD"] or \
          not state["EnableMatrixInstruction"]:
         reject(state, "MIArchVgpr requires gcn support ACC_CD bit for MatrixInstruction")
+        return
+      if not (state["ProblemType"]["ComputeDataType"].isDouble() or \
+              state["ProblemType"]["ComputeDataType"].isSingle() or \
+              (state["ProblemType"]["ComputeDataType"].isHalf() and state["ProblemType"]["HighPrecisionAccumulate"]) or \
+              state["ProblemType"]["ComputeDataType"].isInt32()):
+        reject(state, "MIArchVgpr now only support fp64, fp32, fp16, int8 MatrixInstruction.")
         return
 
     if state["AtomicAddC"]:


### PR DESCRIPTION
Improve weighted performance of HPL Dgemm 512 sizes from **89.43%** to **91.94%**.
Trained HPL 512 sizes with both atomic and non-atomic, weighted performance can reach **93.07%**

Including below features:
1. **optSingleColVgpr** enhancement to reduce valu instructions
2. two low priority slot per unroll loop.
3. use lds to init Acc Registers to reduce valu instructions for 2 waves optimization cases.
4. set low priority beforw sgpr shadowinit of init wave to minimize the impact of unroll loop wave
5. new kernel parameter "**MIArchVgpr**" to let MatrixInstruction use arch vgpr only.
6. merge valu copy and computing alpha valu together as one valu for "MIArchVgpr" alpha case
7. Remove all handles for DisableVgprOverlapping.