### PR TITLE
Fix Navi gpu target to logic mapping

### DIFF
--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -268,7 +268,7 @@ architectureMap = {
   'gfx906':'vega20', 'gfx906:xnack+':'vega20', 'gfx906:xnack-':'vega20',
   'gfx908':'arcturus','gfx908:xnack+':'arcturus', 'gfx908:xnack-':'arcturus',
   'gfx90a':'aldebaran', 'gfx90a:xnack+':'aldebaran', 'gfx90a:xnack-':'aldebaran',
-  'gfx1010':'navi10', 'gfx1011':'navi11', 'gfx1012':'navi12', 'gfx1030':'navi21'
+  'gfx1010':'navi10', 'gfx1011':'navi12', 'gfx1012':'navi14', 'gfx1030':'navi21'
 }
 
 def getArchitectureName(gfxName):


### PR DESCRIPTION
gfx1011 and gfx1012 are mapped to the incorrect logic names, changed them to the correct ones.