### PR TITLE
Fix: Segmentation fault when run i8 datatype with TENSILE_DB=0x80

### DIFF
--- a/Tensile/KernelWriter.py
+++ b/Tensile/KernelWriter.py
@@ -1095,11 +1095,11 @@ class KernelWriter(metaclass=abc.ABCMeta):
       ####
       if self.numVgprBuffer >= kernel["LoopIters"]:
         for vacancy in self.localReadsVacancy:
-          # {"items","letencyLeft","atIter","atMfmaIndex","noReadsAtThisIter"}
+          # {"items","latencyLeft","atIter","atMfmaIndex","noReadsAtThisIter"}
           for localRead in list(localReadItemsThisLoop):
-            if vacancy["letencyLeft"] > localRead.IssueLatency * 2:
+            if vacancy["latencyLeft"] > localRead.IssueLatency * 2:
               if not localRead.readToTempVgpr:
-                vacancy["letencyLeft"] -= localRead.IssueLatency * 2
+                vacancy["latencyLeft"] -= localRead.IssueLatency * 2
                 vacancy["items"].addCode(localRead)
                 localReadItemsThisLoop.remove(localRead)
                 if vacancy["atMfmaIndex"] > self.lwStartMfmaIndex - 1 and kernel["1LDSBuffer"]:
@@ -1113,7 +1113,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
                         self.localReadsWait[readsIter].lgkmcnt += 1
             else:
               # make sure the localread sequence remain the same
-              vacancy["letencyLeft"] = 0
+              vacancy["latencyLeft"] = 0
       numReadsInst = len(localReadItemsThisLoop) if iteration < isBarrier else len(localReadItemsNextLoop)
 
       for i in range(numMfmaPerIter):
@@ -1173,10 +1173,10 @@ class KernelWriter(metaclass=abc.ABCMeta):
         if not localReadItemsThisLoop and latencyLeft > 0 and iteration < isBarrier and \
             not(mfmaIndex > self.lwStartMfmaIndex and kernel["1LDSBuffer"]):
           item = Code.Module()
-          item.addComment0("localReadsVacancy: letencyLeft %d"%(latencyLeft))
+          item.addComment0("localReadsVacancy: latencyLeft %d"%(latencyLeft))
           iterCode.addCode(item)
           self.localReadsVacancy.append({ "items": item, \
-                                          "letencyLeft": latencyLeft, \
+                                          "latencyLeft": latencyLeft, \
                                           "atIter": iteration, \
                                           "atMfmaIndex": mfmaIndex, \
                                           "noReadsAtThisIter": numReadsInst == 0, \

--- a/Tensile/Source/client/include/DataInitializationTyped.hpp
+++ b/Tensile/Source/client/include/DataInitializationTyped.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright 2019-2021 Advanced Micro Devices, Inc.
+ * Copyright 2019-2022 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -479,7 +479,7 @@ namespace Tensile
                 auto p = std::shared_ptr<T>(ptr, hipFree);
                 if(Debug::Instance().printTensorInfo())
                     std::cout << "info: allocate " << title << " " << std::setw(sizew) << size
-                              << " bytes at " << ptr << "\n";
+                              << " bytes at " << static_cast<void*>(ptr) << "\n";
                 return p;
             }
 


### PR DESCRIPTION
Setting TENSILE_DB=0x80 would let tensile runtime try to print tensor buffer address of **(TYPE \*)ptr**.
If datatype is i8, it would try to print **(unsigned char \*) ptr** as string but not buffer address, then cause the crash.
