### PR TITLE
New JSD metric and metric selection functionality

### DIFF
--- a/Tensile/Source/lib/include/Tensile/Debug.hpp
+++ b/Tensile/Source/lib/include/Tensile/Debug.hpp
@@ -67,6 +67,8 @@ namespace Tensile
 
         bool enableDebugSelection() const;
 
+        bool useJSD() const;
+
         int getSolutionIndex() const;
 
     private:
@@ -75,6 +77,7 @@ namespace Tensile
         int  m_value;
         int  m_value2;
         bool m_naivePropertySearch = false;
+        bool m_jsd                 = false;
         bool m_debugSelection      = false;
         int  m_solution_index      = -1;
 

--- a/Tensile/Source/lib/include/Tensile/Debug.hpp
+++ b/Tensile/Source/lib/include/Tensile/Debug.hpp
@@ -67,7 +67,7 @@ namespace Tensile
 
         bool enableDebugSelection() const;
 
-        bool useJSD() const;
+        int useMetric() const;
 
         int getSolutionIndex() const;
 
@@ -77,7 +77,7 @@ namespace Tensile
         int  m_value;
         int  m_value2;
         bool m_naivePropertySearch = false;
-        bool m_jsd                 = false;
+        int  m_use_metric          = -1;
         bool m_debugSelection      = false;
         int  m_solution_index      = -1;
 

--- a/Tensile/Source/lib/include/Tensile/Debug.hpp
+++ b/Tensile/Source/lib/include/Tensile/Debug.hpp
@@ -67,19 +67,19 @@ namespace Tensile
 
         bool enableDebugSelection() const;
 
-        int useMetric() const;
+        std::string getMetric() const;
 
         int getSolutionIndex() const;
 
     private:
         friend LazySingleton<Debug>;
 
-        int  m_value;
-        int  m_value2;
-        bool m_naivePropertySearch = false;
-        int  m_use_metric          = -1;
-        bool m_debugSelection      = false;
-        int  m_solution_index      = -1;
+        int         m_value;
+        int         m_value2;
+        bool        m_naivePropertySearch = false;
+        bool        m_debugSelection      = false;
+        int         m_solution_index      = -1;
+        std::string m_metric              = "";
 
         Debug();
     };

--- a/Tensile/Source/lib/include/Tensile/Distance.hpp
+++ b/Tensile/Source/lib/include/Tensile/Distance.hpp
@@ -182,6 +182,93 @@ namespace Tensile
         };
 
         template <typename Key>
+        struct JSDivergence : public Distance<Key>
+	{
+	  enum
+	    {
+	     HasIndex = false,
+	     HasValue = false
+            };
+	  
+	  static std::string Type()
+	  {
+	    return "JSD";
+	  }
+	  virtual std::string type() const override
+	  {
+	    return Type();
+	  }
+	  
+	  double kl_divergence(double *p, double *q) const
+	  {
+	    double acc = 0.0;
+	    int dims = 3;
+	    
+	    for(int i = 0; i < dims; i++)
+	      acc += p[i] * std::log(p[i]/q[i]);
+	    
+	    return acc;
+	  }
+	  
+	  void normalize(Key const& p, Key const& q, double *norm_p, double *norm_q) const
+	  {
+	    int const dims = 3;
+	    double sum_p = 0.0;
+	    double sum_q = 0.0;
+	    
+	    for(int i = 0; i < dims; i++)
+	      {
+		sum_p += p[i];
+		sum_q += q[i];
+	      }
+	    
+	    for(int i=0; i<dims; i++)
+	      {
+		norm_p[i] = p[i]/sum_p;
+		norm_q[i] = q[i]/sum_q;
+	      }
+	    
+	  }
+	
+	  inline double operator()(Key const& p1, Key const& p2) const
+	  {
+	    double distance = 0.0;
+
+	    double norm_p[3];
+	    double norm_q[3];
+	    double m[3];
+
+	    this->normalize(p1, p2, norm_p, norm_q);
+
+	    for(int i = 0; i < p1.size(); i++)
+	      m[i] = 0.5 * (norm_p[i] + norm_q[i]);
+
+	    distance = 0.5 * this->kl_divergence(norm_p, m) + 0.5 * this->kl_divergence(norm_q, m);
+
+	    return distance;
+	  }
+	
+	  inline bool improvementPossible(Key const& p1,
+					  Key const& p2,
+					  size_t     idx,
+					  double     bestDistance) const
+	  {
+	    double norm_p[3];
+	    double norm_q[3];
+	    double m;
+	  
+	    this->normalize(p1, p2, norm_p, norm_q);
+
+	    m = 0.5 * (norm_p[idx] + norm_q[idx]);
+	  
+	    double d0 = 0.5 * (norm_p[idx] * std::log(norm_p[idx]/m)) +
+	      0.5 * (norm_q[idx] * std::log(norm_q[idx]/m));
+
+	    return (d0 < bestDistance) || (p1 == p2);
+	  }
+	};
+
+        template <typename Key>
         struct RandomDistance : public Distance<Key>
         {
             enum

--- a/Tensile/Source/lib/include/Tensile/Distance.hpp
+++ b/Tensile/Source/lib/include/Tensile/Distance.hpp
@@ -64,6 +64,7 @@ namespace Tensile
         {
         public:
             virtual std::string type() const = 0;
+            virtual int get_distance_id() = 0;
             virtual ~Distance()              = default;
         };
 
@@ -82,6 +83,11 @@ namespace Tensile
             virtual std::string type() const override
             {
                 return Type();
+            }
+
+  	    int get_distance_id() override
+            {
+                return 0;
             }
 
             inline double operator()(Key const& p1, Key const& p2) const
@@ -119,6 +125,11 @@ namespace Tensile
             virtual std::string type() const override
             {
                 return Type();
+            }
+
+	    int get_distance_id() override
+            {
+                return 1;
             }
 
             inline double operator()(Key const& p1, Key const& p2) const
@@ -159,6 +170,11 @@ namespace Tensile
                 return Type();
             }
 
