### PR TITLE
Remove no longer supported benchmarking steps

### DIFF
--- a/Tensile/BenchmarkProblems.py
+++ b/Tensile/BenchmarkProblems.py
@@ -35,7 +35,7 @@ from . import Utils
 from .BenchmarkStructs import BenchmarkProcess, constructForkPermutations, checkForValidParameters
 from .ClientWriter import runClient, writeClientConfig
 from .Common import globalParameters, HR, pushWorkingPath, popWorkingPath, print1, print2, \
-    printExit, printWarning, ensurePath, startTime, validParameters
+        printExit, printWarning, ensurePath, startTime, validParameters
 from .KernelWriterAssembly import KernelWriterAssembly
 from .KernelWriterSource import KernelWriterSource
 from .SolutionStructs import Solution, ProblemType, ProblemSizes
@@ -45,35 +45,35 @@ from .CustomKernels import getCustomKernelConfig
 
 
 def generateForkedSolutions (problemType, constantParams, benchmarkPermutations):
-  """this creates a set or solutions based on the forked parameters using
-     a set of common parameters from which to fork from
+    """this creates a set or solutions based on the forked parameters using
+         a set of common parameters from which to fork from
 
-  Parameters:
-  problemType the problem type
-  hardcodedParameters the set of parameters which overrides the baseline parameters
-  benchmarkPermutations set of baseline parameters from which the the updates are branched form
-  winners previous winning parameters which overrides the derived parameters
-  initialSolutionParameters set of parameters which fills in missing params default parameters
+    Parameters:
+    problemType the problem type
+    hardcodedParameters the set of parameters which overrides the baseline parameters
+    benchmarkPermutations set of baseline parameters from which the the updates are branched form
+    winners previous winning parameters which overrides the derived parameters
+    initialSolutionParameters set of parameters which fills in missing params default parameters
 
-  Returns:
-  list: Soutions list
-  """
-  print1("# Enumerating Solutions")
+    Returns:
+    list: Soutions list
+    """
+    print1("# Enumerating Solutions")
 
-  solutions = []
-  for benchmarkPermutation in benchmarkPermutations:
-    solution = {"ProblemType": deepcopy(problemType.state)}
-    solution.update(constantParams)
-    solution.update(benchmarkPermutation)
+    solutions = []
+    for benchmarkPermutation in benchmarkPermutations:
+        solution = {"ProblemType": deepcopy(problemType.state)}
+        solution.update(constantParams)
+        solution.update(benchmarkPermutation)
 
-    # TODO check if solution matches problem size for exact tile kernels
-    solutionObject = Solution(solution)
-    if solutionObject["Valid"]:
-      solutions.append(solutionObject)
-    elif globalParameters["PrintSolutionRejectionReason"]:
-      print1("rejecting solution " + str(solutionObject))
+        # TODO check if solution matches problem size for exact tile kernels
+        solutionObject = Solution(solution)
+        if solutionObject["Valid"]:
+            solutions.append(solutionObject)
+        elif globalParameters["PrintSolutionRejectionReason"]:
+            print1("rejecting solution " + str(solutionObject))
 
-  return solutions
+    return solutions
 
 def generateCustomKernelSolution(kernelName, directory=globalParameters["CustomKernelDirectory"]):
     """Temp docs"""
