### PR TITLE
[windows] Remove boost dependency in client build.

### DIFF
--- a/HostLibraryTests/client/DataInitialization_test.cpp
+++ b/HostLibraryTests/client/DataInitialization_test.cpp
@@ -33,7 +33,7 @@
 using namespace Tensile;
 using namespace Tensile::Client;
 
-namespace po = boost::program_options;
+namespace po = roc;
 
 template <typename TypedInputs>
 class DataInitializationTest : public ::testing::Test

--- a/Tensile/Source/client/CMakeLists.txt
+++ b/Tensile/Source/client/CMakeLists.txt
@@ -18,7 +18,6 @@ set(client_sources
     source/TimingEvents.cpp
     )
 
-find_package(Boost  COMPONENTS program_options filesystem REQUIRED)
 
 add_library(TensileClient STATIC ${client_sources})
 
@@ -36,7 +35,7 @@ endif()
 
 target_include_directories(TensileClient PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")# "${rocm_smi_root}/include")
 
-target_link_libraries(TensileClient PRIVATE TensileHost ${Boost_LIBRARIES} rocm_smi)
+target_link_libraries(TensileClient PRIVATE TensileHost rocm_smi)
 if(TENSILE_USE_OPENMP)
     target_link_libraries(TensileClient PRIVATE custom_openmp_cxx)
 endif()
@@ -48,7 +47,7 @@ set_target_properties(tensile_client
                       CXX_STANDARD_REQUIRED ON
                       CXX_EXTENSIONS OFF)
 
-target_link_libraries(tensile_client PRIVATE TensileHost TensileClient ${Boost_LIBRARIES})
+target_link_libraries(tensile_client PRIVATE TensileHost TensileClient)
 if(TENSILE_USE_OPENMP)
     target_link_libraries(tensile_client PRIVATE custom_openmp_cxx)
 endif()

--- a/Tensile/Source/client/include/BenchmarkTimer.hpp
+++ b/Tensile/Source/client/include/BenchmarkTimer.hpp
@@ -31,7 +31,7 @@
 #include <chrono>
 #include <cstddef>
 
-#include <boost/program_options.hpp>
+#include "program_options.hpp"
 
 #include <Tensile/ContractionProblem.hpp>
 #include <Tensile/ContractionSolution.hpp>
@@ -40,14 +40,14 @@ namespace Tensile
 {
     namespace Client
     {
-        namespace po = boost::program_options;
+        namespace po = roc;
 
         class BenchmarkTimer : public RunListener
         {
         public:
             using clock = std::chrono::steady_clock;
 
-            BenchmarkTimer(po::variables_map const& args, Hardware const& hardware);
+            BenchmarkTimer(po::variables_map& args, Hardware const& hardware);
 
             virtual bool needMoreBenchmarkRuns() const override;
             virtual void preBenchmarkRun() override;

--- a/Tensile/Source/client/include/CSVStackFile.hpp
+++ b/Tensile/Source/client/include/CSVStackFile.hpp
@@ -31,7 +31,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include <boost/lexical_cast.hpp>
+#include "program_options.hpp"
 
 namespace Tensile
 {
@@ -55,7 +55,7 @@ namespace Tensile
             typename std::enable_if<!std::is_same<T, std::string>::value, void>::type
                 setValueForKey(std::string const& key, T const& value)
             {
-                setValueForKey(key, boost::lexical_cast<std::string>(value));
+                setValueForKey(key, roc::lexical_cast_to_string(value));
             }
 
             void push();

--- a/Tensile/Source/client/include/ClientProblemFactory.hpp
+++ b/Tensile/Source/client/include/ClientProblemFactory.hpp
@@ -31,7 +31,7 @@
 #include <Tensile/KernelLanguageTypes.hpp>
 #include <Tensile/Tensile.hpp>
 
-#include <boost/program_options.hpp>
+#include "program_options.hpp"
 
 #include <cstddef>
 
@@ -40,12 +40,12 @@ namespace Tensile
     namespace Client
     {
 
-        namespace po = boost::program_options;
+        namespace po = roc;
 
         class ClientProblemFactory
         {
         public:
-            ClientProblemFactory(po::variables_map const& args);
+            ClientProblemFactory(po::variables_map& args);
             ~ClientProblemFactory();
 
             ClientProblemFactory(ContractionProblem const& problem)

--- a/Tensile/Source/client/include/DataInitialization.hpp
+++ b/Tensile/Source/client/include/DataInitialization.hpp
@@ -109,17 +109,17 @@ namespace Tensile
    * Factory function.
    */
             static std::shared_ptr<DataInitialization>
-                Get(roc::variables_map&    args,
+                Get(roc::variables_map&         args,
                     ClientProblemFactory const& problemFactory,
                     size_t                      maxWorkspaceSize = 0);
 
             template <typename TypedInputs>
             static std::shared_ptr<TypedDataInitialization<TypedInputs>>
-                GetTyped(roc::variables_map&    args,
+                GetTyped(roc::variables_map&         args,
                          ClientProblemFactory const& problemFactory,
                          size_t                      maxWorkspaceSize = 0);
 
-            DataInitialization(roc::variables_map&    args,
+            DataInitialization(roc::variables_map&         args,
                                ClientProblemFactory const& problemFactory,
                                size_t                      maxWorkspaceSize = 0);
             ~DataInitialization();

--- a/Tensile/Source/client/include/DataInitialization.hpp
+++ b/Tensile/Source/client/include/DataInitialization.hpp
@@ -26,8 +26,6 @@
 
 #pragma once
 
-#include <boost/program_options.hpp>
-
 #include <Tensile/ContractionProblem.hpp>
 
 #include "ClientProblemFactory.hpp"
@@ -37,7 +35,7 @@
 
 #include "RunListener.hpp"
 
-namespace po = boost::program_options;
+namespace po = roc;
 
 namespace Tensile
 {
@@ -105,23 +103,23 @@ namespace Tensile
         class DataInitialization : public RunListener
         {
         public:
-            static double GetRepresentativeBetaValue(po::variables_map const& args);
+            static double GetRepresentativeBetaValue(roc::variables_map& args);
 
             /**
    * Factory function.
    */
             static std::shared_ptr<DataInitialization>
-                Get(po::variables_map const&    args,
+                Get(roc::variables_map&    args,
                     ClientProblemFactory const& problemFactory,
                     size_t                      maxWorkspaceSize = 0);
 
             template <typename TypedInputs>
             static std::shared_ptr<TypedDataInitialization<TypedInputs>>
-                GetTyped(po::variables_map const&    args,
+                GetTyped(roc::variables_map&    args,
                          ClientProblemFactory const& problemFactory,
                          size_t                      maxWorkspaceSize = 0);
 
-            DataInitialization(po::variables_map const&    args,
+            DataInitialization(roc::variables_map&    args,
                                ClientProblemFactory const& problemFactory,
                                size_t                      maxWorkspaceSize = 0);
             ~DataInitialization();

--- a/Tensile/Source/client/include/DataInitializationTyped.hpp
+++ b/Tensile/Source/client/include/DataInitializationTyped.hpp
@@ -135,7 +135,7 @@ namespace Tensile
             using ManagedInputs
                 = ManagedContractionInputs<AType, BType, CType, DType, AlphaType, BetaType>;
 
-            TypedDataInitialization(po::variables_map&    args,
+            TypedDataInitialization(po::variables_map&          args,
                                     ClientProblemFactory const& problemFactory,
                                     size_t                      maxWorkspaceSize = 0)
                 : DataInitialization(args, problemFactory, maxWorkspaceSize)

--- a/Tensile/Source/client/include/DataInitializationTyped.hpp
+++ b/Tensile/Source/client/include/DataInitializationTyped.hpp
@@ -135,7 +135,7 @@ namespace Tensile
             using ManagedInputs
                 = ManagedContractionInputs<AType, BType, CType, DType, AlphaType, BetaType>;
 
-            TypedDataInitialization(po::variables_map const&    args,
+            TypedDataInitialization(po::variables_map&    args,
                                     ClientProblemFactory const& problemFactory,
                                     size_t                      maxWorkspaceSize = 0)
                 : DataInitialization(args, problemFactory, maxWorkspaceSize)

--- a/Tensile/Source/client/include/HardwareMonitorListener.hpp
+++ b/Tensile/Source/client/include/HardwareMonitorListener.hpp
@@ -32,7 +32,7 @@
 #include <cstddef>
 #include <future>
 
-#include <boost/program_options.hpp>
+#include "program_options.hpp"
 
 #include "HardwareMonitor_fwd.hpp"
 
@@ -40,12 +40,12 @@ namespace Tensile
 {
     namespace Client
     {
-        namespace po = boost::program_options;
+        namespace po = roc;
 
         class HardwareMonitorListener : public RunListener
         {
         public:
-            HardwareMonitorListener(po::variables_map const& args);
+            HardwareMonitorListener(po::variables_map& args);
 
             virtual bool needMoreBenchmarkRuns() const override
             {

--- a/Tensile/Source/client/include/LibraryUpdateReporter.hpp
+++ b/Tensile/Source/client/include/LibraryUpdateReporter.hpp
@@ -29,7 +29,7 @@
 #include "CSVStackFile.hpp"
 #include "ResultReporter.hpp"
 
-#include <boost/program_options.hpp>
+#include "program_options.hpp"
 
 #include <cstddef>
 
@@ -37,12 +37,12 @@ namespace Tensile
 {
     namespace Client
     {
-        namespace po = boost::program_options;
+        namespace po = roc;
 
         class LibraryUpdateReporter : public ResultReporter
         {
         public:
-            static std::shared_ptr<LibraryUpdateReporter> Default(po::variables_map const& args);
+            static std::shared_ptr<LibraryUpdateReporter> Default(po::variables_map& args);
 
             static std::shared_ptr<LibraryUpdateReporter> FromFilename(std::string const& filename,
                                                                        bool addComment);

--- a/Tensile/Source/client/include/LogReporter.hpp
+++ b/Tensile/Source/client/include/LogReporter.hpp
@@ -33,10 +33,9 @@
 #include <string>
 #include <unordered_set>
 
-#include <boost/lexical_cast.hpp>
-#include <boost/program_options.hpp>
+#include "program_options.hpp"
 
-namespace po = boost::program_options;
+namespace po = roc;
 
 namespace Tensile
 {
@@ -86,7 +85,7 @@ namespace Tensile
             }
 
             template <typename Stream>
-            static std::shared_ptr<LogReporter> Default(po::variables_map const& args,
+            static std::shared_ptr<LogReporter> Default(po::variables_map& args,
                                                         Stream&                  stream,
                                                         LogLevel level = LogLevel::Count)
             {
@@ -132,7 +131,7 @@ namespace Tensile
                                                                     dumpTensors));
             }
 
-            static std::shared_ptr<LogReporter> Default(po::variables_map const& args)
+            static std::shared_ptr<LogReporter> Default(po::variables_map& args)
             {
                 return Default(args, std::cout);
             }

--- a/Tensile/Source/client/include/LogReporter.hpp
+++ b/Tensile/Source/client/include/LogReporter.hpp
@@ -85,9 +85,8 @@ namespace Tensile
             }
 
             template <typename Stream>
-            static std::shared_ptr<LogReporter> Default(po::variables_map& args,
-                                                        Stream&                  stream,
-                                                        LogLevel level = LogLevel::Count)
+            static std::shared_ptr<LogReporter>
+                Default(po::variables_map& args, Stream& stream, LogLevel level = LogLevel::Count)
             {
                 bool dumpTensors = args["dump-tensors"].as<bool>();
                 using namespace ResultKey;

--- a/Tensile/Source/client/include/PerformanceReporter.hpp
+++ b/Tensile/Source/client/include/PerformanceReporter.hpp
@@ -35,19 +35,19 @@
 #include <limits>
 #include <string>
 
-#include <boost/program_options.hpp>
+#include "program_options.hpp"
 #include <hip/hip_runtime.h>
 
 namespace Tensile
 {
     namespace Client
     {
-        namespace po = boost::program_options;
+        namespace po = roc;
 
         class PerformanceReporter : public ResultReporter
         {
         public:
-            static std::shared_ptr<PerformanceReporter> Default(po::variables_map const& args);
+            static std::shared_ptr<PerformanceReporter> Default(po::variables_map& args);
 
             PerformanceReporter(int    deviceIndex,
                                 double l2ReadHits,

--- a/Tensile/Source/client/include/ProgressListener.hpp
+++ b/Tensile/Source/client/include/ProgressListener.hpp
@@ -32,18 +32,18 @@
 
 #include <cstddef>
 
-#include <boost/program_options.hpp>
+#include "program_options.hpp"
 
 namespace Tensile
 {
     namespace Client
     {
-        namespace po = boost::program_options;
+        namespace po = roc;
 
         class ProgressListener : public RunListener
         {
         public:
-            ProgressListener(po::variables_map const& args);
+            ProgressListener(po::variables_map& args);
 
             virtual bool needMoreBenchmarkRuns() const override;
 

--- a/Tensile/Source/client/include/ReferenceValidator.hpp
+++ b/Tensile/Source/client/include/ReferenceValidator.hpp
@@ -28,7 +28,7 @@
 
 #include "RunListener.hpp"
 
-#include <boost/program_options.hpp>
+#include "program_options.hpp"
 
 #include <ConvolutionProblem.hpp>
 #include <Tensile/ContractionProblem.hpp>
@@ -42,12 +42,12 @@ namespace Tensile
 {
     namespace Client
     {
-        namespace po = boost::program_options;
+        namespace po = roc;
 
         class ReferenceValidator : public RunListener
         {
         public:
-            ReferenceValidator(po::variables_map const&            args,
+            ReferenceValidator(po::variables_map&            args,
                                std::shared_ptr<DataInitialization> dataInit);
 
             virtual bool needMoreBenchmarkRuns() const override;

--- a/Tensile/Source/client/include/ReferenceValidator.hpp
+++ b/Tensile/Source/client/include/ReferenceValidator.hpp
@@ -47,7 +47,7 @@ namespace Tensile
         class ReferenceValidator : public RunListener
         {
         public:
-            ReferenceValidator(po::variables_map&            args,
+            ReferenceValidator(po::variables_map&                  args,
                                std::shared_ptr<DataInitialization> dataInit);
 
             virtual bool needMoreBenchmarkRuns() const override;

--- a/Tensile/Source/client/include/ResultFileReporter.hpp
+++ b/Tensile/Source/client/include/ResultFileReporter.hpp
@@ -29,7 +29,7 @@
 #include "CSVStackFile.hpp"
 #include "ResultReporter.hpp"
 
-#include <boost/program_options.hpp>
+#include "program_options.hpp"
 
 #include <cstddef>
 
@@ -37,12 +37,12 @@ namespace Tensile
 {
     namespace Client
     {
-        namespace po = boost::program_options;
+        namespace po = roc;
 
         class ResultFileReporter : public ResultReporter
         {
         public:
-            static std::shared_ptr<ResultFileReporter> Default(po::variables_map const& args);
+            static std::shared_ptr<ResultFileReporter> Default(po::variables_map& args);
 
             ResultFileReporter(std::string const& filename,
                                bool               exportExtraCols,

--- a/Tensile/Source/client/include/SolutionIterator.hpp
+++ b/Tensile/Source/client/include/SolutionIterator.hpp
@@ -28,7 +28,7 @@
 
 #include <Tensile/MasterSolutionLibrary.hpp>
 
-#include <boost/program_options.hpp>
+#include "program_options.hpp"
 
 #include <functional>
 #include <vector>
@@ -39,7 +39,7 @@ namespace Tensile
 {
     namespace Client
     {
-        namespace po = boost::program_options;
+        namespace po = roc;
 
         /**
  * Not an iterator by the traditional definition but I can't think of a better

--- a/Tensile/Source/client/include/program_options.hpp
+++ b/Tensile/Source/client/include/program_options.hpp
@@ -1,0 +1,1405 @@
+/* ************************************************************************
+ * Copyright 2020-2022 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+// This emulates removed dependency of boost library.
+
+#ifndef PROGRAM_OPTIONS_H
+#define PROGRAM_OPTIONS_H
+
+#include <Tensile/PerformanceMetricTypes.hpp>
+#include <Tensile/DataTypes.hpp>
+#include <Tensile/TensorOps.hpp>
+#include "ResultReporter.hpp"
+
+#include <cinttypes>
+#include <cstdio>
+#include <iomanip>
+#include <map>
+#include <ostream>
+#include <regex>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+#include <iostream>
+#include <fstream>
+
+#define DEBUG_ENABLE 0
+#define DEBUG_LOG_PO(__VA_ARGS__) if (DEBUG_ENABLE) printf(__VA_ARGS__)
+
+using namespace Tensile;
+
+namespace roc
+{
+    template <typename Target>
+    inline Target lexical_cast(const std::string &arg)
+    {
+        Target result = Target(std::stoull(arg, 0, 10));
+        return result;
+    }
+    
+    inline std::string lexical_cast_to_string(const std::string &arg)
+    {
+        std::string result;
+        result = arg;
+        return result;
+    }
+    
+    template <typename Source>
+    inline std::string lexical_cast_to_string(const Source &arg)
+    {
+        std::string result;
+        result = std::to_string(arg);
+        return result;
+    }
+    
+    inline std::vector<std::string>& split(
+    std::vector<std::string>& Result,
+    const std::string& Input,
+    std::string Pred)
+    {
+        std::size_t found = std::string::npos;
+        std::size_t prev = 0;
+        while (1)
+        {
+            found = std::string::npos;
+            for (auto p : Pred)
+            {
+                found = std::min(Input.find(p, prev), found);
+            }                
+            if (found != std::string::npos)
+            {
+                std::string s(Input.begin() + prev, Input.begin() + found);
+                Result.push_back(s);
+                prev = found + 1;
+            }
+            else
+                break;
+        }
+        DEBUG_LOG_PO("[split] loop done\n");
+        std::string f(Input.begin() + prev, Input.end());
+        Result.push_back(f);
+        DEBUG_LOG_PO("[split] done\n");
+        return Result;        
+    }
+    
+    // Regular expression for token delimiters (whitespace and commas)
+    static const std::regex program_options_regex{"[, \\f\\n\\r\\t\\v]+",
+                                                  std::regex_constants::optimize};
+    class any
+    {
+    public: // structors
+        any()
+          : content(0)
+        {
+        }
+
+        any(const any & other)
+          : content(other.content ? other.content->clone() : 0)
+        {
+        }
+
+        ~any()
+        {
+            delete content;
+        }
+
+    public: // modifiers
+
+        any & swap(any & rhs)
+        {
+            placeholder* tmp = content;
+            content = rhs.content;
+            rhs.content = tmp;
+            return *this;
+        }
+
+
+#ifdef BOOST_NO_CXX11_RVALUE_REFERENCES
+        template<typename ValueType>
+        any & operator=(const ValueType & rhs)
+        {
+            any(rhs).swap(*this);
+            return *this;
+        }
+
+        any & operator=(any rhs)
+        {
+            rhs.swap(*this);
+            return *this;
+        }
+
+#else 
+        any & operator=(const any& rhs)
+        {
+            any(rhs).swap(*this);
+            return *this;
+        }
+
+        // move assignment
+        any & operator=(any&& rhs)
+        {
+            rhs.swap(*this);
+            any().swap(rhs);
+            return *this;
+        }
+
+        // Perfect forwarding of ValueType
+        template <class ValueType>
+        any & operator=(ValueType&& rhs)
+        {
+            any(static_cast<ValueType&&>(rhs)).swap(*this);
+            return *this;
+        }
+#endif
+
+    public: // queries
+
+        bool empty() const
+        {
+            return !content;
+        }
+
+        void clear()
+        {
+            any().swap(*this);
+        }
+
+    public: // types (public so any_cast can be non-friend)
+
+        class placeholder
+        {
+        public: // structors
+
+            virtual ~placeholder()
+            {
+            }
+
+        public: // queries
+        
+            virtual placeholder * clone() const = 0;
+
+        };
+
+        template<typename ValueType>
+        class holder
+          : public placeholder
+        {
+        public: // structors
+
+            holder(const ValueType & value)
+              : held(value)
+            {
+            }
+        public: // queries
+
+            placeholder * clone()
+            {
+                return new holder(held);
+            }
+
+        public: // representation
+
+            ValueType held;
+
+        private: // intentionally left unimplemented
+            holder & operator=(const holder &);
+        };
+    public: // representation (public so any_cast can be non-friend)
+        placeholder * content;
+
+    }; //class any
+    
+    class value_base
+    {
+    protected:
+        bool m_has_actual  = false;
+        bool m_has_default = false;
+
+    public:
+        virtual ~value_base() = default;
+
+        bool has_actual() const
+        {
+            return m_has_actual;
+        }
+
+        bool has_default() const
+        {
+            return m_has_default;
+        }
+    };
+
+    // Value parameters
+    template <typename T>
+    class value : public value_base
+    {
+        T  m_var; // Variable to be modified if no pointer provided
+        T* m_var_ptr; // Pointer to variable to be modified
+
+    public:
+        // Constructor
+        explicit value()
+            : m_var_ptr(nullptr)
+        {
+        }
+
+        explicit value(T var, bool defaulted)
+            : m_var(var)
+            , m_var_ptr(nullptr)
+        {
+            m_has_actual  = !defaulted;
+            m_has_default = defaulted;
+        }
+
+        explicit value(T* var_ptr)
+            : m_var_ptr(var_ptr)
+        {
+        }
+
+        // Allows actual_value() and default_value()
+        value* operator->()
+        {
+            return this;
+        }
+
+        // Get the value
+        const T& get_value() const
+        {
+            if(m_var_ptr)
+                return *m_var_ptr;
+            else
+                return m_var;
+        }
+
+        // Set actual value
+        value& actual_value(T val)
+        {
+            if(m_var_ptr){
+                *m_var_ptr = std::move(val);
+            }else{
+                m_var = std::move(val);
+            }
+            m_has_actual = true;
+            return *this;
+        }
+
+        // Set default value
+        value* default_value(T val, std::string const& desc)
+        {
+            if(!m_has_actual)
+            {
+                if(m_var_ptr)
+                    *m_var_ptr = std::move(val);
+                else
+                    m_var = std::move(val);
+                m_has_default = true;
+            }
+            return this;
+        }
+        
+        value& default_value(T val)
+        {
+            if(!m_has_actual)
+            {
+                if(m_var_ptr)
+                    *m_var_ptr = std::move(val);
+                else
+                    m_var = std::move(val);
+                m_has_default = true;
+            }
+            return *this;
+        }
+        
+    };
+
+    // bool_switch is a value<bool>, which is handled specially
+    using bool_switch = value<bool>;
+
+    class variable_value
+    {
+        std::shared_ptr<value_base> m_val;
+
+    public:
+        // Constructor
+        explicit variable_value() = default;
+
+        template <typename T>
+        explicit variable_value(const T& xv, bool xdefaulted)
+            : m_val(std::make_shared<value<T>>(xv, xdefaulted))
+        {
+        }
+
+        explicit variable_value(std::shared_ptr<value_base> val)
+            : m_val(val)
+        {
+        }
+
+        // Member functions
+        bool empty() const
+        {
+            return !m_val.get() || (!m_val->has_actual() && !m_val->has_default());
+        }
+
+        bool defaulted() const
+        {
+            return m_val.get() && !m_val->has_actual() && m_val->has_default();
+        }
+
+        template <typename T>
+        const T& as() const
+        {
+            if(value<T>* val = dynamic_cast<value<T>*>(m_val.get()))
+                return val->get_value();
+            else
+                throw std::logic_error("Internal error: Invalid cast");
+        }
+        
+        template <typename T>
+        const void set(T& in) const
+        {
+            if(value<T>* val = dynamic_cast<value<T>*>(m_val.get()))
+            {
+                val->actual_value(in);
+                return;
+            }
+            else
+                throw std::logic_error("Internal error: Invalid cast");
+        }
+        
+    };
+
+    using variables_map = std::map<std::string, variable_value>;
+
+    class options_description
+    {
+        // desc_option describes a particular option
+        class desc_option
+        {
+            std::string                                  m_opts;
+            std::shared_ptr<value_base>                  m_val;
+            std::string                                  m_desc;
+        public:
+            // Constructor with options, value and description
+            template <typename T>
+            desc_option(std::string opts, value<T>* val, std::string desc)
+                : m_opts(std::move(opts))
+                , m_val(new auto(std::move(*val)))
+                , m_desc(std::move(desc))
+            {
+            }
+            
+            template <typename T>
+            desc_option(std::string opts, value<T> val, std::string desc)
+                : m_opts(std::move(opts))
+                , m_val(new auto(std::move(val)))
+                , m_desc(std::move(desc))
+            {
+            }
+
+            // Constructor with options and description
+            desc_option(std::string opts, std::string desc)
+                : m_opts(std::move(opts))
+                , m_val(nullptr)
+                , m_desc(std::move(desc))
+            {
+            }
+
+            // Copy constructor is deleted
+            desc_option(const desc_option&) = delete;
+
+            // Move constructor
+            desc_option(desc_option&& other) = default;
+
+            // Accessors
+            const std::string& get_opts() const
+            {
+                return m_opts;
+            }
+
+            const std::shared_ptr<value_base> get_val() const
+            {
+                return m_val;
+            }
+
+            const std::string& get_desc() const
+            {
+                return m_desc;
+            }
+
+            // Set a value
+            void set_val(int& argc, char**& argv, std::string inopt, std::unordered_map<std::string,std::string>* p_uncfg) const
+            {
+                // We test all supported types with dynamic_cast and parse accordingly
+                DEBUG_LOG_PO("[set_val] start\n");
+                bool match = false;
+                if(inopt.compare(0, 7, "--init-") == 0)
+                {
+                    DEBUG_LOG_PO("[set_val] skip DEBUG_LOG_PO\n");
+                    if(p_uncfg != nullptr)
+                        (*p_uncfg)[std::string(inopt.begin() + 2, inopt.end())] = std::string(*argv);
+                    match = true;
+                }
+                else if(inopt.compare(0, 14, "--bounds-check") == 0)
+                {
+                    DEBUG_LOG_PO("[set_val] skip BoundsCheckMode\n");
+                    if(p_uncfg != nullptr)
+                        (*p_uncfg)[std::string(inopt.begin() + 2, inopt.end())] = std::string(*argv);
+                    match = true;
+                }
+                else if(inopt == "--problem-size" || 
+                        inopt == "--a-strides" ||
+                        inopt == "--b-strides" ||
+                        inopt == "--c-strides" ||
+                        inopt == "--d-strides" ||
+                        inopt == "--convolution-problem" ||
+                        inopt == "--a-zero-pads" ||
+                        inopt == "--b-zero-pads")
+                {
+                    DEBUG_LOG_PO("[set_val] problem size/a,b,c,d stride\n");
+                    if(auto* ptr = dynamic_cast<value<std::vector<std::vector<size_t>>>*>(m_val.get()))
+                    {
+                        std::string in(*argv);
+                        std::vector<std::string> values;
+                        std::vector<size_t> values_int;
+                        std::string spliter(",");
+                        if(inopt == "--a-zero-pads" || inopt == "--b-zero-pads")
+                            spliter = ",;";
+                        roc::split(values, in, spliter);
+                        size_t tuples = values.size();
+                        auto vals = ptr->get_value();
+                        for(auto v : values)
+                        {
+                            values_int.push_back(lexical_cast<size_t>(v));
+                            if(values_int.size() == tuples)
+                            {
+                                vals.push_back(values_int);
+                                values_int.clear();
+                            }
+                        }
+                        ptr->actual_value(vals);
+                        match = true;
+                        if(!values_int.empty())
+                            match = false;
+                    }
+                }
+                else if(auto* ptr = dynamic_cast<value<TensorOp>*>(m_val.get()))
+                {
+                    DEBUG_LOG_PO("[set_val] TensorOp\n");
+                    std::string in(*argv);
+                    match = true;
+                    if(in == "None")
+                    {
+                        ptr->actual_value(TensorOp(TensorOp::Type::None));
+                    }
+                    else if(in == "ComplexConjugate")
+                    {
+                        ptr->actual_value(TensorOp(TensorOp::Type::ComplexConjugate));
+                    }
+                    else
+                    {
+                        match = false;
+                    }
+                }
+                else if(auto* ptr = dynamic_cast<value<Client::LogLevel>*>(m_val.get()))
+                {
+                    DEBUG_LOG_PO("[set_val] DataType\n");
+                    std::string in(*argv);
+                    match = true;
+                    if(in == "Error")
+                    {
+                        ptr->actual_value(Client::LogLevel::Error);
+                    }
+                    else if(in == "Terse")
+                    {
+                        ptr->actual_value(Client::LogLevel::Terse);
+                    }
+                    else if(in == "Normal")
+                    {
+                        ptr->actual_value(Client::LogLevel::Normal);
+                    }
+                    else if(in == "Verbose")
+                    {
+                        ptr->actual_value(Client::LogLevel::Verbose);
+                    }
+                    else if(in == "Debug")
+                    {
+                        ptr->actual_value(Client::LogLevel::Debug);
+                    }
+                    else
+                    {
+                        match = false;
+                    }
+                }
+                else if(auto* ptr = dynamic_cast<value<DataType>*>(m_val.get()))
+                {
+                    DEBUG_LOG_PO("[set_val] DataType\n");
+                    std::string in(*argv);
+                    match = true;
+                    if(in == "Float")
+                    {
+                        ptr->actual_value(DataType::Float);
+                    }
+                    else if(in == "Double")
+                    {
+                        ptr->actual_value(DataType::Double);
+                    }
+                    else if(in == "ComplexFloat")
+                    {
+                        ptr->actual_value(DataType::ComplexFloat);
+                    }
+                    else if(in == "ComplexDouble")
+                    {
+                        ptr->actual_value(DataType::ComplexDouble);
+                    }
+                    else if(in == "Half")
+                    {
+                        ptr->actual_value(DataType::Half);
+                    }
+                    else if(in == "Int8x4")
+                    {
+                        ptr->actual_value(DataType::Int8x4);
+                    }
+                    else if(in == "Int32")
+                    {
+                        ptr->actual_value(DataType::Int32);
+                    }
+                    else if(in == "BFloat16")
+                    {
+                        ptr->actual_value(DataType::BFloat16);
+                    }
+                    else if(in == "Int8")
+                    {
+                        ptr->actual_value(DataType::Int8);
+                    }
+                    else
+                    {
+                        match = false;
+                    }
+                }
+                else if(auto* ptr = dynamic_cast<value<PerformanceMetric>*>(m_val.get()))
+                {
+                    DEBUG_LOG_PO("[set_val] PerformanceMetric\n");
+                    std::string in(*argv);
+                    match = true;
+                    if(in == "DeviceEfficiency")
+                    {
+                        ptr->actual_value(PerformanceMetric::DeviceEfficiency);
+                    }
+                    else if(in == "CUEfficiency")
+                    {
+                        ptr->actual_value(PerformanceMetric::CUEfficiency);
+                    }
+                    else if(in == "Auto")
+                    {
+                        ptr->actual_value(PerformanceMetric::Auto);
+                    }
+                    else
+                    {
+                        DEBUG_LOG_PO("[set_val] Unsupported PerformanceMetric type\n");
+                        match = false;
+                    }
+                }
+                else if(auto* ptr = dynamic_cast<value<int32_t>*>(m_val.get()))
+                {
+                    DEBUG_LOG_PO("[set_val] int32_t\n");
+                    int32_t val;
+                    match = argc && sscanf(*argv, "%" SCNd32, &val) == 1;
+                    ptr->actual_value(val);
+                }
+                else if(auto* ptr = dynamic_cast<value<uint32_t>*>(m_val.get()))
+                {
+                    DEBUG_LOG_PO("[set_val] uint32_t\n");
+                    uint32_t val;
+                    match = argc && sscanf(*argv, "%" SCNu32, &val) == 1;
+                    ptr->actual_value(val);
+                }
+                else if(auto* ptr = dynamic_cast<value<int64_t>*>(m_val.get()))
+                {
+                    DEBUG_LOG_PO("[set_val] int64_t\n");
+                    int64_t val;
+                    match = argc && sscanf(*argv, "%" SCNd64, &val) == 1;
+                    ptr->actual_value(val);
+                }
+                else if(auto* ptr = dynamic_cast<value<uint64_t>*>(m_val.get()))
+                {
+                    DEBUG_LOG_PO("[set_val] uint64_t\n");
+                    uint64_t val;
+                    match = argc && sscanf(*argv, "%" SCNu64, &val) == 1;
+                    ptr->actual_value(val);
+                }
+                else if(auto* ptr = dynamic_cast<value<float>*>(m_val.get()))
+                {
+                    DEBUG_LOG_PO("[set_val] float\n");
+                    float val;
+                    match = argc && sscanf(*argv, "%f", &val) == 1;
+                    ptr->actual_value(val);
+                }
+                else if(auto* ptr = dynamic_cast<value<double>*>(m_val.get()))
+                {
+                    DEBUG_LOG_PO("[set_val] double\n");
+                    double val;
+                    match = argc && sscanf(*argv, "%lf", &val) == 1;
+                    ptr->actual_value(val);
+                }
+                else if(auto* ptr = dynamic_cast<value<char>*>(m_val.get()))
+                {
+                    DEBUG_LOG_PO("[set_val] char\n");
+                    char val;
+                    match = argc && sscanf(*argv, " %c", &val) == 1;
+                    ptr->actual_value(val);
+                }
+                else if(auto* ptr = dynamic_cast<value<int8_t>*>(m_val.get()))
+                {
+                    DEBUG_LOG_PO("[set_val] int8_t\n");
+                    int8_t val;
+                    match = argc && sscanf(*argv, " %c", &val) == 1;
+                    ptr->actual_value(val);
+                }
+                else if(auto* ptr = dynamic_cast<value<bool>*>(m_val.get()))
+                {
+                    DEBUG_LOG_PO("[set_val] bool\n");
+                    std::string in(*argv);
+                    match = true;
+                    if(in == "True" || in == "true" || in == "1")
+                        ptr->actual_value(true);
+                    else if(in == "False" || in == "false" || in == "0")
+                        ptr->actual_value(false);
+                    else
+                        match = false;
+                }
+                else if(auto* ptr = dynamic_cast<value<std::string>*>(m_val.get()))
+                {
+                    DEBUG_LOG_PO("[set_val] string\n");
+                    if(argc)
+                    {
+                        ptr->actual_value(*argv);
+                        match = true;
+                    }
+                }
+                else if(auto* ptr = dynamic_cast<value<std::vector<std::string>>*>(m_val.get()))
+                {
+                    DEBUG_LOG_PO("[set_val] vector<string>\n");
+                    if(argc)
+                    {
+                        std::string in(*argv);
+                        std::vector<std::string> values;
+                        std::string spliter(",;");
+                        roc::split(values, in, spliter);
+                        ptr->actual_value(values);
+                        match = true;
+                    }
+                }
+                else
+                {
+                    DEBUG_LOG_PO("[set_val] Internal error: Unsupported data type (setting value)\n");
+                    throw std::logic_error("Internal error: Unsupported data type (setting value)");
+                }
+                if(!match)
+                    throw std::invalid_argument(argc ? "Invalid value for " + inopt
+                                                     : "Missing required value for " + inopt);
+
+                // Skip past the argument's value
+                ++argv;
+                --argc;
+            }
+            // Set a value
+            void set_val(int& argc, const char* argv, std::string inopt, std::unordered_map<std::string,std::string>* p_uncfg) const
+            {
+                // We test all supported types with dynamic_cast and parse accordingly
+                DEBUG_LOG_PO("[set_val] start\n");
+                bool match = false;
+                if(inopt.compare(0, 7, "--init-") == 0)
+                {
+                    DEBUG_LOG_PO("[set_val] skip DEBUG_LOG_PO\n");
+                    if(p_uncfg != nullptr)
+                        (*p_uncfg)[std::string(inopt.begin() + 2, inopt.end())] = std::string(argv);
+                    match = true;
+                }
+                else if(inopt.compare(0, 14, "--bounds-check") == 0)
+                {
+                    DEBUG_LOG_PO("[set_val] skip BoundsCheckMode\n");
+                    if(p_uncfg != nullptr)
+                        (*p_uncfg)[std::string(inopt.begin() + 2, inopt.end())] = std::string(argv);
+                    match = true;
+                }
+                else if(inopt == "--problem-size" || 
+                        inopt == "--a-strides" ||
+                        inopt == "--b-strides" ||
+                        inopt == "--c-strides" ||
+                        inopt == "--d-strides" ||
+                        inopt == "--convolution-problem" ||
+                        inopt == "--a-zero-pads" ||
+                        inopt == "--b-zero-pads")
+                {
+                    DEBUG_LOG_PO("[set_val] problem size/a,b,c,d stride\n");
+                    if(auto* ptr = dynamic_cast<value<std::vector<std::vector<size_t>>>*>(m_val.get()))
+                    {
+                        std::string in(argv);
+                        std::vector<std::string> values;
+                        std::vector<size_t> values_int;
+                        std::string spliter(",");
+                        if(inopt == "--a-zero-pads" || inopt == "--b-zero-pads")
+                            spliter = ",;";
+                        roc::split(values, in, spliter);
+                        size_t tuples = values.size();
+                        auto vals = ptr->get_value();
+                        for(auto v : values)
+                        {
+                            values_int.push_back(lexical_cast<size_t>(v));
+                            if(values_int.size() == tuples)
+                            {
+                                vals.push_back(values_int);
+                                values_int.clear();
+                            }
+                        }
+                        ptr->actual_value(vals);
+                        match = true;
+                        if(!values_int.empty())
+                            match = false;
+                    }
+                }
+                else if(auto* ptr = dynamic_cast<value<TensorOp>*>(m_val.get()))
+                {
+                    DEBUG_LOG_PO("[set_val] TensorOp\n");
+                    std::string in(argv);
+                    match = true;
+                    if(in == "None")
+                    {
+                        ptr->actual_value(TensorOp(TensorOp::Type::None));
+                    }
+                    else if(in == "ComplexConjugate")
+                    {
+                        ptr->actual_value(TensorOp(TensorOp::Type::ComplexConjugate));
+                    }
+                    else
+                    {
+                        match = false;
+                    }
+                }
+                else if(auto* ptr = dynamic_cast<value<Client::LogLevel>*>(m_val.get()))
+                {
+                    DEBUG_LOG_PO("[set_val] DataType\n");
+                    std::string in(argv);
+                    match = true;
+                    if(in == "Error")
+                    {
+                        ptr->actual_value(Client::LogLevel::Error);
+                    }
+                    else if(in == "Terse")
+                    {
+                        ptr->actual_value(Client::LogLevel::Terse);
+                    }
+                    else if(in == "Normal")
+                    {
+                        ptr->actual_value(Client::LogLevel::Normal);
+                    }
+                    else if(in == "Verbose")
+                    {
+                        ptr->actual_value(Client::LogLevel::Verbose);
+                    }
+                    else if(in == "Debug")
+                    {
+                        ptr->actual_value(Client::LogLevel::Debug);
+                    }
+                    else
+                    {
+                        match = false;
+                    }
+                }
+                else if(auto* ptr = dynamic_cast<value<DataType>*>(m_val.get()))
+                {
+                    DEBUG_LOG_PO("[set_val] DataType\n");
+                    std::string in(argv);
+                    match = true;
+                    if(in == "Float")
+                    {
+                        ptr->actual_value(DataType::Float);
+                    }
+                    else if(in == "Double")
+                    {
+                        ptr->actual_value(DataType::Double);
+                    }
+                    else if(in == "ComplexFloat")
+                    {
+                        ptr->actual_value(DataType::ComplexFloat);
+                    }
+                    else if(in == "ComplexDouble")
+                    {
+                        ptr->actual_value(DataType::ComplexDouble);
+                    }
+                    else if(in == "Half")
+                    {
+                        ptr->actual_value(DataType::Half);
+                    }
+                    else if(in == "Int8x4")
+                    {
+                        ptr->actual_value(DataType::Int8x4);
+                    }
+                    else if(in == "Int32")
+                    {
+                        ptr->actual_value(DataType::Int32);
+                    }
+                    else if(in == "BFloat16")
+                    {
+                        ptr->actual_value(DataType::BFloat16);
+                    }
+                    else if(in == "Int8")
+                    {
+                        ptr->actual_value(DataType::Int8);
+                    }
+                    else
+                    {
+                        match = false;
+                    }
+                }
+                else if(auto* ptr = dynamic_cast<value<PerformanceMetric>*>(m_val.get()))
+                {
+                    DEBUG_LOG_PO("[set_val] PerformanceMetric\n");
+                    std::string in(argv);
+                    match = true;
+                    if(in == "DeviceEfficiency")
+                    {
+                        ptr->actual_value(PerformanceMetric::DeviceEfficiency);
+                    }
+                    else if(in == "CUEfficiency")
+                    {
+                        ptr->actual_value(PerformanceMetric::CUEfficiency);
+                    }
+                    else if(in == "Auto")
+                    {
+                        ptr->actual_value(PerformanceMetric::Auto);
+                    }
+                    else
+                    {
+                        DEBUG_LOG_PO("[set_val] Unsupported PerformanceMetric type\n");
+                        match = false;
+                    }
+                }
+                else if(auto* ptr = dynamic_cast<value<int32_t>*>(m_val.get()))
+                {
+                    DEBUG_LOG_PO("[set_val] int32_t\n");
+                    int32_t val;
+                    match = argc && sscanf(argv, "%" SCNd32, &val) == 1;
+                    ptr->actual_value(val);
+                }
+                else if(auto* ptr = dynamic_cast<value<uint32_t>*>(m_val.get()))
+                {
+                    DEBUG_LOG_PO("[set_val] uint32_t\n");
+                    uint32_t val;
+                    match = argc && sscanf(argv, "%" SCNu32, &val) == 1;
+                    ptr->actual_value(val);
+                }
+                else if(auto* ptr = dynamic_cast<value<int64_t>*>(m_val.get()))
+                {
+                    DEBUG_LOG_PO("[set_val] int64_t\n");
+                    int64_t val;
+                    match = argc && sscanf(argv, "%" SCNd64, &val) == 1;
+                    ptr->actual_value(val);
+                }
+                else if(auto* ptr = dynamic_cast<value<uint64_t>*>(m_val.get()))
+                {
+                    DEBUG_LOG_PO("[set_val] uint64_t\n");
+                    uint64_t val;
+                    match = argc && sscanf(argv, "%" SCNu64, &val) == 1;
+                    ptr->actual_value(val);
+                }
+                else if(auto* ptr = dynamic_cast<value<float>*>(m_val.get()))
+                {
+                    DEBUG_LOG_PO("[set_val] float\n");
+                    float val;
+                    match = argc && sscanf(argv, "%f", &val) == 1;
+                    ptr->actual_value(val);
+                }
+                else if(auto* ptr = dynamic_cast<value<double>*>(m_val.get()))
+                {
+                    DEBUG_LOG_PO("[set_val] double\n");
+                    double val;
+                    match = argc && sscanf(argv, "%lf", &val) == 1;
+                    ptr->actual_value(val);
+                }
+                else if(auto* ptr = dynamic_cast<value<char>*>(m_val.get()))
+                {
+                    DEBUG_LOG_PO("[set_val] char\n");
+                    char val;
+                    match = argc && sscanf(argv, " %c", &val) == 1;
+                    ptr->actual_value(val);
+                }
+                else if(auto* ptr = dynamic_cast<value<int8_t>*>(m_val.get()))
+                {
+                    DEBUG_LOG_PO("[set_val] int8_t\n");
+                    int8_t val;
+                    match = argc && sscanf(argv, " %c", &val) == 1;
+                    ptr->actual_value(val);
+                }
+                else if(auto* ptr = dynamic_cast<value<bool>*>(m_val.get()))
+                {
+                    DEBUG_LOG_PO("[set_val] bool\n");
+                    std::string in(argv);
+                    match = true;
+                    if(in == "True" || in == "true" || in == "1")
+                        ptr->actual_value(true);
+                    else if(in == "False" || in == "false" || in == "0")
+                        ptr->actual_value(false);
+                    else
+                        match = false;
+                }
+                else if(auto* ptr = dynamic_cast<value<std::string>*>(m_val.get()))
+                {
+                    DEBUG_LOG_PO("[set_val] string\n");
+                    if(argc)
+                    {
+                        ptr->actual_value(argv);
+                        match = true;
+                    }
+                }
+                else if(auto* ptr = dynamic_cast<value<std::vector<std::string>>*>(m_val.get()))
+                {
+                    DEBUG_LOG_PO("[set_val] vector<string>\n");
+                    if(argc)
+                    {
+                        std::string in(argv);
+                        std::vector<std::string> values;
+                        std::string spliter(",;");
+                        roc::split(values, in, spliter);
+                        ptr->actual_value(values);
+                        match = true;
+                    }
+                }
+                else
+                {
+                    DEBUG_LOG_PO("[set_val] Internal error: Unsupported data type (setting value)\n");
+                    throw std::logic_error("Internal error: Unsupported data type (setting value)");
+                }
+                if(!match)
+                    throw std::invalid_argument(argc ? "Invalid value for " + inopt
+                                                     : "Missing required value for " + inopt);
+
+                // Skip past the argument's value
+                --argc;
+            }
+            
+        };
+
+        // Description and option list
+        std::string              m_desc;
+        std::vector<desc_option> m_optlist;
+
+        // desc_optionlist allows chains of options to be parenthesized
+        class desc_optionlist
+        {
+            std::vector<desc_option>& m_list;
+
+        public:
+            explicit desc_optionlist(std::vector<desc_option>& list)
+                : m_list(list)
+            {
+            }
+
+            template <typename... Ts>
+            desc_optionlist operator()(Ts&&... arg)
+            {
+                m_list.push_back(desc_option(std::forward<Ts>(arg)...));
+                return *this;
+            }
+        };
+
+        // Parse an option at the current (argc, argv) position
+        void parse_option(int& argc, std::vector<std::string>& argv, variables_map& vm, bool ignoreUnknown,
+                          std::unordered_map<std::string,std::string>* p_uncfg) const
+        {
+            DEBUG_LOG_PO("[parse_option]\n");
+            // Iterate across all options
+            for(const auto& opt : m_optlist)
+            {
+                // Canonical name used for map
+                std::string canonical_name;
+
+                // Iterate across tokens in the opts
+                DEBUG_LOG_PO("[parse_option] Iterate across tokens in the opts\n");
+                for(std::sregex_token_iterator tok{
+                        opt.get_opts().begin(), opt.get_opts().end(), program_options_regex, -1};
+                    tok != std::sregex_token_iterator();
+                    ++tok)
+                {
+                    // The first option in a list of options is the canonical name
+                    if(!canonical_name.length())
+                        canonical_name = tok->str();
+                       
+                    // If the length of the option is 1, it is single-dash; otherwise double-dash
+                    const char* prefix = tok->length() == 1 ? "-" : "--";
+                    
+                    // If option matches
+                    DEBUG_LOG_PO("[parse_option] Check if option matches\n");
+                    if(argv[argv.size() - argc] == prefix + tok->str())
+                    {
+                        
+                        //++argv;
+                        --argc;
+
+                        // If option has a value, set it
+                        auto got = opt.get_val().get();
+                        if(got){
+                            opt.set_val(argc, argv[argv.size() - argc].c_str(), prefix + tok->str(), p_uncfg);
+                        }
+
+                        // Add seen options to map
+                        vm[canonical_name] = variable_value(opt.get_val());
+                        DEBUG_LOG_PO("[parse_option] Add seen options to map successfully\n");
+                        return; // Return successfully
+                    }
+                    DEBUG_LOG_PO("[parse_option] Check if option matches done\n");
+                }
+            }
+
+            // No options were matched
+            if(ignoreUnknown)
+            {
+                --argc;
+            }
+            else
+            {
+                DEBUG_LOG_PO("[parse_option] ERROR: option not defined\n");
+                throw std::invalid_argument("Option " + std::string(argv[0]) + " is not defined.");
+            }
+        }
+        
+        // Parse an option at the current (argc, argv) position
+        void parse_option(int& argc, char**& argv, variables_map& vm, bool ignoreUnknown,
+                          std::unordered_map<std::string,std::string>* p_uncfg) const
+        {
+            DEBUG_LOG_PO("[parse_option]\n");
+            // Iterate across all options
+            for(const auto& opt : m_optlist)
+            {
+                // Canonical name used for map
+                std::string canonical_name;
+
+                // Iterate across tokens in the opts
+                DEBUG_LOG_PO("[parse_option] Iterate across tokens in the opts\n");
+                for(std::sregex_token_iterator tok{
+                        opt.get_opts().begin(), opt.get_opts().end(), program_options_regex, -1};
+                    tok != std::sregex_token_iterator();
+                    ++tok)
+                {
+                    // The first option in a list of options is the canonical name
+                    if(!canonical_name.length())
+                        canonical_name = tok->str();
+                      
+                    // If the length of the option is 1, it is single-dash; otherwise double-dash
+                    const char* prefix = tok->length() == 1 ? "-" : "--";
+                    
+                    // If option matches
+                    DEBUG_LOG_PO("[parse_option] Check if option matches\n");
+                    if(*argv == prefix + tok->str())
+                    {
+                        
+                        ++argv;
+                        --argc;
+
+                        // If option has a value, set it
+                        auto got = opt.get_val().get();
+                        if(got){
+                            opt.set_val(argc, argv, prefix + tok->str(), p_uncfg);
+                        }
+
+                        // Add seen options to map
+                        vm[canonical_name] = variable_value(opt.get_val());
+                        DEBUG_LOG_PO("[parse_option] Add seen options to map successfully\n");
+                        return; // Return successfully
+                    }
+                    DEBUG_LOG_PO("[parse_option] Check if option matches done\n");
+                }
+            }
+
+            // No options were matched
+            if(ignoreUnknown)
+            {
+                ++argv;
+                --argc;
+            }
+            else
+            {
+                DEBUG_LOG_PO("[parse_option] ERROR: option not defined\n");
+                throw std::invalid_argument("Option " + std::string(argv[0]) + " is not defined.");
+            }
+        }
+
+    public:
+        // Constructor
+        explicit options_description(std::string desc)
+            : m_desc(std::move(desc))
+        {
+        }
+
+        // Start a desc_optionlist chain
+        desc_optionlist add_options() &
+        {
+            return desc_optionlist(m_optlist);
+        }
+
+        // Parse all options
+        void parse_options(int&                                         argc,
+                           char**&                                      argv,
+                           variables_map&                               vm,
+                           bool                                         ignoreUnknown = false,
+                           std::unordered_map<std::string,std::string>* p_uncfg = nullptr) const
+        {
+            // Add options with default values to map
+            for(const auto& opt : m_optlist)
+            {
+                std::sregex_token_iterator tok{
+                    opt.get_opts().begin(), opt.get_opts().end(), program_options_regex, -1};
+
+                // Canonical name used for map
+                std::string canonical_name = tok->str();
+
+                if(opt.get_val().get() && opt.get_val()->has_default())
+                {   
+                    //DEBUG_LOG_PO("[parse_options] add an option\n");
+                    vm[canonical_name] = variable_value(opt.get_val());
+                }
+            }
+            DEBUG_LOG_PO("[parse_options] add options done\n");
+            // Parse options
+            while(argc)
+                parse_option(argc, argv, vm, ignoreUnknown, p_uncfg);
+
+        }
+
+        // Parse all options
+        void parse_options(int&                                         argc,
+                           std::vector<std::string>&                    argv,
+                           variables_map&                               vm,
+                           bool                                         ignoreUnknown = false,
+                           std::unordered_map<std::string,std::string>* p_uncfg = nullptr) const
+        {
+            // Add options with default values to map
+            for(const auto& opt : m_optlist)
+            {
+                std::sregex_token_iterator tok{
+                    opt.get_opts().begin(), opt.get_opts().end(), program_options_regex, -1};
+
+                // Canonical name used for map
+                std::string canonical_name = tok->str();
+
+                if(opt.get_val().get() && opt.get_val()->has_default())
+                {   
+                    //DEBUG_LOG_PO("[parse_options] add an option\n");
+                    vm[canonical_name] = variable_value(opt.get_val());
+                }
+            }
+            DEBUG_LOG_PO("[parse_options] add options done\n");
+            // Parse options
+            while(argc)
+                parse_option(argc, argv, vm, ignoreUnknown, p_uncfg);
+
+        }
+
+        // Formatted output of command-line arguments description
+        friend std::ostream& operator<<(std::ostream& os, const options_description& d)
+        {
+            // Iterate across all options
+            for(const auto& opt : d.m_optlist)
+            {
+                bool               first = true;
+                const char*        delim = "";
+                std::ostringstream left;
+                // Iterate across tokens in the opts
+                for(std::sregex_token_iterator tok{opt.get_opts().begin(),
+                                                   opt.get_opts().end(),
+                                                   program_options_regex,
+                                                   -1};
+                    tok != std::sregex_token_iterator();
+                    ++tok, first = false, delim = " ")
+                {
+                    // If the length of the option is 1, it is single-dash; otherwise double-dash
+                    const char* prefix = tok->length() == 1 ? "-" : "--";
+                    left << delim << (first ? "" : "|") << prefix << tok->str();
+                }  
+
+                os << std::setw(30) << std::left << left.str() << " " << opt.get_desc() << " ";
+                left.str(std::string());
+                
+                // Print the default value of the variable type if it exists
+                // We do not print the default value for bool
+                const value_base* val = opt.get_val().get();
+                if(val && !dynamic_cast<const value<bool>*>(val))
+                {
+                    if(val->has_default())
+                    { 
+                        // We test all supported types with dynamic_cast and print accordingly
+                        left << " (Default value is: ";
+                        if(dynamic_cast<const value<int32_t>*>(val))
+                            left << dynamic_cast<const value<int32_t>*>(val)->get_value();
+                        else if(dynamic_cast<const value<uint32_t>*>(val))
+                            left << dynamic_cast<const value<uint32_t>*>(val)->get_value();
+                        else if(dynamic_cast<const value<int64_t>*>(val))
+                            left << dynamic_cast<const value<int64_t>*>(val)->get_value();
+                        else if(dynamic_cast<const value<uint64_t>*>(val))
+                            left << dynamic_cast<const value<uint64_t>*>(val)->get_value();
+                        else if(dynamic_cast<const value<float>*>(val))
+                            left << dynamic_cast<const value<float>*>(val)->get_value();
+                        else if(dynamic_cast<const value<double>*>(val))
+                            left << dynamic_cast<const value<double>*>(val)->get_value();
+                        else if(dynamic_cast<const value<char>*>(val))
+                            left << dynamic_cast<const value<char>*>(val)->get_value();
+                        else if(dynamic_cast<const value<int8_t>*>(val))
+                            left << dynamic_cast<const value<int8_t>*>(val)->get_value();
+                        else if(dynamic_cast<const value<std::string>*>(val))
+                            left << dynamic_cast<const value<std::string>*>(val)->get_value();
+                        else if(dynamic_cast<const value<Tensile::PerformanceMetric>*>(val))
+                            left << dynamic_cast<const value<Tensile::PerformanceMetric>*>(val)->get_value();
+                        else
+                            left << "Internal error: Unsupported data type (printing value)";
+                        left << ")";
+                    }
+                }
+                os << left.str() << "\n\n";
+            } 
+            return os << std::flush;
+        }
+    };
+
+    // Class representing command line parser
+    class parse_command_line
+    {
+        variables_map m_vm;
+        std::unordered_map<std::string,std::string> m_unconfig;
+    public:
+        parse_command_line(int                        argc,
+                           const char**               argv,
+                           const options_description& desc,
+                           bool                       ignoreUnknown = false)
+        {
+            char** argv_tmp = (char**)argv;
+            ++argv_tmp; // Skip argv[0]
+            --argc;
+            desc.parse_options(argc, argv_tmp, m_vm, ignoreUnknown);
+        }
+        
+        parse_command_line(int                        argc,
+                           char**                     argv,
+                           const options_description& desc,
+                           bool                       ignoreUnknown = false)
+        {
+            ++argv; // Skip argv[0]
+            --argc;
+            desc.parse_options(argc, argv, m_vm, ignoreUnknown);
+        }
+
+        // Copy the variables_map
+        friend inline void store(const parse_command_line& p, variables_map& vm);
+        friend inline void store(const parse_command_line&& p, variables_map& vm);
+
+    };
+    
+    inline void store(const parse_command_line& p, variables_map& vm)
+    {
+        vm = p.m_vm;
+    }
+    
+    inline void store(const parse_command_line&& p, variables_map& vm)
+    {
+        vm = std::move(p.m_vm);
+    }
+    
+    class parse_config_file
+    {
+        variables_map m_vm;
+        std::unordered_map<std::string,std::string> m_unconfig;
+    public:
+        parse_config_file(std::ifstream&             file,
+                          const options_description& desc,
+                          bool                       ignoreUnknown = false)
+        {
+            DEBUG_LOG_PO("[parse_config_file] start\n");
+            //file to argc and argv
+            m_unconfig.clear();
+            std::string line;
+            std::vector<std::string> vecstr;
+            char **argv;
+            int argc = 0;
+            char str[256];
+
+            while(std::getline(file, line))
+            {
+                std::size_t found = line.find('=');
+                if (found != std::string::npos)
+                {
+                    std::string front(line.begin(), line.begin() + found);
+                    std::string back(line.begin() + found + 1, line.end());
+                    if (back.length())
+                    {
+                        vecstr.push_back("--" + front);
+                        argc++;
+                        vecstr.push_back(back);
+                        argc++;
+                    }
+                }
+                else
+                {
+                    // Skip this line
+                }
+            }
+            argv = new char*[argc + 1]; // Skip [0]
+            for (int i = 0; i < argc; i++)
+            {
+                size_t len = vecstr[i].length();
+                argv[i + 1] = new char[len + 1];
+                for(int j = 0; j < len ; j++)
+                {
+                    argv[i + 1][j] = vecstr[i][j];
+                }
+                argv[i + 1][len]='\0';
+            }
+            
+            DEBUG_LOG_PO("[parse_config_file] parse options\n");
+            desc.parse_options(argc, vecstr, m_vm, ignoreUnknown, &m_unconfig);
+            DEBUG_LOG_PO("[parse_config_file] parse options done\n");
+            
+            for (int i = 0; i < argc; i++)
+            {
+                delete[] argv[i + 1];
+            }
+            delete[] argv;
+            
+            DEBUG_LOG_PO("[parse_config_file] done\n");
+        }
+        
+       // Copy the variables_map
+        friend inline void store(const parse_config_file& p, variables_map& vm, std::unordered_map<std::string,std::string>* p_uncfg);
+        friend inline void store(const parse_config_file&& p, variables_map& vm, std::unordered_map<std::string,std::string>* p_uncfg);
+    };
+    
+    inline void store(const parse_config_file& p, variables_map& vm, std::unordered_map<std::string,std::string>* p_uncfg)
+    {
+        vm = p.m_vm;
+        if(p_uncfg != nullptr)
+            *p_uncfg = p.m_unconfig;
+    }
+    
+    inline void store(const parse_config_file&& p, variables_map& vm, std::unordered_map<std::string,std::string>* p_uncfg)
+    {
+        vm = std::move(p.m_vm);
+        if(p_uncfg != nullptr)
+            *p_uncfg = p.m_unconfig;
+    }
+
+    // We can define the notify() function as a no-op for our purposes
+    inline void notify(const variables_map&) {}
+    namespace algorithm {
+        
+        inline std::string 
+        is_any_of( const std::string& Set )
+        {
+            std::string result = Set;
+            return result; 
+        }
+
+    }; // class algorithm
+
+}
+
+#endif

--- a/Tensile/Source/client/include/program_options.hpp
+++ b/Tensile/Source/client/include/program_options.hpp
@@ -678,9 +678,15 @@ namespace roc
                     {
                         std::string              in(*argv);
                         std::vector<std::string> values;
+                        std::vector<std::string> curr;
+                        std::vector<std::string> concat;
                         std::string              spliter(",;");
                         roc::split(values, in, spliter);
-                        ptr->actual_value(values);
+                        curr = ptr->get_value();
+                        concat.reserve(values.size() + curr.size());
+                        concat.insert(concat.end(), curr.begin(), curr.end());
+                        concat.insert(concat.end(), values.begin(), values.end());
+                        ptr->actual_value(concat);
                         match = true;
                     }
                 }
@@ -955,9 +961,15 @@ namespace roc
                     {
                         std::string              in(argv);
                         std::vector<std::string> values;
+                        std::vector<std::string> curr;
+                        std::vector<std::string> concat;
                         std::string              spliter(",;");
                         roc::split(values, in, spliter);
-                        ptr->actual_value(values);
+                        curr = ptr->get_value();
+                        concat.reserve(values.size() + curr.size());
+                        concat.insert(concat.end(), curr.begin(), curr.end());
+                        concat.insert(concat.end(), values.begin(), values.end());
+                        ptr->actual_value(concat);
                         match = true;
                     }
                 }

--- a/Tensile/Source/client/main.cpp
+++ b/Tensile/Source/client/main.cpp
@@ -383,7 +383,7 @@ namespace Tensile
                 else if(strValue == ToString(InitMode::DenormMin))
                     mode = InitMode::DenormMin;
                 else if(strValue == ToString(InitMode::DenormMax))
-                    mode = InitMode::DenormMax; 
+                    mode = InitMode::DenormMax;
                 auto type = args[opt].as<InitMode>();
                 args.at(opt).set(mode);
             }
@@ -418,11 +418,10 @@ namespace Tensile
             }
             else
             {
-                throw std::runtime_error(
-                        concatenate("Can't config ", strValue, " option."));
+                throw std::runtime_error(concatenate("Can't config ", strValue, " option."));
             }
         }
-        
+
         void fix_data_types(pomain::variables_map& args)
         {
             auto type = args["type"].as<DataType>();
@@ -443,7 +442,7 @@ namespace Tensile
 
         pomain::variables_map parse_args(int argc, const char* argv[])
         {
-            auto options = all_options();
+            auto                  options = all_options();
             pomain::variables_map args;
             pomain::store(pomain::parse_command_line(argc, argv, options), args);
             pomain::notify(args);
@@ -453,7 +452,7 @@ namespace Tensile
                 exit(1);
             }
 
-            std::unordered_map<std::string,std::string> unconfig;
+            std::unordered_map<std::string, std::string> unconfig;
             if(args.count("config-file"))
             {
                 auto configFiles = args["config-file"].as<std::vector<std::string>>();
@@ -466,18 +465,17 @@ namespace Tensile
                     pomain::store(pomain::parse_config_file(file, options), args, &unconfig);
                 }
             }
-            
+
             if(!unconfig.empty())
             {
-                for( auto iter = unconfig.begin(); iter != unconfig.end(); iter++)
+                for(auto iter = unconfig.begin(); iter != unconfig.end(); iter++)
                 {
                     std::string opt = iter->first;
                     std::string val = iter->second;
                     parse_unconfig_arg(args, opt, val);
-
                 }
             }
-            
+
             fix_data_types(args);
 
             return args;

--- a/Tensile/Source/client/main.cpp
+++ b/Tensile/Source/client/main.cpp
@@ -50,13 +50,11 @@
 #include "ResultFileReporter.hpp"
 #include "ResultReporter.hpp"
 
-#include <boost/algorithm/string/classification.hpp>
-#include <boost/algorithm/string/split.hpp>
-#include <boost/program_options.hpp>
+#include "program_options.hpp"
 
 #include <cstddef>
 
-namespace po = boost::program_options;
+namespace pomain = roc;
 
 namespace Tensile
 {
@@ -64,186 +62,186 @@ namespace Tensile
     {
 
         template <typename T>
-        po::typed_value<T>* value_default(std::string const& desc)
+        pomain::value<T>* value_default(std::string const& desc)
         {
-            return po::value<T>()->default_value(T(), desc);
+            return pomain::value<T>()->default_value(T());
         }
 
         template <typename T>
-        po::typed_value<T>* value_default()
+        pomain::value<T>* value_default()
         {
-            return po::value<T>()->default_value(T());
+            return pomain::value<T>()->default_value(T());
         }
 
         template <typename T>
-        po::typed_value<std::vector<T>>* vector_default_empty()
+        pomain::value<std::vector<T>>* vector_default_empty()
         {
             return value_default<std::vector<T>>("[]");
         }
 
-        po::options_description all_options()
+        pomain::options_description all_options()
         {
-            po::options_description options("Tensile client options");
+            pomain::options_description options("Tensile client options");
 
             // clang-format off
             options.add_options()
                 ("help,h", "Show help message.")
 
-                ("config-file",              vector_default_empty<std::string>(), "INI config file(s) to read.")
+                ("config-file",              pomain::value<std::vector<std::string>>(), "INI config file(s) to read.")
 
-                ("library-file,l",           po::value<std::string>(), "Load a (YAML) solution library.  If not specified, we will use "
+                ("library-file,l",           pomain::value<std::string>(), "Load a (YAML) solution library.  If not specified, we will use "
                                                                        "the embedded library, if available.")
-                ("code-object,c",            vector_default_empty<std::string>(), "Code object file with kernel(s).  If none are "
+                ("code-object,c",            pomain::value<std::vector<std::string>>(), "Code object file with kernel(s).  If none are "
                                                                                   "specified, we will use the embedded code "
                                                                                   "object(s) if available.")
 
-                ("performance-metric",       po::value<PerformanceMetric>()->default_value(PerformanceMetric::DeviceEfficiency), "Metric for benchmarking results")
+                ("performance-metric",       pomain::value<PerformanceMetric>()->default_value(PerformanceMetric::DeviceEfficiency), "Metric for benchmarking results")
 
-                ("problem-identifier",       po::value<std::string>(), "Problem identifer (Einstein notation). Either "
+                ("problem-identifier",       pomain::value<std::string>(), "Problem identifer (Einstein notation). Either "
                                                                        "this or free/batch/bound must be specified.")
-                ("free",                     value_default<ContractionProblem::FreeIndices>("[]"),  "Free index. Order: a,b,ca,cb,da,db")
-                ("batch",                    value_default<ContractionProblem::BatchIndices>("[]"), "Batch index. Order: a,b,c,d")
-                ("bound",                    value_default<ContractionProblem::BoundIndices>("[]"), "Bound/summation index. Order: a,b")
-
-                ("type",                     po::value<DataType>()->default_value(DataType::None), "Data type")
-                ("a-type",                   po::value<DataType>()->default_value(DataType::None), "A data type")
-                ("b-type",                   po::value<DataType>()->default_value(DataType::None), "B data type")
-                ("c-type",                   po::value<DataType>()->default_value(DataType::None), "C data type")
-                ("d-type",                   po::value<DataType>()->default_value(DataType::None), "D data type")
-                ("alpha-type",               po::value<DataType>()->default_value(DataType::None), "alpha data type")
-                ("beta-type",                po::value<DataType>()->default_value(DataType::None), "beta data type")
-                ("high-precision-accumulate", po::value<bool>()->default_value(false), "Use high-precision accumulate.")
-                ("strided-batched",          po::value<bool>()->default_value(true), "Use strided-batched or general batched")
-                ("kernel-language",          po::value<KernelLanguage>()->default_value(KernelLanguage::Any), "Select kernel language.")
-                ("deterministic-mode",       po::value<bool>()->default_value(false), "Enforce deterministic summation patterns"
+                ("free",                     pomain::value<ContractionProblem::FreeIndices>()->default_value(ContractionProblem::FreeIndices(0)),  "Free index. Order: a,b,ca,cb,da,db")
+                ("batch",                    pomain::value<ContractionProblem::BatchIndices>()->default_value(ContractionProblem::BatchIndices(0)), "Batch index. Order: a,b,c,d")
+                ("bound",                    pomain::value<ContractionProblem::BoundIndices>()->default_value(ContractionProblem::BoundIndices(0)), "Bound/summation index. Order: a,b")
+                
+                ("type",                     pomain::value<DataType>()->default_value(DataType::None), "Data type")
+                ("a-type",                   pomain::value<DataType>()->default_value(DataType::None), "A data type")
+                ("b-type",                   pomain::value<DataType>()->default_value(DataType::None), "B data type")
+                ("c-type",                   pomain::value<DataType>()->default_value(DataType::None), "C data type")
+                ("d-type",                   pomain::value<DataType>()->default_value(DataType::None), "D data type")
+                ("alpha-type",               pomain::value<DataType>()->default_value(DataType::None), "alpha data type")
+                ("beta-type",                pomain::value<DataType>()->default_value(DataType::None), "beta data type")
+                ("high-precision-accumulate", pomain::value<bool>()->default_value(false), "Use high-precision accumulate.")
+                ("strided-batched",          pomain::value<bool>()->default_value(true), "Use strided-batched or general batched")
+                ("kernel-language",          pomain::value<KernelLanguage>()->default_value(KernelLanguage::Any), "Select kernel language.")
+                ("deterministic-mode",       pomain::value<bool>()->default_value(false), "Enforce deterministic summation patterns"
                                                                                       "by not splitting U among workgroups")
-                ("arithmetic-unit",          po::value<ArithmeticUnit>()->default_value(ArithmeticUnit::Any), "Select arithmetic unit.")
+                ("arithmetic-unit",          pomain::value<ArithmeticUnit>()->default_value(ArithmeticUnit::Any), "Select arithmetic unit.")
 
-                ("init-a",                   po::value<InitMode>()->default_value(InitMode::Random), "Initialization for A")
-                ("init-b",                   po::value<InitMode>()->default_value(InitMode::Random), "Initialization for B")
-                ("init-c",                   po::value<InitMode>()->default_value(InitMode::Random), "Initialization for C")
-                ("init-d",                   po::value<InitMode>()->default_value(InitMode::Zero), "Initialization for D")
-                ("init-alpha",               po::value<InitMode>()->default_value(InitMode::Two), "Initialization for alpha")
-                ("init-beta",                po::value<InitMode>()->default_value(InitMode::Two), "Initialization for beta")
-                ("pristine-on-gpu",          po::value<bool>()->default_value(true), "Keep a pristine copy of inputs on GPU for performance")
-                ("c-equal-d",                po::value<bool>()->default_value(false), "C equals D")
-                ("offset-a",                 po::value<size_t>()->default_value(0), "buffer a start offset")
-                ("offset-b",                 po::value<size_t>()->default_value(0), "buffer b start offset")
-                ("offset-c",                 po::value<size_t>()->default_value(0), "buffer c start offset")
-                ("offset-d",                 po::value<size_t>()->default_value(0), "buffer d start offset")
-                ("print-valids",             po::value<bool>()->default_value(false), "Print values that pass validation")
-                ("print-max",                po::value<int>()->default_value(-1), "Max number of values to print")
-                ("num-elements-to-validate", po::value<int>()->default_value(0), "Number of elements to validate")
-                ("bounds-check",             po::value<BoundsCheckMode>()->default_value(BoundsCheckMode::Disable),
+                ("init-a",                   pomain::value<InitMode>()->default_value(InitMode::Random), "Initialization for A")
+                ("init-b",                   pomain::value<InitMode>()->default_value(InitMode::Random), "Initialization for B")
+                ("init-c",                   pomain::value<InitMode>()->default_value(InitMode::Random), "Initialization for C")
+                ("init-d",                   pomain::value<InitMode>()->default_value(InitMode::Zero), "Initialization for D")
+                ("init-alpha",               pomain::value<InitMode>()->default_value(InitMode::Two), "Initialization for alpha")
+                ("init-beta",                pomain::value<InitMode>()->default_value(InitMode::Two), "Initialization for beta")
+                ("pristine-on-gpu",          pomain::value<bool>()->default_value(true), "Keep a pristine copy of inputs on GPU for performance")
+                ("c-equal-d",                pomain::value<bool>()->default_value(false), "C equals D")
+                ("offset-a",                 pomain::value<size_t>()->default_value(0), "buffer a start offset")
+                ("offset-b",                 pomain::value<size_t>()->default_value(0), "buffer b start offset")
+                ("offset-c",                 pomain::value<size_t>()->default_value(0), "buffer c start offset")
+                ("offset-d",                 pomain::value<size_t>()->default_value(0), "buffer d start offset")
+                ("print-valids",             pomain::value<bool>()->default_value(false), "Print values that pass validation")
+                ("print-max",                pomain::value<int>()->default_value(-1), "Max number of values to print")
+                ("num-elements-to-validate", pomain::value<int>()->default_value(0), "Number of elements to validate")
+                ("bounds-check",             pomain::value<BoundsCheckMode>()->default_value(BoundsCheckMode::Disable),
                 "1:Use sentinel values to check memory boundaries."
                 "2:Memory bound check by front guard page"
                 "3:Memory bound check by back guard page"
                 "4:Memory bound check by both side guard page")
 
-                ("print-tensor-a",           po::value<bool>()->default_value(false), "Print tensor A.")
-                ("print-tensor-b",           po::value<bool>()->default_value(false), "Print tensor B.")
-                ("print-tensor-c",           po::value<bool>()->default_value(false), "Print tensor C.")
-                ("print-tensor-d",           po::value<bool>()->default_value(false), "Print tensor D.")
-                ("print-tensor-ref",         po::value<bool>()->default_value(false), "Print reference tensor D.")
+                ("print-tensor-a",           pomain::value<bool>()->default_value(false), "Print tensor A.")
+                ("print-tensor-b",           pomain::value<bool>()->default_value(false), "Print tensor B.")
+                ("print-tensor-c",           pomain::value<bool>()->default_value(false), "Print tensor C.")
+                ("print-tensor-d",           pomain::value<bool>()->default_value(false), "Print tensor D.")
+                ("print-tensor-ref",         pomain::value<bool>()->default_value(false), "Print reference tensor D.")
 
-                ("dump-tensors",             po::value<bool>()->default_value(false), "Binary dump tensors instead of printing.")
+                ("dump-tensors",             pomain::value<bool>()->default_value(false), "Binary dump tensors instead of printing.")
 
-                ("convolution-identifier",   po::value<std::string>(), "Convolution problem identifer:  ConvolutionType_ActFormat_FilterFormat_Filter_Stride_Dilation_Groups.  Example: ConvolutionBackwardWeights_NCHW_filter:3x3_stride:1x1_dilation:1x1_groups:1.  Batch count, spacial dimensions (H,W,D), Cin and Cout filters are determined by the problem dimensions.")
-                ("convolution-vs-contraction",  po::value<bool>()->default_value(false), "Compare reference convolution against contraction.")
+                ("convolution-identifier",   pomain::value<std::string>(), "Convolution problem identifer:  ConvolutionType_ActFormat_FilterFormat_Filter_Stride_Dilation_Groups.  Example: ConvolutionBackwardWeights_NCHW_filter:3x3_stride:1x1_dilation:1x1_groups:1.  Batch count, spacial dimensions (H,W,D), Cin and Cout filters are determined by the problem dimensions.")
+                ("convolution-vs-contraction",  pomain::value<bool>()->default_value(false), "Compare reference convolution against contraction.")
 
-                ("device-idx",               po::value<int>()->default_value(0), "Device index")
-                ("use-default-stream",       po::value<bool>()->default_value(false), "Use default Hip stream to run kernels.")
-                ("platform-idx",             po::value<int>()->default_value(0), "OpenCL Platform Index")
+                ("device-idx",               pomain::value<int>()->default_value(0), "Device index")
+                ("use-default-stream",       pomain::value<bool>()->default_value(false), "Use default Hip stream to run kernels.")
+                ("platform-idx",             pomain::value<int>()->default_value(0), "OpenCL Platform Index")
 
-                ("num-warmups",              po::value<int>()->default_value(0), "Number of warmups to run")
-                ("sync-after-warmups",       po::value<bool>()->default_value(true), "Synchronize GPU after warmup kernel runs")
-                ("num-benchmarks",           po::value<int>()->default_value(1), "Number of benchmarks to run")
-                ("num-enqueues-per-sync",    po::value<int>()->default_value(1), "Enqueues per sync, will affect by min-flops-per-sync")
-                ("num-syncs-per-benchmark",  po::value<int>()->default_value(1), "Syncs per benchmark")
-                ("min-flops-per-sync",       po::value<size_t>()->default_value(0), "Minimum number of flops per sync to increase stability for small problems.")
-                ("use-gpu-timer",            po::value<bool>()->default_value(true), "Use GPU timer")
-                ("sleep-percent",            po::value<int>()->default_value(0), "Sleep percentage")
-                ("hardware-monitor",         po::value<bool>()->default_value(true), "Use hardware monitor.")
+                ("num-warmups",              pomain::value<int>()->default_value(0), "Number of warmups to run")
+                ("sync-after-warmups",       pomain::value<bool>()->default_value(true), "Synchronize GPU after warmup kernel runs")
+                ("num-benchmarks",           pomain::value<int>()->default_value(1), "Number of benchmarks to run")
+                ("num-enqueues-per-sync",    pomain::value<int>()->default_value(1), "Enqueues per sync, will affect by min-flops-per-sync")
+                ("num-syncs-per-benchmark",  pomain::value<int>()->default_value(1), "Syncs per benchmark")
+                ("min-flops-per-sync",       pomain::value<size_t>()->default_value(0), "Minimum number of flops per sync to increase stability for small problems.")
+                ("use-gpu-timer",            pomain::value<bool>()->default_value(true), "Use GPU timer")
+                ("sleep-percent",            pomain::value<int>()->default_value(0), "Sleep percentage")
+                ("hardware-monitor",         pomain::value<bool>()->default_value(true), "Use hardware monitor.")
 
-                ("perf-l2-read-hits",        po::value<double>()->default_value(0.0), "L2 read hits")
-                ("perf-l2-write-hits",       po::value<double>()->default_value(0.5), "L2 write hits")
-                ("perf-l2-read-bw-mul",      po::value<double>()->default_value(2.0), "L2 read bandwidth multiplier")
-                ("perf-read-efficiency",     po::value<double>()->default_value(0.85), "Read efficiency")
-                ("perf-ops-per-cycle",       po::value<int>()->default_value(64), "Ops per cycle")
-                ("csv-export-extra-cols",    po::value<bool>()->default_value(false), "CSV exports winner information")
-                ("csv-merge-same-problems",  po::value<bool>()->default_value(false), "CSV merge rows of same problem id")
+                ("perf-l2-read-hits",        pomain::value<double>()->default_value(0.0), "L2 read hits")
+                ("perf-l2-write-hits",       pomain::value<double>()->default_value(0.5), "L2 write hits")
+                ("perf-l2-read-bw-mul",      pomain::value<double>()->default_value(2.0), "L2 read bandwidth multiplier")
+                ("perf-read-efficiency",     pomain::value<double>()->default_value(0.85), "Read efficiency")
+                ("perf-ops-per-cycle",       pomain::value<int>()->default_value(64), "Ops per cycle")
+                ("csv-export-extra-cols",    pomain::value<bool>()->default_value(false), "CSV exports winner information")
+                ("csv-merge-same-problems",  pomain::value<bool>()->default_value(false), "CSV merge rows of same problem id")
 
-                ("problem-size,p",           vector_default_empty<std::string>(), "Specify a problem size.  Comma-separated list of "
+                ("problem-size,p",           pomain::value<std::vector<std::vector<size_t>>>()->default_value(std::vector<std::vector<size_t>>(0)), "Specify a problem size.  Comma-separated list of "
                                                                                   "sizes, in the order of the Einstein notation.")
 
-                ("a-strides",                vector_default_empty<std::string>(), "Unspecified means default stride "
+                ("a-strides",                pomain::value<std::vector<std::vector<size_t>>>()->default_value(std::vector<std::vector<size_t>>(0)), "Unspecified means default stride "
                                                                                   "(prev_dim_stride*prev_dim_size)"
                                                                                   "specifying once applies to all problem sizes, "
                                                                                   "otherwise specify once per problem size.")
 
-                ("b-strides",                vector_default_empty<std::string>(), "Unspecified means default stride "
+                ("b-strides",                pomain::value<std::vector<std::vector<size_t>>>()->default_value(std::vector<std::vector<size_t>>(0)), "Unspecified means default stride "
                                                                                   "(prev_dim_stride*prev_dim_size)"
                                                                                   "specifying once applies to all problem sizes, "
                                                                                   "otherwise specify once per problem size.")
 
-                ("c-strides",                vector_default_empty<std::string>(), "Unspecified means default stride "
+                ("c-strides",                pomain::value<std::vector<std::vector<size_t>>>()->default_value(std::vector<std::vector<size_t>>(0)), "Unspecified means default stride "
                                                                                   "(prev_dim_stride*prev_dim_size)"
                                                                                   "specifying once applies to all problem sizes, "
                                                                                   "otherwise specify once per problem size.")
 
-                ("d-strides",                vector_default_empty<std::string>(), "Unspecified means default stride "
+                ("d-strides",                pomain::value<std::vector<std::vector<size_t>>>()->default_value(std::vector<std::vector<size_t>>(0)), "Unspecified means default stride "
                                                                                   "(prev_dim_stride*prev_dim_size)"
                                                                                   "specifying once applies to all problem sizes, "
                                                                                   "otherwise specify once per problem size.")
 
-                ("convolution-problem",      vector_default_empty<std::string>(), "Specify a Convolution problem size. Comma-separated list of sizes:"
+                ("convolution-problem",      pomain::value<std::vector<std::vector<size_t>>>()->default_value(std::vector<std::vector<size_t>>(0)), "Specify a Convolution problem size. Comma-separated list of sizes:"
                                                                                   "Spatial(w,h,d),Filter(x,y,z),Stride(v,u,#),"
                                                                                   "Dilation(j,l,^),Pad start(q,p,$),Pad end(q_,p_,$_)")
 
-                ("a-zero-pads",                vector_default_empty<std::string>(), "Comma-separated tuple(s) of anchor dim,"
+                ("a-zero-pads",                pomain::value<std::vector<std::vector<size_t>>>()->default_value(std::vector<std::vector<size_t>>(0)), "Comma-separated tuple(s) of anchor dim,"
                                                                                   "summation dim, leading pad, trailing pad."
                                                                                   "Each tuple must be separated with a semi-colon.")
 
-                ("b-zero-pads",                vector_default_empty<std::string>(), "Comma-separated tuple(s) of anchor dim,"
+                ("b-zero-pads",                pomain::value<std::vector<std::vector<size_t>>>()->default_value(std::vector<std::vector<size_t>>(0)), "Comma-separated tuple(s) of anchor dim,"
                                                                                   "summation dim, leading pad, trailing pad."
                                                                                   "Each tuple must be separated with a semi-colon.")
 
-                ("a-ops",                    vector_default_empty<TensorOp>(), "Operations applied to A.")
-                ("b-ops",                    vector_default_empty<TensorOp>(), "Operations applied to B.")
-                ("c-ops",                    vector_default_empty<TensorOp>(), "Operations applied to C.")
-                ("d-ops",                    vector_default_empty<TensorOp>(), "Operations applied to D.")
+                ("a-ops",                    pomain::value<std::vector<TensorOp>>()->default_value(std::vector<TensorOp>(0)), "Operations applied to A.")
+                ("b-ops",                    pomain::value<std::vector<TensorOp>>()->default_value(std::vector<TensorOp>(0)), "Operations applied to B.")
+                ("c-ops",                    pomain::value<std::vector<TensorOp>>()->default_value(std::vector<TensorOp>(0)), "Operations applied to C.")
+                ("d-ops",                    pomain::value<std::vector<TensorOp>>()->default_value(std::vector<TensorOp>(0)), "Operations applied to D.")
 
-                ("problem-start-idx",        po::value<int>()->default_value(0),  "First problem to run")
-                ("num-problems",             po::value<int>()->default_value(-1), "Number of problems to run")
+                ("problem-start-idx",        pomain::value<int>()->default_value(0),  "First problem to run")
+                ("num-problems",             pomain::value<int>()->default_value(-1), "Number of problems to run")
 
-                ("solution-start-idx",       po::value<int>()->default_value(-1), "First solution to run")
-                ("num-solutions",            po::value<int>()->default_value(-1), "Number of solutions to run")
-                ("best-solution",            po::value<bool>()->default_value(false), "Best solution benchmark mode")
+                ("solution-start-idx",       pomain::value<int>()->default_value(-1), "First solution to run")
+                ("num-solutions",            pomain::value<int>()->default_value(-1), "Number of solutions to run")
+                ("best-solution",            pomain::value<bool>()->default_value(false), "Best solution benchmark mode")
 
-                ("results-file",             po::value<std::string>()->default_value("results.csv"), "File name to write results.")
-                ("log-file",                 po::value<std::string>(),                               "File name for output log.")
-                ("log-file-append",          po::value<bool>()->default_value(false),                "Append to log file.")
-                ("log-level",                po::value<LogLevel>()->default_value(LogLevel::Debug),  "Log level")
+                ("results-file",             pomain::value<std::string>()->default_value("results.csv"), "File name to write results.")
+                ("log-file",                 pomain::value<std::string>(),                               "File name for output log.")
+                ("log-file-append",          pomain::value<bool>()->default_value(false),                "Append to log file.")
+                ("log-level",                pomain::value<LogLevel>()->default_value(LogLevel::Debug),  "Log level")
 
-                ("library-update-file",      po::value<std::string>()->default_value(""), "File name for writing indices "
+                ("library-update-file",      pomain::value<std::string>()->default_value(""), "File name for writing indices "
                                                                                           "and speeds suitable for updating "
                                                                                           "an existing library logic file.")
-                ("library-update-comment",   po::value<bool>()->default_value(false), "Include solution name as a "
+                ("library-update-comment",   pomain::value<bool>()->default_value(false), "Include solution name as a "
                                                                                       "comment in library update "
                                                                                       "file.")
 
 
-                ("exit-on-error",            po::value<bool>()->default_value(false), "Exit run early on failed kernels or other errors.")
-                ("selection-only",           po::value<bool>()->default_value(false), "Don't run any solutions, only print kernel selections.")
-                ("max-workspace-size",       po::value<size_t>()->default_value(32*1024*1024), "Max workspace for training")
-                ("granularity-threshold",    po::value<double>()->default_value(0.0), "Don't run a solution if total granularity is below")
+                ("exit-on-error",            pomain::value<bool>()->default_value(false), "Exit run early on failed kernels or other errors.")
+                ("selection-only",           pomain::value<bool>()->default_value(false), "Don't run any solutions, only print kernel selections.")
+                ("max-workspace-size",       pomain::value<size_t>()->default_value(32*1024*1024), "Max workspace for training")
+                ("granularity-threshold",    pomain::value<double>()->default_value(0.0), "Don't run a solution if total granularity is below")
                 ;
             // clang-format on
 
             return options;
         }
 
-        std::shared_ptr<Hardware> GetHardware(po::variables_map const& args)
+        std::shared_ptr<Hardware> GetHardware(pomain::variables_map& args)
         {
             int deviceCount = 0;
             HIP_CHECK_EXC(hipGetDeviceCount(&deviceCount));
@@ -259,7 +257,7 @@ namespace Tensile
             return hip::GetCurrentDevice();
         }
 
-        hipStream_t GetStream(po::variables_map const& args)
+        hipStream_t GetStream(pomain::variables_map& args)
         {
             if(args["use-default-stream"].as<bool>())
                 return 0;
@@ -270,7 +268,7 @@ namespace Tensile
         }
 
         std::shared_ptr<MasterSolutionLibrary<ContractionProblem>>
-            LoadSolutionLibrary(po::variables_map const& args)
+            LoadSolutionLibrary(pomain::variables_map& args)
         {
             auto filename = args["library-file"];
             if(!filename.empty())
@@ -290,7 +288,7 @@ namespace Tensile
                                      "a library must be specified at runtime.");
         }
 
-        void LoadCodeObjects(po::variables_map const& args, hip::SolutionAdapter& adapter)
+        void LoadCodeObjects(pomain::variables_map& args, hip::SolutionAdapter& adapter)
         {
             auto const& filenames = args["code-object"].as<std::vector<std::string>>();
             auto        logLevel  = args["log-level"].as<LogLevel>();
@@ -327,33 +325,105 @@ namespace Tensile
         std::vector<size_t> split_ints(std::string const& value)
         {
             std::vector<std::string> parts;
-            boost::split(parts, value, boost::algorithm::is_any_of(",;"));
+            pomain::split(parts, value, pomain::algorithm::is_any_of(",;"));
 
             std::vector<size_t> rv;
             rv.reserve(parts.size());
 
             for(auto const& part : parts)
                 if(part != "")
-                    rv.push_back(boost::lexical_cast<size_t>(part));
+                    rv.push_back(pomain::lexical_cast<size_t>(part));
 
             return rv;
         }
 
-        void parse_arg_ints(po::variables_map& args, std::string const& name)
+        void parse_unconfig_arg(pomain::variables_map& args, std::string opt, std::string strValue)
         {
-            auto inValue = args[name].as<std::vector<std::string>>();
-
-            std::vector<std::vector<size_t>> outValue;
-            outValue.reserve(inValue.size());
-            for(auto const& str : inValue)
-                outValue.push_back(split_ints(str));
-
-            boost::any v(outValue);
-
-            args.at(name).value() = v;
+            if(opt.compare(0, 5, "init-") == 0)
+            {
+                InitMode mode;
+                if(strValue == ToString(InitMode::Zero))
+                    mode = InitMode::Zero;
+                else if(strValue == ToString(InitMode::One))
+                    mode = InitMode::One;
+                else if(strValue == ToString(InitMode::Two))
+                    mode = InitMode::Two;
+                else if(strValue == ToString(InitMode::Random))
+                    mode = InitMode::Random;
+                else if(strValue == ToString(InitMode::NaN))
+                    mode = InitMode::NaN;
+                else if(strValue == ToString(InitMode::Inf))
+                    mode = InitMode::Inf;
+                else if(strValue == ToString(InitMode::BadInput))
+                    mode = InitMode::BadInput;
+                else if(strValue == ToString(InitMode::BadOutput))
+                    mode = InitMode::BadOutput;
+                else if(strValue == ToString(InitMode::SerialIdx))
+                    mode = InitMode::SerialIdx;
+                else if(strValue == ToString(InitMode::SerialDim0))
+                    mode = InitMode::SerialDim0;
+                else if(strValue == ToString(InitMode::SerialDim1))
+                    mode = InitMode::SerialDim1;
+                else if(strValue == ToString(InitMode::Identity))
+                    mode = InitMode::Identity;
+                else if(strValue == ToString(InitMode::TrigSin))
+                    mode = InitMode::TrigSin;
+                else if(strValue == ToString(InitMode::TrigCos))
+                    mode = InitMode::TrigCos;
+                else if(strValue == ToString(InitMode::TrigAbsSin))
+                    mode = InitMode::TrigAbsSin;
+                else if(strValue == ToString(InitMode::TrigAbsCos))
+                    mode = InitMode::TrigAbsCos;
+                else if(strValue == ToString(InitMode::RandomNarrow))
+                    mode = InitMode::RandomNarrow;
+                else if(strValue == ToString(InitMode::NegOne))
+                    mode = InitMode::NegOne;
+                else if(strValue == ToString(InitMode::Max))
+                    mode = InitMode::Max;
+                else if(strValue == ToString(InitMode::DenormMin))
+                    mode = InitMode::DenormMin;
+                else if(strValue == ToString(InitMode::DenormMax))
+                    mode = InitMode::DenormMax; 
+                auto type = args[opt].as<InitMode>();
+                args.at(opt).set(mode);
+            }
+            else if(opt.compare(0, 12, "bounds-check") == 0)
+            {
+                BoundsCheckMode mode;
+                if(strValue == "Disable")
+                    mode = BoundsCheckMode::Disable;
+                else if(strValue == "NaN")
+                    mode = BoundsCheckMode::NaN;
+                else if(strValue == "GuardPageFront")
+                    mode = BoundsCheckMode::GuardPageFront;
+                else if(strValue == "GuardPageBack")
+                    mode = BoundsCheckMode::GuardPageBack;
+                else if(strValue == "GuardPageAll")
+                    mode = BoundsCheckMode::GuardPageAll;
+                else if(std::all_of(strValue.begin(), strValue.end(), isdigit))
+                {
+                    int value = atoi(strValue.c_str());
+                    if(value >= 0 && value < static_cast<int>(BoundsCheckMode::MaxMode))
+                        mode = static_cast<BoundsCheckMode>(value);
+                    else
+                        throw std::runtime_error(
+                            concatenate("Can't convert ", strValue, " to BoundsCheckMode."));
+                }
+                else
+                {
+                    throw std::runtime_error(
+                        concatenate("Can't convert ", opt, " to BoundsCheckMode."));
+                }
+                args.at(opt).set(mode);
+            }
+            else
+            {
+                throw std::runtime_error(
+                        concatenate("Can't config ", strValue, " option."));
+            }
         }
-
-        void fix_data_types(po::variables_map& args)
+        
+        void fix_data_types(pomain::variables_map& args)
         {
             auto type = args["type"].as<DataType>();
 
@@ -362,29 +432,28 @@ namespace Tensile
             if(type == DataType::Float || type == DataType::Double || type == DataType::ComplexFloat
                || type == DataType::ComplexDouble || type == DataType::Int32)
             {
-                args.at("a-type").value()     = boost::any(type);
-                args.at("b-type").value()     = boost::any(type);
-                args.at("c-type").value()     = boost::any(type);
-                args.at("d-type").value()     = boost::any(type);
-                args.at("alpha-type").value() = boost::any(type);
-                args.at("beta-type").value()  = boost::any(type);
+                args.at("a-type").set(type);
+                args.at("b-type").set(type);
+                args.at("c-type").set(type);
+                args.at("d-type").set(type);
+                args.at("alpha-type").set(type);
+                args.at("beta-type").set(type);
             }
         }
 
-        po::variables_map parse_args(int argc, const char* argv[])
+        pomain::variables_map parse_args(int argc, const char* argv[])
         {
             auto options = all_options();
-
-            po::variables_map args;
-            po::store(po::parse_command_line(argc, argv, options), args);
-            po::notify(args);
-
+            pomain::variables_map args;
+            pomain::store(pomain::parse_command_line(argc, argv, options), args);
+            pomain::notify(args);
             if(args.count("help"))
             {
                 std::cout << options << std::endl;
                 exit(1);
             }
 
+            std::unordered_map<std::string,std::string> unconfig;
             if(args.count("config-file"))
             {
                 auto configFiles = args["config-file"].as<std::vector<std::string>>();
@@ -394,28 +463,29 @@ namespace Tensile
                     std::ifstream file(filename.c_str());
                     if(file.bad())
                         throw std::runtime_error(concatenate("Could not open ", filename));
-                    po::store(po::parse_config_file(file, options), args);
+                    pomain::store(pomain::parse_config_file(file, options), args, &unconfig);
                 }
             }
+            
+            if(!unconfig.empty())
+            {
+                for( auto iter = unconfig.begin(); iter != unconfig.end(); iter++)
+                {
+                    std::string opt = iter->first;
+                    std::string val = iter->second;
+                    parse_unconfig_arg(args, opt, val);
 
+                }
+            }
+            
             fix_data_types(args);
 
-            parse_arg_ints(args, "problem-size");
-            parse_arg_ints(args, "a-strides");
-            parse_arg_ints(args, "b-strides");
-            parse_arg_ints(args, "c-strides");
-            parse_arg_ints(args, "d-strides");
-            parse_arg_ints(args, "a-zero-pads");
-            parse_arg_ints(args, "b-zero-pads");
-
-            if(args["convolution-vs-contraction"].as<bool>())
-                parse_arg_ints(args, "convolution-problem");
             return args;
         }
 
         size_t getMaxWorkspace(std::shared_ptr<MasterSolutionLibrary<ContractionProblem>>& library,
                                std::shared_ptr<Hardware>&                                  hardware,
-                               po::variables_map&                                          args,
+                               pomain::variables_map const&                                args,
                                std::vector<ContractionProblem>&                            problems,
                                int firstProblemIdx,
                                int lastProblemIdx)

--- a/Tensile/Source/client/source/BenchmarkTimer.cpp
+++ b/Tensile/Source/client/source/BenchmarkTimer.cpp
@@ -41,7 +41,7 @@ namespace Tensile
     {
         static_assert(BenchmarkTimer::clock::is_steady, "Clock must be steady.");
 
-        BenchmarkTimer::BenchmarkTimer(po::variables_map const& args, Hardware const& hardware)
+        BenchmarkTimer::BenchmarkTimer(po::variables_map& args, Hardware const& hardware)
             : m_numWarmups(args["num-warmups"].as<int>())
             , m_syncAfterWarmups(args["sync-after-warmups"].as<bool>())
             , m_numBenchmarks(args["num-benchmarks"].as<int>())

--- a/Tensile/Source/client/source/ClientProblemFactory.cpp
+++ b/Tensile/Source/client/source/ClientProblemFactory.cpp
@@ -33,7 +33,7 @@ namespace Tensile
 {
     namespace Client
     {
-        ClientProblemFactory::ClientProblemFactory(po::variables_map const& args)
+        ClientProblemFactory::ClientProblemFactory(po::variables_map& args)
             : m_freeIndices(args["free"].as<ContractionProblem::FreeIndices>())
             , m_batchIndices(args["batch"].as<ContractionProblem::BatchIndices>())
             , m_boundIndices(args["bound"].as<ContractionProblem::BoundIndices>())

--- a/Tensile/Source/client/source/ConvolutionProblem.cpp
+++ b/Tensile/Source/client/source/ConvolutionProblem.cpp
@@ -22,9 +22,9 @@
  * THE SOFTWARE.
  */
 
+#include "program_options.hpp"
 #include <ConvolutionProblem.hpp>
 #include <Tensile/ContractionProblem.hpp>
-#include "program_options.hpp"
 #include <vector>
 
 namespace Tensile

--- a/Tensile/Source/client/source/ConvolutionProblem.cpp
+++ b/Tensile/Source/client/source/ConvolutionProblem.cpp
@@ -24,9 +24,7 @@
 
 #include <ConvolutionProblem.hpp>
 #include <Tensile/ContractionProblem.hpp>
-#include <boost/algorithm/string/classification.hpp>
-#include <boost/algorithm/string/split.hpp>
-#include <boost/lexical_cast.hpp>
+#include "program_options.hpp"
 #include <vector>
 
 namespace Tensile
@@ -304,7 +302,7 @@ namespace Tensile
         // example identifier:
         // ConvolutionForward_NCHW_KCHW_NCHW_filter:3x3x1_stride:1x1x1_dilation:1x1x1_groups:1
         std::vector<std::string> parts;
-        boost::split(parts, identifier, boost::algorithm::is_any_of("_"));
+        roc::split(parts, identifier, roc::algorithm::is_any_of("_"));
 
         if(parts.size() < 4)
             // id, formatA, formatB, outputTensor
@@ -322,17 +320,17 @@ namespace Tensile
         for(auto part = parts.begin() + 4; part != parts.end(); part++)
         {
             std::vector<std::string> flags;
-            boost::split(flags, *part, boost::algorithm::is_any_of(":"));
+            roc::split(flags, *part, roc::algorithm::is_any_of(":"));
             assert(flags.size() == 2); // must be key:value pair
 
             if(flags[0] == "spatialDims")
-                m_numSpatialDims = boost::lexical_cast<size_t>(flags[1]);
+                m_numSpatialDims = roc::lexical_cast<size_t>(flags[1]);
             else if(flags[0] == "indices")
             {
             }
             else if(flags[0] == "groups")
             {
-                m_groups = boost::lexical_cast<int>(flags[1]);
+                m_groups = roc::lexical_cast<int>(flags[1]);
                 assert(m_groups == 1); // not supported yet
             }
             else

--- a/Tensile/Source/client/source/DataInitialization.cpp
+++ b/Tensile/Source/client/source/DataInitialization.cpp
@@ -228,7 +228,7 @@ namespace Tensile
 
         template <typename TypedInputs>
         std::shared_ptr<TypedDataInitialization<TypedInputs>>
-            DataInitialization::GetTyped(po::variables_map&    args,
+            DataInitialization::GetTyped(po::variables_map&          args,
                                          ClientProblemFactory const& problemFactory,
                                          size_t                      maxWorkspaceSize)
         {
@@ -239,7 +239,7 @@ namespace Tensile
         }
 
         std::shared_ptr<DataInitialization>
-            DataInitialization::Get(po::variables_map&    args,
+            DataInitialization::Get(po::variables_map&          args,
                                     ClientProblemFactory const& problemFactory,
                                     size_t                      maxWorkspaceSize)
         {

--- a/Tensile/Source/client/source/DataInitialization.cpp
+++ b/Tensile/Source/client/source/DataInitialization.cpp
@@ -213,7 +213,7 @@ namespace Tensile
             return stream;
         }
 
-        double DataInitialization::GetRepresentativeBetaValue(po::variables_map const& args)
+        double DataInitialization::GetRepresentativeBetaValue(po::variables_map& args)
         {
             auto argValue = args["init-beta"].as<int>();
 
@@ -228,7 +228,7 @@ namespace Tensile
 
         template <typename TypedInputs>
         std::shared_ptr<TypedDataInitialization<TypedInputs>>
-            DataInitialization::GetTyped(po::variables_map const&    args,
+            DataInitialization::GetTyped(po::variables_map&    args,
                                          ClientProblemFactory const& problemFactory,
                                          size_t                      maxWorkspaceSize)
         {
@@ -239,7 +239,7 @@ namespace Tensile
         }
 
         std::shared_ptr<DataInitialization>
-            DataInitialization::Get(po::variables_map const&    args,
+            DataInitialization::Get(po::variables_map&    args,
                                     ClientProblemFactory const& problemFactory,
                                     size_t                      maxWorkspaceSize)
         {
@@ -328,7 +328,7 @@ namespace Tensile
                                                  betaType));
         }
 
-        DataInitialization::DataInitialization(po::variables_map const&    args,
+        DataInitialization::DataInitialization(po::variables_map&          args,
                                                ClientProblemFactory const& problemFactory,
                                                size_t                      maxWorkspaceSize)
             : m_aInit(args["init-a"].as<InitMode>())

--- a/Tensile/Source/client/source/HardwareMonitorListener.cpp
+++ b/Tensile/Source/client/source/HardwareMonitorListener.cpp
@@ -25,7 +25,6 @@
  *******************************************************************************/
 
 #include "HardwareMonitor.hpp"
-#endif
 
 #include <hip/hip_runtime.h>
 

--- a/Tensile/Source/client/source/HardwareMonitorListener.cpp
+++ b/Tensile/Source/client/source/HardwareMonitorListener.cpp
@@ -25,8 +25,7 @@
  *******************************************************************************/
 
 #include "HardwareMonitor.hpp"
-
-#include <unistd.h>
+#endif
 
 #include <hip/hip_runtime.h>
 
@@ -39,7 +38,7 @@ namespace Tensile
 {
     namespace Client
     {
-        HardwareMonitorListener::HardwareMonitorListener(po::variables_map const& args)
+        HardwareMonitorListener::HardwareMonitorListener(po::variables_map& args)
             : m_useGPUTimer(args["use-gpu-timer"].as<bool>())
             , m_active(args["hardware-monitor"].as<bool>())
         {

--- a/Tensile/Source/client/source/LibraryUpdateReporter.cpp
+++ b/Tensile/Source/client/source/LibraryUpdateReporter.cpp
@@ -33,7 +33,7 @@ namespace Tensile
     namespace Client
     {
         std::shared_ptr<LibraryUpdateReporter>
-            LibraryUpdateReporter::Default(po::variables_map const& args)
+            LibraryUpdateReporter::Default(po::variables_map& args)
         {
             auto filename = args["library-update-file"].as<std::string>();
             auto comment  = args["library-update-comment"].as<bool>();
@@ -70,7 +70,7 @@ namespace Tensile
         template <typename T>
         void LibraryUpdateReporter::reportValue(std::string const& key, T const& value)
         {
-            std::string valueStr = boost::lexical_cast<std::string>(value);
+            std::string valueStr = roc::lexical_cast_to_string(value);
             //m_stream << key << " = " << valueStr << std::endl;
 
             if(key == ResultKey::Validation)

--- a/Tensile/Source/client/source/PerformanceReporter.cpp
+++ b/Tensile/Source/client/source/PerformanceReporter.cpp
@@ -36,8 +36,7 @@ namespace Tensile
 {
     namespace Client
     {
-        std::shared_ptr<PerformanceReporter>
-            PerformanceReporter::Default(po::variables_map& args)
+        std::shared_ptr<PerformanceReporter> PerformanceReporter::Default(po::variables_map& args)
         {
             int    deviceIndex        = args["device-idx"].as<int>();
             double l2ReadHits         = args["perf-l2-read-hits"].as<double>();

--- a/Tensile/Source/client/source/PerformanceReporter.cpp
+++ b/Tensile/Source/client/source/PerformanceReporter.cpp
@@ -37,7 +37,7 @@ namespace Tensile
     namespace Client
     {
         std::shared_ptr<PerformanceReporter>
-            PerformanceReporter::Default(po::variables_map const& args)
+            PerformanceReporter::Default(po::variables_map& args)
         {
             int    deviceIndex        = args["device-idx"].as<int>();
             double l2ReadHits         = args["perf-l2-read-hits"].as<double>();

--- a/Tensile/Source/client/source/ProgressListener.cpp
+++ b/Tensile/Source/client/source/ProgressListener.cpp
@@ -27,15 +27,16 @@
 #include <ProgressListener.hpp>
 
 #include <cstddef>
+#include <iostream>
 #include <iomanip>
-
-#include <sys/time.h>
+#include <sstream>
+#include <ctime>
 
 namespace Tensile
 {
     namespace Client
     {
-        ProgressListener::ProgressListener(po::variables_map const& args)
+        ProgressListener::ProgressListener(po::variables_map& args)
             : m_runOnce(args["selection-only"].as<bool>())
         {
         }
@@ -142,18 +143,15 @@ namespace Tensile
                                                 TimingEvents const&                startEvents,
                                                 TimingEvents const&                stopEvents)
         {
-            struct timeval tmnow;
-            struct tm*     tm;
-            gettimeofday(&tmnow, NULL); // microsecond resolution
-            tm = localtime(&tmnow.tv_sec);
-            std::cout.fill('0');
+            std::time_t result = std::time(nullptr);
+            std::tm* tm = std::localtime(&result);
 
             std::ostringstream msg;
             msg.fill('0');
             msg << (tm->tm_year + 1900) << "-" << std::setw(2) << (tm->tm_mon + 1) << "-"
                 << std::setw(2) << tm->tm_mday << " " << std::setw(2) << tm->tm_hour << ":"
                 << std::setw(2) << tm->tm_min << ":" << std::setw(2) << tm->tm_sec << "."
-                << std::setw(6) << static_cast<int>(tmnow.tv_usec);
+                << std::setw(6);
 
             m_reporter->report(ResultKey::EnqueueTime, msg.str());
         }

--- a/Tensile/Source/client/source/ProgressListener.cpp
+++ b/Tensile/Source/client/source/ProgressListener.cpp
@@ -27,10 +27,10 @@
 #include <ProgressListener.hpp>
 
 #include <cstddef>
-#include <iostream>
-#include <iomanip>
-#include <sstream>
 #include <ctime>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
 
 namespace Tensile
 {
@@ -144,7 +144,7 @@ namespace Tensile
                                                 TimingEvents const&                stopEvents)
         {
             std::time_t result = std::time(nullptr);
-            std::tm* tm = std::localtime(&result);
+            std::tm*    tm     = std::localtime(&result);
 
             std::ostringstream msg;
             msg.fill('0');

--- a/Tensile/Source/client/source/ReferenceValidator.cpp
+++ b/Tensile/Source/client/source/ReferenceValidator.cpp
@@ -40,7 +40,7 @@ namespace Tensile
 {
     namespace Client
     {
-        ReferenceValidator::ReferenceValidator(po::variables_map const&            args,
+        ReferenceValidator::ReferenceValidator(po::variables_map&                  args,
                                                std::shared_ptr<DataInitialization> dataInit)
             : m_dataInit(dataInit)
         {

--- a/Tensile/Source/client/source/ResultFileReporter.cpp
+++ b/Tensile/Source/client/source/ResultFileReporter.cpp
@@ -33,7 +33,7 @@ namespace Tensile
     namespace Client
     {
         std::shared_ptr<ResultFileReporter>
-            ResultFileReporter::Default(po::variables_map const& args)
+            ResultFileReporter::Default(po::variables_map& args)
         {
             return std::make_shared<ResultFileReporter>(
                 args["results-file"].as<std::string>(),
@@ -60,7 +60,7 @@ namespace Tensile
         template <typename T>
         void ResultFileReporter::reportValue(std::string const& key, T const& value)
         {
-            std::string valueStr = boost::lexical_cast<std::string>(value);
+            std::string valueStr = roc::lexical_cast_to_string(value);
 
             if(key == ResultKey::Validation)
             {

--- a/Tensile/Source/client/source/ResultFileReporter.cpp
+++ b/Tensile/Source/client/source/ResultFileReporter.cpp
@@ -32,8 +32,7 @@ namespace Tensile
 {
     namespace Client
     {
-        std::shared_ptr<ResultFileReporter>
-            ResultFileReporter::Default(po::variables_map& args)
+        std::shared_ptr<ResultFileReporter> ResultFileReporter::Default(po::variables_map& args)
         {
             return std::make_shared<ResultFileReporter>(
                 args["results-file"].as<std::string>(),

--- a/Tensile/Source/client/source/SolutionIterator.cpp
+++ b/Tensile/Source/client/source/SolutionIterator.cpp
@@ -37,7 +37,7 @@ namespace Tensile
             std::shared_ptr<Hardware>                                  hardware,
             po::variables_map const&                                   args)
         {
-            bool bestSolution = args["best-solution"].as<bool>();
+            bool bestSolution = args.at("best-solution").as<bool>();
 
             if(bestSolution)
             {
@@ -45,8 +45,8 @@ namespace Tensile
             }
             else
             {
-                int firstSolutionIdx = args["solution-start-idx"].as<int>();
-                int numSolutions     = args["num-solutions"].as<int>();
+                int firstSolutionIdx = args.at("solution-start-idx").as<int>();
+                int numSolutions     = args.at("num-solutions").as<int>();
 
                 return std::make_shared<AllSolutionsIterator>(
                     library,
@@ -118,7 +118,7 @@ namespace Tensile
         {
             RunCriteria criteria;
 
-            double granThresh = args["granularity-threshold"].as<double>();
+            double granThresh = args.at("granularity-threshold").as<double>();
             if(granThresh > 0.0)
             {
                 criteria.push_back([granThresh](ContractionProblem const&  problem,


### PR DESCRIPTION
In windows platform, the boost library filename is modified.
So remove boost.