### PR TITLE
Revert "win32 clang 15.0.0 branches may only take -inputs (#1527)"

### DIFF
--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -225,8 +225,7 @@ def buildSourceCodeObjectFile(CxxCompiler, outputPath, kernelFile):
       # for hipclang 5.2 and above, clang offload bundler changes the way input/output files are specified
       inflag = "-inputs"
       outflag = "-outputs"
-      # clang 15.0.0 still wants inputs on windows so the hipcc version condition doesn't work
-      if os.name != "nt" and ((hipccMaj == 5 and hipccMin >= 2) or hipccMaj >= 6):
+      if (hipccMaj == 5 and hipccMin >= 2) or hipccMaj >= 6:
         inflag = "-input"
         outflag = "-output"
 


### PR DESCRIPTION
* This reverts commit 50f32c62266154704142da6b077b5d5114069a94 which was a workaround
* hipcc version wasn't tightly linked to clang-offload-version but should work now on windows CI as updated hip 