### PR TITLE
refactor parsing of Architecture

### DIFF
--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -136,6 +136,35 @@ def which(p):
                 return candidate
     return None
 
+def splitArchs():
+  # Helper for architecture
+  def isSupported(arch):
+    return globalParameters["AsmCaps"][arch]["SupportedISA"] and \
+           globalParameters["AsmCaps"][arch]["SupportedSource"]
+
+  if ";" in globalParameters["Architecture"]:
+    wantedArchs = globalParameters["Architecture"].split(";")
+  else:
+    wantedArchs = globalParameters["Architecture"].split("_")
+  archs = []
+  cmdlineArchs = []
+  if "all" in wantedArchs:
+    for arch in globalParameters['SupportedISA']:
+      if isSupported(arch):
+        if (arch == (9,0,6) or arch == (9,0,8) or arch == (9,0,10)):
+          if (arch == (9,0,10)):
+            archs += [gfxName(arch) + '-xnack+']
+            cmdlineArchs += [gfxName(arch) + ':xnack+']
+          archs += [gfxName(arch) + '-xnack-']
+          cmdlineArchs += [gfxName(arch) + ':xnack-']
+        else:
+          archs += [gfxName(arch)]
+          cmdlineArchs += [gfxName(arch)]
+  else:
+    for arch in wantedArchs:
+      archs += [re.sub(":", "-", arch)]
+      cmdlineArchs += [arch]
+  return archs, cmdlineArchs
 
 def buildSourceCodeObjectFile(CxxCompiler, outputPath, kernelFile):
     buildPath = ensurePath(os.path.join(globalParameters['WorkingPath'], 'code_object_tmp'))
@@ -149,24 +178,8 @@ def buildSourceCodeObjectFile(CxxCompiler, outputPath, kernelFile):
     objectFilename = base + '.o'
     soFilename = base + '.so'
 
-    def isSupported(arch):
-        return globalParameters["AsmCaps"][arch]["SupportedISA"] and \
-               globalParameters["AsmCaps"][arch]["SupportedSource"]
-
     if (CxxCompiler == "hipcc"):
-      archs = []
-      cmdlineArchs = []
-      for arch in globalParameters['SupportedISA']:
-        if isSupported(arch):
-          if (arch == (9,0,6) or arch == (9,0,8) or arch == (9,0,10)):
-            if (arch == (9,0,10)):
-              archs += [gfxName(arch) + '-xnack+']
-              cmdlineArchs += [gfxName(arch) + ':xnack+']
-            archs += [gfxName(arch) + '-xnack-']
-            cmdlineArchs += [gfxName(arch) + ':xnack-']
-          else:
-            archs += [gfxName(arch)]
-            cmdlineArchs += [gfxName(arch)]
+      archs, cmdlineArchs = splitArchs()
 
       archFlags = ['--offload-arch=' + arch for arch in cmdlineArchs]
 
@@ -1063,11 +1076,6 @@ def buildObjectFileNames(solutionWriter, kernelWriterSource, kernelWriterAssembl
   sourceKernels = list([k for k in kernels if k['KernelLanguage'] == 'Source'])
   asmKernels = list([k for k in kernels if k['KernelLanguage'] == 'Assembly'])
 
-  # Helper for architecture
-  def isSupported(arch):
-        return globalParameters["AsmCaps"][arch]["SupportedISA"] and \
-               globalParameters["AsmCaps"][arch]["SupportedSource"]
-
   # Build a list of kernel object names.
   for kernel in sourceKernels:
     sourceKernelNames += [kernelWriterSource.getKernelFileBase(kernel)]
@@ -1081,15 +1089,7 @@ def buildObjectFileNames(solutionWriter, kernelWriterSource, kernelWriterAssembl
 
   # Source based kernels are built for all supported architectures
   if (cxxCompiler == 'hipcc'):
-    sourceArchs = []
-    for arch in globalParameters['SupportedISA']:
-      if isSupported(arch):
-        if (arch == (9,0,6) or arch == (9,0,8) or arch == (9,0,10)):
-          if (arch == (9,0,10)):
-            sourceArchs += [gfxName(arch) + '-xnack+']
-          sourceArchs += [gfxName(arch) + '-xnack-']
-        else:
-          sourceArchs += [gfxName(arch)]
+    sourceArchs, _ = splitArchs()
   else:
     raise RuntimeError("Unknown compiler %s" % cxxCompiler)
 


### PR DESCRIPTION
Addresses Tensile issue #1395.  Compilation of Kernels.cpp now honors user-specified (via `install.sh -a`) list of architectures.  Tested subset build of rocBLAS with "`-a gfx906:xnack-;gfx908:xnack-`", generated just the code object bundles specified:
```
$ ls *co
Kernels.so-000-gfx906-xnack-.hsaco  TensileLibrary_gfx906.co
Kernels.so-000-gfx908-xnack-.hsaco  TensileLibrary_gfx908.co
```