### PR TITLE
Refactor vgpr occupancy calculation for Aldebaran's new hardware capability Unified Register Files 

### DIFF
--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -1653,12 +1653,13 @@ def GetAsmCaps(isaVersion):
 
 def GetArchCaps(isaVersion):
   rv = {}
-  rv["HasEccHalf"]       = (isaVersion==(9,0,6) or isaVersion==(9,0,8) or isaVersion==(9,0,10))
-  rv["Waitcnt0Disabled"] = (isaVersion == (9,0,8) or isaVersion==(9,0,10))
-  rv["SeparateVscnt"]    = isaVersion[0] == 10
-  rv["CMPXWritesSGPR"]   = isaVersion[0] != 10
-  rv["HasWave32"]        = isaVersion[0] == 10
-  rv["HasAccCD"]         = (isaVersion==(9,0,10))
+  rv["HasEccHalf"]         = (isaVersion==(9,0,6) or isaVersion==(9,0,8) or isaVersion==(9,0,10))
+  rv["Waitcnt0Disabled"]   = (isaVersion == (9,0,8) or isaVersion==(9,0,10))
+  rv["SeparateVscnt"]      = isaVersion[0] == 10
+  rv["CMPXWritesSGPR"]     = isaVersion[0] != 10
+  rv["HasWave32"]          = isaVersion[0] == 10
+  rv["HasAccCD"]           = (isaVersion==(9,0,10))
+  rv["ArchAccUnifiedRegs"] = (isaVersion==(9,0,10))
 
   return rv
 

--- a/Tensile/Components/Signature.py
+++ b/Tensile/Components/Signature.py
@@ -389,13 +389,11 @@ class SignatureCOV3(Signature):
         totalVgprs = writer.vgprPool.size()
         totalSgprs = writer.sgprPool.size()
 
-        # accumulator offset for gfx90a
+        # accumulator offset for Unified Register Files
         vgprCount = totalVgprs
-        if writer.version == (9,0,10):
-            agprStart = ceil(totalVgprs/4)*4
-            if writer.agprPool.size() != 0:
-                agprStart = ceil(totalVgprs/8)*8
-                vgprCount = agprStart + writer.agprPool.size()
+        if writer.archCaps["ArchAccUnifiedRegs"]:
+            agprStart = ceil(totalVgprs/8)*8
+            vgprCount = agprStart + writer.agprPool.size()
 
             tWord = ".amdhsa_accum_offset"
             kStr += "  %s %u // accvgpr offset%s" % (tWord, agprStart, writer.endLine)

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -400,31 +400,6 @@ class ZeroPadReg:
   def isMatch(self, perp, sPerp, para, sPara):
     return self.perp==perp and self.sPerp==sPerp and self.para==para and self.sPara==sPara
 
-class VgprOccupancyCurve:
-  def __init__(self):
-    self._vgprOccupancy = [0]*(256+1)
-    for i in range(0,   24+1): self._vgprOccupancy[i] = 10
-    for i in range(25,  28+1): self._vgprOccupancy[i] = 9
-    for i in range(29,  32+1): self._vgprOccupancy[i] = 8
-    for i in range(33,  36+1): self._vgprOccupancy[i] = 7
-    for i in range(37,  40+1): self._vgprOccupancy[i] = 6
-    for i in range(41,  48+1): self._vgprOccupancy[i] = 5
-    for i in range(49,  64+1): self._vgprOccupancy[i] = 4
-    for i in range(65,  84+1): self._vgprOccupancy[i] = 3
-    for i in range(85, 128+1): self._vgprOccupancy[i] = 2
-    for i in range(129,256+1): self._vgprOccupancy[i] = 1
-  def __call__(self, index):
-    if index < 0 or index > 256:
-      return 0
-    return self._vgprOccupancy[index]
-  def __getitem__(self, item):
-    return self(item)
-  def __len__(self):
-    return len(self._vgprOccupancy)
-
-vgprOccupancy = VgprOccupancyCurve()
-
-
 class PreLoopVmcntCase(Enum):
   Undefined = 0
   Basic_Load = 1