@@ -86,280 +86,280 @@ def generateCustomKernelSolution(kernelName, directory=globalParameters["CustomK
     return Solution(kernelConfig)
 
 def benchmarkProblemType( problemTypeConfig, problemSizeGroupConfig, problemSizeGroupIdx):
-  """Temp docs"""
-  benchmarkTestFails = 0
+    """Temp docs"""
+    benchmarkTestFails = 0
 
-  # convert config to full benchmark process (resolves defaults)
-  print1("")
-  print1(HR)
-  print1("# Converting Config to BenchmarkProcess Object")
-  print1(HR)
-  print1("")
-  benchmarkProcess = BenchmarkProcess(problemTypeConfig, problemSizeGroupConfig)
-
-  enableTileSelection = benchmarkProcess.problemType["TileAwareSelection"]
-  problemTypeName = str(benchmarkProcess.problemType)
-  problemSizeGroupName = "%s_%02u" % (problemTypeName, problemSizeGroupIdx)
-  pushWorkingPath(problemSizeGroupName)
-  ensurePath(os.path.join(globalParameters["WorkingPath"],"Data"))
-
-  totalBenchmarkSteps = len(benchmarkProcess)
-  resultsFileBaseFinal = None
-
-  print1("# NumBenchmarkSteps: {}".format(totalBenchmarkSteps))
-  print1("")
-  print1(HR)
-  print1("# Done Creating BenchmarkProcess Object")
-  print1(HR)
-
-
-  for benchmarkStepIdx in range(0, totalBenchmarkSteps):
-    benchmarkStep = benchmarkProcess[benchmarkStepIdx]
-    stepName = str(benchmarkStep)
-    shortName = benchmarkStep.abbreviation()
-
-    print1("\n")
+    # convert config to full benchmark process (resolves defaults)
+    print1("")
     print1(HR)
-    currentTime = time.time()
-    elapsedTime = currentTime - startTime
-    print1("# Benchmark Step: {} - {} {:.3f}s".format(problemSizeGroupName, stepName, elapsedTime))
-    print1("# Num Sizes: {}".format(benchmarkStep.problemSizes.totalProblemSizes))
-    print1("# Fork Parameters:")
-    for k, v in benchmarkStep.forkParams.items():
-      print1("#     {}: {}".format(k, v))
+    print1("# Converting Config to BenchmarkProcess Object")
+    print1(HR)
+    print1("")
+    benchmarkProcess = BenchmarkProcess(problemTypeConfig, problemSizeGroupConfig)
 
-    pushWorkingPath(shortName)
+    enableTileSelection = benchmarkProcess.problemType["TileAwareSelection"]
+    problemTypeName = str(benchmarkProcess.problemType)
+    problemSizeGroupName = "%s_%02u" % (problemTypeName, problemSizeGroupIdx)
+    pushWorkingPath(problemSizeGroupName)
+    ensurePath(os.path.join(globalParameters["WorkingPath"],"Data"))
 
-    # copy files to benchmark source directory
-    stepBaseDir = globalParameters["WorkingPath"]
-    sourceDir = os.path.join(stepBaseDir, "source" )
-    ensurePath(sourceDir)
+    totalBenchmarkSteps = len(benchmarkProcess)
+    resultsFileBaseFinal = None
 
-    filesToCopy = []
-    pushWorkingPath("source")
-    filesToCopy = [
-        "TensileTypes.h",
-        "tensile_bfloat16.h",
-        "KernelHeader.h",
-        ]
+    print1("# NumBenchmarkSteps: {}".format(totalBenchmarkSteps))
+    print1("")
+    print1(HR)
+    print1("# Done Creating BenchmarkProcess Object")
+    print1(HR)
 
-    for f in filesToCopy:
-      shutil.copy(
-          os.path.join(globalParameters["SourcePath"], f),
-          globalParameters["WorkingPath"] )
-    if globalParameters["RuntimeLanguage"] == "OCL":
-      shutil.copy(
-          os.path.join(globalParameters["SourcePath"], "FindOpenCL.cmake"),
-          globalParameters["WorkingPath"] )
-    else:
-      shutil.copy(
-          os.path.join(globalParameters["SourcePath"], "FindHIP.cmake"),
-          globalParameters["WorkingPath"] )
 
-    # enumerate benchmark permutations and create resulting solution objects
-    benchmarkPermutations = constructForkPermutations(benchmarkStep.forkParams)
-    maxPossibleSolutions = len(benchmarkPermutations) #* numHardcoded
-    solutions = generateForkedSolutions(benchmarkProcess.problemType, \
-        benchmarkStep.constantParams, benchmarkPermutations)
+    for benchmarkStepIdx in range(0, totalBenchmarkSteps):
+        benchmarkStep = benchmarkProcess[benchmarkStepIdx]
+        stepName = str(benchmarkStep)
+        shortName = benchmarkStep.abbreviation()
 
-    # add custom kernels to list of solutions
-    customKernelList = problemSizeGroupConfig.get("CustomKernels", [])
-    customKernelWildcard = False
-    if customKernelList == ["*"]:
-      customKernelList = \
-          [fname[:-2] for fname in os.listdir(globalParameters["CustomKernelDirectory"]) \
-          if fname.endswith(".s")]
-      customKernelWildcard = True
+        print1("\n")
+        print1(HR)
+        currentTime = time.time()
+        elapsedTime = currentTime - startTime
+        print1("# Benchmark Step: {} - {} {:.3f}s".format(problemSizeGroupName, stepName, elapsedTime))
+        print1("# Num Sizes: {}".format(benchmarkStep.problemSizes.totalProblemSizes))
+        print1("# Fork Parameters:")
+        for k, v in benchmarkStep.forkParams.items():
+            print1("#     {}: {}".format(k, v))
 
-    for kernelName in customKernelList:
-      print1("# Processing custom kernel {}".format(kernelName))
-      customSolution = generateCustomKernelSolution(kernelName)
-      if customSolution["ProblemType"] != benchmarkProcess.problemType:
-        # Raise error if this kernel was specifically requested and problem type doesn't match
-        if not customKernelWildcard:
-          missingParams = [p for p in benchmarkProcess.problemType \
-              if p not in customSolution["ProblemType"]]
-          extraParams   = [p for p in customSolution["ProblemType"] \
-              if p not in benchmarkProcess.problemType]
+        pushWorkingPath(shortName)
 
-          msg  = "The problem type in the config file does not match" \
-                 "that of the custom kernel, {0}.".format(kernelName)
-          msg += "\nMissing config parameters:\n" + str(missingParams)
-          msg += "\nExtra custom kernel parameters:\n" + str(extraParams)
-          raise RuntimeError(msg)
+        # copy files to benchmark source directory
+        stepBaseDir = globalParameters["WorkingPath"]
+        sourceDir = os.path.join(stepBaseDir, "source" )
+        ensurePath(sourceDir)
+
+        filesToCopy = []
+        pushWorkingPath("source")
+        filesToCopy = [
+                "TensileTypes.h",
+                "tensile_bfloat16.h",
+                "KernelHeader.h",
+                ]
+
+        for f in filesToCopy:
+            shutil.copy(
+                    os.path.join(globalParameters["SourcePath"], f),
+                    globalParameters["WorkingPath"] )
+        if globalParameters["RuntimeLanguage"] == "OCL":
+            shutil.copy(
+                    os.path.join(globalParameters["SourcePath"], "FindOpenCL.cmake"),
+                    globalParameters["WorkingPath"] )
         else:
-          print1("# Rejected {}: Problem Type doesn't match".format(kernelName))
-      else:
-        print1("# Added {} to solutions".format(kernelName))
-        maxPossibleSolutions += 1
-        if customSolution["Valid"]:
-          solutions.append(customSolution)
-        elif globalParameters["PrintSolutionRejectionReason"]:
-          print1("rejecting solution " + str(customSolution))
+            shutil.copy(
+                    os.path.join(globalParameters["SourcePath"], "FindHIP.cmake"),
+                    globalParameters["WorkingPath"] )
 
-    print1("# Actual Solutions: {} / {} after SolutionStructs\n" \
-        .format(len(solutions), maxPossibleSolutions))
+        # enumerate benchmark permutations and create resulting solution objects
+        benchmarkPermutations = constructForkPermutations(benchmarkStep.forkParams)
+        maxPossibleSolutions = len(benchmarkPermutations) #* numHardcoded
+        solutions = generateForkedSolutions(benchmarkProcess.problemType, \
+                benchmarkStep.constantParams, benchmarkPermutations)
 
-    # handle no valid solutions
-    if len(solutions) == 0:
-        msg = "Your parameters resulted in 0 valid solutions."
-        if globalParameters["PrintSolutionRejectionReason"]:
-            msg += "\nExamine reject and backtrace messages above to see why" \
-                "and where solutions were rejected."
+        # add custom kernels to list of solutions
+        customKernelList = problemSizeGroupConfig.get("CustomKernels", [])
+        customKernelWildcard = False
+        if customKernelList == ["*"]:
+            customKernelList = \
+                    [fname[:-2] for fname in os.listdir(globalParameters["CustomKernelDirectory"]) \
+                    if fname.endswith(".s")]
+            customKernelWildcard = True
+
+        for kernelName in customKernelList:
+            print1("# Processing custom kernel {}".format(kernelName))
+            customSolution = generateCustomKernelSolution(kernelName)
+            if customSolution["ProblemType"] != benchmarkProcess.problemType:
+                # Raise error if this kernel was specifically requested and problem type doesn't match
+                if not customKernelWildcard:
+                    missingParams = [p for p in benchmarkProcess.problemType \
+                            if p not in customSolution["ProblemType"]]
+                    extraParams   = [p for p in customSolution["ProblemType"] \
+                            if p not in benchmarkProcess.problemType]
+
+                    msg  = "The problem type in the config file does not match" \
+                                 "that of the custom kernel, {0}.".format(kernelName)
+                    msg += "\nMissing config parameters:\n" + str(missingParams)
+                    msg += "\nExtra custom kernel parameters:\n" + str(extraParams)
+                    raise RuntimeError(msg)
+                else:
+                    print1("# Rejected {}: Problem Type doesn't match".format(kernelName))
+            else:
+                print1("# Added {} to solutions".format(kernelName))
+                maxPossibleSolutions += 1
+                if customSolution["Valid"]:
+                    solutions.append(customSolution)
+                elif globalParameters["PrintSolutionRejectionReason"]:
+                    print1("rejecting solution " + str(customSolution))
+
+        print1("# Actual Solutions: {} / {} after SolutionStructs\n" \
+                .format(len(solutions), maxPossibleSolutions))
+
+        # handle no valid solutions
+        if len(solutions) == 0:
+                msg = "Your parameters resulted in 0 valid solutions."
+                if globalParameters["PrintSolutionRejectionReason"]:
+                        msg += "\nExamine reject and backtrace messages above to see why" \
+                                "and where solutions were rejected."
+                else:
+                        msg += "\nYou should re-run with \"PrintSolutionRejectionReason: True\"" \
+                                "to see why each parameter combination was rejected."
+                printExit(msg)
+
+        if globalParameters["PrintLevel"] >= 1:
+            for solution in solutions:
+                print2("#    (%u:%u) %s" % (0, 0, Solution.getNameFull(solution) ))
+            print2(HR)
+
+        # write benchmarkFiles
+        prevCount = len(solutions)
+        writeBenchmarkFiles(stepBaseDir, solutions, benchmarkStep.problemSizes, \
+                shortName, filesToCopy, benchmarkProcess.solutionSummationSizes)
+        # ^ this mutates solutions
+
+        print1("# Actual Solutions: %u / %u after KernelWriter\n" \
+                    % (len(solutions), prevCount ))
+
+        popWorkingPath() # source
+
+        # run benchmarking client
+        resultsFileBase = os.path.normpath(os.path.join( \
+                globalParameters["WorkingPath"], "../Data", shortName))
+        if benchmarkStep.isFinal():
+            resultsFileBaseFinal = resultsFileBase
+        resultsFileName = resultsFileBase + ".csv"
+        solutionsFileName = resultsFileBase + ".yaml"
+
+        if not os.path.exists(resultsFileName) or globalParameters["ForceRedoBenchmarkProblems"]:
+            libraryLogicPath = None
+            forBenchmark = True
+            returncode = runClient(libraryLogicPath, forBenchmark, enableTileSelection)
+
+            if returncode:
+                benchmarkTestFails += 1
+                printWarning("BenchmarkProblems: Benchmark Process exited with code %u" % returncode)
         else:
-            msg += "\nYou should re-run with \"PrintSolutionRejectionReason: True\"" \
-                "to see why each parameter combination was rejected."
-        printExit(msg)
+            print1("# Already benchmarked; skipping.")
 
-    if globalParameters["PrintLevel"] >= 1:
-      for solution in solutions:
-        print2("#    (%u:%u) %s" % (0, 0, Solution.getNameFull(solution) ))
-      print2(HR)
+        # write solutions YAML
+        LibraryIO.writeSolutions(solutionsFileName, benchmarkStep.problemSizes, solutions)
 
-    # write benchmarkFiles
-    prevCount = len(solutions)
-    writeBenchmarkFiles(stepBaseDir, solutions, benchmarkStep.problemSizes, \
-        shortName, filesToCopy, benchmarkProcess.solutionSummationSizes)
-    # ^ this mutates solutions
+        # End Iteration
+        popWorkingPath() # stepName
+        currentTime = time.time()
+        elapsedTime = currentTime - startTime
+        print1("%s\n# %s\n# %s: End - %.3fs\n%s\n" \
+                % (HR, problemSizeGroupName, shortName, elapsedTime, HR))
 
-    print1("# Actual Solutions: %u / %u after KernelWriter\n" \
-          % (len(solutions), prevCount ))
-
-    popWorkingPath() # source
-
-    # run benchmarking client
-    resultsFileBase = os.path.normpath(os.path.join( \
-        globalParameters["WorkingPath"], "../Data", shortName))
-    if benchmarkStep.isFinal():
-      resultsFileBaseFinal = resultsFileBase
-    resultsFileName = resultsFileBase + ".csv"
-    solutionsFileName = resultsFileBase + ".yaml"
-
-    if not os.path.exists(resultsFileName) or globalParameters["ForceRedoBenchmarkProblems"]:
-      libraryLogicPath = None
-      forBenchmark = True
-      returncode = runClient(libraryLogicPath, forBenchmark, enableTileSelection)
-
-      if returncode:
-        benchmarkTestFails += 1
-        printWarning("BenchmarkProblems: Benchmark Process exited with code %u" % returncode)
-    else:
-      print1("# Already benchmarked; skipping.")
-
-    # write solutions YAML
-    LibraryIO.writeSolutions(solutionsFileName, benchmarkStep.problemSizes, solutions)
-
-    # End Iteration
-    popWorkingPath() # stepName
-    currentTime = time.time()
-    elapsedTime = currentTime - startTime
-    print1("%s\n# %s\n# %s: End - %.3fs\n%s\n" \
-        % (HR, problemSizeGroupName, shortName, elapsedTime, HR))
-
-  popWorkingPath() # ProblemType
-  return (resultsFileBaseFinal, benchmarkTestFails)
+    popWorkingPath() # ProblemType
+    return (resultsFileBaseFinal, benchmarkTestFails)
 # End benchmarkProblemType()
 
 def compareResults(old, new, name):
     """Temp doc"""
     import math
     if name == " WinnerIdx":
-      return 0
+        return 0
 
     try:
-        old = float(old)
+            old = float(old)
     except (ValueError, TypeError):
-        old = -1
+            old = -1
 
     try:
-        new = float(new)
+            new = float(new)
     except (ValueError, TypeError):
-        new = -1
+            new = -1
 
     def isbad(x):
-        return x <= 0 or math.isnan(x) or math.isinf(x)
+            return x <= 0 or math.isnan(x) or math.isinf(x)
 
     if isbad(old) and isbad(new):
-        return 0
+            return 0
     if isbad(old):
-        return 1
+            return 1
     if isbad(new):
-        raise ValueError("Old is good ({}) and new is bad ({}). Name: {}".format(old, new, name))
+            raise ValueError("Old is good ({}) and new is bad ({}). Name: {}".format(old, new, name))
 
     return abs((old-new)/old)
 
 def getResults(resultsFileName, solutions, enableTileSelection, newResultsFileName=None):
-  """Temp docs"""
-  print1("# Get Results from CSV")
-  try:
-    resultsFile = open(resultsFileName, "r")
-  except IOError:
-    printExit("Can't open \"%s\" to get results" % resultsFileName )
+    """Temp docs"""
+    print1("# Get Results from CSV")
+    try:
+        resultsFile = open(resultsFileName, "r")
+    except IOError:
+        printExit("Can't open \"%s\" to get results" % resultsFileName )
 
-  newCSV = itertools.repeat(None)
-  if newResultsFileName is not None:
-    newFile = open(newResultsFileName, 'r')
-    newCSV = csv.reader(newFile)
+    newCSV = itertools.repeat(None)
+    if newResultsFileName is not None:
+        newFile = open(newResultsFileName, 'r')
+        newCSV = csv.reader(newFile)
 
-    diffFile = open(newResultsFileName+'-diff.csv', 'w')
-    diffCSV = csv.writer(diffFile)
+        diffFile = open(newResultsFileName+'-diff.csv', 'w')
+        diffCSV = csv.writer(diffFile)
 
-  # setup data structures
-  results = []
-  numSolutions = 0
-  for solutionsForHardcoded in solutions:
-    results.append([])
-    for solution in solutionsForHardcoded:
-      numColForProblemSize = solution["ProblemType"]["TotalIndices"]
-      results[-1].append([])
-      numSolutions += 1
+    # setup data structures
+    results = []
+    numSolutions = 0
+    for solutionsForHardcoded in solutions:
+        results.append([])
+        for solution in solutionsForHardcoded:
+            numColForProblemSize = solution["ProblemType"]["TotalIndices"]
+            results[-1].append([])
+            numSolutions += 1
 
-  # read results in gflops
-  csvFile = csv.reader(resultsFile)
+    # read results in gflops
+    csvFile = csv.reader(resultsFile)
 
-  if globalParameters["CSVExportWinner"]:
-    # in both old/new clients, csv files always output "GFlops" ,...., "LDD" "LDC" "LDA" "LDB" "TotalFlops" "WinnerGFlops" "WinnerTimeUS" "WinnerIdx" "WinnerName" columns
-    startIdx = numColForProblemSize + 10
-  else:
-    # in both old/new clients, csv files always output "GFlops" ,...., "LDD" "LDC" "LDA" "LDB"columns
-    # old client, non-GEMM csv files don't contain "LDD" "LDC" "LDA" "LDB", so we output an "N/A" text (in csv only) for alignment purpose (-diff.csv)
-    startIdx = numColForProblemSize + 5
-
-  rowLength = startIdx + numSolutions
-
-  rowIdx = 0
-  for row,newRow in zip(csvFile, newCSV):
-    rowIdx+=1
-    if rowIdx == 1:
-      if newRow is not None:
-        diffCSV.writerow(row)
-        diffCSV.writerow(newRow)
-        headerRow = row
-      continue
+    if globalParameters["CSVExportWinner"]:
+        # in both old/new clients, csv files always output "GFlops" ,...., "LDD" "LDC" "LDA" "LDB" "TotalFlops" "WinnerGFlops" "WinnerTimeUS" "WinnerIdx" "WinnerName" columns
+        startIdx = numColForProblemSize + 10
     else:
-      if len(row) < rowLength:
-        printWarning("CSV File %s row %u doesn't have %u elements; ignoring remainer of file." \
-            % (resultsFileName, rowIdx, rowLength) )
-        break
-      if newRow is not None:
-        diffCSV.writerow([compareResults(old,new,name) for old,new,name in itertools.zip_longest(row, newRow, headerRow)])
+        # in both old/new clients, csv files always output "GFlops" ,...., "LDD" "LDC" "LDA" "LDB"columns
+        # old client, non-GEMM csv files don't contain "LDD" "LDC" "LDA" "LDB", so we output an "N/A" text (in csv only) for alignment purpose (-diff.csv)
+        startIdx = numColForProblemSize + 5
 
-      idx = startIdx
-      for i,solutionsForHardcoded in enumerate(solutions):
-        for j,solution in enumerate(solutionsForHardcoded):
-          gflops = float(row[idx])
+    rowLength = startIdx + numSolutions
 
-          results[i][j].append(gflops)
-          idx += 1
-  if rowIdx < 2 and not enableTileSelection:
-    printExit("CSV File %s only has %u row(s); prior benchmark must not have run long enough to produce data." \
-        % (resultsFileName, rowIdx) )
+    rowIdx = 0
+    for row,newRow in zip(csvFile, newCSV):
+        rowIdx+=1
+        if rowIdx == 1:
+            if newRow is not None:
+                diffCSV.writerow(row)
+                diffCSV.writerow(newRow)
+                headerRow = row
+            continue
+        else:
+            if len(row) < rowLength:
+                printWarning("CSV File %s row %u doesn't have %u elements; ignoring remainer of file." \
+                        % (resultsFileName, rowIdx, rowLength) )
+                break
+            if newRow is not None:
+                diffCSV.writerow([compareResults(old,new,name) for old,new,name in itertools.zip_longest(row, newRow, headerRow)])
 
-  resultsFile.close()
-  if newResultsFileName is not None:
-    newFile.close()
-    diffFile.close()
-  return results
+            idx = startIdx
+            for i,solutionsForHardcoded in enumerate(solutions):
+                for j,solution in enumerate(solutionsForHardcoded):
+                    gflops = float(row[idx])
+
+                    results[i][j].append(gflops)
+                    idx += 1
+    if rowIdx < 2 and not enableTileSelection:
+        printExit("CSV File %s only has %u row(s); prior benchmark must not have run long enough to produce data." \
+                % (resultsFileName, rowIdx) )
+
+    resultsFile.close()
+    if newResultsFileName is not None:
+        newFile.close()
+        diffFile.close()
+    return results
 
 def writeBenchmarkFiles(stepBaseDir, solutions, problemSizes, \
     stepName, filesToCopy, solutionSummationSizes):
@@ -440,84 +440,84 @@ def writeBenchmarkFiles(stepBaseDir, solutions, problemSizes, \
     idealProblemSizes = ProblemSizes(problemType, idealSizes)
     writeClientConfig(True, solutions, idealProblemSizes, stepName, stepBaseDir, newLibrary, codeObjectFiles, True)
 
-  if len(solutions) == 0:
-    printExit("write solutions and kernels results 0 valid soultion.")
+    if len(solutions) == 0:
+        printExit("write solutions and kernels results 0 valid soultion.")
 
-  # write CMake
-  outputPath = globalParameters["WorkingPath"]
+    # write CMake
+    outputPath = globalParameters["WorkingPath"]
 
-  (solutionFiles,
-   sourceKernelFiles,
-   asmKernelFiles,
-   sourceLibFiles,
-   asmLibFiles) = buildObjectFileNames(solutionWriter, kernelWriterSource, \
-    kernelWriterAssembly, solutions, kernels, kernelHelperOjbs)
+    (solutionFiles,
+     sourceKernelFiles,
+     asmKernelFiles,
+     sourceLibFiles,
+     asmLibFiles) = buildObjectFileNames(solutionWriter, kernelWriterSource, \
+        kernelWriterAssembly, solutions, kernels, kernelHelperOjbs)
 
-  writeCMake(outputPath, solutionFiles, sourceKernelFiles, filesToCopy)
+    writeCMake(outputPath, solutionFiles, sourceKernelFiles, filesToCopy)
 
-  for fileName in filesToCopy:
-    shutil.copy( os.path.join(globalParameters["SourcePath"], fileName), \
-      outputPath )
+    for fileName in filesToCopy:
+        shutil.copy( os.path.join(globalParameters["SourcePath"], fileName), \
+            outputPath )
 
 
 def main(config):
-  """Entry point for the "BenchmarkProblems" section of a Tensile config yaml"""
-  ClientExecutable.getClientExecutable()
+    """Entry point for the "BenchmarkProblems" section of a Tensile config yaml"""
+    ClientExecutable.getClientExecutable()
 
-  dataPath = os.path.join(globalParameters["WorkingPath"], globalParameters["BenchmarkDataPath"])
-  pushWorkingPath(globalParameters["BenchmarkProblemsPath"])
-  ensurePath(dataPath)
+    dataPath = os.path.join(globalParameters["WorkingPath"], globalParameters["BenchmarkDataPath"])
+    pushWorkingPath(globalParameters["BenchmarkProblemsPath"])
+    ensurePath(dataPath)
 
-  totalTestFails = 0
-  for benchmarkProblemTypeConfig in config:
-    problemTypeConfig = benchmarkProblemTypeConfig[0]
-    if len(benchmarkProblemTypeConfig) < 2:
-      problemSizeGroupConfigs = [{}]
-    else:
-      problemSizeGroupConfigs = benchmarkProblemTypeConfig[1:]
+    totalTestFails = 0
+    for benchmarkProblemTypeConfig in config:
+        problemTypeConfig = benchmarkProblemTypeConfig[0]
+        if len(benchmarkProblemTypeConfig) < 2:
+            problemSizeGroupConfigs = [{}]
+        else:
+            problemSizeGroupConfigs = benchmarkProblemTypeConfig[1:]
 
-    for problemSizeGroupIdx, problemSizeGroupConfig in enumerate(problemSizeGroupConfigs):
-      print2("ProblemTypeConfig: {}".format(problemTypeConfig))
-      problemTypeObj = ProblemType(problemTypeConfig)
-      globalParameters["EnableHalf"] = problemTypeObj["DataType"].isHalf()
+        for problemSizeGroupIdx, problemSizeGroupConfig in enumerate(problemSizeGroupConfigs):
+            print2("ProblemTypeConfig: {}".format(problemTypeConfig))
+            problemTypeObj = ProblemType(problemTypeConfig)
+            globalParameters["EnableHalf"] = problemTypeObj["DataType"].isHalf()
 
-      # using a suffix to check the csv version (for later addFromCSV())
-      csvSuffix = "_CSVWinner" if globalParameters["CSVExportWinner"] else ""
-      # results files will be named
-      newResultsFileName = os.path.join(dataPath, "{}_{:02d}{}.csv" \
-          .format(str(problemTypeObj), problemSizeGroupIdx, csvSuffix) )
-      newSolutionsFileName = os.path.join(dataPath, "{}_{:02d}{}.yaml" \
-          .format(str(problemTypeObj), problemSizeGroupIdx, csvSuffix) )
-      newGranularityFileName = os.path.join(dataPath, "{}_{:02d}{}.gsp" \
-          .format(str(problemTypeObj), problemSizeGroupIdx, csvSuffix) )
+            # using a suffix to check the csv version (for later addFromCSV())
+            csvSuffix = "_CSVWinner" if globalParameters["CSVExportWinner"] else ""
+            # results files will be named
+            newResultsFileName = os.path.join(dataPath, "{}_{:02d}{}.csv" \
+                    .format(str(problemTypeObj), problemSizeGroupIdx, csvSuffix) )
+            newSolutionsFileName = os.path.join(dataPath, "{}_{:02d}{}.yaml" \
+                    .format(str(problemTypeObj), problemSizeGroupIdx, csvSuffix) )
+            newGranularityFileName = os.path.join(dataPath, "{}_{:02d}{}.gsp" \
+                    .format(str(problemTypeObj), problemSizeGroupIdx, csvSuffix) )
 
-      # skip if possible
-      if globalParameters["ForceRedoBenchmarkProblems"] \
-          or not os.path.exists(newResultsFileName):
+            # skip if possible
+            if globalParameters["ForceRedoBenchmarkProblems"] \
+                    or not os.path.exists(newResultsFileName):
 
-        # benchmark problem size group
-        (resultsFileBaseFinal, benchmarkErrors) = \
-            benchmarkProblemType(problemTypeConfig, problemSizeGroupConfig, problemSizeGroupIdx)
-        totalTestFails += benchmarkErrors
+                # benchmark problem size group
+                (resultsFileBaseFinal, benchmarkErrors) = \
+                        benchmarkProblemType(problemTypeConfig, problemSizeGroupConfig, problemSizeGroupIdx)
+                totalTestFails += benchmarkErrors
 
-        print("clientExit={} {} for {}" \
-            .format(totalTestFails, "(ERROR)" if totalTestFails else "(PASS)", \
-            globalParameters["ConfigPath"]) )
+                print("clientExit={} {} for {}" \
+                        .format(totalTestFails, "(ERROR)" if totalTestFails else "(PASS)", \
+                        globalParameters["ConfigPath"]) )
 
-        # copy data
-        resultsFileBase = resultsFileBaseFinal
-        resultsFileName = resultsFileBase + ".csv"
-        solutionsFileName = resultsFileBase + ".yaml"
-        granularityFileName = resultsFileBase + "_Granularity.csv"
-        shutil.copy( resultsFileName, newResultsFileName )
-        shutil.copy( solutionsFileName, newSolutionsFileName )
-        if os.path.isfile(granularityFileName):
-          shutil.copy( granularityFileName, newGranularityFileName )
-      else:
-        print1("# {}_{:02d} already benchmarked; skipping." \
-            .format(str(problemTypeObj), problemSizeGroupIdx) )
+                # copy data
+                resultsFileBase = resultsFileBaseFinal
+                resultsFileName = resultsFileBase + ".csv"
+                solutionsFileName = resultsFileBase + ".yaml"
+                granularityFileName = resultsFileBase + "_Granularity.csv"
+                shutil.copy( resultsFileName, newResultsFileName )
+                shutil.copy( solutionsFileName, newSolutionsFileName )
+                if os.path.isfile(granularityFileName):
+                    shutil.copy( granularityFileName, newGranularityFileName )
+            else:
+                print1("# {}_{:02d} already benchmarked; skipping." \
+                        .format(str(problemTypeObj), problemSizeGroupIdx) )
 
-  popWorkingPath()
+    popWorkingPath()
 
-  if globalParameters["ExitOnFails"] and totalTestFails:
-    sys.exit(1)
+    if globalParameters["ExitOnFails"] and totalTestFails:
+        sys.exit(1)

--- a/Tensile/BenchmarkProblems.py
+++ b/Tensile/BenchmarkProblems.py
@@ -19,8 +19,6 @@
 # CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ################################################################################
 
-import csv
-import itertools
 import os
 import shutil
 import sys
@@ -40,31 +38,19 @@ from .KernelWriterAssembly import KernelWriterAssembly
 from .KernelWriterSource import KernelWriterSource
 from .SolutionStructs import Solution, ProblemType, ProblemSizes
 from .SolutionWriter import SolutionWriter
-from .TensileCreateLibrary import writeSolutionsAndKernels, writeCMake, buildObjectFileNames
-from .CustomKernels import getAllCustomKernelNames, getCustomKernelConfig
+from .TensileCreateLibrary import copyStaticFiles, writeSolutionsAndKernels
+from .CustomKernels import getCustomKernelConfig
 
 
-def generateForkedSolutions (problemType, constantParams, benchmarkPermutations):
-    """this creates a set or solutions based on the forked parameters using
-         a set of common parameters from which to fork from
-
-    Parameters:
-    problemType the problem type
-    hardcodedParameters the set of parameters which overrides the baseline parameters
-    benchmarkPermutations set of baseline parameters from which the the updates are branched form
-    winners previous winning parameters which overrides the derived parameters
-    initialSolutionParameters set of parameters which fills in missing params default parameters
-
-    Returns:
-    list: Soutions list
-    """
+def generateForkedSolutions(problemType, constantParams, forkPermutations):
+    """Creates a list with a Solution object for each parameter combination in forkPermutations"""
     print1("# Enumerating Solutions")
 
     solutions = []
-    for benchmarkPermutation in benchmarkPermutations:
+    for perm in forkPermutations:
         solution = {"ProblemType": deepcopy(problemType.state)}
         solution.update(constantParams)
-        solution.update(benchmarkPermutation)
+        solution.update(perm)
 
         # TODO check if solution matches problem size for exact tile kernels
         solutionObject = Solution(solution)
@@ -75,21 +61,141 @@ def generateForkedSolutions (problemType, constantParams, benchmarkPermutations)
 
     return solutions
 
-def generateCustomKernelSolution(kernelName, directory=globalParameters["CustomKernelDirectory"]):
-    """Temp docs"""
+def getCustomKernelSolutionObj(kernelName, directory=globalParameters["CustomKernelDirectory"]):
+    """Creates the Solution object for a custom kernel"""
     kernelConfig = getCustomKernelConfig(kernelName, directory)
-    checkParametersAreValid({p: [kernelConfig[p]] for p in kernelConfig if p != "ProblemType"}, validParameters)
-    # test if problem type matches with configuration file
-    kernelConfig["KernelLanguage"] = "Assembly"   # replacement kernels are always assembly kernels?
+    checkParametersAreValid({p: [kernelConfig[p]] for p in kernelConfig \
+            if p != "ProblemType"}, validParameters)
+    kernelConfig["KernelLanguage"] = "Assembly"
     kernelConfig["CustomKernelName"] = kernelName
 
     return Solution(kernelConfig)
 
-def benchmarkProblemType( problemTypeConfig, problemSizeGroupConfig, problemSizeGroupIdx):
-    """Temp docs"""
+def generateCustomKernelSolutions(problemType, customKernels, failOnMismatch):
+    """Creates a list with a Solution object for each name in customKernel"""
+    solutions = []
+    for kernelName in customKernels:
+        print1("# Processing custom kernel {}".format(kernelName))
+        solution = getCustomKernelSolutionObj(kernelName)
+        if solution["ProblemType"] != problemType:
+            # Raise error if this kernel was specifically requested and problem type doesn't match
+            if failOnMismatch:
+                foo = [(k,tuple(v)) if type(v) is list else (k,v) \
+                        for k,v in problemType.items()]
+                bar = [(k,tuple(v)) if type(v) is list else (k,v) \
+                        for k,v in solution["ProblemType"].items()]
+
+                benchmarkSet = set(foo)
+                customSet    = set(bar)
+                msg = "The problem type in the config file does not match " \
+                        "that of the custom kernel, {}.".format(kernelName) \
+                        + "\nDifferent benchmark parameters:\n" \
+                        + str(benchmarkSet - (customSet & benchmarkSet)) \
+                        + "\nDifferent custom kernel parameters:\n" \
+                        +  str(customSet - (customSet & benchmarkSet))
+                raise RuntimeError(msg)
+            else:
+                print1("# Rejected {}: Problem Type doesn't match".format(kernelName))
+        else:
+            print1("# Added {} to solutions".format(kernelName))
+            if solution["Valid"]:
+                solutions.append(solution)
+            elif globalParameters["PrintSolutionRejectionReason"]:
+                print1("rejecting solution " + str(solution))
+
+    return solutions
+
+def writeBenchmarkFiles(stepBaseDir, solutions, problemSizes, \
+        stepName, solutionSummationSizes):
+    """Write all the files needed for a given benchmarking step"""
+    if not globalParameters["MergeFiles"]:
+        ensurePath(os.path.join(globalParameters["WorkingPath"], "Solutions"))
+        ensurePath(os.path.join(globalParameters["WorkingPath"], "Kernels"))
+
+    copyStaticFiles()
+
+    kernels           = []
+    kernelHelperOjbs  = []
+    kernelNames       = set()
+    kernelHelperNames = set()
+
+    # get unique kernels and kernel helpers
+    for solution in Utils.tqdm(solutions, "Finding unique solutions"):
+        solutionKernels = solution.getKernels()
+        for kernel in solutionKernels:
+            kName = Solution.getNameFull(kernel)
+            if kName not in kernelNames:
+                kernels.append(kernel)
+                kernelNames.add(kName)
+
+        solutionHelperKernels = solution.getHelperKernelObjects()
+        for ko in solutionHelperKernels:
+            kname = ko.getKernelName()
+            if kname not in kernelHelperNames:
+                kernelHelperOjbs.append(ko)
+                kernelHelperNames.add(kname)
+
+    solutionSerialNaming = Solution.getSerialNaming(solutions)
+    kernelSerialNaming   = Solution.getSerialNaming(kernels)
+    solutionMinNaming    = Solution.getMinNaming(solutions)
+    kernelMinNaming      = Solution.getMinNaming(kernels)
+    solutionWriter       = SolutionWriter(solutionMinNaming, \
+            solutionSerialNaming, kernelMinNaming, kernelSerialNaming)
+    kernelWriterSource   = KernelWriterSource(kernelMinNaming, kernelSerialNaming)
+    kernelWriterAssembly = KernelWriterAssembly(kernelMinNaming, kernelSerialNaming)
+
+    # write solution, kernels and CMake
+    problemType = solutions[0]["ProblemType"]
+    codeObjectFiles = writeSolutionsAndKernels( \
+            globalParameters["WorkingPath"], globalParameters["CxxCompiler"], \
+            [problemType], solutions, kernels, kernelHelperOjbs, solutionWriter, \
+            kernelWriterSource, kernelWriterAssembly, errorTolerant=True )
+    # ^ this is where solutions is mutated
+
+    newLibraryDir = ensurePath(os.path.join(globalParameters["WorkingPath"], 'library'))
+    newLibraryFile = os.path.join(newLibraryDir, "TensileLibrary")
+    newLibrary = SolutionLibrary.MasterSolutionLibrary.BenchmarkingLibrary(solutions)
+    newLibrary.applyNaming(kernelMinNaming)
+    LibraryIO.write(newLibraryFile, Utils.state(newLibrary), globalParameters["LibraryFormat"])
+
+    codeObjectFiles = [os.path.relpath(f, globalParameters["WorkingPath"]) \
+            for f in codeObjectFiles]
+
+    if "TileAwareSelection" in problemType and problemType["TileAwareSelection"]:
+        maxMacroTile0 = 0
+        maxMacroTile1 = 0
+        for solution in solutions:
+            macroTile0 = solution["MacroTile0"]
+            macroTile1 = solution["MacroTile1"]
+            if macroTile0 > maxMacroTile0:
+                maxMacroTile0 = macroTile0
+            if macroTile1 > maxMacroTile1:
+                maxMacroTile1 = macroTile1
+        idealM = 36 * maxMacroTile0
+        idealN = 36 * maxMacroTile1
+        idealSizes = []
+        if problemType["Batched"]:
+                for idealK in solutionSummationSizes:
+                    idealSize = {"Exact": [idealM, idealN, 1, idealK]}
+                    idealSizes.append(idealSize)
+        else:
+                for idealK in solutionSummationSizes:
+                    idealSize = {"Exact": [idealM, idealN, idealK]}
+                    idealSizes.append(idealSize)
+        idealProblemSizes = ProblemSizes(problemType, idealSizes)
+        writeClientConfig(True, solutions, idealProblemSizes, stepName, stepBaseDir, \
+            newLibrary, codeObjectFiles, True)
+    else:
+        writeClientConfig(True, solutions, problemSizes, stepName, stepBaseDir, \
+            newLibrary, codeObjectFiles, False)
+
+    if len(solutions) == 0:
+        printExit("write solutions and kernels results 0 valid soultion.")
+
+def benchmarkProblemType(problemTypeConfig, problemSizeGroupConfig, problemSizeGroupIdx):
+    """Run the benchmarking for a single entry in the BenchmarkProblems of a Tensile config"""
     benchmarkTestFails = 0
 
-    # convert config to full benchmark process (resolves defaults)
     print1("")
     print1(HR)
     print1("# Converting Config to BenchmarkProcess Object")
@@ -98,10 +204,9 @@ def benchmarkProblemType( problemTypeConfig, problemSizeGroupConfig, problemSize
     benchmarkProcess = BenchmarkProcess(problemTypeConfig, problemSizeGroupConfig)
 
     enableTileSelection = benchmarkProcess.problemType["TileAwareSelection"]
-    problemTypeName = str(benchmarkProcess.problemType)
-    problemSizeGroupName = "%s_%02u" % (problemTypeName, problemSizeGroupIdx)
-    pushWorkingPath(problemSizeGroupName)
-    ensurePath(os.path.join(globalParameters["WorkingPath"],"Data"))
+    groupName = "{}_{:02d}".format(str(benchmarkProcess.problemType), problemSizeGroupIdx)
+    pushWorkingPath(groupName)
+    ensurePath(os.path.join(globalParameters["WorkingPath"], "Data"))
 
     totalBenchmarkSteps = len(benchmarkProcess)
     resultsFileBaseFinal = None
@@ -112,7 +217,6 @@ def benchmarkProblemType( problemTypeConfig, problemSizeGroupConfig, problemSize
     print1("# Done Creating BenchmarkProcess Object")
     print1(HR)
 
-
     for benchmarkStepIdx in range(0, totalBenchmarkSteps):
         benchmarkStep = benchmarkProcess[benchmarkStepIdx]
         stepName = str(benchmarkStep)
@@ -122,99 +226,55 @@ def benchmarkProblemType( problemTypeConfig, problemSizeGroupConfig, problemSize
         print1(HR)
         currentTime = time.time()
         elapsedTime = currentTime - startTime
-        print1("# Benchmark Step: {} - {} {:.3f}s".format(problemSizeGroupName, stepName, elapsedTime))
+        print1("# Benchmark Step: {} - {} {:.3f}s".format(groupName, stepName, elapsedTime))
         print1("# Num Sizes: {}".format(benchmarkStep.problemSizes.totalProblemSizes))
         print1("# Fork Parameters:")
         for k, v in benchmarkStep.forkParams.items():
             print1("#     {}: {}".format(k, v))
 
         pushWorkingPath(shortName)
-
-        # copy files to benchmark source directory
         stepBaseDir = globalParameters["WorkingPath"]
-        sourceDir = os.path.join(stepBaseDir, "source" )
-        ensurePath(sourceDir)
-
-        filesToCopy = []
         pushWorkingPath("source")
-        filesToCopy = [
-                "TensileTypes.h",
-                "tensile_bfloat16.h",
-                "KernelHeader.h",
-                ]
-
-        for f in filesToCopy:
-            shutil.copy(
-                    os.path.join(globalParameters["SourcePath"], f),
-                    globalParameters["WorkingPath"] )
-        if globalParameters["RuntimeLanguage"] == "OCL":
-            shutil.copy(
-                    os.path.join(globalParameters["SourcePath"], "FindOpenCL.cmake"),
-                    globalParameters["WorkingPath"] )
-        else:
-            shutil.copy(
-                    os.path.join(globalParameters["SourcePath"], "FindHIP.cmake"),
-                    globalParameters["WorkingPath"] )
 
         # enumerate benchmark permutations and create resulting solution objects
         forkPermutations = constructForkPermutations(benchmarkStep.forkParams)
-        maxPossibleSolutions = len(forkPermutations) #* numHardcoded
-        solutions = generateForkedSolutions(benchmarkProcess.problemType, \
+        maxPossibleSolutions = len(forkPermutations)
+
+        regSolutions = generateForkedSolutions(benchmarkProcess.problemType, \
                 benchmarkStep.constantParams, forkPermutations)
+        kcSolutions = generateCustomKernelSolutions(benchmarkProcess.problemType, \
+                benchmarkStep.customKernels, not benchmarkStep.customKernelWildcard)
 
-        for kernelName in benchmarkStep.customKernels:
-            print1("# Processing custom kernel {}".format(kernelName))
-            customSolution = generateCustomKernelSolution(kernelName)
-            if customSolution["ProblemType"] != benchmarkProcess.problemType:
-                # Raise error if this kernel was specifically requested and problem type doesn't match
-                if not benchmarkStep.customKernelWildcard:
-                    missingParams = [p for p in benchmarkProcess.problemType \
-                            if p not in customSolution["ProblemType"]]
-                    extraParams   = [p for p in customSolution["ProblemType"] \
-                            if p not in benchmarkProcess.problemType]
-
-                    msg  = "The problem type in the config file does not match " \
-                                 "that of the custom kernel, {0}.".format(kernelName)
-                    msg += "\nMissing config parameters:\n" + str(missingParams)
-                    msg += "\nExtra custom kernel parameters:\n" + str(extraParams)
-                    raise RuntimeError(msg)
-                else:
-                    print1("# Rejected {}: Problem Type doesn't match".format(kernelName))
-            else:
-                print1("# Added {} to solutions".format(kernelName))
-                maxPossibleSolutions += 1
-                if customSolution["Valid"]:
-                    solutions.append(customSolution)
-                elif globalParameters["PrintSolutionRejectionReason"]:
-                    print1("rejecting solution " + str(customSolution))
+        maxPossibleSolutions += len(kcSolutions)
+        solutions = regSolutions + kcSolutions
 
         print1("# Actual Solutions: {} / {} after SolutionStructs\n" \
-                .format(len(solutions), maxPossibleSolutions))
+            .format(len(solutions), maxPossibleSolutions))
 
         # handle no valid solutions
         if len(solutions) == 0:
-                msg = "Your parameters resulted in 0 valid solutions."
-                if globalParameters["PrintSolutionRejectionReason"]:
-                        msg += "\nExamine reject and backtrace messages above to see why" \
-                                "and where solutions were rejected."
-                else:
-                        msg += "\nYou should re-run with \"PrintSolutionRejectionReason: True\"" \
-                                "to see why each parameter combination was rejected."
-                printExit(msg)
+            msg = "Your parameters resulted in 0 valid solutions."
+            if globalParameters["PrintSolutionRejectionReason"]:
+                msg += "\nExamine reject and backtrace messages above to see why" \
+                        "and where solutions were rejected."
+            else:
+                msg += "\nYou should re-run with \"PrintSolutionRejectionReason: True\"" \
+                        "to see why each parameter combination was rejected."
+            printExit(msg)
 
         if globalParameters["PrintLevel"] >= 1:
             for solution in solutions:
-                print2("#    (%u:%u) %s" % (0, 0, Solution.getNameFull(solution) ))
+                print2("#    ({}:{}) {}".format(0, 0, Solution.getNameFull(solution)) )
             print2(HR)
 
         # write benchmarkFiles
         prevCount = len(solutions)
         writeBenchmarkFiles(stepBaseDir, solutions, benchmarkStep.problemSizes, \
-                shortName, filesToCopy, [])
+                shortName, [])
         # ^ this mutates solutions
 
-        print1("# Actual Solutions: %u / %u after KernelWriter\n" \
-                    % (len(solutions), prevCount ))
+        print1("# Actual Solutions: {} / {} after KernelWriter\n" \
+                .format(len(solutions), prevCount ))
 
         popWorkingPath() # source
 
@@ -233,7 +293,8 @@ def benchmarkProblemType( problemTypeConfig, problemSizeGroupConfig, problemSize
 
             if returncode:
                 benchmarkTestFails += 1
-                printWarning("BenchmarkProblems: Benchmark Process exited with code %u" % returncode)
+                printWarning("BenchmarkProblems: Benchmark Process exited with code {}" \
+                        .format(returncode))
         else:
             print1("# Already benchmarked; skipping.")
 
@@ -244,211 +305,11 @@ def benchmarkProblemType( problemTypeConfig, problemSizeGroupConfig, problemSize
         popWorkingPath() # stepName
         currentTime = time.time()
         elapsedTime = currentTime - startTime
-        print1("%s\n# %s\n# %s: End - %.3fs\n%s\n" \
-                % (HR, problemSizeGroupName, shortName, elapsedTime, HR))
+        print1("{}\n# {}\n# {}: End - {:.3f}s\n{}\n" \
+                .format(HR, groupName, shortName, elapsedTime, HR))
 
     popWorkingPath() # ProblemType
     return (resultsFileBaseFinal, benchmarkTestFails)
-# End benchmarkProblemType()
-
-def compareResults(old, new, name):
-    """Temp doc"""
-    import math
-    if name == " WinnerIdx":
-        return 0
-
-    try:
-            old = float(old)
-    except (ValueError, TypeError):
-            old = -1
-
-    try:
-            new = float(new)
-    except (ValueError, TypeError):
-            new = -1
-
-    def isbad(x):
-            return x <= 0 or math.isnan(x) or math.isinf(x)
-
-    if isbad(old) and isbad(new):
-            return 0
-    if isbad(old):
-            return 1
-    if isbad(new):
-            raise ValueError("Old is good ({}) and new is bad ({}). Name: {}".format(old, new, name))
-
-    return abs((old-new)/old)
-
-def getResults(resultsFileName, solutions, enableTileSelection, newResultsFileName=None):
-    """Temp docs"""
-    print1("# Get Results from CSV")
-    try:
-        resultsFile = open(resultsFileName, "r")
-    except IOError:
-        printExit("Can't open \"%s\" to get results" % resultsFileName )
-
-    newCSV = itertools.repeat(None)
-    if newResultsFileName is not None:
-        newFile = open(newResultsFileName, 'r')
-        newCSV = csv.reader(newFile)
-
-        diffFile = open(newResultsFileName+'-diff.csv', 'w')
-        diffCSV = csv.writer(diffFile)
-
-    # setup data structures
-    results = []
-    numSolutions = 0
-    for solutionsForHardcoded in solutions:
-        results.append([])
-        for solution in solutionsForHardcoded:
-            numColForProblemSize = solution["ProblemType"]["TotalIndices"]
-            results[-1].append([])
-            numSolutions += 1
-
-    # read results in gflops
-    csvFile = csv.reader(resultsFile)
-
-    if globalParameters["CSVExportWinner"]:
-        # in both old/new clients, csv files always output "GFlops" ,...., "LDD" "LDC" "LDA" "LDB" "TotalFlops" "WinnerGFlops" "WinnerTimeUS" "WinnerIdx" "WinnerName" columns
-        startIdx = numColForProblemSize + 10
-    else:
-        # in both old/new clients, csv files always output "GFlops" ,...., "LDD" "LDC" "LDA" "LDB"columns
-        # old client, non-GEMM csv files don't contain "LDD" "LDC" "LDA" "LDB", so we output an "N/A" text (in csv only) for alignment purpose (-diff.csv)
-        startIdx = numColForProblemSize + 5
-
-    rowLength = startIdx + numSolutions
-
-    rowIdx = 0
-    for row,newRow in zip(csvFile, newCSV):
-        rowIdx+=1
-        if rowIdx == 1:
-            if newRow is not None:
-                diffCSV.writerow(row)
-                diffCSV.writerow(newRow)
-                headerRow = row
-            continue
-        else:
-            if len(row) < rowLength:
-                printWarning("CSV File %s row %u doesn't have %u elements; ignoring remainer of file." \
-                        % (resultsFileName, rowIdx, rowLength) )
-                break
-            if newRow is not None:
-                diffCSV.writerow([compareResults(old,new,name) for old,new,name in itertools.zip_longest(row, newRow, headerRow)])
-
-            idx = startIdx
-            for i,solutionsForHardcoded in enumerate(solutions):
-                for j,solution in enumerate(solutionsForHardcoded):
-                    gflops = float(row[idx])
-
-                    results[i][j].append(gflops)
-                    idx += 1
-    if rowIdx < 2 and not enableTileSelection:
-        printExit("CSV File %s only has %u row(s); prior benchmark must not have run long enough to produce data." \
-                % (resultsFileName, rowIdx) )
-
-    resultsFile.close()
-    if newResultsFileName is not None:
-        newFile.close()
-        diffFile.close()
-    return results
-
-def writeBenchmarkFiles(stepBaseDir, solutions, problemSizes, \
-    stepName, filesToCopy, solutionSummationSizes):
-  """Temp doc"""
-  if not globalParameters["MergeFiles"] or globalParameters["NumMergedFiles"] > 1:
-    ensurePath(os.path.join(globalParameters["WorkingPath"], "Solutions"))
-    ensurePath(os.path.join(globalParameters["WorkingPath"], "Kernels"))
-
-  # min Naming
-  kernels = []
-  kernelHelperOjbs = []
-
-  kernelNames = set()
-  kernelHelperNames = set()
-
-  for solution in Utils.tqdm(solutions, "Finding unique solutions"):
-    solutionKernels = solution.getKernels()
-    for kernel in solutionKernels:
-      kName = Solution.getNameFull(kernel)
-      if kName not in kernelNames:
-        kernels.append(kernel)
-        kernelNames.add(kName)
-
-    solutionHelperKernels = solution.getHelperKernelObjects()
-    for ko in solutionHelperKernels:
-      kname = ko.getKernelName()
-      if kname not in kernelHelperNames:
-        kernelHelperOjbs.append(ko)
-        kernelHelperNames.add(kname)
-
-
-  solutionSerialNaming = Solution.getSerialNaming(solutions)
-  kernelSerialNaming   = Solution.getSerialNaming(kernels)
-  solutionMinNaming    = Solution.getMinNaming(solutions)
-  kernelMinNaming      = Solution.getMinNaming(kernels)
-  solutionWriter       = SolutionWriter(solutionMinNaming, solutionSerialNaming, kernelMinNaming, kernelSerialNaming)
-  kernelWriterSource   = KernelWriterSource(kernelMinNaming, kernelSerialNaming)
-  kernelWriterAssembly = KernelWriterAssembly(kernelMinNaming, kernelSerialNaming)
-
-  # write solution, kernels and CMake
-  problemType = solutions[0]["ProblemType"]
-  codeObjectFiles = writeSolutionsAndKernels( \
-      globalParameters["WorkingPath"], globalParameters["CxxCompiler"], [problemType], solutions, kernels, kernelHelperOjbs, \
-      solutionWriter, kernelWriterSource, kernelWriterAssembly, errorTolerant=True )
-  # ^ this is where solutions is mutated
-
-  newLibraryDir = ensurePath(os.path.join(globalParameters["WorkingPath"], 'library'))
-  newLibraryFile = os.path.join(newLibraryDir, "TensileLibrary")
-  newLibrary = SolutionLibrary.MasterSolutionLibrary.BenchmarkingLibrary(solutions)
-  newLibrary.applyNaming(kernelMinNaming)
-  LibraryIO.write(newLibraryFile, Utils.state(newLibrary), globalParameters["LibraryFormat"])
-
-  codeObjectFiles = [os.path.relpath(f, globalParameters["WorkingPath"]) for f in codeObjectFiles]
-
-  writeClientConfig(True, solutions, problemSizes, stepName, stepBaseDir, newLibrary, codeObjectFiles, False)
-
-  if "TileAwareSelection" in problemType and problemType["TileAwareSelection"]:
-    maxMacroTile0 = 0
-    maxMacroTile1 = 0
-    for solution in solutions:
-      macroTile0 = solution["MacroTile0"]
-      macroTile1 = solution["MacroTile1"]
-      if macroTile0 > maxMacroTile0:
-        maxMacroTile0 = macroTile0
-      if macroTile1 > maxMacroTile1:
-        maxMacroTile1 = macroTile1
-    idealM = 36 * maxMacroTile0
-    idealN = 36 * maxMacroTile1
-    idealSizes = []
-    if problemType["Batched"]:
-        for idealK in solutionSummationSizes:
-          idealSize = {"Exact": [idealM, idealN, 1, idealK]}
-          idealSizes.append(idealSize)
-    else:
-        for idealK in solutionSummationSizes:
-          idealSize = {"Exact": [idealM, idealN, idealK]}
-          idealSizes.append(idealSize)
-    idealProblemSizes = ProblemSizes(problemType, idealSizes)
-    writeClientConfig(True, solutions, idealProblemSizes, stepName, stepBaseDir, newLibrary, codeObjectFiles, True)
-
-    if len(solutions) == 0:
-        printExit("write solutions and kernels results 0 valid soultion.")
-
-    # write CMake
-    outputPath = globalParameters["WorkingPath"]
-
-    (solutionFiles,
-     sourceKernelFiles,
-     asmKernelFiles,
-     sourceLibFiles,
-     asmLibFiles) = buildObjectFileNames(solutionWriter, kernelWriterSource, \
-        kernelWriterAssembly, solutions, kernels, kernelHelperOjbs)
-
-    writeCMake(outputPath, solutionFiles, sourceKernelFiles, filesToCopy)
-
-    for fileName in filesToCopy:
-        shutil.copy( os.path.join(globalParameters["SourcePath"], fileName), \
-            outputPath )
 
 
 def main(config):
@@ -467,7 +328,7 @@ def main(config):
         else:
             problemSizeGroupConfigs = benchmarkProblemTypeConfig[1:]
 
-        for problemSizeGroupIdx, problemSizeGroupConfig in enumerate(problemSizeGroupConfigs):
+        for idx, problemSizeGroupConfig in enumerate(problemSizeGroupConfigs):
             print2("ProblemTypeConfig: {}".format(problemTypeConfig))
             problemTypeObj = ProblemType(problemTypeConfig)
             globalParameters["EnableHalf"] = problemTypeObj["DataType"].isHalf()
@@ -476,11 +337,11 @@ def main(config):
             csvSuffix = "_CSVWinner" if globalParameters["CSVExportWinner"] else ""
             # results files will be named
             newResultsFileName = os.path.join(dataPath, "{}_{:02d}{}.csv" \
-                    .format(str(problemTypeObj), problemSizeGroupIdx, csvSuffix) )
+                    .format(str(problemTypeObj), idx, csvSuffix) )
             newSolutionsFileName = os.path.join(dataPath, "{}_{:02d}{}.yaml" \
-                    .format(str(problemTypeObj), problemSizeGroupIdx, csvSuffix) )
+                    .format(str(problemTypeObj), idx, csvSuffix) )
             newGranularityFileName = os.path.join(dataPath, "{}_{:02d}{}.gsp" \
-                    .format(str(problemTypeObj), problemSizeGroupIdx, csvSuffix) )
+                    .format(str(problemTypeObj), idx, csvSuffix) )
 
             # skip if possible
             if globalParameters["ForceRedoBenchmarkProblems"] \
@@ -488,7 +349,7 @@ def main(config):
 
                 # benchmark problem size group
                 (resultsFileBaseFinal, benchmarkErrors) = \
-                        benchmarkProblemType(problemTypeConfig, problemSizeGroupConfig, problemSizeGroupIdx)
+                        benchmarkProblemType(problemTypeConfig, problemSizeGroupConfig, idx)
                 totalTestFails += benchmarkErrors
 
                 print("clientExit={} {} for {}" \
@@ -496,9 +357,9 @@ def main(config):
                         globalParameters["ConfigPath"]) )
 
                 # copy data
-                resultsFileBase = resultsFileBaseFinal
-                resultsFileName = resultsFileBase + ".csv"
-                solutionsFileName = resultsFileBase + ".yaml"
+                resultsFileBase     = resultsFileBaseFinal
+                resultsFileName     = resultsFileBase + ".csv"
+                solutionsFileName   = resultsFileBase + ".yaml"
                 granularityFileName = resultsFileBase + "_Granularity.csv"
                 shutil.copy( resultsFileName, newResultsFileName )
                 shutil.copy( solutionsFileName, newSolutionsFileName )
@@ -506,7 +367,7 @@ def main(config):
                     shutil.copy( granularityFileName, newGranularityFileName )
             else:
                 print1("# {}_{:02d} already benchmarked; skipping." \
-                        .format(str(problemTypeObj), problemSizeGroupIdx) )
+                        .format(str(problemTypeObj), idx) )
 
     popWorkingPath()
 

--- a/Tensile/BenchmarkProblems.py
+++ b/Tensile/BenchmarkProblems.py
@@ -80,20 +80,19 @@ def generateCustomKernelSolutions(problemType, customKernels, failOnMismatch):
         if solution["ProblemType"] != problemType:
             # Raise error if this kernel was specifically requested and problem type doesn't match
             if failOnMismatch:
-                foo = [(k,tuple(v)) if type(v) is list else (k,v) \
-                        for k,v in problemType.items()]
-                bar = [(k,tuple(v)) if type(v) is list else (k,v) \
-                        for k,v in solution["ProblemType"].items()]
+                benchmarkSet = set([(k,tuple(v)) if type(v) is list else (k,v) \
+                        for k,v in problemType.items()])
+                customSet = set([(k,tuple(v)) if type(v) is list else (k,v) \
+                        for k,v in solution["ProblemType"].items()])
 
-                benchmarkSet = set(foo)
-                customSet    = set(bar)
                 msg = "The problem type in the config file does not match " \
                         "that of the custom kernel, {}.".format(kernelName) \
-                        + "\nDifferent benchmark parameters:\n" \
-                        + str(benchmarkSet - (customSet & benchmarkSet)) \
-                        + "\nDifferent custom kernel parameters:\n" \
-                        +  str(customSet - (customSet & benchmarkSet))
-                raise RuntimeError(msg)
+                        + "\nDiffering parameters:\n" \
+                        + "\tConfig values:\n\t" \
+                        + str(sorted(benchmarkSet - (customSet & benchmarkSet))) \
+                        + "\n\tCustom kernel values:\n\t" \
+                        +  str(sorted(customSet - (customSet & benchmarkSet)))
+                printExit(msg)
             else:
                 print1("# Rejected {}: Problem Type doesn't match".format(kernelName))
         else:

--- a/Tensile/BenchmarkProblems.py
+++ b/Tensile/BenchmarkProblems.py
@@ -47,6 +47,7 @@ def generateForkedSolutions(problemType, constantParams, forkPermutations):
     print1("# Enumerating Solutions")
 
     solutions = []
+    solutionSet = set()
     for perm in forkPermutations:
         solution = {"ProblemType": deepcopy(problemType.state)}
         solution.update(constantParams)
@@ -55,7 +56,9 @@ def generateForkedSolutions(problemType, constantParams, forkPermutations):
         # TODO check if solution matches problem size for exact tile kernels
         solutionObject = Solution(solution)
         if solutionObject["Valid"]:
-            solutions.append(solutionObject)
+            if solutionObject not in solutionSet:
+                solutionSet.add(solutionObject)
+                solutions.append(solutionObject)
         elif globalParameters["PrintSolutionRejectionReason"]:
             print1("rejecting solution " + str(solutionObject))
 

--- a/Tensile/BenchmarkStructs.py
+++ b/Tensile/BenchmarkStructs.py
@@ -125,10 +125,16 @@ class BenchmarkProcess:
         elif len(badsInConfig) > 1:
             printExit("Benchmark steps {} are no longer supported".format(badsInConfig))
 
-        # get supported legacy benchmark steps
-        benchmarkCommonParams = config.get("BenchmarkCommonParameters", [])
-        forkParams            = config.get("ForkParameters", [])
-        self.customKernels    = config.get("CustomKernels", [])
+        # get supported benchmark steps
+        def getNonNoneFromConfig(key, default):
+            if config.get(key) is not None:
+                return config[key]
+            else:
+                return default
+
+        benchmarkCommonParams = getNonNoneFromConfig("BenchmarkCommonParameters", [])
+        forkParams            = getNonNoneFromConfig("ForkParameters", [])
+        self.customKernels    = getNonNoneFromConfig("CustomKernels", [])
 
         if "BenchmarkFinalParameters" in config:
             sizes = config["BenchmarkFinalParameters"][0]["ProblemSizes"]

--- a/Tensile/BenchmarkStructs.py
+++ b/Tensile/BenchmarkStructs.py
@@ -21,247 +21,247 @@
 
 from copy import copy, deepcopy
 from .Common import print1, print2, printWarning, defaultSolution, \
-    defaultBenchmarkFinalProblemSizes, defaultBatchedBenchmarkFinalProblemSizes, \
-    defaultBenchmarkCommonParameters, hasParam, printExit, \
-    validParameters, globalParameters
+        defaultBenchmarkFinalProblemSizes, defaultBatchedBenchmarkFinalProblemSizes, \
+        defaultBenchmarkCommonParameters, hasParam, printExit, \
+        validParameters, globalParameters
 from .SolutionStructs import Solution, ProblemType, ProblemSizes
 
 
 def getDefaultsForMissingParameters(parameterConfigurationList, defaultParameters):
-  """Temp doc"""
-  benchmarkParameters = []
-  for paramDict in defaultParameters:
-    for paramName in paramDict:
-      if not hasParam(paramName, parameterConfigurationList) \
-          or paramName == "ProblemSizes":
-        benchmarkParameters.append(paramDict)
-  return benchmarkParameters
+    """Temp doc"""
+    benchmarkParameters = []
+    for paramDict in defaultParameters:
+        for paramName in paramDict:
+            if not hasParam(paramName, parameterConfigurationList) \
+                    or paramName == "ProblemSizes":
+                benchmarkParameters.append(paramDict)
+    return benchmarkParameters
 
 def checkForValidParameters(params, validParameterNames):
-  """Temp doc"""
-  for paramName in params:
-    if paramName in ["ProblemSizes"]:
-      continue
-    else:
-      if paramName not in validParameterNames:
-        raise RuntimeError("Invalid parameter name: %s\nValid parameters are %s." \
-            % (paramName, sorted(validParameterNames)))
-      paramValues = params[paramName]
-      for paramValue in paramValues:
-        if validParameters[paramName] != -1 and paramValue not in validParameters[paramName]:
-          raise RuntimeError("Invalid parameter value: %s = %s\nValid values for %s are %s%s." \
-                    % (paramName, paramValue, paramName, validParameters[paramName][:32],
-                        " (only first 32 combos printed)\nRefer to Common.py for more info" if len(validParameters[paramName])>32 else ""))
+    """Temp doc"""
+    for paramName in params:
+        if paramName in ["ProblemSizes"]:
+            continue
+        else:
+            if paramName not in validParameterNames:
+                raise RuntimeError("Invalid parameter name: %s\nValid parameters are %s." \
+                        % (paramName, sorted(validParameterNames)))
+            paramValues = params[paramName]
+            for paramValue in paramValues:
+                if validParameters[paramName] != -1 and paramValue not in validParameters[paramName]:
+                    raise RuntimeError("Invalid parameter value: %s = %s\nValid values for %s are %s%s." \
+                                        % (paramName, paramValue, paramName, validParameters[paramName][:32],
+                                                " (only first 32 combos printed)\nRefer to Common.py for more info" if len(validParameters[paramName])>32 else ""))
 
 def constructForkPermutations(forkParametersConfig):
-  """Temp doc"""
-  totalPermutations = 1
-  for k, v in forkParametersConfig.items():
-    totalPermutations *= len(v)
-  forkPermutations = []
-  for i in range(0, totalPermutations):
-    forkPermutations.append({})
-    pIdx = i
+    """Temp doc"""
+    totalPermutations = 1
     for k, v in forkParametersConfig.items():
-      values = deepcopy(v)
-      valueIdx = pIdx % len(v)
-      forkPermutations[i][k] = values[valueIdx]
-      pIdx //= len(values)
-  return forkPermutations
+        totalPermutations *= len(v)
+    forkPermutations = []
+    for i in range(0, totalPermutations):
+        forkPermutations.append({})
+        pIdx = i
+        for k, v in forkParametersConfig.items():
+            values = deepcopy(v)
+            valueIdx = pIdx % len(v)
+            forkPermutations[i][k] = values[valueIdx]
+            pIdx //= len(values)
+    return forkPermutations
 
 def getSingleValues(parameterSetList):
-  """Temp doc"""
-  singleVaules = {}
-  for stepList in parameterSetList:
-    for paramDict in copy(stepList):
-      for paramName in copy(paramDict):
-        paramValues = paramDict[paramName]
-        if paramValues == None:
-          printExit("You must specify value for parameters \"%s\"" % paramName )
-        if len(paramValues) < 2 and paramName != "ProblemSizes":
-          paramDict.pop(paramName)
-          singleVaules[paramName] = paramValues[0]
-          if len(paramDict) == 0:
-            stepList.remove(paramDict)
+    """Temp doc"""
+    singleVaules = {}
+    for stepList in parameterSetList:
+        for paramDict in copy(stepList):
+            for paramName in copy(paramDict):
+                paramValues = paramDict[paramName]
+                if paramValues == None:
+                    printExit("You must specify value for parameters \"%s\"" % paramName )
+                if len(paramValues) < 2 and paramName != "ProblemSizes":
+                    paramDict.pop(paramName)
+                    singleVaules[paramName] = paramValues[0]
+                    if len(paramDict) == 0:
+                        stepList.remove(paramDict)
 
-  return singleVaules
+    return singleVaules
 
 def checkCDBufferAndStrides(problemType, problemSizes, isCEqualD):
-  """Temp doc"""
-  if isCEqualD and problemType["OperationType"] == "GEMM":
-    for problem in problemSizes.problems:
-      ldd = problem.sizes[problemType["IndexAssignmentsLD"][0]]
-      ldc = problem.sizes[problemType["IndexAssignmentsLD"][1]]
-      if ldd != ldc:
-        printExit("LDD(%d) != LDC(%d) causes unpredictable result when CEqualD(True)" % (ldd, ldc))
+    """Temp doc"""
+    if isCEqualD and problemType["OperationType"] == "GEMM":
+        for problem in problemSizes.problems:
+            ldd = problem.sizes[problemType["IndexAssignmentsLD"][0]]
+            ldc = problem.sizes[problemType["IndexAssignmentsLD"][1]]
+            if ldd != ldc:
+                printExit("LDD(%d) != LDC(%d) causes unpredictable result when CEqualD(True)" % (ldd, ldc))
 
 
 class BenchmarkProcess:
-  """
-  Steps in config need to be expanded and missing elements need to be assigned a default.
-  TODO better docs
-  """
+    """
+    Steps in config need to be expanded and missing elements need to be assigned a default.
+    TODO better docs
+    """
 
-  def __init__(self, problemTypeConfig, problemSizeGroupConfig):
-    """Temp doc"""
-    self.problemType = ProblemType(problemTypeConfig)
-    self.isBatched = "Batched" in problemTypeConfig and problemTypeConfig["Batched"]
-    print2("# BenchmarkProcess beginning %s" % str(self.problemType))
+    def __init__(self, problemTypeConfig, problemSizeGroupConfig):
+        """Temp doc"""
+        self.problemType = ProblemType(problemTypeConfig)
+        self.isBatched = "Batched" in problemTypeConfig and problemTypeConfig["Batched"]
+        print2("# BenchmarkProcess beginning %s" % str(self.problemType))
 
-    # create initial solution parameters
-    self.initialSolutionParameters = { "ProblemType": problemTypeConfig }
-    self.initialSolutionParameters.update(defaultSolution)
+        # create initial solution parameters
+        self.initialSolutionParameters = { "ProblemType": problemTypeConfig }
+        self.initialSolutionParameters.update(defaultSolution)
 
-    # fill parameter values from config
-    self.singleValueParameters = {}
-    self.multiValueParameters = {}
-    self.getConfigParameter(self.isBatched, problemSizeGroupConfig)
+        # fill parameter values from config
+        self.singleValueParameters = {}
+        self.multiValueParameters = {}
+        self.getConfigParameter(self.isBatched, problemSizeGroupConfig)
 
-    # convert parameter lists to steps
-    # currently only 1 benchmark step is possible, more may be added back later
-    self.currentProblemSizes = []
-    self.benchmarkStepIdx = 0
-    self.convertParametersToSteps()
+        # convert parameter lists to steps
+        # currently only 1 benchmark step is possible, more may be added back later
+        self.currentProblemSizes = []
+        self.benchmarkStepIdx = 0
+        self.convertParametersToSteps()
 
-  def getConfigParameter(self, isbatched, config):
-    """Temp doc"""
-    print2("")
-    print2("####################################################################")
-    print1("# Filling in Parameters With Defaults")
-    print2("####################################################################")
-    print2("")
+    def getConfigParameter(self, isbatched, config):
+        """Temp doc"""
+        print2("")
+        print2("####################################################################")
+        print1("# Filling in Parameters With Defaults")
+        print2("####################################################################")
+        print2("")
 
-    # check for no longer supported legacy benchmark steps
-    badParams = ["InitialSolutionParameters", "BenchmarkForkParameters", \
-                 "JoinParameters", "BenchmarkJoinParameters"]
-    badsInConfig = []
+        # check for no longer supported legacy benchmark steps
+        badParams = ["InitialSolutionParameters", "BenchmarkForkParameters", \
+                                 "JoinParameters", "BenchmarkJoinParameters"]
+        badsInConfig = []
 
-    for p in badParams:
-      if config.get(p) is not None:
-        badsInConfig.append(p)
+        for p in badParams:
+            if config.get(p) is not None:
+                badsInConfig.append(p)
 
-    if len(badsInConfig) == 1:
-      printExit("Benchmark step {} is no longer supported".format("'" + badsInConfig[0] + "'"))
-    elif len(badsInConfig) > 1:
-      printExit("Benchmark steps {} are no longer supported".format(badsInConfig))
+        if len(badsInConfig) == 1:
+            printExit("Benchmark step {} is no longer supported".format("'" + badsInConfig[0] + "'"))
+        elif len(badsInConfig) > 1:
+            printExit("Benchmark steps {} are no longer supported".format(badsInConfig))
 
-    # get supported legacy benchmark steps
-    defaultSizes = [{"ProblemSizes": defaultBatchedBenchmarkFinalProblemSizes}] if isbatched \
-        else [{"ProblemSizes": defaultBenchmarkFinalProblemSizes}]
+        # get supported legacy benchmark steps
+        defaultSizes = [{"ProblemSizes": defaultBatchedBenchmarkFinalProblemSizes}] if isbatched \
+                else [{"ProblemSizes": defaultBenchmarkFinalProblemSizes}]
 
-    benchmarkCommonParameters      = config.get("BenchmarkCommonParameters", [])
-    forkParameters                 = config.get("ForkParameters", [])
-    self.benchmarkFinalParameters  = config.get("BenchmarkFinalParameters", defaultSizes)
+        benchmarkCommonParameters      = config.get("BenchmarkCommonParameters", [])
+        forkParameters                 = config.get("ForkParameters", [])
+        self.benchmarkFinalParameters  = config.get("BenchmarkFinalParameters", defaultSizes)
 
-    configParameters = benchmarkCommonParameters + forkParameters
+        configParameters = benchmarkCommonParameters + forkParameters
 
-    # ensure only valid solution parameters were requested
-    validParameterNames = set(validParameters.keys())
-    for paramDict in configParameters:
-      try:
-        checkForValidParameters(paramDict, validParameterNames)
-      except RuntimeError as e:
-        printExit(str(e))
+        # ensure only valid solution parameters were requested
+        validParameterNames = set(validParameters.keys())
+        for paramDict in configParameters:
+            try:
+                checkForValidParameters(paramDict, validParameterNames)
+            except RuntimeError as e:
+                printExit(str(e))
 
-    # get defaults for parameters not specified in config file
-    missingParameters = getDefaultsForMissingParameters( \
-        configParameters, deepcopy(defaultBenchmarkCommonParameters))
+        # get defaults for parameters not specified in config file
+        missingParameters = getDefaultsForMissingParameters( \
+                configParameters, deepcopy(defaultBenchmarkCommonParameters))
 
-    # split parameters into single value and multi-value
-    self.singleValueParameters = getSingleValues([missingParameters, configParameters])
+        # split parameters into single value and multi-value
+        self.singleValueParameters = getSingleValues([missingParameters, configParameters])
 
-    # above function call removes singles
-    self.multiValueParameters = {}
-    for paramDict in configParameters:
-      for param, values in paramDict.items():
-        self.multiValueParameters[param] = values
+        # above function call removes singles
+        self.multiValueParameters = {}
+        for paramDict in configParameters:
+            for param, values in paramDict.items():
+                self.multiValueParameters[param] = values
 
-    # print summary of parameter values
-    print2("Single Value Parameters:")
-    for k, v in self.singleValueParameters.items():
-      print2("    {}: {}".format(k, v))
-    print2("Multi-Value Parameters:")
-    for k, v in self.multiValueParameters.items():
-      print2("    {}: {}".format(k, v))
+        # print summary of parameter values
+        print2("Single Value Parameters:")
+        for k, v in self.singleValueParameters.items():
+            print2("    {}: {}".format(k, v))
+        print2("Multi-Value Parameters:")
+        for k, v in self.multiValueParameters.items():
+            print2("    {}: {}".format(k, v))
 
-  def convertParametersToSteps(self):
-    """Temp doc"""
-    print2("")
-    print2("####################################################################")
-    print1("# Convert Parameters to Benchmark Step(s)")
-    print2("####################################################################")
-    print2("")
+    def convertParametersToSteps(self):
+        """Temp doc"""
+        print2("")
+        print2("####################################################################")
+        print1("# Convert Parameters to Benchmark Step(s)")
+        print2("####################################################################")
+        print2("")
 
-    # currently only a single step is supported
-    print2("")
-    print2("####################################################################")
-    print1("# Benchmark Final")
-    for problemSizesDict in self.benchmarkFinalParameters:
-        problemSizes = problemSizesDict["ProblemSizes"]
-        self.currentProblemSizes = ProblemSizes(self.problemType, problemSizes)
-        checkCDBufferAndStrides(self.problemType, \
-            self.currentProblemSizes, globalParameters["CEqualD"])
-        benchmarkStep = BenchmarkStep( \
-            self.multiValueParameters, \
-            self.singleValueParameters, \
-            self.currentProblemSizes, \
-            self.benchmarkStepIdx )
-        self.benchmarkSteps.append(benchmarkStep)
-        self.benchmarkStepIdx+=1
+        # currently only a single step is supported
+        print2("")
+        print2("####################################################################")
+        print1("# Benchmark Final")
+        for problemSizesDict in self.benchmarkFinalParameters:
+                problemSizes = problemSizesDict["ProblemSizes"]
+                self.currentProblemSizes = ProblemSizes(self.problemType, problemSizes)
+                checkCDBufferAndStrides(self.problemType, \
+                        self.currentProblemSizes, globalParameters["CEqualD"])
+                benchmarkStep = BenchmarkStep( \
+                        self.multiValueParameters, \
+                        self.singleValueParameters, \
+                        self.currentProblemSizes, \
+                        self.benchmarkStepIdx )
+                self.benchmarkSteps.append(benchmarkStep)
+                self.benchmarkStepIdx+=1
 
-  def __len__(self):
-    return len(self.benchmarkSteps)
+    def __len__(self):
+        return len(self.benchmarkSteps)
 
-  def __getitem__(self, key):
-    return self.benchmarkSteps[key]
+    def __getitem__(self, key):
+        return self.benchmarkSteps[key]
 
-  def __str__(self):
-    string = "BenchmarkProcess:\n"
-    for step in self.benchmarkSteps:
-      string += str(step)
-    return string
+    def __str__(self):
+        string = "BenchmarkProcess:\n"
+        for step in self.benchmarkSteps:
+            string += str(step)
+        return string
 
-  def __repr__(self):
-    return self.__str__()
+    def __repr__(self):
+        return self.__str__()
 
 
 class BenchmarkStep:
-  """Temp doc"""
-
-  def __init__(self, forkParams, constantParams, problemSizes, idx):
     """Temp doc"""
-    #TODO see if deepcopy really needed
-    self.forkParams = deepcopy(forkParams)
-    self.constantParams = deepcopy(constantParams)
-    self.problemSizes = deepcopy(problemSizes)
-    self.stepIdx = idx
 
-    print2("# Creating BenchmarkStep: {} fork params and {} sizes" \
-        .format( len(forkParams), problemSizes.totalProblemSizes))
+    def __init__(self, forkParams, constantParams, problemSizes, idx):
+        """Temp doc"""
+        #TODO see if deepcopy really needed
+        self.forkParams = deepcopy(forkParams)
+        self.constantParams = deepcopy(constantParams)
+        self.problemSizes = deepcopy(problemSizes)
+        self.stepIdx = idx
 
-  def isFinal(self):
-    """Temp doc"""
-    # currently only one benchmark step is possible
-    return True
+        print2("# Creating BenchmarkStep: {} fork params and {} sizes" \
+                .format( len(forkParams), problemSizes.totalProblemSizes))
 
-  def abbreviation(self):
-    """Temp doc"""
-    string = "{:02d}".format(self.stepIdx)
-    if self.isFinal():
-      string += "_Final"
-    else:
-      for param in self.benchmarkParameters:
-        string += "_" + Solution.getParameterNameAbbreviation(param)
-    return string
+    def isFinal(self):
+        """Temp doc"""
+        # currently only one benchmark step is possible
+        return True
 
-  def __str__(self):
-    string = "{:02d}".format(self.stepIdx)
-    if self.isFinal():
-      string += "_Final"
-    else:
-      for param in self.benchmarkParameters:
-        string += "_" + str(param)
-    return string
+    def abbreviation(self):
+        """Temp doc"""
+        string = "{:02d}".format(self.stepIdx)
+        if self.isFinal():
+            string += "_Final"
+        else:
+            for param in self.benchmarkParameters:
+                string += "_" + Solution.getParameterNameAbbreviation(param)
+        return string
 
-  def __repr__(self):
-    return self.__str__()
+    def __str__(self):
+        string = "{:02d}".format(self.stepIdx)
+        if self.isFinal():
+            string += "_Final"
+        else:
+            for param in self.benchmarkParameters:
+                string += "_" + str(param)
+        return string
+
+    def __repr__(self):
+        return self.__str__()

--- a/Tensile/BenchmarkStructs.py
+++ b/Tensile/BenchmarkStructs.py
@@ -24,8 +24,7 @@ from .Common import print1, print2, hasParam, printExit, \
         defaultBenchmarkFinalProblemSizes, defaultBatchedBenchmarkFinalProblemSizes, \
         defaultBenchmarkCommonParameters, validParameters, globalParameters
 from .CustomKernels import getAllCustomKernelNames
-from .SolutionStructs import Solution, ProblemType, ProblemSizes
-from Tensile import CustomKernels
+from .SolutionStructs import ProblemType, ProblemSizes
 
 
 def getDefaultsForMissingParameters(paramList, defaultParams):
@@ -41,7 +40,7 @@ def getDefaultsForMissingParameters(paramList, defaultParams):
 def checkParametersAreValid(params, validParams):
     """Ensures paramaters in params exist and have valid values as specified by validParames"""
     for name, values in params.items():
-        if name in ["ProblemSizes"]:
+        if name == "ProblemSizes":
             continue
 
         if name not in validParams:
@@ -88,19 +87,19 @@ class BenchmarkProcess:
         """Create from the two sections of a config for a BenchmarkProblem"""
         self.problemType = ProblemType(problemTypeConfig)
         self.isBatched = "Batched" in problemTypeConfig and problemTypeConfig["Batched"]
-        print2("# BenchmarkProcess beginning %s" % str(self.problemType))
+        print2("# BenchmarkProcess beginning {}".format(self.problemType))
 
         # fill parameter values from config
         self.singleValueParams = {}
-        self.multiValueParams = {}
-        self.customKernels = []
-        self.sizes = None
+        self.multiValueParams  = {}
+        self.customKernels     = []
+        self.sizes             = None
         self.getConfigParameters(self.isBatched, problemSizeGroupConfig)
 
         # convert parameter lists to steps
         # previously, multiple benchmark steps were possible
         # currently only 1 benchmark step is possible; more may be added back later
-        self.benchmarkSteps = []
+        self.benchmarkSteps   = []
         self.benchmarkStepIdx = 0
         self.convertParametersToSteps()
 
@@ -222,11 +221,11 @@ class BenchmarkStep:
 
     def __init__(self, forkParams, constantParams, customKernels, problemSizes, idx):
         """Basic constructor storing each argument"""
-        self.forkParams = forkParams
+        self.forkParams     = forkParams
         self.constantParams = constantParams
-        self.customKernels = customKernels
-        self.problemSizes = problemSizes
-        self.stepIdx = idx
+        self.customKernels  = customKernels
+        self.problemSizes   = problemSizes
+        self.stepIdx        = idx
 
         self.customKernelWildcard = False
         if self.customKernels == ["*"]:

--- a/Tensile/ClientWriter.py
+++ b/Tensile/ClientWriter.py
@@ -19,11 +19,12 @@
 # CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ################################################################################
 
-from .Common import globalParameters, pushWorkingPath, popWorkingPath, print1, printExit, CHeader, printWarning, listToInitializer, ClientExecutionLock
 from . import ClientExecutable
 from . import Common
 from . import LibraryIO
+from .Common import globalParameters, pushWorkingPath, popWorkingPath, print1, printExit, CHeader, printWarning, listToInitializer, ClientExecutionLock
 from .SolutionStructs import ProblemType, ProblemSizesMock
+from .TensileCreateLibrary import copyStaticFiles
 
 import os
 import subprocess
@@ -60,6 +61,7 @@ class ClientLogLevel(Enum):
   Verbose = 2
   Debug = 3
 
+
 ################################################################################
 # Main
 ################################################################################
@@ -68,29 +70,8 @@ def main( config ):
       globalParameters["LibraryLogicPath"])
   stepBaseDir = pushWorkingPath(globalParameters["LibraryClientPath"])
 
-
-  ##############################################################################
-  # Copy Source Files
-  ##############################################################################
   pushWorkingPath("source")
-  filesToCopy = [
-      "TensileTypes.h",
-      "tensile_bfloat16.h",
-      "KernelHeader.h",
-      ]
-
-  for f in filesToCopy:
-    shutil.copy(
-        os.path.join(globalParameters["SourcePath"], f),
-        globalParameters["WorkingPath"] )
-  if globalParameters["RuntimeLanguage"] == "OCL":
-    shutil.copy(
-        os.path.join(globalParameters["SourcePath"], "FindOpenCL.cmake"),
-        globalParameters["WorkingPath"] )
-  else:
-    shutil.copy(
-        os.path.join(globalParameters["SourcePath"], "FindHIP.cmake"),
-        globalParameters["WorkingPath"] )
+  copyStaticFiles()
 
   ##############################################################################
   # Read Logic Files

--- a/Tensile/ClientWriter.py
+++ b/Tensile/ClientWriter.py
@@ -28,8 +28,7 @@ from .SolutionStructs import ProblemType, ProblemSizesMock
 import os
 import subprocess
 import shlex
-from shutil import copy as shutil_copy
-from shutil import rmtree
+import shutil
 from enum import Enum
 
 from .Contractions import FreeIndex
@@ -75,29 +74,21 @@ def main( config ):
   ##############################################################################
   pushWorkingPath("source")
   filesToCopy = [
-      "SolutionMapper.h",
-      "Client.cpp",
-      "Client.h",
-      "DeviceStats.h",
-      "ReferenceCPU.h",
-      "TensorUtils.h",
-      "MathTemplates.cpp",
-      "MathTemplates.h",
+      "TensileTypes.h",
+      "tensile_bfloat16.h",
       "KernelHeader.h",
-      "Tools.h",
-      "TensileCreateLibrary.cmake",
       ]
 
   for f in filesToCopy:
-    shutil_copy(
+    shutil.copy(
         os.path.join(globalParameters["SourcePath"], f),
         globalParameters["WorkingPath"] )
   if globalParameters["RuntimeLanguage"] == "OCL":
-    shutil_copy(
+    shutil.copy(
         os.path.join(globalParameters["SourcePath"], "FindOpenCL.cmake"),
         globalParameters["WorkingPath"] )
   else:
-    shutil_copy(
+    shutil.copy(
         os.path.join(globalParameters["SourcePath"], "FindHIP.cmake"),
         globalParameters["WorkingPath"] )
 
@@ -157,7 +148,7 @@ def main( config ):
   ##############################################################################
   # if redo=true, clobber the build directory
   if globalParameters["ForceRedoLibraryClient"]:
-    rmtree(os.path.join(globalParameters["WorkingPath"], "build"), \
+    shutil.rmtree(os.path.join(globalParameters["WorkingPath"], "build"), \
         ignore_errors=True)
 
   forBenchmark = False

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -1299,19 +1299,12 @@ defaultBenchmarkCommonParameters = [
     {"GroupLoadStore":            [ False ] },
     {"MIArchVgpr":                [ False ] },
     ]
-# benchmark these solution independently
-defaultForkParameters = []
-defaultBenchmarkForkParameters = []
-defaultJoinParameters = []
-defaultBenchmarkJoinParameters = []
 
-# dictionary of defaults comprised for 1st option for each parameter
+# dictionary of defaults comprised of default option for each parameter
 defaultSolution = {}
-for paramList in [defaultBenchmarkCommonParameters, defaultForkParameters, \
-    defaultBenchmarkForkParameters,defaultBenchmarkJoinParameters]:
-  for paramDict in paramList:
-    for key, value in paramDict.items():
-      defaultSolution[key] = value[0]
+for paramDict in defaultBenchmarkCommonParameters:
+  for key, value in paramDict.items():
+    defaultSolution[key] = value[0]
 # other non-benchmark options for solutions
 
 # valid fields in ConvolutionConfig and explanations:
@@ -1746,7 +1739,7 @@ def detectGlobalCurrentISA():
   Returns returncode if detection failure
   """
   global globalParameters
-  
+
   if globalParameters["CurrentISA"] == (0,0,0) and globalParameters["ROCmAgentEnumeratorPath"]:
     process = subprocess.run([globalParameters["ROCmAgentEnumeratorPath"]], stdout=subprocess.PIPE)
     if os.name == "nt":
@@ -1771,7 +1764,7 @@ def detectGlobalCurrentISA():
       printWarning("%s exited with code %u" % (globalParameters["ROCmAgentEnumeratorPath"], process.returncode))
     return process.returncode
   return 0
-      
+
 def restoreDefaultGlobalParameters():
   """
   Restores `globalParameters` back to defaults.

--- a/Tensile/CustomKernels.py
+++ b/Tensile/CustomKernels.py
@@ -31,6 +31,9 @@ def isCustomKernelConfig(config):
 def getCustomKernelFilepath(name, directory=globalParameters["CustomKernelDirectory"]):
     return os.path.join(directory, (name + ".s"))
 
+def getAllCustomKernelNames(directory=globalParameters["CustomKernelDirectory"]):
+    return [fname[:-2] for fname in os.listdir(directory) if fname.endswith(".s")]
+
 def getCustomKernelContents(name, directory=globalParameters["CustomKernelDirectory"]):
     try:
         with open(getCustomKernelFilepath(name, directory)) as f:
@@ -41,7 +44,7 @@ def getCustomKernelContents(name, directory=globalParameters["CustomKernelDirect
 def getCustomKernelConfigAndAssembly(name, directory=globalParameters["CustomKernelDirectory"]):
     contents  = getCustomKernelContents(name, directory)
     config = "\n"    #Yaml configuration properties
-    assembly = "" 
+    assembly = ""
     inConfig = False
     for line in contents.splitlines():
         if   line == "---": inConfig = True                          #Beginning of yaml section
@@ -49,7 +52,7 @@ def getCustomKernelConfigAndAssembly(name, directory=globalParameters["CustomKer
         elif      inConfig: config   += line + "\n"
         else              : assembly += line + "\n"; config += "\n"  #Second statement to keep line numbers consistent for yaml errors
 
-    return (config, assembly)  
+    return (config, assembly)
 
 def getCustomKernelConfig(name, directory=globalParameters["CustomKernelDirectory"]):
     rawConfig, _ = getCustomKernelConfigAndAssembly(name, directory)

--- a/Tensile/LibraryIO.py
+++ b/Tensile/LibraryIO.py
@@ -71,17 +71,16 @@ def writeSolutions(filename, problemSizes, solutions):
 
     # convert objects to nested dictionaries
     solutionStates = []
-    for hardcoded in solutions:
-        for solution in hardcoded:
-            solutionState = solution.getAttributes()
-            solutionState["ProblemType"] = solutionState["ProblemType"].state
-            solutionState["ProblemType"]["DataType"] = \
-                    solutionState["ProblemType"]["DataType"].value
-            solutionState["ProblemType"]["DestDataType"] = \
-                    solutionState["ProblemType"]["DestDataType"].value
-            solutionState["ProblemType"]["ComputeDataType"] = \
-                    solutionState["ProblemType"]["ComputeDataType"].value
-            solutionStates.append(solutionState)
+    for solution in solutions:
+        solutionState = solution.getAttributes()
+        solutionState["ProblemType"] = solutionState["ProblemType"].state
+        solutionState["ProblemType"]["DataType"] = \
+                solutionState["ProblemType"]["DataType"].value
+        solutionState["ProblemType"]["DestDataType"] = \
+                solutionState["ProblemType"]["DestDataType"].value
+        solutionState["ProblemType"]["ComputeDataType"] = \
+                solutionState["ProblemType"]["ComputeDataType"].value
+        solutionStates.append(solutionState)
     # write dictionaries
     with open(filename, "w") as f:
         f.write("- MinimumRequiredVersion: %s\n" % __version__ )

--- a/Tensile/LibraryIO.py
+++ b/Tensile/LibraryIO.py
@@ -110,9 +110,9 @@ def parseSolutionsFile(filename):
 
 def parseSolutionsData(data, srcFile="?"):
     """Parses problem sizes and solutions from the data of a solutions file."""
-
     if len(data) < 3:
-        printExit("Solution file {} is missing required fields (len = {} < 3".format(srcFile, len(data)))
+        printExit("Solution file {} is missing required fields (len = {} < 3" \
+                .format(srcFile, len(data)))
 
     versionString = data[0]["MinimumRequiredVersion"]
     if not versionIsCompatible(versionString):
@@ -142,9 +142,9 @@ def parseLibraryLogicFile(filename):
 
 def parseLibraryLogicData(data, srcFile="?"):
     """Parses the data of a library logic file."""
-
     if len(data) < 9:
-        printExit("Library logic file {} is missing required fields (len = {} < 9)".format(srcFile, len(data)))
+        printExit("Library logic file {} is missing required fields (len = {} < 9)" \
+                .format(srcFile, len(data)))
 
     versionString     = data[0]["MinimumRequiredVersion"]
     scheduleName      = data[1]

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -91,7 +91,7 @@ def getAssemblyCodeObjectFiles(kernels, kernelWriterAssembly, outputPath):
           coFile = os.path.join(os.path.normcase(destArchDir), 'TensileLibrary_{}.co'.format(archName))
 
         if os.name == "nt":
-          # On Windows, the objectFiles list command line (including spaces) 
+          # On Windows, the objectFiles list command line (including spaces)
           # exceeds the limit of 8191 characters, so using response file
 
           responseArgs = objectFiles
@@ -109,7 +109,7 @@ def getAssemblyCodeObjectFiles(kernels, kernelWriterAssembly, outputPath):
         coFiles.append(coFile)
       else:
         # no mergefiles
-        
+
         assemblyKernelNames = [kernelWriterAssembly.getKernelFileBase(k) for k in archKernels]
         origCOFiles = [os.path.join(asmDir,  k + '.co') for k in assemblyKernelNames]
         newCOFiles  = []
@@ -319,8 +319,8 @@ def buildKernelSourceAndHeaderFiles(results, outputPath, kernelsWithBuildErrs, \
     kernelSourceFile:     File to write source data to
     kernelHeaderFile:     File to write header data to
 
-  Returns: 
-    sourceFilenames:      Array containing source kernel filenames 
+  Returns:
+    sourceFilenames:      Array containing source kernel filenames
   """
   sourceFilenames = []
 
@@ -336,19 +336,19 @@ def buildKernelSourceAndHeaderFiles(results, outputPath, kernelsWithBuildErrs, \
     if len(src.strip()) == 0:
       continue
     kernelsToWrite.append((err, src, header, kernelName))
-  
+
   # Write kernel data to files
   if globalParameters["MergeFiles"]:
 
     # Merge all kernels into one file
-    if globalParameters["NumMergedFiles"] == 1: 
+    if globalParameters["NumMergedFiles"] == 1:
       sourceFilenames.append(os.path.join(os.path.normcase(outputPath), "Kernels.cpp"))
       for (err,src,header,kernelName) in kernelsToWrite:
         kernelSourceFile.write(src)
         kernelHeaderFile.write(header)
 
     # Merge kernels into n seperate files
-    else: 
+    else:
 
       # Calculate num of kernels per file
       numValidKernels = len(kernelsToWrite)
@@ -358,7 +358,7 @@ def buildKernelSourceAndHeaderFiles(results, outputPath, kernelsWithBuildErrs, \
 
       # Number of kernels per file (except the last file which gets this plus any remainder)
       kernelsPerFile = numValidKernels // numMergedFiles
-    
+
       # Group kernel sources and headers into a list of lists for writing
       kernelSourceList = []
       kernelHeaderList = []
@@ -399,7 +399,7 @@ def buildKernelSourceAndHeaderFiles(results, outputPath, kernelsWithBuildErrs, \
             kernelHeaderFile.write(header)
 
   # Write kernels into seperate files
-  else: 
+  else:
     for (err,src,header,kernelName) in kernelsToWrite:
 
       # write kernel.cpp
@@ -417,7 +417,7 @@ def buildKernelSourceAndHeaderFiles(results, outputPath, kernelsWithBuildErrs, \
       kernelHeaderFile.write(CHeader)
       kernelHeaderFile.write(header)
       kernelHeaderFile.close()
-  
+
   return sourceFilenames
 
 ################################################################################
@@ -987,7 +987,9 @@ def getSolutionAndKernelWriters(solutions, kernels):
 ################################################################################
 # copy static cpp files and headers
 ################################################################################
-def copyStaticFiles(outputPath):
+def copyStaticFiles(outputPath=None):
+  if outputPath is None:
+    outputPath = globalParameters["WorkingPath"]
   libraryStaticFiles = [
     "TensileTypes.h",
     "tensile_bfloat16.h",
@@ -1454,7 +1456,7 @@ def TensileCreateLibrary():
   if globalParameters["GenerateManifestAndExit"] == True:
     return
 
-  # generate cmake for the source kernels
+  # generate cmake for the source kernels,
   if not arguments["GenerateSourcesAndExit"]:
     writeCMake(outputPath, solutionFiles, sourceKernelFiles, staticFiles)
 
@@ -1468,13 +1470,13 @@ def TensileCreateLibrary():
 
   codeObjectFiles = writeSolutionsAndKernels(outputPath, CxxCompiler, problemTypes, solutions,
                                              kernels, kernelHelperObjs, solutionWriter, kernelWriterSource, kernelWriterAssembly)
-  
+
   bothLibSet = set(sourceLibPaths + asmLibPaths)
-  setA = set( map( os.path.normcase, set(codeObjectFiles) ) ) 
+  setA = set( map( os.path.normcase, set(codeObjectFiles) ) )
   setB = set( map( os.path.normcase, bothLibSet ) )
 
-  sanityCheck0 = setA - setB 
-  sanityCheck1 = setB - setA 
+  sanityCheck0 = setA - setB
+  sanityCheck1 = setB - setA
 
   if globalParameters["PrintCodeCommands"]:
     print("codeObjectFiles:", codeObjectFiles)
@@ -1519,4 +1521,3 @@ def TensileCreateLibrary():
   print1("# Tensile Library Writer DONE")
   print1(HR)
   print1("")
-  

--- a/Tensile/TensileRetuneLibrary.py
+++ b/Tensile/TensileRetuneLibrary.py
@@ -88,32 +88,9 @@ def runBenchmarking(solutions, problemSizes, outPath, update):
     if update:
         Common.globalParameters["LibraryUpdateFile"] = os.path.join(resultsDir, "update.yaml")
 
-    # legacy
     pushWorkingPath(shortName)
     pushWorkingPath("source")
-
-    filesToCopy = [
-        "TensileTypes.h",
-        "tensile_bfloat16.h",
-        "KernelHeader.h",
-        ]
-
-    for f in filesToCopy:
-        shutil.copy(
-            os.path.join(globalParameters["SourcePath"], f),
-            globalParameters["WorkingPath"] )
-    if globalParameters["RuntimeLanguage"] == "OCL":
-        shutil.copy(
-            os.path.join(globalParameters["SourcePath"], "FindOpenCL.cmake"),
-            globalParameters["WorkingPath"] )
-    else:
-        shutil.copy(
-            os.path.join(globalParameters["SourcePath"], "FindHIP.cmake"),
-            globalParameters["WorkingPath"] )
-    # end legacy
-
-    BenchmarkProblems.writeBenchmarkFiles(benchmarkDir, solutions, problemSizes, shortName, filesToCopy, [])
-
+    BenchmarkProblems.writeBenchmarkFiles(benchmarkDir, solutions, problemSizes, shortName, [])
     popWorkingPath() # source
 
     libraryLogicPath = None

--- a/Tensile/Tests/extended/stagger_u/big_skinny_A_NN.yaml
+++ b/Tensile/Tests/extended/stagger_u/big_skinny_A_NN.yaml
@@ -28,16 +28,6 @@ BenchmarkProblems:
 
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
-        - AssertMinApproxSize: [0]
-        - AssertStrideBEqual: [ { 0: 1 } ]
-        - BufferLoad: [True] #
-        - GlobalReadVectorWidth: [1]
-        - UseSgprForGRO: [1]
-        - VectorAtomicWidth: [1]
-        - DirectToLds: True
-        - EnableMatrixInstruction: True
-        - VectorWidth: [1]
-        - LoopTail: True
       BenchmarkCommonParameters:
         - AssertMinApproxSize: [0]
         - AssertStrideBEqual: [ { 0: 1 } ]
@@ -58,8 +48,6 @@ BenchmarkProblems:
         - VectorWidth: [1]
       BenchmarkForkParameters:
       JoinParameters:
-        - MacroTile
-        - GlobalSplitU
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:

--- a/Tensile/Tests/extended/stagger_u/big_skinny_A_NT.yaml
+++ b/Tensile/Tests/extended/stagger_u/big_skinny_A_NT.yaml
@@ -28,16 +28,6 @@ BenchmarkProblems:
 
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
-        - AssertMinApproxSize: [0]
-        - AssertStrideBEqual: [ { 0: 1 } ]
-        - BufferLoad: [True] #
-        - GlobalReadVectorWidth: [1]
-        - UseSgprForGRO: [1]
-        - VectorAtomicWidth: [1]
-        - DirectToLds: True
-        - EnableMatrixInstruction: True
-        - VectorWidth: [1]
-        - LoopTail: True
       BenchmarkCommonParameters:
         - AssertMinApproxSize: [0]
         - AssertStrideBEqual: [ { 0: 1 } ]
@@ -58,8 +48,6 @@ BenchmarkProblems:
         - VectorWidth: [1]
       BenchmarkForkParameters:
       JoinParameters:
-        - MacroTile
-        - GlobalSplitU
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:

--- a/Tensile/Tests/extended/stagger_u/big_skinny_A_TN.yaml
+++ b/Tensile/Tests/extended/stagger_u/big_skinny_A_TN.yaml
@@ -28,16 +28,6 @@ BenchmarkProblems:
 
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
-        - AssertMinApproxSize: [0]
-        - AssertStrideBEqual: [ { 0: 1 } ]
-        - BufferLoad: [True] #
-        - GlobalReadVectorWidth: [1]
-        - UseSgprForGRO: [1]
-        - VectorAtomicWidth: [1]
-        - DirectToLds: True
-        - EnableMatrixInstruction: True
-        - VectorWidth: [1]
-        - LoopTail: True
       BenchmarkCommonParameters:
         - AssertMinApproxSize: [0]
         - AssertStrideBEqual: [ { 0: 1 } ]
@@ -58,8 +48,6 @@ BenchmarkProblems:
         - VectorWidth: [1]
       BenchmarkForkParameters:
       JoinParameters:
-        - MacroTile
-        - GlobalSplitU
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:

--- a/Tensile/Tests/extended/stagger_u/big_skinny_A_TT.yaml
+++ b/Tensile/Tests/extended/stagger_u/big_skinny_A_TT.yaml
@@ -28,16 +28,6 @@ BenchmarkProblems:
 
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
-        - AssertMinApproxSize: [0]
-        - AssertStrideBEqual: [ { 0: 1 } ]
-        - BufferLoad: [True] #
-        - GlobalReadVectorWidth: [1]
-        - UseSgprForGRO: [1]
-        - VectorAtomicWidth: [1]
-        - DirectToLds: True
-        - EnableMatrixInstruction: True
-        - VectorWidth: [1]
-        - LoopTail: True
       BenchmarkCommonParameters:
         - AssertMinApproxSize: [0]
         - AssertStrideBEqual: [ { 0: 1 } ]
@@ -58,8 +48,6 @@ BenchmarkProblems:
         - VectorWidth: [1]
       BenchmarkForkParameters:
       JoinParameters:
-        - MacroTile
-        - GlobalSplitU
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:

--- a/Tensile/Tests/extended/stagger_u/big_skinny_B_NN.yaml
+++ b/Tensile/Tests/extended/stagger_u/big_skinny_B_NN.yaml
@@ -28,16 +28,6 @@ BenchmarkProblems:
 
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
-        - AssertMinApproxSize: [0]
-        - AssertStrideBEqual: [ { 0: 1 } ]
-        - BufferLoad: [True] #
-        - GlobalReadVectorWidth: [1]
-        - UseSgprForGRO: [1]
-        - VectorAtomicWidth: [1]
-        - DirectToLds: True
-        - EnableMatrixInstruction: True
-        - VectorWidth: [1]
-        - LoopTail: True
       BenchmarkCommonParameters:
         - AssertMinApproxSize: [0]
         - AssertStrideBEqual: [ { 0: 1 } ]
@@ -58,8 +48,6 @@ BenchmarkProblems:
         - VectorWidth: [1]
       BenchmarkForkParameters:
       JoinParameters:
-        - MacroTile
-        - GlobalSplitU
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:

--- a/Tensile/Tests/extended/stagger_u/big_skinny_B_NT.yaml
+++ b/Tensile/Tests/extended/stagger_u/big_skinny_B_NT.yaml
@@ -28,16 +28,6 @@ BenchmarkProblems:
 
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
-        - AssertMinApproxSize: [0]
-        - AssertStrideBEqual: [ { 0: 1 } ]
-        - BufferLoad: [True] #
-        - GlobalReadVectorWidth: [1]
-        - UseSgprForGRO: [1]
-        - VectorAtomicWidth: [1]
-        - DirectToLds: True
-        - EnableMatrixInstruction: True
-        - VectorWidth: [1]
-        - LoopTail: True
       BenchmarkCommonParameters:
         - AssertMinApproxSize: [0]
         - AssertStrideBEqual: [ { 0: 1 } ]
@@ -58,8 +48,6 @@ BenchmarkProblems:
         - VectorWidth: [1]
       BenchmarkForkParameters:
       JoinParameters:
-        - MacroTile
-        - GlobalSplitU
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:

--- a/Tensile/Tests/extended/stagger_u/big_skinny_B_TN.yaml
+++ b/Tensile/Tests/extended/stagger_u/big_skinny_B_TN.yaml
@@ -28,16 +28,6 @@ BenchmarkProblems:
 
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
-        - AssertMinApproxSize: [0]
-        - AssertStrideBEqual: [ { 0: 1 } ]
-        - BufferLoad: [True] #
-        - GlobalReadVectorWidth: [1]
-        - UseSgprForGRO: [1]
-        - VectorAtomicWidth: [1]
-        - DirectToLds: True
-        - EnableMatrixInstruction: True
-        - VectorWidth: [1]
-        - LoopTail: True
       BenchmarkCommonParameters:
         - AssertMinApproxSize: [0]
         - AssertStrideBEqual: [ { 0: 1 } ]
@@ -58,8 +48,6 @@ BenchmarkProblems:
         - VectorWidth: [1]
       BenchmarkForkParameters:
       JoinParameters:
-        - MacroTile
-        - GlobalSplitU
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:

--- a/Tensile/Tests/extended/stagger_u/big_skinny_B_TT.yaml
+++ b/Tensile/Tests/extended/stagger_u/big_skinny_B_TT.yaml
@@ -28,16 +28,6 @@ BenchmarkProblems:
 
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
-        - AssertMinApproxSize: [0]
-        - AssertStrideBEqual: [ { 0: 1 } ]
-        - BufferLoad: [True] #
-        - GlobalReadVectorWidth: [1]
-        - UseSgprForGRO: [1]
-        - VectorAtomicWidth: [1]
-        - DirectToLds: True
-        - EnableMatrixInstruction: True
-        - VectorWidth: [1]
-        - LoopTail: True
       BenchmarkCommonParameters:
         - AssertMinApproxSize: [0]
         - AssertStrideBEqual: [ { 0: 1 } ]
@@ -58,8 +48,6 @@ BenchmarkProblems:
         - VectorWidth: [1]
       BenchmarkForkParameters:
       JoinParameters:
-        - MacroTile
-        - GlobalSplitU
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:

--- a/Tensile/Tests/unit/test_CustomKernels.py
+++ b/Tensile/Tests/unit/test_CustomKernels.py
@@ -22,7 +22,7 @@
 import pytest
 import os
 from Tensile.CustomKernels import getCustomKernelConfig, getCustomKernelContents
-from Tensile.BenchmarkProblems import generateCustomKernelSolution
+from Tensile.BenchmarkProblems import getCustomKernelSolutionObj
 from Tensile.Common import assignGlobalParameters
 import yaml
 
@@ -38,7 +38,7 @@ def test_FindCustomKernel(objs):
         assert False
 
 configResult = yaml.safe_load(
-"""  
+"""
 ProblemType:
     OperationType: GEMM
     DataType: s
@@ -62,7 +62,7 @@ def test_ReadCustomKernelConfig(objs):
     try:
         name, directory, result = objs
         config = getCustomKernelConfig(name, directory)
-        config["custom.config"] = result  
+        config["custom.config"] = result
     except:
         assert False
 
@@ -72,7 +72,7 @@ def test_CreateSolutionFromCustomKernel(objs):
         assignGlobalParameters({})
 
         name, directory = objs
-        solution = generateCustomKernelSolution(name, directory)
+        solution = getCustomKernelSolutionObj(name, directory)
         assert solution["Valid"]
     except:
         assert False

--- a/Tensile/Tests/unit/test_TensileCreateLibrary.py
+++ b/Tensile/Tests/unit/test_TensileCreateLibrary.py
@@ -28,28 +28,9 @@ import Tensile.LibraryIO as LibraryIO
 import Tensile.Common as Common
 import Tensile.ClientWriter as ClientWriter
 import Tensile.SolutionStructs as SolutionStructs
-import Tensile.BenchmarkProblems as BenchmarkProblems
-import Tensile.BenchmarkStructs as BenchmarkStructs
 import yaml
 
 mylogger = logging.getLogger()
-
-def test_generateSolutions(useGlobalParameters):
-    with useGlobalParameters():
-        scriptDir = os.path.dirname(os.path.realpath(__file__))
-        dataDir = os.path.realpath(os.path.join(scriptDir, "..", "test_data", "unit"))
-        problemTypeFilePath = os.path.join(dataDir, "library_data", "problemType.yaml")
-        hardcodedParametersFilePath = os.path.join(dataDir, "library_data", "hardcodedParameters.yaml")
-        initialSolutionParametersFilePath = os.path.join(dataDir, "library_data", "initialSolutionParameters.yaml")
-
-        problemType = LibraryIO.readYAML(problemTypeFilePath)["ProblemType"]
-        problemTypeObject = SolutionStructs.ProblemType(problemType)
-        hardcodedParameters = LibraryIO.readYAML(hardcodedParametersFilePath)
-        initialSolutionParameters = LibraryIO.readYAML(initialSolutionParametersFilePath)
-
-        solutionList = BenchmarkProblems.generateForkedSolutions (problemTypeObject, hardcodedParameters, [initialSolutionParameters])
-
-        assert len(solutionList) == 2
 
 def test_loadSolutions(caplog, useGlobalParameters):
     with useGlobalParameters():

--- a/Tensile/Tests/unit/test_TensileCreateLibrary.py
+++ b/Tensile/Tests/unit/test_TensileCreateLibrary.py
@@ -34,25 +34,6 @@ import yaml
 
 mylogger = logging.getLogger()
 
-def test_assignParameters():
-    problemTypeConfig = \
-        {"Batched": True, "DataType": "s", "OperationType": "GEMM", "TransposeA": False, "TransposeB": False, "UseBeta": True}
-
-    benchmarkCommonParameters = [{"LoopTail": [True]}, {"KernelLanguage": ["Assembly"]}, \
-        {"EdgeType": ["ShiftPtr"]}, {"GlobalSplitU": [1]}, {"VectorWidth": [-1]}, {"FractionalLoad": [1]}, \
-        {"PrefetchGlobalRead": [True]}]
-
-    configForkParameters = \
-        [{"WorkGroup": [[16, 16, 1]]}, {"ThreadTile": [[4, 4],[8, 8]]}]
-
-    problemTypeObj, hardcodedParameters, initialSolutionParameters = \
-        BenchmarkStructs.assignParameters(problemTypeConfig, benchmarkCommonParameters, configForkParameters)
-
-
-    assert problemTypeObj != None
-    assert hardcodedParameters != None
-    assert initialSolutionParameters != None
-
 def test_generateSolutions(useGlobalParameters):
     with useGlobalParameters():
         scriptDir = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
Several sections of BenchmarkProblems in config files have been unofficially unsupported for quite some time now:
- InitialSolutionParameters
- BenchmarkForkParameters
- JoinParameters
- BenchmarkJoinParameters
 
Previously, Tensile would simply fail with cryptic runtime errors if these steps had non-null values in a config file. This PR officially removes support for them; Tensile will now exit with a helpful error message if any of these steps have non-null values and all the code related to them has been removed.

I also did a fairly extensive refactoring of the relevant files, mostly BenchmarkProblems.py and BenchmarkStructs.py.

These changes should also make future extensions to our benchmarking process easier now that the code is cleaner and all the unnecessary parts are gone.