### PR TITLE
Add TensileUpdateLibrary for updating old library logic files

### DIFF
--- a/Tensile/LibraryIO.py
+++ b/Tensile/LibraryIO.py
@@ -250,9 +250,6 @@ def createLibraryLogic(schedulePrefix, architectureName, deviceNames, logicTuple
                 solutionState["ProblemType"]["DestDataType"].value
         solutionState["ProblemType"]["ComputeDataType"] = \
                 solutionState["ProblemType"]["ComputeDataType"].value
-
-        solutionState["ISA"] = list(solutionState["ISA"])
-        #solutionState["Fp16AltImpl"] = True
         solutionList.append(solutionState)
 
     if tileSelection:
@@ -266,9 +263,6 @@ def createLibraryLogic(schedulePrefix, architectureName, deviceNames, logicTuple
                     solutionState["ProblemType"]["DestDataType"].value
             solutionState["ProblemType"]["ComputeDataType"] = \
                     solutionState["ProblemType"]["ComputeDataType"].value
-
-
-
             solutionList.append(solutionState)
 
     data.append(solutionList)
@@ -276,10 +270,10 @@ def createLibraryLogic(schedulePrefix, architectureName, deviceNames, logicTuple
     data.append(indexOrder)
 
     # exactLogic
-    # exactLogicList = []
-    # for key in exactLogic:
-    #     exactLogicList.append([list(key), exactLogic[key]])
-    data.append(exactLogic)
+    exactLogicList = []
+    for key in exactLogic:
+        exactLogicList.append([list(key), exactLogic[key]])
+    data.append(exactLogicList)
 
     # rangeLogic
     data.append(rangeLogic)

--- a/Tensile/LibraryIO.py
+++ b/Tensile/LibraryIO.py
@@ -250,6 +250,9 @@ def createLibraryLogic(schedulePrefix, architectureName, deviceNames, logicTuple
                 solutionState["ProblemType"]["DestDataType"].value
         solutionState["ProblemType"]["ComputeDataType"] = \
                 solutionState["ProblemType"]["ComputeDataType"].value
+
+        solutionState["ISA"] = list(solutionState["ISA"])
+        #solutionState["Fp16AltImpl"] = True
         solutionList.append(solutionState)
 
     if tileSelection:
@@ -263,6 +266,9 @@ def createLibraryLogic(schedulePrefix, architectureName, deviceNames, logicTuple
                     solutionState["ProblemType"]["DestDataType"].value
             solutionState["ProblemType"]["ComputeDataType"] = \
                     solutionState["ProblemType"]["ComputeDataType"].value
+
+
+
             solutionList.append(solutionState)
 
     data.append(solutionList)
@@ -270,10 +276,10 @@ def createLibraryLogic(schedulePrefix, architectureName, deviceNames, logicTuple
     data.append(indexOrder)
 
     # exactLogic
-    exactLogicList = []
-    for key in exactLogic:
-        exactLogicList.append([list(key), exactLogic[key]])
-    data.append(exactLogicList)
+    # exactLogicList = []
+    # for key in exactLogic:
+    #     exactLogicList.append([list(key), exactLogic[key]])
+    data.append(exactLogic)
 
     # rangeLogic
     data.append(rangeLogic)

--- a/Tensile/TensileUpdateLibrary.py
+++ b/Tensile/TensileUpdateLibrary.py
@@ -90,7 +90,6 @@ def TensileUpdateLibrary(userArgs):
                 solutionState["ProblemType"]["ComputeDataType"].value
 
         solutionState["ISA"] = list(solutionState["ISA"])
-        solutionState["Fp16AltImpl"] = True
         solutionList.append(solutionState)
 
     # update yaml

--- a/Tensile/TensileUpdateLibrary.py
+++ b/Tensile/TensileUpdateLibrary.py
@@ -19,12 +19,9 @@
 # CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ################################################################################
 
-
-from . import LibraryIO
-
 from . import Common
-from .Common import assignGlobalParameters, globalParameters, print1, ensurePath, \
-        restoreDefaultGlobalParameters, HR
+from . import LibraryIO
+from .Common import assignGlobalParameters, print1, restoreDefaultGlobalParameters, HR
 from .Tensile import addCommonArguments, argUpdatedGlobalParameters
 from . import __version__
 
@@ -34,7 +31,7 @@ import os
 import sys
 
 
-def TensileRetuneLibrary(userArgs):
+def TensileUpdateLibrary(userArgs):
     print1("")
     print1(HR)
     print1("#")
@@ -44,8 +41,8 @@ def TensileRetuneLibrary(userArgs):
     argParser = argparse.ArgumentParser()
     argParser.add_argument("LogicFile", type=os.path.realpath,
                            help="Library logic file to update")
-    argParser.add_argument("OutputFile",
-                           help="Output file for update logic file")
+    argParser.add_argument("OutputPath", type=os.path.realpath,
+                           help="Where to place updated logic file")
 
     addCommonArguments(argParser)
     args = argParser.parse_args(userArgs)
@@ -56,10 +53,7 @@ def TensileRetuneLibrary(userArgs):
     print1(HR)
     print1("")
 
-
-    ##############################################
-    # Retuning
-    ##############################################
+    # setup global parameters
     restoreDefaultGlobalParameters()
     assignGlobalParameters({})
     overrideParameters = argUpdatedGlobalParameters(args)
@@ -67,21 +61,44 @@ def TensileRetuneLibrary(userArgs):
         print1("Overriding {0}={1}".format(key, value))
         Common.globalParameters[key] = value
 
-
-    #outPath = ensurePath(os.path.abspath(args.OutputPath))
+    # update logic file
+    outPath = Common.ensurePath(os.path.abspath(args.OutputPath))
+    filename = os.path.basename(libPath)
+    outFile = os.path.join(outPath, filename)
 
     libYaml = LibraryIO.readYAML(libPath)
     # parseLibraryLogicData mutates the original data, so make a copy
     fields = LibraryIO.parseLibraryLogicData(copy.deepcopy(libYaml), libPath)
-    (scheduleName, deviceNames, problemType, solutions, indexOrder, \
-            exactLogic, rangeLogic, newLibrary, architectureName) = fields
+    (_, _, problemType, solutions, _, _, _, _, _) = fields
 
-    logicTuple = (problemType, solutions, indexOrder, exactLogic, rangeLogic, None, None, None)
-    #print(exactLogic)
-    updated = LibraryIO.createLibraryLogic(scheduleName, architectureName, deviceNames, logicTuple)
+    # problem type object to state
+    problemTypeState = problemType.state
+    problemTypeState["DataType"] = problemTypeState["DataType"].value
+    problemTypeState["DestDataType"] = problemTypeState["DestDataType"].value
+    problemTypeState["ComputeDataType"] = problemTypeState["ComputeDataType"].value
 
-    LibraryIO.writeYAML(args.OutputFile, updated, explicit_start=False, explicit_end=False)
+    # solution objects to state
+    solutionList = []
+    for solution in solutions:
+        solutionState = solution.getAttributes()
+        solutionState["ProblemType"] = solutionState["ProblemType"].state
+        solutionState["ProblemType"]["DataType"] = \
+                solutionState["ProblemType"]["DataType"].value
+        solutionState["ProblemType"]["DestDataType"] = \
+                solutionState["ProblemType"]["DestDataType"].value
+        solutionState["ProblemType"]["ComputeDataType"] = \
+                solutionState["ProblemType"]["ComputeDataType"].value
+
+        solutionState["ISA"] = list(solutionState["ISA"])
+        solutionState["Fp16AltImpl"] = True
+        solutionList.append(solutionState)
+
+    # update yaml
+    libYaml[0] = {"MinimumRequiredVersion":__version__}
+    libYaml[4] = problemTypeState
+    libYaml[5] = solutionList
+    LibraryIO.writeYAML(outFile, libYaml, explicit_start=False, explicit_end=False)
 
 
 def main():
-    TensileRetuneLibrary(sys.argv[1:])
+    TensileUpdateLibrary(sys.argv[1:])

--- a/Tensile/TensileUpdateLibrary.py
+++ b/Tensile/TensileUpdateLibrary.py
@@ -1,0 +1,87 @@
+###############################################################################
+# Copyright 2016-2022 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell cop-
+# ies of the Software, and to permit persons to whom the Software is furnished
+# to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM-
+# PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNE-
+# CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+################################################################################
+
+
+from . import LibraryIO
+
+from . import Common
+from .Common import assignGlobalParameters, globalParameters, print1, ensurePath, \
+        restoreDefaultGlobalParameters, HR
+from .Tensile import addCommonArguments, argUpdatedGlobalParameters
+from . import __version__
+
+import argparse
+import copy
+import os
+import sys
+
+
+def TensileRetuneLibrary(userArgs):
+    print1("")
+    print1(HR)
+    print1("#")
+    print1("#  Tensile Update Library v{}".format(__version__))
+
+    # argument parsing and related setup
+    argParser = argparse.ArgumentParser()
+    argParser.add_argument("LogicFile", type=os.path.realpath,
+                           help="Library logic file to update")
+    argParser.add_argument("OutputFile",
+                           help="Output file for update logic file")
+
+    addCommonArguments(argParser)
+    args = argParser.parse_args(userArgs)
+
+    libPath = args.LogicFile
+    print1("#  Library Logic: {}".format(libPath))
+    print1("#")
+    print1(HR)
+    print1("")
+
+
+    ##############################################
+    # Retuning
+    ##############################################
+    restoreDefaultGlobalParameters()
+    assignGlobalParameters({})
+    overrideParameters = argUpdatedGlobalParameters(args)
+    for key, value in overrideParameters.items():
+        print1("Overriding {0}={1}".format(key, value))
+        Common.globalParameters[key] = value
+
+
+    #outPath = ensurePath(os.path.abspath(args.OutputPath))
+
+    libYaml = LibraryIO.readYAML(libPath)
+    # parseLibraryLogicData mutates the original data, so make a copy
+    fields = LibraryIO.parseLibraryLogicData(copy.deepcopy(libYaml), libPath)
+    (scheduleName, deviceNames, problemType, solutions, indexOrder, \
+            exactLogic, rangeLogic, newLibrary, architectureName) = fields
+
+    logicTuple = (problemType, solutions, indexOrder, exactLogic, rangeLogic, None, None, None)
+    #print(exactLogic)
+    updated = LibraryIO.createLibraryLogic(scheduleName, architectureName, deviceNames, logicTuple)
+
+    LibraryIO.writeYAML(args.OutputFile, updated, explicit_start=False, explicit_end=False)
+
+
+def main():
+    TensileRetuneLibrary(sys.argv[1:])

--- a/Tensile/bin/TensileUpdateLibrary
+++ b/Tensile/bin/TensileUpdateLibrary
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+################################################################################
+# Copyright 2016-2022 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell cop-
+# ies of the Software, and to permit persons to whom the Software is furnished
+# to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM-
+# PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNE-
+# CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+################################################################################
+# This script only gets called by CMake
+
+try:
+    from Tensile import TensileUpdateLibrary
+except ImportError:
+    import os.path
+    import sys
+    parentdir = os.path.normpath(os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", ".."))
+    sys.path.append(parentdir)
+
+    from Tensile import TensileUpdateLibrary
+
+# script run from commandline
+if __name__ == "__main__":
+    TensileUpdateLibrary.main()


### PR DESCRIPTION
As Tensile is updated with new solution parameters, solutions from old library logic files will not have values for said new parameters. On the surface this is not an issue, as the missing parameters will be assigned default values when being parsed by Tensile. However, these missing parameters _can_ lead to issues with the merge utility script, where solutions are treated as different when they are actually the same due to missing parameters in one of the solutions. As a result, duplicate solutions can be present after a merge. 

Thus far, these duplicate solutions have not been an issue, as they get identified as duplicates and handled properly during TensileCreateLibrary. Recently though, this did cause issues for a rocBLAS tuning PR that had to update the Fp16AltImpl files. To solve the problem, I wrote a simple program to update the solutions in a given library logic file to have all the most current solution parameters. After cleaning it up to a point that makes it generally useful to others, I figured we might as well put it into mainline Tensile. 

By leveraging existing Tensile functions, the program is quite simple. In short, it parses the problem type and solution objects from the library logic file, then turns these objects back into their yaml representations and updates the file. 