### PR TITLE
It is redundant to call syncThreads if the number of threads in a block is equal to the size of wavefront.

### DIFF
--- a/Tensile/KernelWriterSource.py
+++ b/Tensile/KernelWriterSource.py
@@ -2757,7 +2757,7 @@ class KernelWriterSource(KernelWriter):
                 self.tileChar0, self.tileChar1, \
                 s, self.tileChar1, j, self.tileChar0, self.tileChar1, vc, i, s, \
                 self.tileChar0, j, self.tileChar0, self.endLine)
-    kStr += self.indent + self.syncStr + self.endLine
+    kStr += self.syncThreads(kernel);
     """
 
     kStr += "    /* print Local state */" + self.endLine
@@ -3311,7 +3311,13 @@ class KernelWriterSource(KernelWriter):
   # SyncThreads
   ##############################################################################
   def syncThreads(self, kernel, comment=""):
-    return self.indent + self.syncStr + " //" + comment + self.endLine
+    if globalParameters["CurrentISA"] == (9,0,8):
+      return self.indent + self.syncStr + " //" + comment + self.endLine
+    else:
+      if kernel["SubGroup0"]*kernel["SubGroup1"]*kernel["LocalSplitU"] != kernel["WavefrontSize"]:
+        return self.indent + self.syncStr + " //" + comment + self.endLine
+      else:
+        return self.indent + self.endLine
 
   ##############################################################################
   # MapAcctoArch


### PR DESCRIPTION
This modification remove software overhead if blocksize is equal to wavefrontsize. The LocalSplitU is used in optimizing GEMM performance for M=1. The best bloksize is equal to 64 (wavefrontsize) on MI100 and MI200. This modification can improve GEMM performance on MI200.  However,  performance changes are not observed on MI100. 