### PR TITLE
Add NumWarmups parameter, pass value to client

### DIFF
--- a/Tensile/ClientWriter.py
+++ b/Tensile/ClientWriter.py
@@ -510,16 +510,15 @@ def writeClientConfigIni(problemSizes, problemType, sourceDir, codeObjectFiles, 
         param("bounds-check",             boundsCheckName(int(globalParameters["BoundsCheck"])))
         param("print-valids",             globalParameters["ValidationPrintValids"])
         param("print-max",                globalParameters["ValidationMaxToPrint"])
-        param("num-benchmarks",           globalParameters["NumBenchmarks"])
         param("num-elements-to-validate", globalParameters["NumElementsToValidate"])
+        param("num-benchmarks",           globalParameters["NumBenchmarks"])
+        param("num-warmups",              globalParameters["NumWarmups"])
         param("num-enqueues-per-sync",    globalParameters["EnqueuesPerSync"])
         param("num-syncs-per-benchmark",  globalParameters["SyncsPerBenchmark"])
         param("use-gpu-timer",            globalParameters["KernelTime"])
         param("hardware-monitor",         globalParameters["HardwareMonitor"])
         if convValidation:
             param("convolution-vs-contraction", globalParameters["ConvolutionVsContraction"])
-        if not globalParameters["KernelTime"]:
-            param("num-warmups", 1)
         param("sleep-percent",            globalParameters["SleepPercent"])
         param("perf-l2-read-hits",        globalParameters["PerfModelL2ReadHits"])
         param("perf-l2-write-hits",       globalParameters["PerfModelL2WriteHits"])

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -65,6 +65,7 @@ globalParameters["SortProblems"] = False          # sort problems by size; else 
 globalParameters["PinClocks"] = False             # T=pin gpu clocks and fan, F=don't
 globalParameters["HardwareMonitor"] = True        # False: disable benchmarking client monitoring clocks using rocm-smi.
 globalParameters["NumBenchmarks"] = 1             # how many benchmark data points to collect per problem/solution
+globalParameters["NumWarmups"] = 0                # how many warmup runs to perform before benchmark
 globalParameters["SyncsPerBenchmark"] = 1         # how iterations of the stream synchronization for-loop to do per benchmark data point
 globalParameters["EnqueuesPerSync"] = 1           # how many solution enqueues to perform per synchronization
 globalParameters["SleepPercent"] = 300            # how long to sleep after every data point: 25 means 25% of solution time. Sleeping lets gpu cool down more.


### PR DESCRIPTION
Allow configuring warmups in yaml file, and pass value through to client. Make default number of warmups consistent ( was 0 or 1 depending on how client was invoked, and what type of timing was used).