### PR TITLE
Split global read

### DIFF
--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -396,6 +396,11 @@ validParameters = {
     "WaveSeparateGlobalReadA":    [ 0, 1 ],
     "WaveSeparateGlobalReadB":    [ 0, 1 ],
 
+    # Splits global read addresses within a wave into a number of smaller groups
+    # The default value of 1 reads the most contiguous elements across lanes,
+    # but higher values may help avoid bank conflicts
+    "SplitGlobalRead":            [1, 2, 4, 8, 16, 32],
+
     # PrefetchGlobalRead = 1:
     # Requires 2X LDS space, and VGPRs for buffering data on way into LDS
     #   prefetch / double-buffer reads from global memory -> vgprs -> lds.
@@ -1228,13 +1233,14 @@ defaultBenchmarkCommonParameters = [
     {"MaxOccupancy":              [ 40 ] },
     {"VectorWidth":               [ -1 ] },
     {"VectorStore":               [ -1 ] },
-    {"StoreVectorWidth":         [ -1 ] },
+    {"StoreVectorWidth":          [ -1 ] },
     {"GlobalReadVectorWidth":     [ -1 ] },
     {"LocalReadVectorWidth":      [ -1 ] },
     {"GlobalReadCoalesceVectorA": [ True ] },
     {"GlobalReadCoalesceVectorB": [ True ] },
-    {"WaveSeparateGlobalReadA":    [ 0 ] },
-    {"WaveSeparateGlobalReadB":    [ 0 ] },
+    {"WaveSeparateGlobalReadA":   [ 0 ] },
+    {"WaveSeparateGlobalReadB":   [ 0 ] },
+    {"SplitGlobalRead":           [ 1 ] },
     {"GlobalReadCoalesceGroupA":  [ True ] },
     {"GlobalReadCoalesceGroupB":  [ True ] },
     {"PrefetchGlobalRead":        [ 1 ] },

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -399,7 +399,7 @@ validParameters = {
     # Splits global read addresses within a wave into a number of smaller groups
     # The default value of 1 reads the most contiguous elements across lanes,
     # but higher values may help avoid bank conflicts
-    "SplitGlobalRead":            [1, 2, 4, 8, 16, 32],
+    "SplitGlobalRead":            [1, 2, 4, 8],
 
     # PrefetchGlobalRead = 1:
     # Requires 2X LDS space, and VGPRs for buffering data on way into LDS

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -3423,7 +3423,7 @@ class KernelWriterAssembly(KernelWriter):
     splitRead = kernel["SplitGlobalRead"]
     # Split global read reorders reading rows within lanes of a wavefront
     # If the wavefront is reading all from a single row, then disable split global read for this tensor
-    if divisor > 64:
+    if divisor > self.kernel["WavefrontSize"]:
       splitRead = 1
 
     if kernel["DirectToVgpr%s"%tc]:

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -3421,6 +3421,10 @@ class KernelWriterAssembly(KernelWriter):
       kStr += vectorStaticRemainder(dummy, dividendReg, "Serial", self.kernel["WavefrontSize"], tmpVgpr, tmpSgpr)
 
     splitRead = kernel["SplitGlobalRead"]
+    # Split global read reorders reading rows within lanes of a wavefront
+    # If the wavefront is reading all from a single row, then disable split global read for this tensor
+    if divisor > 64:
+      splitRead = 1
 
     if kernel["DirectToVgpr%s"%tc]:
       # offset calculation for DirectToVgpr

--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -3215,6 +3215,8 @@ class Solution(collections.abc.Mapping):
     state["LVPB"] = roundupRatio(state["LSPB"] , state["GlobalLoadVectorWidthB"])
 
     if state["SplitGlobalRead"] > 1:
+      if state["DirectToLds"]:
+        reject(state, "SplitGlobalRead not yet supported with DirectToLds")
       if state["DirectToVgprA"] or state["DirectToVgprB"]:
         reject(state, "SplitGlobalRead does not work with DirectToVgpr")
       if state["GlobalReadCoalesceGroupA"]:

--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -3232,7 +3232,7 @@ class Solution(collections.abc.Mapping):
           divisorName = "LVPA"
       divisor = state[divisorName]
       if state["SplitGlobalRead"] >= divisor:
-        reject(state, "SplitGlobalRead must be less than lvc/lsc/lvp/lsc")
+        reject(state, "SplitGlobalRead must be less than lvc/lsc/lvp/lsp")
 
     for tc in ('A','B'):
       if problemType["TLU%s"%tc]:


### PR DESCRIPTION
Add SplitGlobalRead option to create new global load patterns. If one wavefront accesses multiple rows, SplitGlobalRead enables rows to be arranged differently across lanes to avoid conflicts.