+	    int get_distance_id() override
+            {
+                return 2;
+            }
+
             inline double operator()(Key const& p1, Key const& p2) const
             {
                 double distance = 0.0;
@@ -192,12 +208,17 @@ namespace Tensile
 	  
 	  static std::string Type()
 	  {
-	    return "JSD";
+	      return "JSD";
 	  }
 	  virtual std::string type() const override
 	  {
-	    return Type();
+	      return Type();
 	  }
+
+	  int get_distance_id() override
+          {
+              return 3;
+          }
 	  
 	  double kl_divergence(double *p, double *q) const
 	  {
@@ -284,6 +305,11 @@ namespace Tensile
             virtual std::string type() const override
             {
                 return Type();
+            }
+
+	    int get_distance_id() override
+            {
+                return 4;
             }
 
             inline double operator()(Key const& p1, Key const& p2) const

--- a/Tensile/Source/lib/include/Tensile/Serialization/MatchingLibrary.hpp
+++ b/Tensile/Source/lib/include/Tensile/Serialization/MatchingLibrary.hpp
@@ -26,9 +26,9 @@
 
 #pragma once
 
+#include <Tensile/Debug.hpp>
 #include <Tensile/Distance.hpp>
 #include <Tensile/MatchingLibrary.hpp>
-#include <Tensile/Debug.hpp>
 
 #include <cstddef>
 #include <unordered_set>
@@ -130,32 +130,32 @@ namespace Tensile
 
                 bool success = false;
 
-		const int use_metric = Debug::Instance().useMetric();
+                std::string tensile_metric = Debug::Instance().getMetric();
 
-                if(use_metric != -1)
-                  distanceType = "";
+                if(!tensile_metric.empty())
+                    distanceType = tensile_metric;
 
-                if(use_metric == 2 || distanceType == "Euclidean")
+                if(distanceType == "Euclidean")
                 {
                     success = mappingDistance<Key, Matching::EuclideanDistance<Key>>(
                         io, lib, properties);
                 }
-		else if(use_metric == 3 || distanceType == "JSD")
+                else if(distanceType == "JSD")
                 {
-                    success = mappingDistance<Key, Matching::JSDivergence<Key>>(
-                        io, lib, properties);
+                    success
+                        = mappingDistance<Key, Matching::JSDivergence<Key>>(io, lib, properties);
                 }
-                else if(use_metric == 1 || distanceType == "Manhattan")
+                else if(distanceType == "Manhattan")
                 {
                     success = mappingDistance<Key, Matching::ManhattanDistance<Key>>(
                         io, lib, properties);
                 }
-                else if(use_metric == 0 || distanceType == "Ratio")
+                else if(distanceType == "Ratio")
                 {
                     success
                         = mappingDistance<Key, Matching::RatioDistance<Key>>(io, lib, properties);
                 }
-                else if(use_metric == 4 || distanceType == "Random")
+                else if(distanceType == "Random")
                 {
                     success
                         = mappingDistance<Key, Matching::RandomDistance<Key>>(io, lib, properties);

--- a/Tensile/Source/lib/include/Tensile/Serialization/MatchingLibrary.hpp
+++ b/Tensile/Source/lib/include/Tensile/Serialization/MatchingLibrary.hpp
@@ -28,6 +28,7 @@
 
 #include <Tensile/Distance.hpp>
 #include <Tensile/MatchingLibrary.hpp>
+#include <Tensile/Debug.hpp>
 
 #include <cstddef>
 #include <unordered_set>
@@ -129,9 +130,19 @@ namespace Tensile
 
                 bool success = false;
 
+		const bool jsd = Debug::Instance().useJSD();
+
+		if(jsd)
+		  distanceType = "JSD";
+
                 if(distanceType == "Euclidean")
                 {
                     success = mappingDistance<Key, Matching::EuclideanDistance<Key>>(
+                        io, lib, properties);
+                }
+		else if(distanceType == "JSD")
+                {
+                    success = mappingDistance<Key, Matching::JSDivergence<Key>>(
                         io, lib, properties);
                 }
                 else if(distanceType == "Manhattan")

--- a/Tensile/Source/lib/include/Tensile/Serialization/MatchingLibrary.hpp
+++ b/Tensile/Source/lib/include/Tensile/Serialization/MatchingLibrary.hpp
@@ -130,32 +130,32 @@ namespace Tensile
 
                 bool success = false;
 
-		const bool jsd = Debug::Instance().useJSD();
+		const int use_metric = Debug::Instance().useMetric();
 
-		if(jsd)
-		  distanceType = "JSD";
+                if(use_metric != -1)
+                  distanceType = "";
 
-                if(distanceType == "Euclidean")
+                if(use_metric == 2 || distanceType == "Euclidean")
                 {
                     success = mappingDistance<Key, Matching::EuclideanDistance<Key>>(
                         io, lib, properties);
                 }
-		else if(distanceType == "JSD")
+		else if(use_metric == 3 || distanceType == "JSD")
                 {
                     success = mappingDistance<Key, Matching::JSDivergence<Key>>(
                         io, lib, properties);
                 }
-                else if(distanceType == "Manhattan")
+                else if(use_metric == 1 || distanceType == "Manhattan")
                 {
                     success = mappingDistance<Key, Matching::ManhattanDistance<Key>>(
                         io, lib, properties);
                 }
-                else if(distanceType == "Ratio")
+                else if(use_metric == 0 || distanceType == "Ratio")
                 {
                     success
                         = mappingDistance<Key, Matching::RatioDistance<Key>>(io, lib, properties);
                 }
-                else if(distanceType == "Random")
+                else if(use_metric == 4 || distanceType == "Random")
                 {
                     success
                         = mappingDistance<Key, Matching::RandomDistance<Key>>(io, lib, properties);

--- a/Tensile/Source/lib/source/Debug.cpp
+++ b/Tensile/Source/lib/source/Debug.cpp
@@ -119,6 +119,11 @@ namespace Tensile
         return m_debugSelection;
     }
 
+    bool Debug::useJSD() const
+    {
+      return m_jsd;
+    }
+
     int Debug::getSolutionIndex() const
     {
         return m_solution_index;
@@ -147,6 +152,10 @@ namespace Tensile
         const char* solution_index = std::getenv("TENSILE_SOLUTION_INDEX");
         if(solution_index)
             m_solution_index = strtol(solution_index, nullptr, 0);
+
+	const char* jsd = std::getenv("USE_JSD");
+        if(jsd)
+            m_jsd = strtol(jsd, nullptr, 0);
     }
 
 } // namespace Tensile

--- a/Tensile/Source/lib/source/Debug.cpp
+++ b/Tensile/Source/lib/source/Debug.cpp
@@ -119,9 +119,9 @@ namespace Tensile
         return m_debugSelection;
     }
 
-    bool Debug::useJSD() const
+    int Debug::useMetric() const
     {
-      return m_jsd;
+      return m_use_metric;
     }
 
     int Debug::getSolutionIndex() const
@@ -153,9 +153,9 @@ namespace Tensile
         if(solution_index)
             m_solution_index = strtol(solution_index, nullptr, 0);
 
-	const char* jsd = std::getenv("USE_JSD");
-        if(jsd)
-            m_jsd = strtol(jsd, nullptr, 0);
+	const char* use_metric = std::getenv("USE_METRIC");
+        if(use_metric)
+            m_use_metric = strtol(use_metric, nullptr, 0);
     }
 
 } // namespace Tensile

