### PR TITLE
Make flopsPerMac 8 for 4xint8 inputs

### DIFF
--- a/Tensile/Source/lib/source/ContractionProblem.cpp
+++ b/Tensile/Source/lib/source/ContractionProblem.cpp
@@ -1049,10 +1049,7 @@ namespace Tensile
 
     size_t ContractionProblem::flopsPerMac() const
     {
-        if(m_a.dataType() == DataType::Int8x4 && m_b.dataType() == DataType::Int8x4)
-            return 4 * 2;
-        else
-            return 2;
+        return 2 * DataTypeInfo::Get(m_a.dataType()).packing;
     }
 
     size_t ContractionProblem::flopCount() const


### PR DESCRIPTION
Gflop values in older (e.g. vega20) rocBLAS logic files suggest the old client calculated total ops for problems in a way consistent with the change in this PR, although I didn't check the old client code directly to confirm this. 