@@ -556,6 +531,7 @@ class KernelWriterAssembly(KernelWriter):
     self.maxVgprs = 256
     # max allowed is 112 out of 112 , 6 is used by hardware 4 SGPRs are wasted
     self.maxSgprs = 102
+    self.maxOccupancy = 10
 
     self.endLine = "\n"
     self.syncStr = "s_barrier"
@@ -633,39 +609,55 @@ class KernelWriterAssembly(KernelWriter):
 
     return rv
 
+  def getVgprOccupancy(self, numThreads, vgprs, unifiedVgprRegs=False):
+    multiplier = int(ceil(max(numThreads, 256) / 256.0)) # example: wg=512 multiplier=2, 1024=4
+    maxOccupancy = self.maxOccupancy//multiplier
+
+    vgprAllocateAligned = 4    if not unifiedVgprRegs else 8
+    totalVgprs = self.maxVgprs if not unifiedVgprRegs else self.maxVgprs*2
+    vgprsAligned = int(ceil(vgprs/vgprAllocateAligned))*vgprAllocateAligned
+    vgprsAligned *= multiplier
+
+    if   vgprsAligned > totalVgprs:  return 0
+    elif vgprsAligned < 1:           return maxOccupancy
+    occupancy = min(totalVgprs//vgprsAligned, maxOccupancy)
+
+    #print("vgprs = ", vgprs, "vgprsAligned = ", vgprsAligned, "unifiedVgprRegs = " ,unifiedVgprRegs, "Occupancy = ", occupancy)
+
+    return occupancy
+
   ########################################
-  @staticmethod
-  def getOccupancy(numThreads, vgprs, ldsSize, accvgprs=0):
-    multiplier = int(ceil(max(numThreads, 256) / 256.0))
-    # example: wg=512 multiplier=2, 1024=4
+  def getOccupancy(self, numThreads, vgprs, ldsSize, accvgprs=0, unifiedVgprRegs=False):
 
-    ldsLimitedOccupancy = KernelWriterAssembly.getLdsLimitedOccupancy(ldsSize)
+    ldsLimitedOccupancy = self.getLdsLimitedOccupancy(ldsSize)
 
-    vgprs *= multiplier
-    vgprLimitedOccupancy =  vgprOccupancy[vgprs]
-
-    accvgprs *= multiplier
-    accvgprLimitedOccupancy =  vgprOccupancy[accvgprs]
+    if not unifiedVgprRegs:
+      vgprLimitedOccupancy    = self.getVgprOccupancy(numThreads, vgprs,          unifiedVgprRegs)
+      accvgprLimitedOccupancy = self.getVgprOccupancy(numThreads, accvgprs,       unifiedVgprRegs)
+    else:
+      vgprLimitedOccupancy    = self.getVgprOccupancy(numThreads, vgprs+accvgprs, unifiedVgprRegs)
+      accvgprLimitedOccupancy = vgprLimitedOccupancy
 
     return min(ldsLimitedOccupancy, vgprLimitedOccupancy, accvgprLimitedOccupancy)
 
   # TODO: also consider sgpr
-  @staticmethod
-  def getMaxRegsForOccupancy(numThreads, vgprs, ldsSize, accvgprs=0):
-    multiplier = int(ceil(max(numThreads, 256) / 256.0))
-    vgprs*=multiplier # convert to per simd vgpr count
-                      # eg, 512-thread wg means 2 waves per simd, meaning vgpr count per simd is 2x the vgpr count per wave
+  def getMaxRegsForOccupancy(self, numThreads, vgprs, ldsSize, accvgprs=0, unifiedVgprRegs=False):
     lastVgprs = vgprs
-    initOccupancy = KernelWriterAssembly.getOccupancy(numThreads, vgprs, ldsSize, accvgprs)
-    while vgprs < len(vgprOccupancy):
+    considerAccVgprs = 0       if not unifiedVgprRegs else accvgprs
+    totalVgprs = self.maxVgprs if not unifiedVgprRegs else self.maxVgprs*2
+
+    initOccupancy = self.getOccupancy(numThreads, vgprs, ldsSize, accvgprs, unifiedVgprRegs)
+    if initOccupancy == 0: return lastVgprs
+
+    while (vgprs + considerAccVgprs) < totalVgprs and vgprs < self.maxVgprs:
       vgprs += 1
-      if vgprOccupancy[vgprs] >= initOccupancy:
+      if self.getVgprOccupancy(numThreads, vgprs + considerAccVgprs, unifiedVgprRegs) >= initOccupancy:
         lastVgprs = vgprs
         next
       else:
         break
 
-    return lastVgprs//multiplier # convert back to per wave vgpr count
+    return lastVgprs
 
   @staticmethod
   def getLdsLimitedOccupancy(ldsSize):
@@ -1122,6 +1114,10 @@ class KernelWriterAssembly(KernelWriter):
       defaultIsa = (9,0,0)
       print("warning: ISA:", self.version, " is not supported; overriding with ", defaultIsa)
       self.version = defaultIsa
+
+    self.unifiedVgprRegs = False
+    if globalParameters["ArchCaps"][self.version]["ArchAccUnifiedRegs"]:
+      self.unifiedVgprRegs = True
 
     if kernel["EnableMatrixInstruction"]:
       if (kernel["ProblemType"]["DataType"].MIOutputTypeNameAbbrev() == 'f64') and (not self.asmCaps["HasMFMA_f64"]):
@@ -10380,7 +10376,8 @@ class KernelWriterAssembly(KernelWriter):
 
         #print self.vgprPool.state()
         # Use VGPR up to next occupancy threshold:
-        maxVgprs = self.getMaxRegsForOccupancy(kernel["NumThreads"], self.vgprPool.size(), self.getLdsSize(kernel), self.agprPool.size())
+        maxVgprs = self.getMaxRegsForOccupancy(kernel["NumThreads"], self.vgprPool.size(), \
+                                               self.getLdsSize(kernel), self.agprPool.size(), self.unifiedVgprRegs)
         if self.serializedStore: # get aggresive when serializedStore is on; not necessarily exclusive to this parameter
           len(elements[edgeI])
           tl = []
@@ -10406,9 +10403,10 @@ class KernelWriterAssembly(KernelWriter):
           print("numVgprAvailable=", numVgprAvailable, "minElements=", minElements, "minNeeded=", minNeeded)
         if numVgprAvailable < minNeeded:
           gwvwOrig = gwvw
-          currentOccupancy = self.getOccupancy(kernel["NumThreads"], self.getLdsSize(kernel), self.vgprPool.size(), self.agprPool.size())
+          currentOccupancy = self.getOccupancy(kernel["NumThreads"], self.getLdsSize(kernel), \
+              self.vgprPool.size(), self.agprPool.size(), self.unifiedVgprRegs)
           futureOccupancy = self.getOccupancy(kernel["NumThreads"], self.getLdsSize(kernel), \
-              self.vgprPool.size() - numVgprAvailable + minNeeded, self.agprPool.size())
+              self.vgprPool.size() - numVgprAvailable + minNeeded, self.agprPool.size(), self.unifiedVgprRegs)
 
           if shrinkDb:
             print("currentOccupancy=%u futureOccupancy=%u VGPRs=%u numVgprAvail=%u vgprPerElem=%u" \
@@ -11805,7 +11803,8 @@ class KernelWriterAssembly(KernelWriter):
       self.overflowedResources = 2
 
     if kernel["ScheduleIterAlg"] == 2 and \
-        self.getOccupancy(kernel["NumThreads"], self.vgprPool.size(), self.getLdsSize(kernel), self.agprPool.size()) < 2:
+        self.getOccupancy(kernel["NumThreads"], self.vgprPool.size(), \
+        self.getLdsSize(kernel), self.agprPool.size(), self.unifiedVgprRegs) < 2:
       self.overflowedResources = 6
 
     vgprPerCU = 65536

--- a/Tensile/Tests/unit/test_KernelWriterAssembly.py
+++ b/Tensile/Tests/unit/test_KernelWriterAssembly.py
@@ -22,46 +22,117 @@
 from Tensile.KernelWriterAssembly import KernelWriterAssembly
 
 def test_occupancy():
+    kw = KernelWriterAssembly("","")
     # numThreads = 256
-    assert KernelWriterAssembly.getOccupancy(256,  10, 65536,   0) == 1
-    assert KernelWriterAssembly.getOccupancy(256,  10, 16384, 128) == 2
-    assert KernelWriterAssembly.getOccupancy(256,  65,  8192,  64) == 3
-    assert KernelWriterAssembly.getOccupancy(256,  10, 65536) == 1
-    assert KernelWriterAssembly.getOccupancy(256,  10, 32768) == 2
-    assert KernelWriterAssembly.getOccupancy(256, 129, 32768) == 1
-    assert KernelWriterAssembly.getOccupancy(256,  10, 16384) == 4
-    assert KernelWriterAssembly.getOccupancy(256, 256, 32768) == 1
+    assert kw.getOccupancy(256,  10, 65536,   0) == 1
+    assert kw.getOccupancy(256,  10, 16384, 128) == 2
+    assert kw.getOccupancy(256,  65,  8192,  64) == 3
+    assert kw.getOccupancy(256,  10, 65536) == 1
+    assert kw.getOccupancy(256,  10, 32768) == 2
+    assert kw.getOccupancy(256, 129, 32768) == 1
+    assert kw.getOccupancy(256,  10, 16384) == 4
+    assert kw.getOccupancy(256, 256, 32768) == 1
 
     # numThreads = 512
-    assert KernelWriterAssembly.getOccupancy(512,  10, 65536,   0) == 1
-    assert KernelWriterAssembly.getOccupancy(512,  10, 16384, 128) == 1
-    assert KernelWriterAssembly.getOccupancy(512,  65,  8192,  64) == 1
-    assert KernelWriterAssembly.getOccupancy(512,  10, 65536) == 1
-    assert KernelWriterAssembly.getOccupancy(512,  10, 32768) == 2
-    assert KernelWriterAssembly.getOccupancy(512, 129, 32768) == 0
-    assert KernelWriterAssembly.getOccupancy(512,  10, 16384) == 4
-    assert KernelWriterAssembly.getOccupancy(512, 256, 32768) == 0
+    assert kw.getOccupancy(512,  10, 65536,   0) == 1
+    assert kw.getOccupancy(512,  10, 16384, 128) == 1
+    assert kw.getOccupancy(512,  65,  8192,  64) == 1
+    assert kw.getOccupancy(512,  10, 65536) == 1
+    assert kw.getOccupancy(512,  10, 32768) == 2
+    assert kw.getOccupancy(512, 129, 32768) == 0
+    assert kw.getOccupancy(512,  10, 16384) == 4
+    assert kw.getOccupancy(512, 256, 32768) == 0
+    assert kw.getOccupancy(512,  13,  1024) == 5
+
+    #----------- unifiedVgprRegs = True ---------------
+    # numThreads = 256
+    assert kw.getOccupancy(256, 256, 32768, 128, True) ==  1
+    assert kw.getOccupancy(256, 128, 65536, 128, True) ==  1
+    assert kw.getOccupancy(256, 256, 32768,   0, True) ==  2
+    assert kw.getOccupancy(256, 128, 32768, 128, True) ==  2
+    assert kw.getOccupancy(256, 128,  1024, 128, True) ==  2
+    assert kw.getOccupancy(256,  97,  8192,   0, True) ==  4
+    assert kw.getOccupancy(256,  65,  8192,  32, True) ==  4
+    assert kw.getOccupancy(256,  64,  8192,  32, True) ==  5
+    assert kw.getOccupancy(256,  65,  8192,   0, True) ==  7
+    assert kw.getOccupancy(256,   0,  8192,  64, True) ==  8
+    assert kw.getOccupancy(256,  24,  8192,  24, True) ==  8
+    assert kw.getOccupancy(256,  49,  1024,   0, True) ==  9
+    assert kw.getOccupancy(256,  24,  1024,  24, True) == 10
+    assert kw.getOccupancy(256,  48,  1024,   0, True) == 10
+    assert kw.getOccupancy(256,   3,  1024,  16, True) == 10
+
+    # numThreads = 512
+    assert kw.getOccupancy(512, 256, 32768, 128, True) ==  0
+    assert kw.getOccupancy(512, 128, 65536, 128, True) ==  1
+    assert kw.getOccupancy(512, 256, 32768,   0, True) ==  1
+    assert kw.getOccupancy(512, 128, 32768, 128, True) ==  1
+    assert kw.getOccupancy(512, 128,  1024, 128, True) ==  1
+    assert kw.getOccupancy(512,  97,  8192,   0, True) ==  2
+    assert kw.getOccupancy(512,  65,  8192,  32, True) ==  2
+    assert kw.getOccupancy(512,  64,  8192,  32, True) ==  2
+    assert kw.getOccupancy(512,  65,  8192,   0, True) ==  3
+    assert kw.getOccupancy(512,   0,  8192,  64, True) ==  4
+    assert kw.getOccupancy(512,  49,  1024,   0, True) ==  4
+    assert kw.getOccupancy(512,  24,  1024,  24, True) ==  5
+    assert kw.getOccupancy(512,  48,  1024,   0, True) ==  5
+    assert kw.getOccupancy(512,   3,  1024,  16, True) ==  5
 
 def test_max_regs():
-    # numThreads = 256
-    assert KernelWriterAssembly.getMaxRegsForOccupancy(256,  10, 65536,   0) == 256
-    assert KernelWriterAssembly.getMaxRegsForOccupancy(256,  10, 16384, 128) == 128
-    assert KernelWriterAssembly.getMaxRegsForOccupancy(256,  65,  8192,  64) == 84
-    assert KernelWriterAssembly.getMaxRegsForOccupancy(256,  10, 65536) == 256
-    assert KernelWriterAssembly.getMaxRegsForOccupancy(256,  10, 32768) == 128
-    assert KernelWriterAssembly.getMaxRegsForOccupancy(256, 129, 32768) == 256
-    assert KernelWriterAssembly.getMaxRegsForOccupancy(256,  10, 16384) == 64
-    assert KernelWriterAssembly.getMaxRegsForOccupancy(256, 256, 32768) == 256
+    kw = KernelWriterAssembly("","")
+    assert kw.getMaxRegsForOccupancy(256,  10, 65536,   0) == 256
+    assert kw.getMaxRegsForOccupancy(256,  10, 16384, 128) == 128
+    assert kw.getMaxRegsForOccupancy(256,  65,  8192,  64) == 84
+    assert kw.getMaxRegsForOccupancy(256,  10, 65536) == 256
+    assert kw.getMaxRegsForOccupancy(256,  10, 32768) == 128
+    assert kw.getMaxRegsForOccupancy(256, 129, 32768) == 256
+    assert kw.getMaxRegsForOccupancy(256,  10, 16384) == 64
+    assert kw.getMaxRegsForOccupancy(256, 256, 32768) == 256
 
     # numThreads = 512
-    assert KernelWriterAssembly.getMaxRegsForOccupancy(512,  10, 65536,   0) == 128
-    assert KernelWriterAssembly.getMaxRegsForOccupancy(512,  10, 16384, 128) == 128
-    assert KernelWriterAssembly.getMaxRegsForOccupancy(512,  65,  8192,  64) == 128
-    assert KernelWriterAssembly.getMaxRegsForOccupancy(512,  10, 65536) == 128
-    assert KernelWriterAssembly.getMaxRegsForOccupancy(512,  10, 32768) == 64
-    assert KernelWriterAssembly.getMaxRegsForOccupancy(512, 129, 32768) == 129
-    assert KernelWriterAssembly.getMaxRegsForOccupancy(512,  10, 16384) == 32
-    assert KernelWriterAssembly.getMaxRegsForOccupancy(512, 256, 32768) == 256
+    assert kw.getMaxRegsForOccupancy(512,  10, 65536,   0) == 128
+    assert kw.getMaxRegsForOccupancy(512,  10, 16384, 128) == 128
+    assert kw.getMaxRegsForOccupancy(512,  65,  8192,  64) == 128
+    assert kw.getMaxRegsForOccupancy(512,  10, 65536) == 128
+    assert kw.getMaxRegsForOccupancy(512,  10, 32768) ==  64
+    assert kw.getMaxRegsForOccupancy(512, 129, 32768) == 129
+    assert kw.getMaxRegsForOccupancy(512,  10, 16384) ==  32
+    assert kw.getMaxRegsForOccupancy(512, 256, 32768) == 256
+    assert kw.getMaxRegsForOccupancy(512,  13,  1024) ==  24
+
+    #----------- unifiedVgprRegs = True ---------------
+    # numThreads = 256
+    assert kw.getMaxRegsForOccupancy(256, 256, 32768, 128, True) ==  256
+    assert kw.getMaxRegsForOccupancy(256, 128, 65536, 128, True) ==  256
+    assert kw.getMaxRegsForOccupancy(256, 256, 32768,   0, True) ==  256
+    assert kw.getMaxRegsForOccupancy(256, 128, 32768, 128, True) ==  128
+    assert kw.getMaxRegsForOccupancy(256, 128,  1024, 128, True) ==  128
+    assert kw.getMaxRegsForOccupancy(256,  97,  8192,   0, True) ==  128
+    assert kw.getMaxRegsForOccupancy(256,  65,  8192,  32, True) ==   96
+    assert kw.getMaxRegsForOccupancy(256,  64,  8192,  32, True) ==   64
+    assert kw.getMaxRegsForOccupancy(256,  65,  8192,   0, True) ==   72
+    assert kw.getMaxRegsForOccupancy(256,   0,  8192,  64, True) ==    0
+    assert kw.getMaxRegsForOccupancy(256,  24,  8192,  24, True) ==   40
+    assert kw.getMaxRegsForOccupancy(256,  49,  1024,   0, True) ==   56
+    assert kw.getMaxRegsForOccupancy(256,  24,  1024,  24, True) ==   24
+    assert kw.getMaxRegsForOccupancy(256,  48,  1024,   0, True) ==   48
+    assert kw.getMaxRegsForOccupancy(256,   3,  1024,  16, True) ==   32
+
+    # numThreads = 512
+    assert kw.getMaxRegsForOccupancy(512, 256, 32768, 128, True) ==  256
+    assert kw.getMaxRegsForOccupancy(512, 128, 65536, 128, True) ==  128
+    assert kw.getMaxRegsForOccupancy(512, 256, 32768,   0, True) ==  256
+    assert kw.getMaxRegsForOccupancy(512, 128, 32768, 128, True) ==  128
+    assert kw.getMaxRegsForOccupancy(512, 128,  1024, 128, True) ==  128
+    assert kw.getMaxRegsForOccupancy(512,  97,  8192,   0, True) ==  128
+    assert kw.getMaxRegsForOccupancy(512,  65,  8192,  32, True) ==   96
+    assert kw.getMaxRegsForOccupancy(512,  64,  8192,  32, True) ==   96
+    assert kw.getMaxRegsForOccupancy(512,  65,  8192,   0, True) ==   80
+    assert kw.getMaxRegsForOccupancy(512,   0,  8192,  64, True) ==    0
+    assert kw.getMaxRegsForOccupancy(512,  49,  1024,   0, True) ==   64
+    assert kw.getMaxRegsForOccupancy(512,  24,  1024,  24, True) ==   24
+    assert kw.getMaxRegsForOccupancy(512,  48,  1024,   0, True) ==   48
+    assert kw.getMaxRegsForOccupancy(512,   3,  1024,  16, True) ==   32
 
 # test_occupancy()
 # test_max_regs()


### PR DESCRIPTION
For UnifiedRegisterFiles, arch vgpr and acc vgpr share same pool of 512 registers.
This PR refactor the getOccupany calculation of KernelWriter and extend getOccupancy CI tests.