### PR TITLE
Option to print time for solution selection

### DIFF
--- a/Tensile/Source/lib/include/Tensile/Debug.hpp
+++ b/Tensile/Source/lib/include/Tensile/Debug.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2020 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -60,6 +60,8 @@ namespace Tensile
         bool printLookupEfficiency() const;
 
         bool printWinningKernelName() const;
+
+        bool printSolutionSelectionTime() const;
 
         bool naivePropertySearch() const;
 

--- a/Tensile/Source/lib/include/Tensile/MasterSolutionLibrary.hpp
+++ b/Tensile/Source/lib/include/Tensile/MasterSolutionLibrary.hpp
@@ -91,10 +91,8 @@ namespace Tensile
                 auto result = findBestSolution_runner(problem, hardware, fitness);
                 auto end    = std::chrono::steady_clock::now();
 
-                auto time
-                    = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();
-                //double time = static_cast<double>(duration);
-                std::cout << "Solution selection time: " << time << " nanoseconds" << std::endl;
+                double time = std::chrono::duration<double, std::micro>(end - start).count();
+                std::cout << "Solution selection time: " << time << " us" << std::endl;
 
                 return result;
             }

--- a/Tensile/Source/lib/include/Tensile/MasterSolutionLibrary.hpp
+++ b/Tensile/Source/lib/include/Tensile/MasterSolutionLibrary.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright 2019-2020 Advanced Micro Devices, Inc.
+ * Copyright 2019-2022 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <map>
 #include <memory>
 
@@ -83,6 +84,29 @@ namespace Tensile
                                                              Hardware const&  hardware,
                                                              double*          fitness
                                                              = nullptr) const override
+        {
+            if(Debug::Instance().printSolutionSelectionTime())
+            {
+                auto start  = std::chrono::steady_clock::now();
+                auto result = findBestSolution_runner(problem, hardware, fitness);
+                auto end    = std::chrono::steady_clock::now();
+
+                auto time
+                    = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();
+                //double time = static_cast<double>(duration);
+                std::cout << "Solution selection time: " << time << " nanoseconds" << std::endl;
+
+                return result;
+            }
+            else
+            {
+                return findBestSolution_runner(problem, hardware, fitness);
+            }
+        }
+
+        std::shared_ptr<MySolution> findBestSolution_runner(MyProblem const& problem,
+                                                            Hardware const&  hardware,
+                                                            double* fitness = nullptr) const
         {
             const int solution_index = Debug::Instance().getSolutionIndex();
 

--- a/Tensile/Source/lib/source/Debug.cpp
+++ b/Tensile/Source/lib/source/Debug.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2020 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -102,6 +102,11 @@ namespace Tensile
     bool Debug::printWinningKernelName() const
     {
         return m_value & 0x8000;
+    }
+
+    bool Debug::printSolutionSelectionTime() const
+    {
+        return m_value & 0x10000;
     }
 
     bool Debug::naivePropertySearch() const


### PR DESCRIPTION
Adds a TENSILE_DB option (0x10000) to time and report how long solution selection takes.

