### PR TITLE
Fix benchmark timings when using warmups and/or validation

### DIFF
--- a/Tensile/Source/client/main.cpp
+++ b/Tensile/Source/client/main.cpp
@@ -602,36 +602,22 @@ int main(int argc, const char* argv[])
                             TimingEvents warmupStartEvents(warmupInvocations, eventCount);
                             TimingEvents warmupStopEvents(warmupInvocations, eventCount);
 
-                            if(warmupInvocations > 0)
+                            for(int i = 0; i < warmupInvocations; i++)
                             {
-                                // Do validation after first warmup
                                 listeners.preWarmup();
                                 if(gpuTimer)
                                     HIP_CHECK_EXC(adapter.launchKernels(kernels,
                                                                         stream,
-                                                                        warmupStartEvents[0],
-                                                                        warmupStopEvents[0]));
+                                                                        warmupStartEvents[i],
+                                                                        warmupStopEvents[i]));
                                 else
                                     HIP_CHECK_EXC(
                                         adapter.launchKernels(kernels, stream, nullptr, nullptr));
                                 listeners.postWarmup();
-                                listeners.validateWarmups(
-                                    inputs, warmupStartEvents, warmupStopEvents);
-
-                                // Remainder of warmups
-                                for(int i = 1; i < warmupInvocations; i++)
-                                {
-                                    listeners.preWarmup();
-                                    if(gpuTimer)
-                                        HIP_CHECK_EXC(adapter.launchKernels(kernels,
-                                                                            stream,
-                                                                            warmupStartEvents[i],
-                                                                            warmupStopEvents[i]));
-                                    else
-                                        HIP_CHECK_EXC(adapter.launchKernels(
-                                            kernels, stream, nullptr, nullptr));
-                                    listeners.postWarmup();
-                                }
+                                // Do validation after first warmup
+                                if(i == 0)
+                                    listeners.validateWarmups(
+                                        inputs, warmupStartEvents, warmupStopEvents);
                             }
 
                             size_t syncs = listeners.numSyncs();

--- a/Tensile/Source/client/main.cpp
+++ b/Tensile/Source/client/main.cpp
@@ -602,7 +602,7 @@ int main(int argc, const char* argv[])
                             TimingEvents warmupStartEvents(warmupInvocations, eventCount);
                             TimingEvents warmupStopEvents(warmupInvocations, eventCount);
 
-                            if (warmupInvocations > 0)
+                            if(warmupInvocations > 0)
                             {
                                 // Do validation after first warmup
                                 listeners.preWarmup();
@@ -615,7 +615,8 @@ int main(int argc, const char* argv[])
                                     HIP_CHECK_EXC(
                                         adapter.launchKernels(kernels, stream, nullptr, nullptr));
                                 listeners.postWarmup();
-                                listeners.validateWarmups(inputs, warmupStartEvents, warmupStopEvents);
+                                listeners.validateWarmups(
+                                    inputs, warmupStartEvents, warmupStopEvents);
 
                                 // Remainder of warmups
                                 for(int i = 1; i < warmupInvocations; i++)
@@ -627,8 +628,8 @@ int main(int argc, const char* argv[])
                                                                             warmupStartEvents[i],
                                                                             warmupStopEvents[i]));
                                     else
-                                        HIP_CHECK_EXC(
-                                            adapter.launchKernels(kernels, stream, nullptr, nullptr));
+                                        HIP_CHECK_EXC(adapter.launchKernels(
+                                            kernels, stream, nullptr, nullptr));
                                     listeners.postWarmup();
                                 }
                             }

--- a/Tensile/Source/client/source/BenchmarkTimer.cpp
+++ b/Tensile/Source/client/source/BenchmarkTimer.cpp
@@ -182,6 +182,8 @@ namespace Tensile
         {
             if(!m_useGPUTimer)
             {
+                // Synchronize before timer so warmup runs are not included in benchmark time
+                HIP_CHECK_EXC(hipDeviceSynchronize());
                 m_startTime = clock::now();
             }
         }

