### PR TITLE
Tensile uses static C++ msgpackc header library

### DIFF
--- a/Tensile/Source/lib/CMakeLists.txt
+++ b/Tensile/Source/lib/CMakeLists.txt
@@ -99,14 +99,9 @@ if(TENSILE_USE_LLVM OR TENSILE_USE_MSGPACK)
 endif()
 
 if(TENSILE_USE_MSGPACK)
+    find_package(msgpack REQUIRED)
     target_compile_definitions(TensileHost PUBLIC -DTENSILE_MSGPACK=1)
-
-    find_package(msgpack)
-    if(TARGET msgpackc-static)
-        target_link_libraries(TensileHost PRIVATE msgpackc-static)
-    else()
-        target_link_libraries(TensileHost PRIVATE msgpackc)
-    endif()
+    target_include_directories(TensileHost PRIVATE "${msgpack_DIR}/include")
 endif()
 
 if(TENSILE_USE_LLVM)

--- a/Tensile/Source/lib/CMakeLists.txt
+++ b/Tensile/Source/lib/CMakeLists.txt
@@ -101,7 +101,14 @@ endif()
 if(TENSILE_USE_MSGPACK)
     find_package(msgpack REQUIRED)
     target_compile_definitions(TensileHost PUBLIC -DTENSILE_MSGPACK=1)
-    target_include_directories(TensileHost PRIVATE "${msgpack_DIR}/include")
+
+    if(DEFINED msgpackc-cxx)
+        # Target defines include headers
+        target_link_libraries(TensileHost PRIVATE msgpackc-cxx)
+    else()
+        # Otherwise include C++ headers manually
+        target_include_directories(TensileHost PRIVATE "${msgpack_DIR}/include")
+    endif()
 endif()
 
 if(TENSILE_USE_LLVM)


### PR DESCRIPTION
Remove unused shared lib linkage, due to using only C++ header library for msgpackc.
Creates problems downstream with other projects linking TensileHost library