### PR TITLE
Tools for creating Tensile client config files

### DIFF
--- a/Tensile/TensileClientConfig.py
+++ b/Tensile/TensileClientConfig.py
@@ -1,0 +1,109 @@
+###############################################################################
+# Copyright 2016-2022 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell cop-
+# ies of the Software, and to permit persons to whom the Software is furnished
+# to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM-
+# PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNE-
+# CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+################################################################################
+
+from . import Common
+from . import ClientWriter
+from . import LibraryIO
+from .Contractions import ProblemType as ContractionsProblemType
+from .SolutionStructs import ProblemSizes, ProblemType
+from .Common import print1, printExit, assignGlobalParameters, restoreDefaultGlobalParameters, HR
+from .Tensile import addCommonArguments, argUpdatedGlobalParameters
+from . import __version__
+
+import argparse
+import os
+import sys
+
+def parseConfig(config):
+    globalParameters = config["GlobalParameters"]
+    ssProblemType = ProblemType(config["BenchmarkProblems"][0][0])
+    problemDict = config["BenchmarkProblems"][0][1]["BenchmarkFinalParameters"][0]["ProblemSizes"]
+    sizes = ProblemSizes(ssProblemType, problemDict)
+
+    conProblemType = ContractionsProblemType.FromOriginalState(ssProblemType)
+
+    return (globalParameters, conProblemType, sizes)
+
+def TensileClientConfig(userArgs):
+    print1("")
+    print1(HR)
+    print1("#")
+    print1("#  Tensile Client Config v{}".format(__version__))
+    print1("#")
+    print1(HR)
+    print1("")
+
+    # argument parsing
+    argParser = argparse.ArgumentParser()
+    argParser.add_argument("ConfigYaml", type=os.path.realpath, nargs="+",
+                           help="Config yaml(s) containing parameters and problem and size information")
+    argParser.add_argument("OutputConfig", type=os.path.realpath,
+                           help="Path to output resulting client config file")
+
+    addCommonArguments(argParser)
+    args = argParser.parse_args(userArgs)
+
+    # parse config inputs
+    configs = [LibraryIO.readYAML(x) for x in args.ConfigYaml]
+
+    globalParams = {}
+    problemType = None
+    sizes = []
+
+    for config in configs:
+        # get all information we can get from each config
+        (myGlobalParams, myProblemType, mySizes) = parseConfig(config)
+
+        if myGlobalParams != {}:
+            if globalParams == {}:
+                globalParams = myGlobalParams
+            else:
+                printExit("duplicate global params")
+
+        if myProblemType is not None:
+            if problemType is None:
+                problemType = myProblemType
+            else:
+                printExit("duplicate problem type")
+
+        if mySizes is not None:
+            if sizes == []:
+                sizes = mySizes
+            else:
+                printExit("duplicate sizes")
+
+    if problemType is None:
+        printExit("could not parse problem type from inputs")
+
+    # update globals
+    restoreDefaultGlobalParameters()
+    assignGlobalParameters(globalParams)
+
+    overrideParameters = argUpdatedGlobalParameters(args)
+    for key, value in overrideParameters.items():
+        print1("Overriding {0}={1}".format(key, value))
+        Common.globalParameters[key] = value
+
+    # write output
+    ClientWriter.writeClientConfigIni(sizes, problemType, "", [], "", args.OutputConfig, None)
+
+def main():
+    TensileClientConfig(sys.argv[1:])

--- a/Tensile/TensileClientConfig.py
+++ b/Tensile/TensileClientConfig.py
@@ -48,7 +48,7 @@ def getGlobalParams(config):
 def getProblemDict(config):
     """Try to parse out a problem type dict from the places it could be"""
     problemDict = None
-    try: # Tensile Config file (first entry)
+    try:  # Tensile Config file (first entry)
         problemDict = config["BenchmarkProblems"][0][0]
         if len(config["BenchmarkProblems"]) > 1:
             printWarning("More than one BenchmarkProblem in config file: only using first")
@@ -57,7 +57,7 @@ def getProblemDict(config):
     else:
         return problemDict
 
-    try: # Solution Selection "base" file
+    try:  # Solution Selection "base" file
         problemDict = config["ProblemType"]
     except (TypeError, LookupError):
         pass
