### PR TITLE
GridBased kernel selection

### DIFF
--- a/Tensile/Source/lib/include/Tensile/Distance.hpp
+++ b/Tensile/Source/lib/include/Tensile/Distance.hpp
@@ -331,6 +331,58 @@ namespace Tensile
             }
         };
 
+        template <typename Key>
+        struct GridBasedDistance : public Distance<Key>
+        {
+            enum
+            {
+                HasIndex = false,
+                HasValue = false
+            };
+
+            static std::string Type()
+            {
+                return "GridBased";
+            }
+            virtual std::string type() const override
+            {
+                return Type();
+            }
+
+            inline double operator()(Key const& p1, Key const& p2) const
+            {
+                double distance = 0.0;
+
+                double M = p2[0];
+                double N = p2[1];
+                double K = p2[2];
+
+                // This is hard coding workaround solution //
+                // If incoming_size falls inside grid boundary (32768 in this case), searching toward larger M,N.
+                // If incoming_N > 32768, searching toward larger M and nearest boundary.
+                // IF incoming_M > 32768, searching toward larger N and nearest boundary.
+                double stepM = (p1[0] <= 32768)? std::ceil(p1[0] / M): 1;
+                double stepN = (p1[1] <= 32768)? std::ceil(p1[1] / N): 1;
+                if (p1[0] <= 32768 && p1[1] <= 32768) {
+                    distance = std::round(100 * stepM * stepN / std::pow((p1[0] * p1[1]) / (stepM * M * stepN * N),2) );
+                } else {
+                    distance = std::round(10000 * stepM * stepN * std::pow(std::pow(p1[0] - p2[0],2) + std::pow(p1[1] - p2[1],2),0.5));
+                }
+                // and nearest K
+                distance += (std::abs(K - p1[2]) / (K + p1[2] * 8));
+
+                return distance;
+            }
+
+            inline bool improvementPossible(Key const& p1,
+                                            Key const& p2,
+                                            size_t     idx,
+                                            double     bestDistance) const
+            {
+                return true;
+            }
+        };
+
         /**
  * @}
  */

--- a/Tensile/Source/lib/include/Tensile/Serialization/MatchingLibrary.hpp
+++ b/Tensile/Source/lib/include/Tensile/Serialization/MatchingLibrary.hpp
@@ -164,6 +164,11 @@ namespace Tensile
                     success
                         = mappingDistance<Key, Matching::RandomDistance<Key>>(io, lib, properties);
                 }
+                else if(distanceType == "GridBased")
+                {
+                    success
+                        = mappingDistance<Key, Matching::GridBasedDistance<Key>>(io, lib, properties);
+                }
                 else
                 {
                     iot::setError(io, concatenate("Unknown distance function", distanceType));
@@ -247,7 +252,8 @@ namespace Tensile
                 return SubclassMap({Base::template Pair<Matching::RatioDistance<Key>>(),
                                     Base::template Pair<Matching::ManhattanDistance<Key>>(),
                                     Base::template Pair<Matching::EuclideanDistance<Key>>(),
-                                    Base::template Pair<Matching::RandomDistance<Key>>()});
+                                    Base::template Pair<Matching::RandomDistance<Key>>(),
+                                    Base::template Pair<Matching::GridBasedDistance<Key>>()});
             }
         };
 
@@ -277,6 +283,12 @@ namespace Tensile
         template <typename Key, typename IO>
         struct MappingTraits<Matching::RandomDistance<Key>, IO>
             : public AutoMappingTraits<Matching::RandomDistance<Key>, IO>
+        {
+        };
+
+        template <typename Key, typename IO>
+        struct MappingTraits<Matching::GridBasedDistance<Key>, IO>
+            : public AutoMappingTraits<Matching::GridBasedDistance<Key>, IO>
         {
         };
     } // namespace Serialization


### PR DESCRIPTION
This solution selection need rocblas to point to custom logic file consist of grid sizes.
If incoming size falls inside grid boundary (32768 in this case), searching toward larger M,N, and nearest K. Otherwise, searching toward nearest boundary and nearest K.