### PR TITLE
Fix hipErrorInvalidHandle during benchmarks

### DIFF
--- a/Tensile/Source/lib/source/hip/HipSolutionAdapter.cpp
+++ b/Tensile/Source/lib/source/hip/HipSolutionAdapter.cpp
@@ -231,6 +231,8 @@ namespace Tensile
                                        &argsSize,
                                        HIP_LAUNCH_PARAM_END};
 
+            if(startEvent != nullptr)
+                HIP_CHECK_RETURN(hipEventRecord(startEvent, stream));
             HIP_CHECK_RETURN(hipExtModuleLaunchKernel(function,
                                                       kernel.numWorkItems.x,
                                                       kernel.numWorkItems.y,
@@ -242,9 +244,11 @@ namespace Tensile
                                                       stream, // stream
                                                       nullptr,
                                                       (void**)&hipLaunchParams,
-                                                      startEvent, // event
-                                                      stopEvent // event
+                                                      nullptr, // event
+                                                      nullptr // event
                                                       ));
+            if(stopEvent != nullptr)
+                HIP_CHECK_RETURN(hipEventRecord(stopEvent, stream));
             return hipSuccess;
         }
 


### PR DESCRIPTION
[From the rocm 4.2 release notes:](https://rocmdocs.amd.com/en/latest/Current_Release_Notes/Current-Release-Notes.html)

>HIP events in kernel dispatch using hipExtLaunchKernelGGL/hipExtLaunchKernel and passed in the API are not explicitly recorded and should only be used to get elapsed time for that specific launch.
Events used across multiple dispatches, for example, start and stop events from different hipExtLaunchKernelGGL/hipExtLaunchKernel calls, are treated as invalid unrecorded events. In such scenarios, HIP will display the error hipErrorInvalidHandle from hipEventElapsedTime.

The code change in this PR adds additional overhead to launching kernels compared to the old method---about 6 or 7 microseconds per kernel launch based on my brief experiments. This means benchmarking will slightly favour single kernel solutions vs muli-kernel ones (e.g. non-gsu vs gsu), but for problem sizes where this could make a difference, I think the single kernel solution will always be faster anyways.

Please share any ideas for a better solution to this problem. 