@@ -71,7 +71,7 @@ def getSizeList(config):
     (including the whole config being the list)
     """
     sizeList = None
-    try: # Tensile config file (first entry)
+    try:  # Tensile config file (first entry)
         sizeList = config["BenchmarkProblems"][0][1]["BenchmarkFinalParameters"][0]["ProblemSizes"]
     except (TypeError, LookupError):
         pass
@@ -112,6 +112,7 @@ def TensileClientConfig(userArgs):
     print1("")
 
     # argument parsing
+    # yapf: disable
     argParser = argparse.ArgumentParser()
     argParser.add_argument("ConfigYaml", type=os.path.realpath, nargs="+",
             help="Config yaml(s) containing parameters and problem and size information")
@@ -119,6 +120,7 @@ def TensileClientConfig(userArgs):
             required=True, help="Path to output resulting client config file")
     argParser.add_argument("--merge-sizes", dest="MergeSizes", action="store_true",
             help="Allow sizes from multiple config files")
+    # yapf: enable
 
     addCommonArguments(argParser)
     args = argParser.parse_args(userArgs)
@@ -139,15 +141,15 @@ def TensileClientConfig(userArgs):
             if globalParams == {} or globalParams == myGlobalParams:
                 globalParams = myGlobalParams
             else:
-                printExit("Multiple definitions for GlobalParameters found:\n{}\nand\n{}"
-                    .format(globalParams, myGlobalParams))
+                printExit("Multiple definitions for GlobalParameters found:\n{}\nand\n{}".format(
+                    globalParams, myGlobalParams))
 
         if myProblemDict is not None:
             if problemDict is None or problemDict == myProblemDict:
                 problemDict = myProblemDict
             else:
-                printExit("Multiple definitions for ProblemType found:\n{}\nand\n{}"
-                    .format(problemDict, myProblemDict))
+                printExit("Multiple definitions for ProblemType found:\n{}\nand\n{}".format(
+                    problemDict, myProblemDict))
 
         if mySizeList is not None:
             if sizeList is None or sizeList == mySizeList:
@@ -156,8 +158,8 @@ def TensileClientConfig(userArgs):
                 sizeList += mySizeList
             else:
                 printExit("Multiple size lists found:\n{}\nand\n{}\n"
-                    "Run with --merge-sizes to keep all size lists found"
-                    .format(sizeList, mySizeList))
+                          "Run with --merge-sizes to keep all size lists found".format(
+                              sizeList, mySizeList))
 
     if problemDict is None:
         printExit("No ProblemType found; cannot produce output")
@@ -166,7 +168,7 @@ def TensileClientConfig(userArgs):
 
     ssProblemType = ProblemType(problemDict)
     conProblemType = ContractionsProblemType.FromOriginalState(ssProblemType)
-    sizes = ProblemSizes(ssProblemType, sizeList) # TODO doesn't seem to work for range sizes
+    sizes = ProblemSizes(ssProblemType, sizeList)  # TODO doesn't seem to work for range sizes
 
     # update globals
     restoreDefaultGlobalParameters()

--- a/Tensile/TensileClientConfig.py
+++ b/Tensile/TensileClientConfig.py
@@ -114,9 +114,11 @@ def TensileClientConfig(userArgs):
     # argument parsing
     argParser = argparse.ArgumentParser()
     argParser.add_argument("ConfigYaml", type=os.path.realpath, nargs="+",
-                           help="Config yaml(s) containing parameters and problem and size information")
-    argParser.add_argument("OutputConfig", type=os.path.realpath,
-                           help="Path to output resulting client config file")
+            help="Config yaml(s) containing parameters and problem and size information")
+    argParser.add_argument("--output-config", "-o", dest="OutputConfig", type=os.path.realpath,
+            required=True, help="Path to output resulting client config file")
+    argParser.add_argument("--merge-sizes", dest="MergeSizes", action="store_true",
+            help="Allow sizes from multiple config files")
 
     addCommonArguments(argParser)
     args = argParser.parse_args(userArgs)
@@ -132,7 +134,7 @@ def TensileClientConfig(userArgs):
         (myGlobalParams, myProblemDict, mySizeList) = parseConfig(config)
 
         # if we got data from the config, keep it
-        # if we already had that data, abort
+        # if we already had that data, warn and exit
         if myGlobalParams is not None:
             if globalParams == {} or globalParams == myGlobalParams:
                 globalParams = myGlobalParams
@@ -147,11 +149,14 @@ def TensileClientConfig(userArgs):
                 printExit("Multiple definitions for ProblemType found:\n{}\nand\n{}"
                     .format(problemDict, myProblemDict))
 
-        if mySizeList is not None or sizeList == mySizeList:
-            if sizeList is None:
+        if mySizeList is not None:
+            if sizeList is None or sizeList == mySizeList:
                 sizeList = mySizeList
+            elif args.MergeSizes:
+                sizeList += mySizeList
             else:
-                printExit("Multiple size lists found:\n{}\nand\n{}"
+                printExit("Multiple size lists found:\n{}\nand\n{}\n"
+                    "Run with --merge-sizes to keep all size lists found"
                     .format(sizeList, mySizeList))
 
     if problemDict is None:

--- a/Tensile/TensileClientConfig.py
+++ b/Tensile/TensileClientConfig.py
@@ -39,7 +39,7 @@ def getGlobalParams(config):
     globalParams = None
     try:
         globalParams = config["GlobalParameters"]
-    except:
+    except (TypeError, LookupError):
         pass
 
     return globalParams
@@ -52,14 +52,14 @@ def getProblemDict(config):
         problemDict = config["BenchmarkProblems"][0][0]
         if len(config["BenchmarkProblems"]) > 1:
             printWarning("More than one BenchmarkProblem in config file: only using first")
-    except:
+    except (TypeError, LookupError):
         pass
     else:
         return problemDict
 
     try: # Solution Selection "base" file
         problemDict = config["ProblemType"]
-    except:
+    except (TypeError, LookupError):
         pass
 
     return problemDict
@@ -73,7 +73,7 @@ def getSizeList(config):
     sizeList = None
     try: # Tensile config file (first entry)
         sizeList = config["BenchmarkProblems"][0][1]["BenchmarkFinalParameters"][0]["ProblemSizes"]
-    except:
+    except (TypeError, LookupError):
         pass
     else:
         return sizeList

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -1566,8 +1566,8 @@ def TensileCreateLibrary():
   if args.BuildClient:
     print1("# Building Tensile Client")
     ClientExecutable.getClientExecutable(outputPath)
-  if args.ClientConfig:
 
+  if args.ClientConfig:
     # write simple ini for best solution mode linked to library we just made
     iniFile = os.path.join(outputPath, "best-solution.ini")
     with open(iniFile, "w") as f:

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -1361,8 +1361,8 @@ def TensileCreateLibrary():
   argParser.add_argument("--version", help="Version string to embed into library file.")
   argParser.add_argument("--generate-manifest-and-exit",   dest="GenerateManifestAndExit", action="store_true",
                           default=False, help="Output manifest file with list of expected library objects and exit.")
-  argParser.add_argument("--library-format", dest="LibraryFormat", choices=["yaml", "msgpack"], \
-      action="store", default="msgpack", help="select which library format to use")
+  argParser.add_argument("--library-format", dest="LibraryFormat", choices=["yaml", "msgpack"],
+                         action="store", default="msgpack", help="select which library format to use")
   argParser.add_argument("--generate-sources-and-exit",   dest="GenerateSourcesAndExit", action="store_true",
                           default=False, help="Output source files only and exit.")
   argParser.add_argument("--jobs", "-j", dest="CpuThreads", type=int,
@@ -1371,10 +1371,11 @@ def TensileCreateLibrary():
                           default=1, help="Set printout verbosity level.")
   argParser.add_argument("--separate-architectures", dest="SeparateArchitectures", action="store_true",
                          default=False, help="Separates TensileLibrary file by architecture")
-
+  argParser.add_argument("--build-client", dest="BuildClient", action="store_true",
+                         help="Build Tensile client")
+  argParser.add_argument("--client-config", dest="ClientConfig", action="store_true",
+                         help="Create client config for setting the library and code object files")
   argParser.add_argument("--global-parameters", nargs="+", type=splitExtraParameters, default=[])
-  argParser.add_argument("--build-client", dest="BuildClient", action="store_true")
-  argParser.add_argument("--client-config", dest="ClientConfig", action="store_true")
 
   args = argParser.parse_args()
 

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright 2016-2021 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright 2016-2022 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -25,6 +25,7 @@ if __name__ == "__main__":
     exit(1)
 
 from . import Common
+from . import ClientExecutable
 from . import EmbeddedData
 from . import LibraryIO
 from . import Utils
@@ -1203,7 +1204,7 @@ def generateKernelObjectsFromSolutions(solutions):
       kernelHelperNames.add(ko.getKernelName())
 
   # remove duplicates while preserving order
-  kernels = list(dict.fromkeys(kernels)) 
+  kernels = list(dict.fromkeys(kernels))
   kernelHelperObjs = list(dict.fromkeys(kernelHelperObjs))
   return (kernels, kernelHelperObjs, kernelHelperNames)
 
@@ -1258,9 +1259,9 @@ def generateLogicDataAndSolutions(logicFiles, args):
         value.merge(deepcopy(masterLibraries["fallback"]))
 
     masterLibraries.pop("fallback")
-  
+
   # remove duplicates while preserving order
-  solutions = list(dict.fromkeys(solutions)) 
+  solutions = list(dict.fromkeys(solutions))
   return logicData, solutions, masterLibraries, fullMasterLibrary
 
 ################################################################################
@@ -1372,6 +1373,9 @@ def TensileCreateLibrary():
                          default=False, help="Separates TensileLibrary file by architecture")
 
   argParser.add_argument("--global-parameters", nargs="+", type=splitExtraParameters, default=[])
+  argParser.add_argument("--build-client", dest="BuildClient", action="store_true")
+  argParser.add_argument("--client-config", dest="ClientConfig", action="store_true")
+
   args = argParser.parse_args()
 
   logicPath = args.LogicPath
@@ -1557,6 +1561,27 @@ def TensileCreateLibrary():
           for co in Utils.tqdm(codeObjectFiles):
               embedFile.embed_file("SolutionAdapter", co, nullTerminated=False,
                                    key=args.EmbedLibraryKey)
+
+  if args.BuildClient:
+    print1("# Building Tensile Client")
+    ClientExecutable.getClientExecutable(outputPath)
+  if args.ClientConfig:
+
+    # write simple ini for best solution mode linked to library we just made
+    iniFile = os.path.join(outputPath, "best-solution.ini")
+    with open(iniFile, "w") as f:
+      def param(key, value):
+        f.write("{}={}\n".format(key, value))
+
+      libraryFile = masterFile + ".yaml" \
+        if globalParameters["LibraryFormat"] == "yaml" else masterFile + ".dat"
+
+      param("library-file", libraryFile)
+      for coFile in codeObjectFiles:
+        param("code-object", os.path.join(outputPath,coFile))
+
+      param("best-solution", True)
+
 
   print1("# Tensile Library Writer DONE")
   print1(HR)

--- a/Tensile/bin/TensileClientConfig
+++ b/Tensile/bin/TensileClientConfig
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+################################################################################
+# Copyright 2016-2022 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell cop-
+# ies of the Software, and to permit persons to whom the Software is furnished
+# to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM-
+# PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNE-
+# CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+################################################################################
+
+
+try:
+    from Tensile import TensileClientConfig
+except ImportError:
+    import os.path
+    import sys
+    parentdir = os.path.normpath(os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", ".."))
+    sys.path.append(parentdir)
+
+    from Tensile import TensileClientConfig
+
+# script run from commandline
+if __name__ == "__main__":
+    TensileClientConfig.main()


### PR DESCRIPTION
Using the Tensile client in best-solution mode it a lightweight option for doing GEMM benchmarks without the overhead of rocBLAS. This PR adds some tools for easily creating Tensile client config files to facilitate this process. 

For context, this is to support the work on improving the solution selection in Tensile and addresses [LWPSOLSEL-5](https://ontrack-internal.amd.com/browse/LWPSOLSEL-5).

### TensileCreateLibrary changes
This PR adds two new optional CLI arguments
--build-client: simply builds the Tensile client in the output directory after doing all the normal work
--client-config: outputs a client config file with the library-file and code-object parameters set to the respective files created by the invocation. Also sets best-solution-mode to True

### New TensileClientConfig tool
This tool is meant to provide a quick way to generate a config with the remaining needed parameters set (the ones _not_ set by the --client-config option in CreateLibrary). 

The input to the program is a list of yaml files which need to contain information on the global parameters, a problem definition, and a list of sizes. The exact format of the file(s), however, is a bit flexible. Currently, it can accept a normal Tensile config yaml **or** a set of files being used internally for the solution selection project.

For now, I've made the (potentially controversial choice) to keep the interface very flexible. Instead of specifying what format the input yaml(s) are in, the program does it's best to parse out all the information it can from each file provided based on the formats it knows about. The benefit of this approach is new supported formats can be added and used without having to change how the tool is called. As the code in the solution selection workgroup matures and becomes less volatile, this can be revisited and a more "concrete" interface decided on.

