### PR TITLE
Update clang offload bundler flag to reflect tool change

### DIFF
--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -202,14 +202,14 @@ def buildSourceCodeObjectFile(CxxCompiler, outputPath, kernelFile):
 
       infile = os.path.join(buildPath, objectFilename)
       try:
-        bundlerArgs = [globalParameters["ClangOffloadBundlerPath"], "-type=o", "-inputs=%s" % infile, "-list"]
+        bundlerArgs = [globalParameters["ClangOffloadBundlerPath"], "-type=o", "-input=%s" % infile, "-list"]
         listing = subprocess.check_output(bundlerArgs, stderr=subprocess.STDOUT).decode().split("\n")
         for target in listing:
           matched = re.search("gfx.*$", target)
           if matched:
             arch = re.sub(":", "-", matched.group())
             outfile = os.path.join(buildPath, "{0}-000-{1}.hsaco".format(soFilename, arch))
-            bundlerArgs = [globalParameters["ClangOffloadBundlerPath"], "-type=o", "-targets=%s" % target, "-inputs=%s" % infile, "-outputs=%s" % outfile, "-unbundle"]
+            bundlerArgs = [globalParameters["ClangOffloadBundlerPath"], "-type=o", "-targets=%s" % target, "-input=%s" % infile, "-output=%s" % outfile, "-unbundle"]
             if globalParameters["PrintCodeCommands"]:
               print(' '.join(bundlerArgs))
             subprocess.check_call(bundlerArgs)
@@ -217,7 +217,7 @@ def buildSourceCodeObjectFile(CxxCompiler, outputPath, kernelFile):
       except subprocess.CalledProcessError:
         for i in range(len(archs)):
           outfile = os.path.join(buildPath, "{0}-000-{1}.hsaco".format(soFilename, archs[i]))
-          bundlerArgs = [globalParameters["ClangOffloadBundlerPath"], "-type=o", "-targets=hip-amdgcn-amd-amdhsa--%s" % cmdlineArchs[i], "-inputs=%s" % infile, "-outputs=%s" % outfile, "-unbundle"]
+          bundlerArgs = [globalParameters["ClangOffloadBundlerPath"], "-type=o", "-targets=hip-amdgcn-amd-amdhsa--%s" % cmdlineArchs[i], "-input=%s" % infile, "-output=%s" % outfile, "-unbundle"]
           if globalParameters["PrintCodeCommands"]:
             print(' '.join(bundlerArgs))
           subprocess.check_call(bundlerArgs)


### PR DESCRIPTION
Clang offload bundler changed the flags -inputs and -outputs to -input and -output, update Tensile to reflect tool change.