### PR TITLE
Added better control of parallelism and memory usage

### DIFF
--- a/Tensile/Source/TensileCreateLibrary.cmake
+++ b/Tensile/Source/TensileCreateLibrary.cmake
@@ -33,7 +33,8 @@ function(TensileCreateLibraryCmake
     Tensile_LIBRARY_FORMAT
     Tensile_MERGE_FILES
     Tensile_SHORT_FILE_NAMES
-    Tensile_LIBRARY_PRINT_DEBUG )
+    Tensile_LIBRARY_PRINT_DEBUG
+    Tensile_CPU_THREADS )
 
 # make Tensile_PACKAGE_LIBRARY and optional parameter
 # to avoid breaking applications which us this
@@ -51,6 +52,7 @@ function(TensileCreateLibraryCmake
   message(STATUS "Tensile_COMPILER            from TensileCreateLibraryCmake : ${Tensile_COMPILER}")
   message(STATUS "Tensile_ARCHITECTURE        from TensileCreateLibraryCmake : ${Tensile_ARCHITECTURE}")
   message(STATUS "Tensile_LIBRARY_FORMAT      from TensileCreateLibraryCmake : ${Tensile_LIBRARY_FORMAT}")
+  message(STATUS "Tensile_CPU_THREADS         from TensileCreateLibraryCmake : ${Tensile_CPU_THREADS}")
 
   #execute_process(COMMAND chmod 755 ${Tensile_ROOT}/bin/TensileCreateLibrary)
   #execute_process(COMMAND chmod 755 ${Tensile_ROOT}/bin/Tensile)
@@ -89,7 +91,8 @@ function(TensileCreateLibraryCmake
   set(Tensile_CREATE_COMMAND ${Tensile_CREATE_COMMAND} "--code-object-version=${Tensile_CODE_OBJECT_VERSION}")
   set(Tensile_CREATE_COMMAND ${Tensile_CREATE_COMMAND} "--cxx-compiler=${Tensile_COMPILER}")
   set(Tensile_CREATE_COMMAND ${Tensile_CREATE_COMMAND} "--library-format=${Tensile_LIBRARY_FORMAT}")
-
+  set(Tensile_CREATE_COMMAND ${Tensile_CREATE_COMMAND} "--jobs=${Tensile_CPU_THREADS}")
+  
   # TensileLibraryWriter positional arguments
   set(Tensile_CREATE_COMMAND ${Tensile_CREATE_COMMAND}
     ${Tensile_LOGIC_PATH}

--- a/Tensile/cmake/TensileConfig.cmake
+++ b/Tensile/cmake/TensileConfig.cmake
@@ -112,6 +112,7 @@ function(TensileCreateLibraryFiles
        LIBRARY_FORMAT
        TENSILE_ROOT
        VAR_PREFIX
+       CPU_THREADS
        )
 
   # Multi value settings
@@ -182,6 +183,10 @@ function(TensileCreateLibraryFiles
 
   if(Tensile_COMPILER_PATH)
     set(Options ${Options} "--cmake-cxx-compiler=${Tensile_COMPILER_PATH}")
+  endif()
+
+  if(Tensile_CPU_THREADS)
+    set(Options ${Options} "--jobs=${Tensile_CPU_THREADS}")
   endif()
 
   if(Tensile_LIBRARY_FORMAT)


### PR DESCRIPTION
Tensile uses a lot of memory when running TensileCreateLibrary due to parallelized code.
This change allows control of parallelism and thus memory usage by letting the user specify the process count with  -j or --jobs

