### PR TITLE
always use hipDeviceAttributePhysicalMultiProcessorCount as multiProcessorCount for Tensile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Change Log for Tensile
 
+## (Unreleased) Tensile 4.33.0
+### Added
+- TensileUpdateLibrary for updating old library logic files
+- Support for TensileRetuneLibrary to use sizes from separate file
+- ZGEMM DirectToVgpr/DirectToLds/StoreCInUnroll/MIArchVgpr support
+- Tests for denorm correctness
+- Option to write different architectures to different TensileLibrary files
+### Optimized
+- Optimize MessagePackLoadLibraryFile by switching to fread
+- DGEMM tail loop optimization for PrefetchAcrossPersistentMode=1/DirectToVgpr
+### Changed
+- Alpha/beta datatype remains as F32 for HPA HGEMM
+- Force assembly kernels to not flush denorms
+- Use hipDeviceAttributePhysicalMultiProcessorCount as multiProcessorCount
+### Fixed
+- Fix segmentation fault when run i8 datatype with TENSILE_DB=0x80
+
 ## Tensile 4.32.0 for ROCm 5.1.0
 ### Added
 - Better control of parallelism to control memory usage

--- a/Tensile/SolutionWriter.py
+++ b/Tensile/SolutionWriter.py
@@ -298,6 +298,16 @@ class SolutionWriter:
       s += "%shipDeviceProp_t deviceProperties;\n" % (t)
       # TODO - should cache the device properties - expensive to call on each iteration here:
       s += "%shipGetDeviceProperties( &deviceProperties, deviceId );\n" % (t)
+      s += "#if HIP_VERSION >= 50120531\n"
+      s += "%sint hip_version;\n" % (t)
+      s += "%shipRuntimeGetVersion(&hip_version);\n" % (t)
+      s += "%sif(hip_version >= 50120531)\n" (t)
+      s += "%s{\n" (t)
+      s += "%s    hipDeviceGetAttribute(&deviceProperties.multiProcessorCount,\n" (t)
+      s += "%s                          hipDeviceAttributePhysicalMultiProcessorCount,\n" (t)
+      s += "%s                          deviceId);\n" (t)
+      s += "%s}\n" (t)
+      s += "#endif\n"
       s += "%sunsigned int numGroups = totalWorkGroups0 * totalWorkGroups1;\n" % (t)
       s += "%sglobalWorkSize[0][0] = (deviceProperties.multiProcessorCount * %u < numGroups) ? (deviceProperties.multiProcessorCount * %u) : numGroups;\n" \
               % (t, persistent, persistent)

--- a/Tensile/Source/client/source/HardwareMonitor.cpp
+++ b/Tensile/Source/client/source/HardwareMonitor.cpp
@@ -64,6 +64,16 @@ namespace Tensile
             hipDeviceProp_t props;
 
             HIP_CHECK_EXC(hipGetDeviceProperties(&props, hipDeviceIndex));
+#if HIP_VERSION >= 50120531
+            int hip_version;
+            HIP_CHECK_EXC(hipRuntimeGetVersion(&hip_version));
+            if(hip_version >= 50120531)
+            {
+                HIP_CHECK_EXC(hipDeviceGetAttribute(&props.multiProcessorCount,
+                                                    hipDeviceAttributePhysicalMultiProcessorCount,
+                                                    hipDeviceIndex));
+            }
+#endif
 
             uint64_t hipPCIID = 0;
             hipPCIID |= props.pciDeviceID & 0xFF;

--- a/Tensile/Source/client/source/PerformanceReporter.cpp
+++ b/Tensile/Source/client/source/PerformanceReporter.cpp
@@ -56,6 +56,16 @@ namespace Tensile
                                                  double readEff)
         {
             hipGetDeviceProperties(&m_props, deviceIndex);
+#if HIP_VERSION >= 50120531
+            int hip_version;
+            hipRuntimeGetVersion(&hip_version);
+            if(hip_version >= 50120531)
+            {
+                hipDeviceGetAttribute(&m_props.multiProcessorCount,
+                                      hipDeviceAttributePhysicalMultiProcessorCount,
+                                      deviceIndex);
+            }
+#endif
             setNumCUs();
             setMemoryBusWidth();
             setPerfModel(l2ReadHits, l2WriteHits, l2ReadBwMultiplier, readEff);

--- a/Tensile/Source/lib/source/hip/HipHardware.cpp
+++ b/Tensile/Source/lib/source/hip/HipHardware.cpp
@@ -51,6 +51,16 @@ namespace Tensile
         {
             hipDeviceProp_t prop;
             HIP_CHECK_EXC(hipGetDeviceProperties(&prop, deviceId));
+#if HIP_VERSION >= 50120531
+            int hip_version;
+            HIP_CHECK_EXC(hipRuntimeGetVersion(&hip_version));
+            if(hip_version >= 50120531)
+            {
+                HIP_CHECK_EXC(hipDeviceGetAttribute(&prop.multiProcessorCount,
+                                                    hipDeviceAttributePhysicalMultiProcessorCount,
+                                                    deviceId));
+            }
+#endif
 
             return GetDevice(prop);
         }


### PR DESCRIPTION
Also updated CHANGELOG.md for next ROCm release.