### PR TITLE
Have separate-architectures flag include hip solutions

### DIFF
--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -1237,8 +1237,6 @@ def generateLogicDataAndSolutions(logicFiles, args):
       else:
         masterLibraries[architectureName] = deepcopy(newLibrary)
         masterLibraries[architectureName].version = args.version
-        masterLibraries[architectureName].remapSolutionIndicesStartingFrom(nextSolIndex)
-        nextSolIndex += max(masterLibraries[architectureName].solutions.keys()) + 1
     else:
       if fullMasterLibrary is None:
         fullMasterLibrary = deepcopy(newLibrary)
@@ -1253,6 +1251,13 @@ def generateLogicDataAndSolutions(logicFiles, args):
 
     for solution in solutionsForSchedule:
       solutions.append(solution)
+
+  if globalParameters["SeparateArchitectures"] and "fallback" in masterLibraries.keys():
+    for key, value in masterLibraries.items():
+      if key != "fallback":
+        value.merge(deepcopy(masterLibraries["fallback"]))
+
+    masterLibraries.pop("fallback")
   
   # remove duplicates while preserving order
   solutions = list(dict.fromkeys(solutions)) 


### PR DESCRIPTION
rocBLAS was seeing test failures when trying to use the separate-architectures flag from PR #1477 due to hip solutions not being included in the architecture specific TensileLibrary files. This PR makes two changes to fix this:
1. Adds hip solutions to each architecture file
2. Remove reindexing (which ensured each solution in a TensileLibrary file had a distinct index from solutions in other TensileLibrary files) The first change results in duplication of the hip solutions for each .dat file. There are a total of 707 hip kernels per architecture, compared to 40,000 kernels in total. The second change was originally intended for easy dynamic c++ library merging at runtime, however that code was cut from PR #1477, and at this point it introduces more risk of error, while not helping any current functionality. I think it would be worthwhile for me to revisit these changes after the release to create a separate TensileLibrary_hip.dat file with all of the hip solutions in it, and then reintroduce the reindexing and dynamic merging code when we have more time to confirm it's working correctly.