--- a/Tensile/Source/client/source/Reference.cpp
+++ b/Tensile/Source/client/source/Reference.cpp
@@ -29,6 +29,8 @@
 #include "Tensile/Utils.hpp"
 
 #include <cstddef>
+#include <cstdlib>
+#include <stdlib.h>
 
 #include <omp.h>
 
@@ -175,9 +177,12 @@ namespace Tensile
                 }
             }
 
-            // Enable dynamic thread adjustment and set num threads to avoid defaulting to 1
+            // Set num threads and enable proc_bind to prevent main thread from migrating
             // Defaults cause validation to affect benchmark timing
-            omp_set_dynamic(1);
+            // Dynamic thread mode causes HostLibraryTests to fail
+            const char* env_bind = std::getenv("OMP_PROC_BIND");
+            if (env_bind == nullptr)
+                setenv("OMP_PROC_BIND", "true", 1);
             omp_set_num_threads(64);
 #pragma omp parallel for
             for(size_t dNum = 0; dNum < d.totalLogicalElements(); dNum += validationStride)
@@ -323,6 +328,8 @@ namespace Tensile
                     + ((beta == zero) ? static_cast<Accumulator>(zero)
                                       : multiply<Accumulator>(beta, inputs.c[cIndex])));
             }
+            if (env_bind == nullptr)
+                unsetenv("OMP_PROC_BIND");
         }
 
         void SolveCPU(ContractionProblem const& problem,

--- a/Tensile/Source/client/source/Reference.cpp
+++ b/Tensile/Source/client/source/Reference.cpp
@@ -30,6 +30,8 @@
 
 #include <cstddef>
 
+#include <omp.h>
+
 namespace Tensile
 {
     namespace Client
@@ -173,6 +175,8 @@ namespace Tensile
                 }
             }
 
+            omp_set_dynamic(1);
+            omp_set_num_threads(64);
 #pragma omp parallel for
             for(size_t dNum = 0; dNum < d.totalLogicalElements(); dNum += validationStride)
             {

--- a/Tensile/Source/client/source/Reference.cpp
+++ b/Tensile/Source/client/source/Reference.cpp
@@ -175,6 +175,8 @@ namespace Tensile
                 }
             }
 
+            // Enable dynamic thread adjustment and set num threads to avoid defaulting to 1
+            // Defaults cause validation to affect benchmark timing
             omp_set_dynamic(1);
             omp_set_num_threads(64);
 #pragma omp parallel for

--- a/Tensile/Source/client/source/Reference.cpp
+++ b/Tensile/Source/client/source/Reference.cpp
@@ -181,7 +181,7 @@ namespace Tensile
             // Defaults cause validation to affect benchmark timing
             // Dynamic thread mode causes HostLibraryTests to fail
             const char* env_bind = std::getenv("OMP_PROC_BIND");
-            if (env_bind == nullptr)
+            if(env_bind == nullptr)
                 setenv("OMP_PROC_BIND", "true", 1);
             omp_set_num_threads(64);
 #pragma omp parallel for
@@ -328,7 +328,7 @@ namespace Tensile
                     + ((beta == zero) ? static_cast<Accumulator>(zero)
                                       : multiply<Accumulator>(beta, inputs.c[cIndex])));
             }
-            if (env_bind == nullptr)
+            if(env_bind == nullptr)
                 unsetenv("OMP_PROC_BIND");
         }
 


### PR DESCRIPTION
Fix some bugs that caused incorrect benchmark timing results. GPU timing is impacted by the overhead of using hip events, on small kernels, the timing is noticeable. CPU timing is more precise, but when using warmups, the warmup run time was included in the benchmark time, but only averaged over the actual number of benchmark runs.
Also, when doing both benchmarking and validation the times would be very inaccurate. To prevent validation from impacting benchmark times, validation is now done after the first benchmark run instead of the last (for best results there should be at least 2 warmups). OpenMP was also defaulting to 1 thread, which was somehow impacting other code. Set num threads to 64 and enabled the option for dynamic adjustment based on hardware.