### PR TITLE
Print solution index selected after search

### DIFF
--- a/Tensile/Source/lib/include/Tensile/PropertyMatching.hpp
+++ b/Tensile/Source/lib/include/Tensile/PropertyMatching.hpp
@@ -346,7 +346,7 @@ namespace Tensile
                     std::cout << "Considered " << considered << "% of entries." << std::endl;
                 }
 
-                if(T_Debug)
+                if(T_Debug && bestMatch)
                     std::cout << "Solution index selected: " << bestMatch->index << std::endl;
 
                 return std::make_tuple(bestMatch, bestDistance);
@@ -417,7 +417,7 @@ namespace Tensile
                     iter++;
                 }
 
-                if(T_Debug)
+                if(T_Debug && bestMatch)
                     std::cout << "Solution index selected: " << bestMatch->index << std::endl;
 
                 return std::make_tuple(bestMatch, bestDistance);

--- a/Tensile/Source/lib/include/Tensile/PropertyMatching.hpp
+++ b/Tensile/Source/lib/include/Tensile/PropertyMatching.hpp
@@ -346,6 +346,9 @@ namespace Tensile
                     std::cout << "Considered " << considered << "% of entries." << std::endl;
                 }
 
+                if(T_Debug)
+                    std::cout << "Solution index selected: " << bestMatch->index << std::endl;
+
                 return std::make_tuple(bestMatch, bestDistance);
             }
 
@@ -413,6 +416,9 @@ namespace Tensile
 
                     iter++;
                 }
+
+                if(T_Debug)
+                    std::cout << "Solution index selected: " << bestMatch->index << std::endl;
 
                 return std::make_tuple(bestMatch, bestDistance);
             }


### PR DESCRIPTION
Prints the solution index selected when DB mode is enabled. It works for both Binary and Naive search.
This information is useful for a proper use of TENSILE_SOLUTION_INDEX.