### PR TITLE
Update tensile_client executable to std=c++14

### DIFF
--- a/Tensile/Source/client/CMakeLists.txt
+++ b/Tensile/Source/client/CMakeLists.txt
@@ -42,6 +42,11 @@ if(TENSILE_USE_OPENMP)
 endif()
 
 add_executable(tensile_client main.cpp)
+set_target_properties(tensile_client
+                      PROPERTIES
+                      CXX_STANDARD 14
+                      CXX_STANDARD_REQUIRED ON
+                      CXX_EXTENSIONS OFF)
 
 target_link_libraries(tensile_client PRIVATE TensileHost TensileClient ${Boost_LIBRARIES})
 if(TENSILE_USE_OPENMP)


### PR DESCRIPTION
Update the tensile_client executable to use c++14:
- Linked libraries TensileHost and TensileClient are built with c++14
- Warnings when building main.cpp due to inclusion of headers with constexpr functions requiring c++14 (e.g. BitFieldGenerator object).
- Good to keep code standards consistent