### PR TITLE
Fix merge.py keeping duplicate solutions

### DIFF
--- a/Tensile/Tests/unit/test_mergeLogic.py
+++ b/Tensile/Tests/unit/test_mergeLogic.py
@@ -22,6 +22,9 @@
 from Tensile.Utilities.merge import cmpHelper, fixSizeInconsistencies, removeUnusedKernels, mergeLogic
 import yaml, pytest
 
+# the merge scripts does not differentiate solutions based on index or name
+# so "DummyParam" is used to mark if solutions should be equal or not
+
 logicPrefix = r"""
 - DummyVersionRequirement
 - DummyLanguage
@@ -34,13 +37,13 @@ baseLogic=logicPrefix + r"""
 -
   - SolutionIndex: 2
     SolutionNameMin: InUseForSize256
-    InUseForSize256: 0
+    DummyParam: InUseForSize256
   - SolutionIndex: 1
     SolutionNameMin: UnusedSolution
-    UnusedSolution: 0
+    DummyParam: UnusedSolution
   - SolutionIndex: 0
     SolutionNameMin: InUseForSize128or64
-    InUseForSize128or64: 0
+    DummyParam: InUseForSize128or64
 - DummyIndexAssignment
 -
   - - [256, 256, 1, 256]
@@ -55,10 +58,10 @@ incLogic=logicPrefix + r"""
 -
   - SolutionIndex: 39
     SolutionNameMin: InUseForSize256or1024xxx
-    InUseForSize256or1024xxx: 0
+    DummyParam: InUseForSize256or1024xxx
   - SolutionIndex: 1
     SolutionNameMin: InUseForSize128xxx
-    InUseForSize128xxx: 0
+    DummyParam: InUseForSize128xxx
 - DummyIndexAssignment
 -
   - - [128, 128, 1, 128]
@@ -73,20 +76,20 @@ notUniqueSolution=logicPrefix+r"""
 -
   - SolutionIndex: 0
     SolutionNameMin: Kernel0
-    Kernel0: 0
+    DummyParam: Kernel0
   - SolutionIndex: 1
     SolutionNameMin: Kernel0
-    Kernel0: 0
+    DummyParam: Kernel0
 """
 
 uniqueSolution=logicPrefix+r"""
 -
   - SolutionIndex: 0
     SolutionNameMin: Kernel0
-    Kernel0: 0
+    DummyParam: Kernel0
   - SolutionIndex: 1
     SolutionNameMin: Kernel1
-    Kernel1: 0
+    DummyParam: Kernel1
 """
 
 notTrimmedSize=r"""
@@ -117,12 +120,12 @@ mfmaMergeBaseLogic=logicPrefix+r"""
 -
   - SolutionIndex: 0
     SolutionNameMin: MFMA_base
-    MFMA_base: 0
+    DummyParam: MFMA_base
     EnableMatrixInstruction: True
     MatrixInstruction: [16, 16, 4, 1]
   - SolutionIndex: 1
     SolutionNameMin: VALU_base
-    VALU_base: 0
+    DummyParam: VALU_base
     EnableMatrixInstruction: False
     MatrixInstruction: []
 - DummyIndexAssignment
@@ -132,12 +135,12 @@ mfmaMergeIncLogic=logicPrefix+r"""
 -
   - SolutionIndex: 0
     SolutionNameMin: MFMA_inc
-    MFMA_inc: 0
+    DummyParam: MFMA_inc
     EnableMatrixInstruction: True
     MatrixInstruction: [16, 16, 4, 1]
   - SolutionIndex: 1
     SolutionNameMin: VALU_inc
-    VALU_inc: 0
+    DummyParam: VALU_inc
     EnableMatrixInstruction: False
     MatrixInstruction: []
 - DummyIndexAssignment

--- a/Tensile/Tests/unit/test_mergeLogic.py
+++ b/Tensile/Tests/unit/test_mergeLogic.py
@@ -34,10 +34,13 @@ baseLogic=logicPrefix + r"""
 -
   - SolutionIndex: 2
     SolutionNameMin: InUseForSize256
+    InUseForSize256: 0
   - SolutionIndex: 1
     SolutionNameMin: UnusedSolution
+    UnusedSolution: 0
   - SolutionIndex: 0
     SolutionNameMin: InUseForSize128or64
+    InUseForSize128or64: 0
 - DummyIndexAssignment
 -
   - - [256, 256, 1, 256]
@@ -52,8 +55,10 @@ incLogic=logicPrefix + r"""
 -
   - SolutionIndex: 39
     SolutionNameMin: InUseForSize256or1024xxx
+    InUseForSize256or1024xxx: 0
   - SolutionIndex: 1
     SolutionNameMin: InUseForSize128xxx
+    InUseForSize128xxx: 0
 - DummyIndexAssignment
 -
   - - [128, 128, 1, 128]
@@ -68,16 +73,20 @@ notUniqueSolution=logicPrefix+r"""
 -
   - SolutionIndex: 0
     SolutionNameMin: Kernel0
+    Kernel0: 0
   - SolutionIndex: 1
     SolutionNameMin: Kernel0
+    Kernel0: 0
 """
 
 uniqueSolution=logicPrefix+r"""
 -
   - SolutionIndex: 0
     SolutionNameMin: Kernel0
+    Kernel0: 0
   - SolutionIndex: 1
     SolutionNameMin: Kernel1
+    Kernel1: 0
 """
 
 notTrimmedSize=r"""
@@ -108,10 +117,12 @@ mfmaMergeBaseLogic=logicPrefix+r"""
 -
   - SolutionIndex: 0
     SolutionNameMin: MFMA_base
