### PR TITLE
updating HHS tests - LWPTENSILE-29

### DIFF
--- a/Tensile/Tests/bugs/hpa_beta.yaml
+++ b/Tensile/Tests/bugs/hpa_beta.yaml
@@ -36,6 +36,7 @@ BenchmarkProblems:
     - # ProblemType
       OperationType: GEMM
       DataType: h
+      ComputeDataType: s
       HighPrecisionAccumulate: 1
       TransposeA: False
       TransposeB: True

--- a/Tensile/Tests/dot/mixmad-nt.yaml
+++ b/Tensile/Tests/dot/mixmad-nt.yaml
@@ -36,6 +36,7 @@ BenchmarkProblems:
     - # ProblemType
       OperationType: GEMM
       DataType: h
+      ComputeDataType: s
       HighPrecisionAccumulate: 1
       TransposeA: False
       TransposeB: True

--- a/Tensile/Tests/dot/mixmad.yaml
+++ b/Tensile/Tests/dot/mixmad.yaml
@@ -36,6 +36,7 @@ BenchmarkProblems:
     - # ProblemType
       OperationType: GEMM
       DataType: h
+      ComputeDataType: s
       HighPrecisionAccumulate: 1
       TransposeA: True
       TransposeB: False

--- a/Tensile/Tests/emulation/hgemm_hpa_asm_nn.yaml
+++ b/Tensile/Tests/emulation/hgemm_hpa_asm_nn.yaml
@@ -15,6 +15,7 @@ BenchmarkProblems:
       OperationType: GEMM
       DataType: h
       DestDataType: h
+      ComputeDataType: s
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False

--- a/Tensile/Tests/emulation/hgemm_hpa_asm_nt.yaml
+++ b/Tensile/Tests/emulation/hgemm_hpa_asm_nt.yaml
@@ -14,6 +14,7 @@ BenchmarkProblems:
       OperationType: GEMM
       DataType: h
       DestDataType: h
+      ComputeDataType: s
       HighPrecisionAccumulate: True
       TransposeA: True
       TransposeB: False

--- a/Tensile/Tests/emulation/hgemm_hpa_asm_tn.yaml
+++ b/Tensile/Tests/emulation/hgemm_hpa_asm_tn.yaml
@@ -15,6 +15,7 @@ BenchmarkProblems:
       OperationType: GEMM
       DataType: h
       DestDataType: h
+      ComputeDataType: s
       HighPrecisionAccumulate: True
       TransposeA: True
       TransposeB: False

--- a/Tensile/Tests/emulation/hgemm_hpa_asm_tt.yaml
+++ b/Tensile/Tests/emulation/hgemm_hpa_asm_tt.yaml
@@ -13,6 +13,7 @@ BenchmarkProblems:
       OperationType: GEMM
       DataType: h
       DestDataType: h
+      ComputeDataType: s
       HighPrecisionAccumulate: True
       TransposeA: True
       TransposeB: True

--- a/Tensile/Tests/emulation/mfma/1LDSB.yaml
+++ b/Tensile/Tests/emulation/mfma/1LDSB.yaml
@@ -107,6 +107,7 @@ BenchmarkProblems:
   #   - # ProblemType
   #     OperationType: GEMM
   #     DataType: h
+  #     ComputeDataType: s
   #     HighPrecisionAccumulate: True
   #     TransposeA: True
   #     TransposeB: False

--- a/Tensile/Tests/emulation/mfma/hpa_hgemm_asm.yaml
+++ b/Tensile/Tests/emulation/mfma/hpa_hgemm_asm.yaml
@@ -14,6 +14,7 @@ BenchmarkProblems:
     - # ProblemType
       OperationType: GEMM
       DataType: h
+      ComputeDataType: s
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: True
@@ -122,6 +123,7 @@ BenchmarkProblems:
   #   - # ProblemType
   #     OperationType: GEMM
   #     DataType: h
+  #     ComputeDataType: s
   #     HighPrecisionAccumulate: True
   #     TransposeA: True
   #     TransposeB: False
@@ -230,6 +232,7 @@ BenchmarkProblems:
   #   - # ProblemType
   #     OperationType: GEMM
   #     DataType: h