--- a/Tensile/Source/lib/source/Debug.cpp
+++ b/Tensile/Source/lib/source/Debug.cpp
@@ -119,9 +119,9 @@ namespace Tensile
         return m_debugSelection;
     }
 
-    int Debug::useMetric() const
+    std::string Debug::getMetric() const
     {
-      return m_use_metric;
+        return m_metric;
     }
 
     int Debug::getSolutionIndex() const
@@ -153,9 +153,9 @@ namespace Tensile
         if(solution_index)
             m_solution_index = strtol(solution_index, nullptr, 0);
 
-	const char* use_metric = std::getenv("USE_METRIC");
-        if(use_metric)
-            m_use_metric = strtol(use_metric, nullptr, 0);
+        const char* tensile_metric = std::getenv("TENSILE_METRIC");
+        if(tensile_metric)
+            m_metric = tensile_metric;
     }
 
 } // namespace Tensile


### PR DESCRIPTION
This PR adds a new distance metric (even though is not technically a metric) and sketches a new functionality in Tensile to select a particular distance metric based on the value of the USE_METRIC environment variable.
The assignment a certain integer value to a metric is currently done statically. A better solution would be to rely on a method (sketched) in the class Distance to retrieve the right index. 
Suggestions on how to implement this new functionality in a clean way are more than welcome.