### PR TITLE
Add CleanupBuildFiles global param and ClientPath Tensile param

### DIFF
--- a/Tensile/BenchmarkProblems.py
+++ b/Tensile/BenchmarkProblems.py
@@ -29,7 +29,6 @@ import time
 
 from copy import deepcopy
 
-from . import ClientExecutable
 from . import SolutionLibrary
 from . import LibraryIO
 from . import Utils

--- a/Tensile/BenchmarkProblems.py
+++ b/Tensile/BenchmarkProblems.py
@@ -367,8 +367,6 @@ def benchmarkProblemType(problemTypeConfig, problemSizeGroupConfig, problemSizeG
 
 def main(config, useCache):
     """Entry point for the "BenchmarkProblems" section of a Tensile config yaml"""
-    ClientExecutable.getClientExecutable()
-
     dataPath = os.path.join(globalParameters["WorkingPath"], globalParameters["BenchmarkDataPath"])
     pushWorkingPath(globalParameters["BenchmarkProblemsPath"])
     ensurePath(dataPath)

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -204,6 +204,7 @@ globalParameters["NumMergedFiles"] = 1            # The number of files that ker
 globalParameters["MaxFileName"] = 64              # If a file name would be longer than this, shorten it with a hash.
 globalParameters["SupportedISA"] = [(8,0,3), (9,0,0), (9,0,6), (9,0,8), (9,0,10), (10,1,0), (10,1,1), (10,1,2), (10,3,0), (11,0,0), (11,0,1), (11,0,2)] # assembly kernels writer supports these architectures
 
+globalParameters["CleanupBuildFiles"] = False                     # cleanup build files (e.g. kernel assembly) once no longer needed
 globalParameters["GenerateManifestAndExit"] = False               # Output manifest file with list of expected library objects and exit
 globalParameters["NewClient"] = 2                                 # Old client deprecated: NewClient must be set to 2.
 globalParameters["ClientBuildPath"] = "0_Build"                   # subdirectory for host code build directory

--- a/Tensile/Tensile.py
+++ b/Tensile/Tensile.py
@@ -32,6 +32,7 @@ import argparse
 from .Common import globalParameters, print1, printExit, ensurePath, \
     assignGlobalParameters, restoreDefaultGlobalParameters, HR
 from . import BenchmarkProblems
+from . import ClientExecutable
 from . import ClientWriter
 from . import LibraryIO
 from . import LibraryLogic
@@ -205,6 +206,8 @@ def Tensile(userArgs):
             "and optional second file is size list")
     argParser.add_argument("--no-cache", dest="NoCache", action="store_true",
             help="Ignore cache; redo parameter forking and solution generation")
+    argParser.add_argument("--client-path", dest="ClientPath", default=None,
+            help="Path to directory to build benchmarking client")
     # yapf: enable
 
     addCommonArguments(argParser)
@@ -285,6 +288,8 @@ def Tensile(userArgs):
         globalParameters[key] = value
 
     # Execute Steps in the config script
+    clientPath = os.path.abspath(args.ClientPath)
+    ClientExecutable.getClientExecutable(clientPath)
     executeStepsInConfig(config)
 
 

--- a/Tensile/Tensile.py
+++ b/Tensile/Tensile.py
@@ -216,6 +216,7 @@ def Tensile(userArgs):
     configPaths = args.config_file
     altFormat = args.AlternateFormat
     useCache = not args.NoCache
+    clientPath = args.ClientPath
 
     if altFormat and len(configPaths) > 2:
         printExit("Only 1 or 2 config_files are accepted for the alternate config format: "
@@ -288,7 +289,8 @@ def Tensile(userArgs):
         globalParameters[key] = value
 
     # Execute Steps in the config script
-    clientPath = os.path.abspath(args.ClientPath)
+    if clientPath is not None:
+        clientPath = os.path.abspath(clientPath)
     ClientExecutable.getClientExecutable(clientPath)
     executeStepsInConfig(config)
 

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -582,8 +582,12 @@ def writeSolutionsAndKernels(outputPath, CxxCompiler, problemTypes, solutions, k
   stop = time.time()
   print("# Kernel Building elapsed time = %.1f secs" % (stop-start))
 
+  Common.popWorkingPath() # outputPath.upper()
+
+  if globalParameters["CleanupBuildFiles"]:
+    shutil.rmtree(globalParameters["WorkingPath"])
+
   Common.popWorkingPath() # build_tmp
-  Common.popWorkingPath() # workingDir
 
   return codeObjectFiles
 


### PR DESCRIPTION
Two small additions to help with Tuning/benchmarking automation and quality of life. 

If `CleanupBuildFiles` is true, TensileCreateLibrary will delete the build_tmp directory after use. I made this a global param since it affects all front ends that depend on TensileCreateLibrary, which is most of them.

The `ClientPath` param for Tensile allows for full control over the path to the benchmarking client. The current way we're dealing with building the client is sorta a mess and is due for a complete overhaul imo, so this is more of an interim solution. I'd like to do a follow up that merges this new `ClientPath` param with the existing `ClientBuildPath` and `PrebuiltClient` global params.