+  #     ComputeDataType: s
   #     HighPrecisionAccumulate: True
   #     TransposeA: False
   #     TransposeB: False
@@ -338,6 +341,7 @@ BenchmarkProblems:
   #   - # ProblemType
   #     OperationType: GEMM
   #     DataType: h
+  #     ComputeDataType: s
   #     HighPrecisionAccumulate: True
   #     TransposeA: True
   #     TransposeB: True

--- a/Tensile/Tests/extended/dot2/hgemm_hpa_dot2_nn.yaml
+++ b/Tensile/Tests/extended/dot2/hgemm_hpa_dot2_nn.yaml
@@ -36,6 +36,7 @@ BenchmarkProblems:
     - # ProblemType
       OperationType: GEMM
       DataType: h
+      ComputeDataType: s
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False

--- a/Tensile/Tests/extended/dot2/hgemm_hpa_dot2_tn.yaml
+++ b/Tensile/Tests/extended/dot2/hgemm_hpa_dot2_tn.yaml
@@ -36,6 +36,7 @@ BenchmarkProblems:
     - # ProblemType
       OperationType: GEMM
       DataType: h
+      ComputeDataType: s
       HighPrecisionAccumulate: True
       TransposeA: True
       TransposeB: False

--- a/Tensile/Tests/extended/dot2/hgemm_hpa_dot2_tn_2.yaml
+++ b/Tensile/Tests/extended/dot2/hgemm_hpa_dot2_tn_2.yaml
@@ -28,6 +28,7 @@ BenchmarkProblems:
     - # ProblemType
       OperationType: GEMM
       DataType: h
+      ComputeDataType: s
       HighPrecisionAccumulate: True
       TransposeA: True
       TransposeB: False

--- a/Tensile/Tests/extended/hpa_source/test_hgemm_hpa_src_nn.yaml
+++ b/Tensile/Tests/extended/hpa_source/test_hgemm_hpa_src_nn.yaml
@@ -10,6 +10,7 @@ BenchmarkProblems:
       OperationType: GEMM
       DataType: h
       DestDataType: h
+      ComputeDataType: s
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
@@ -74,6 +75,7 @@ BenchmarkProblems:
       OperationType: GEMM
       DataType: h
       DestDataType: h
+      ComputeDataType: s
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: True

--- a/Tensile/Tests/extended/hpa_source/test_hgemm_hpa_src_nt.yaml
+++ b/Tensile/Tests/extended/hpa_source/test_hgemm_hpa_src_nt.yaml
@@ -10,6 +10,7 @@ BenchmarkProblems:
       OperationType: GEMM
       DataType: h
       DestDataType: h
+      ComputeDataType: s
       HighPrecisionAccumulate: True
       TransposeA: True
       TransposeB: False

--- a/Tensile/Tests/extended/hpa_source/test_hgemm_hpa_src_tn.yaml
+++ b/Tensile/Tests/extended/hpa_source/test_hgemm_hpa_src_tn.yaml
@@ -11,6 +11,7 @@ BenchmarkProblems:
       OperationType: GEMM
       DataType: h
       DestDataType: h
+      ComputeDataType: s
       HighPrecisionAccumulate: True
       TransposeA: True
       TransposeB: False

--- a/Tensile/Tests/extended/hpa_source/test_hgemm_hpa_src_tt.yaml
+++ b/Tensile/Tests/extended/hpa_source/test_hgemm_hpa_src_tt.yaml
@@ -9,6 +9,7 @@ BenchmarkProblems:
       OperationType: GEMM
       DataType: h
       DestDataType: h
+      ComputeDataType: s
       HighPrecisionAccumulate: True
       TransposeA: True
       TransposeB: True

--- a/Tensile/Tests/pre_checkin/denorm/hgemm_hpa_asm_nn.yaml
+++ b/Tensile/Tests/pre_checkin/denorm/hgemm_hpa_asm_nn.yaml
@@ -21,6 +21,7 @@ BenchmarkProblems:
       OperationType: GEMM
       DataType: h
       DestDataType: h
+      ComputeDataType: s
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False

--- a/Tensile/Tests/pre_checkin/denorm/mfma/hgemm_denorm.yaml
+++ b/Tensile/Tests/pre_checkin/denorm/mfma/hgemm_denorm.yaml
@@ -21,6 +21,7 @@ BenchmarkProblems:
     - # ProblemType
       OperationType: GEMM
       DataType: h