+    MFMA_base: 0
     EnableMatrixInstruction: True
     MatrixInstruction: [16, 16, 4, 1]
   - SolutionIndex: 1
     SolutionNameMin: VALU_base
+    VALU_base: 0
     EnableMatrixInstruction: False
     MatrixInstruction: []
 - DummyIndexAssignment
@@ -121,10 +132,12 @@ mfmaMergeIncLogic=logicPrefix+r"""
 -
   - SolutionIndex: 0
     SolutionNameMin: MFMA_inc
+    MFMA_inc: 0
     EnableMatrixInstruction: True
     MatrixInstruction: [16, 16, 4, 1]
   - SolutionIndex: 1
     SolutionNameMin: VALU_inc
+    VALU_inc: 0
     EnableMatrixInstruction: False
     MatrixInstruction: []
 - DummyIndexAssignment

--- a/Tensile/Utilities/merge.py
+++ b/Tensile/Utilities/merge.py
@@ -68,12 +68,7 @@ def fixSizeInconsistencies(sizes, fileType):
     return sizes_, len(sizes_)
 
 # remove dict keys "SolutionIndex" and "SolutionNameMin" from dict
-# update dependant parameters if StaggerU == 0
 def cmpHelper(sol):
-    if sol["StaggerU"] == 0:
-        sol["StaggerUMapping"] = 0
-        sol["StaggerUStride"] = 0
-        sol["_staggerStrideShift"] = 0
     return {k:v for k, v in sol.items() if k!="SolutionIndex" and k!="SolutionNameMin"}
 
 def addKernel(solutionPool, solution):
@@ -90,6 +85,14 @@ def addKernel(solutionPool, solution):
         debug("...A new kernel has been added", end="")
     debug("({}) {}".format(index, solutionPool[index]["SolutionNameMin"] if "SolutionNameMin" in solutionPool[index] else "(SolutionName N/A)"))
     return solutionPool, index
+
+# update dependant parameters if StaggerU == 0
+def sanitizeSolutions(solList):
+    for sol in solList:
+        if sol.get("StaggerU") == 0:
+            sol["StaggerUMapping"] = 0
+            sol["StaggerUStride"] = 0
+            sol["_staggerStrideShift"] = 0
 
 def removeUnusedKernels(origData, prefix=""):
     origNumSolutions = len(origData[5])
@@ -305,6 +308,8 @@ def mergeLogic(origData, incData, forceMerge, trimSize=True, addSolutionTags=Fal
         [origData[7], origNumSizes] = fixSizeInconsistencies(origData[7], "base")
         [incData[7], incNumSizes] = fixSizeInconsistencies(incData[7], "incremental")
 
+    sanitizeSolutions(origData[5])
+    sanitizeSolutions(incData[5])
     origData, numOrigRemoved = removeUnusedKernels(origData, "Base logic file: ")
     incData, numIncRemoved = removeUnusedKernels(incData, "Inc logic file: ")
 

--- a/Tensile/Utilities/merge.py
+++ b/Tensile/Utilities/merge.py
@@ -67,9 +67,14 @@ def fixSizeInconsistencies(sizes, fileType):
         verbose(len(duplicates), "duplicate size(s) removed from", fileType, "logic file")
     return sizes_, len(sizes_)
 
-# remove dict key "SolutionIndex" from dict
+# remove dict keys "SolutionIndex" and "SolutionNameMin" from dict
+# update dependant parameters if StaggerU == 0
 def cmpHelper(sol):
-    return {k:v for k, v in sol.items() if k!="SolutionIndex"}
+    if sol["StaggerU"] == 0:
+        sol["StaggerUMapping"] = 0
+        sol["StaggerUStride"] = 0
+        sol["_staggerStrideShift"] = 0
+    return {k:v for k, v in sol.items() if k!="SolutionIndex" and k!="SolutionNameMin"}
 
 def addKernel(solutionPool, solution):
     for item in solutionPool:


### PR DESCRIPTION
For solutions where `StaggerU == 0`, we end up setting `StaggerUMapping`, `StaggerUStride`, and `_staggerStrideShift` all to zero also (see [lines 2646-2659 of SolutionStructs.py](https://github.com/ROCmSoftwarePlatform/Tensile/blob/develop/Tensile/SolutionStructs.py#L2646)). However, there are solutions in the logic files in rocBLAS that have `StaggerU == 0` and non-zero values for one or more of the other above parameters. This discrepancy can result in solutions being duplicated after using the merge scripts since the comparison between solutions in the original and incremental logic files doesn't account for this.

Instead of updating all the existing logic files in rocBLAS, I figured it would be easier to update the merge script to fix this issue. The main risk I can see of doing things this way is if the logic changes in SolutionStructs.py, the merge script also would need to be updated else bugs could be introduced. Ideally, I think we should make the move to have the merge script interface directly with the same code used for creating solutions, but this is a much larger change.

Feedback on if we think this is an appropriate interim workaround (and if not, other possible solutions) is appreciated. 