### PR TITLE
Reduced max ram usage and optimized runtime of TensileCreateLibraries

### DIFF
--- a/Tensile/Parallel.py
+++ b/Tensile/Parallel.py
@@ -60,7 +60,7 @@ def apply_print_exception(item, *args):
     sys.stdout.flush()
     sys.stderr.flush()
 
-def ProcessingPool(enable=True):
+def ProcessingPool(enable=True, maxTasksPerChild=None):
   import multiprocessing
   import multiprocessing.dummy
 
@@ -69,9 +69,9 @@ def ProcessingPool(enable=True):
   if (not enable) or threadCount <= 1:
     return multiprocessing.dummy.Pool(1)
 
-  return multiprocessing.Pool(threadCount)
+  return multiprocessing.Pool(threadCount, maxtasksperchild=maxTasksPerChild)
 
-def ParallelMap(function, objects, message="", enable=True, method=None):
+def ParallelMap(function, objects, message="", enable=True, method=None, maxTasksPerChild=None):
   """
   Generally equivalent to list(map(function, objects)), possibly executing in parallel.
 
@@ -85,7 +85,7 @@ def ParallelMap(function, objects, message="", enable=True, method=None):
   """
   from .Common import globalParameters
   threadCount = CPUThreadCount(enable)
-  pool = ProcessingPool(enable)
+  pool = ProcessingPool(enable, maxTasksPerChild)
 
   if threadCount <= 1 and globalParameters["ShowProgressBar"]:
     # Provide a progress bar for single-threaded operation.


### PR DESCRIPTION
- Refactored some code into its own method to reduce memory used
- Enabled control over the maxtasksperchild value during multiprocessing to avoid reusing processes to save on memory usage
- Optimized the runtime of code that runs at the initial stage of TensileCreateLibraries

Overall memory usage is down by ~15GB and runtime is about 30% faster when running for all architectures

Tests passed:
- linting
- kernel unit tests
- client tests