+      ComputeDataType: s
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: True

--- a/Tensile/Tests/pre_checkin/hgemm_general_batch_hpa_asm_nn.yaml
+++ b/Tensile/Tests/pre_checkin/hgemm_general_batch_hpa_asm_nn.yaml
@@ -16,6 +16,7 @@ BenchmarkProblems:
       OperationType: GEMM
       DataType: h
       DestDataType: h
+      ComputeDataType: s
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False

--- a/Tensile/Tests/pre_checkin/hgemm_hpa_asm_nn.yaml
+++ b/Tensile/Tests/pre_checkin/hgemm_hpa_asm_nn.yaml
@@ -12,6 +12,7 @@ BenchmarkProblems:
       OperationType: GEMM
       DataType: h
       DestDataType: h
+      ComputeDataType: s
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False

--- a/Tensile/Tests/pre_checkin/hgemm_hpa_asm_nt.yaml
+++ b/Tensile/Tests/pre_checkin/hgemm_hpa_asm_nt.yaml
@@ -11,6 +11,7 @@ BenchmarkProblems:
       OperationType: GEMM
       DataType: h
       DestDataType: h
+      ComputeDataType: s
       HighPrecisionAccumulate: True
       TransposeA: True
       TransposeB: False

--- a/Tensile/Tests/pre_checkin/hgemm_hpa_asm_tn.yaml
+++ b/Tensile/Tests/pre_checkin/hgemm_hpa_asm_tn.yaml
@@ -12,6 +12,7 @@ BenchmarkProblems:
       OperationType: GEMM
       DataType: h
       DestDataType: h
+      ComputeDataType: s
       HighPrecisionAccumulate: True
       TransposeA: True
       TransposeB: False

--- a/Tensile/Tests/pre_checkin/hgemm_hpa_asm_tt.yaml
+++ b/Tensile/Tests/pre_checkin/hgemm_hpa_asm_tt.yaml
@@ -10,6 +10,7 @@ BenchmarkProblems:
       OperationType: GEMM
       DataType: h
       DestDataType: h
+      ComputeDataType: s
       HighPrecisionAccumulate: True
       TransposeA: True
       TransposeB: True

--- a/Tensile/Tests/pre_checkin/hgemm_hpa_iu2_asm_nn.yaml
+++ b/Tensile/Tests/pre_checkin/hgemm_hpa_iu2_asm_nn.yaml
@@ -12,6 +12,7 @@ BenchmarkProblems:
       OperationType: GEMM
       DataType: h
       DestDataType: h
+      ComputeDataType: s
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False

--- a/Tensile/Tests/pre_checkin/hgemm_hpa_iu2_asm_nt.yaml
+++ b/Tensile/Tests/pre_checkin/hgemm_hpa_iu2_asm_nt.yaml
@@ -11,6 +11,7 @@ BenchmarkProblems:
       OperationType: GEMM
       DataType: h
       DestDataType: h
+      ComputeDataType: s
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: True

--- a/Tensile/Tests/pre_checkin/hgemm_hpa_iu2_asm_tn.yaml
+++ b/Tensile/Tests/pre_checkin/hgemm_hpa_iu2_asm_tn.yaml
@@ -12,6 +12,7 @@ BenchmarkProblems:
       OperationType: GEMM
       DataType: h
       DestDataType: h
+      ComputeDataType: s
       HighPrecisionAccumulate: True
       TransposeA: True
       TransposeB: False

--- a/Tensile/Tests/pre_checkin/mfma/1LDSB.yaml
+++ b/Tensile/Tests/pre_checkin/mfma/1LDSB.yaml
@@ -107,6 +107,7 @@ BenchmarkProblems:
     - # ProblemType
       OperationType: GEMM
       DataType: h
+      ComputeDataType: s
       HighPrecisionAccumulate: True
       TransposeA: True
       TransposeB: False

--- a/Tensile/Tests/pre_checkin/mfma/hpa_hgemm_asm.yaml
+++ b/Tensile/Tests/pre_checkin/mfma/hpa_hgemm_asm.yaml
@@ -14,6 +14,7 @@ BenchmarkProblems:
     - # ProblemType
       OperationType: GEMM
       DataType: h
+      ComputeDataType: s
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: True
@@ -147,6 +148,7 @@ BenchmarkProblems:
     - # ProblemType
       OperationType: GEMM
       DataType: h
+      ComputeDataType: s
       HighPrecisionAccumulate: True
       TransposeA: True
       TransposeB: False
@@ -280,6 +282,7 @@ BenchmarkProblems:
     - # ProblemType
       OperationType: GEMM
       DataType: h
+      ComputeDataType: s
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
@@ -413,6 +416,7 @@ BenchmarkProblems:
     - # ProblemType
       OperationType: GEMM
       DataType: h
+      ComputeDataType: s
       HighPrecisionAccumulate: True
       TransposeA: True
       TransposeB: True

--- a/Tensile/Tests/pre_checkin/mfma/hpa_hgemm_general_batch_asm.yaml
+++ b/Tensile/Tests/pre_checkin/mfma/hpa_hgemm_general_batch_asm.yaml
@@ -18,6 +18,7 @@ BenchmarkProblems:
     - # ProblemType
       OperationType: GEMM
       DataType: h
+      ComputeDataType: s
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: True
@@ -90,6 +91,7 @@ BenchmarkProblems:
     - # ProblemType
       OperationType: GEMM
       DataType: h
+      ComputeDataType: s
       HighPrecisionAccumulate: True
       TransposeA: True
       TransposeB: False
@@ -161,6 +163,7 @@ BenchmarkProblems:
     - # ProblemType
       OperationType: GEMM
       DataType: h
+      ComputeDataType: s
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
@@ -232,6 +235,7 @@ BenchmarkProblems:
     - # ProblemType
       OperationType: GEMM
       DataType: h
+      ComputeDataType: s
       HighPrecisionAccumulate: True
       TransposeA: True
       TransposeB: True

--- a/Tensile/Tests/pre_checkin/mfma/hpa_hgemm_split_lds.yaml
+++ b/Tensile/Tests/pre_checkin/mfma/hpa_hgemm_split_lds.yaml
@@ -13,6 +13,7 @@ BenchmarkProblems:
     - # ProblemType
       OperationType: GEMM
       DataType: h
+      ComputeDataType: s
       HighPrecisionAccumulate: True
       TransposeA: True
       TransposeB: False

--- a/Tensile/Tests/pre_checkin/mfma/wider_local_read.yaml
+++ b/Tensile/Tests/pre_checkin/mfma/wider_local_read.yaml
@@ -105,6 +105,7 @@ BenchmarkProblems:
     - # ProblemType
       OperationType: GEMM
       DataType: h
+      ComputeDataType: s
       HighPrecisionAccumulate: True
       TransposeA: True
       TransposeB: False
@@ -236,6 +237,7 @@ BenchmarkProblems:
     - # ProblemType
       OperationType: GEMM
       DataType: h
+      ComputeDataType: s
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: True
@@ -371,6 +373,7 @@ BenchmarkProblems:
     - # ProblemType
       OperationType: GEMM
       DataType: h
+      ComputeDataType: s
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False

--- a/Tensile/Tests/pre_checkin/source/test_hgemm_hpa.yaml
+++ b/Tensile/Tests/pre_checkin/source/test_hgemm_hpa.yaml
@@ -3,6 +3,7 @@ BenchmarkProblems:
     - # ProblemType
       OperationType: GEMM
       DataType: h
+      ComputeDataType: s
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: True
@@ -12,6 +13,7 @@ BenchmarkProblems:
     - # ProblemType
       OperationType: GEMM
       DataType: h
+      ComputeDataType: s
       HighPrecisionAccumulate: True
       TransposeA: False
       TransposeB: False
@@ -21,6 +23,7 @@ BenchmarkProblems:
     - # ProblemType
       OperationType: GEMM
       DataType: h
+      ComputeDataType: s
       HighPrecisionAccumulate: True
       TransposeA: True
       TransposeB: False


### PR DESCRIPTION
ComputeDataType is added to all HHS yaml files in Tensile/Tests so that Tensile does not throw the data type inconsistency warning. 