### PR TITLE
Option to output library logic in dict format

### DIFF
--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -215,7 +215,7 @@ globalParameters["LibraryClientPath"] = "4_LibraryClient"         # subdirectory
 globalParameters["ClientExecutionLockPath"] = None                # Path for a file lock to ensure only one client is executed at once.  filelock module is required if this is enabled.
 globalParameters["LibraryUpdateFile"] = ""                        # File name for writing indices and speeds suitable for updating an existing library logic file
 globalParameters["LibraryUpdateComment"] = False                  # Include solution name as a comment in the library update file
-globalParameters["LibraryLogicFormat"] = "dict"
+globalParameters["DictLibraryLogic"] = True
 
 # internal, i.e., gets set during startup
 globalParameters["CurrentISA"] = (0,0,0)

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -215,7 +215,7 @@ globalParameters["LibraryClientPath"] = "4_LibraryClient"         # subdirectory
 globalParameters["ClientExecutionLockPath"] = None                # Path for a file lock to ensure only one client is executed at once.  filelock module is required if this is enabled.
 globalParameters["LibraryUpdateFile"] = ""                        # File name for writing indices and speeds suitable for updating an existing library logic file
 globalParameters["LibraryUpdateComment"] = False                  # Include solution name as a comment in the library update file
-globalParameters["DictLibraryLogic"] = True
+globalParameters["DictLibraryLogic"] = False
 
 # internal, i.e., gets set during startup
 globalParameters["CurrentISA"] = (0,0,0)

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -215,6 +215,7 @@ globalParameters["LibraryClientPath"] = "4_LibraryClient"         # subdirectory
 globalParameters["ClientExecutionLockPath"] = None                # Path for a file lock to ensure only one client is executed at once.  filelock module is required if this is enabled.
 globalParameters["LibraryUpdateFile"] = ""                        # File name for writing indices and speeds suitable for updating an existing library logic file
 globalParameters["LibraryUpdateComment"] = False                  # Include solution name as a comment in the library update file
+globalParameters["LibraryLogicFormat"] = "dict"
 
 # internal, i.e., gets set during startup
 globalParameters["CurrentISA"] = (0,0,0)

--- a/Tensile/LibraryIO.py
+++ b/Tensile/LibraryIO.py
@@ -67,7 +67,7 @@ def writeYAML(filename, data, **kwargs):
         kwargs["default_flow_style"] = None
 
     with open(filename, "w") as f:
-        yaml.dump(data, f, sort_keys=False, **kwargs)
+        yaml.dump(data, f, **kwargs)
 
 
 def writeMsgPack(filename, data):
@@ -277,7 +277,10 @@ def rawLibraryLogic(data):
 #################
 # Other functions
 #################
-def createLibraryLogic(schedulePrefix, architectureName, deviceNames, logicTuple):
+def createLibraryLogic(schedulePrefix, architectureName, deviceNames, logicTuple, dictFormat):
+    if not dictFormat:
+        return createLibraryLogicList(schedulePrefix, architectureName, deviceNames, logicTuple)
+
     rv = {}
     rv["MinimumRequiredVersion"] = __version__
     rv["ScheduleName"] = schedulePrefix
@@ -330,9 +333,6 @@ def createLibraryLogic(schedulePrefix, architectureName, deviceNames, logicTuple
     rv["Library"]["table"] = exactLogicList
     rv["Library"]["distance"] = "Euclidean"
     rv["PerfMetric"] = logicTuple[7]
-
-    # if listFormat:
-    #     return libraryLogicToList(rv)
 
     return rv
 

--- a/Tensile/LibraryIO.py
+++ b/Tensile/LibraryIO.py
@@ -43,6 +43,12 @@ except ImportError:
     print("Message pack python library not detected. Must use YAML backend instead.")
 
 
+def updateProblemDatatypes(problemType):
+    problemType["DataType"] = problemType["DataType"].value
+    problemType["DestDataType"] = problemType["DestDataType"].value
+    problemType["ComputeDataType"] = problemType["ComputeDataType"].value
+
+
 ###################
 # Writing functions
 ###################
@@ -89,12 +95,7 @@ def writeSolutions(filename, problemSizes, solutions, cache=False):
         for solution in solutions:
             solutionState = solution.getAttributes()
             solutionState["ProblemType"] = solutionState["ProblemType"].state
-            solutionState["ProblemType"]["DataType"] = \
-                    solutionState["ProblemType"]["DataType"].value
-            solutionState["ProblemType"]["DestDataType"] = \
-                    solutionState["ProblemType"]["DestDataType"].value
-            solutionState["ProblemType"]["ComputeDataType"] = \
-                    solutionState["ProblemType"]["ComputeDataType"].value
+            updateProblemDatatypes(solutionState["ProblemType"])
             solutionStates.append(solutionState)
     # write dictionaries
     with open(filename, "w") as f:
@@ -231,9 +232,8 @@ def parseLibraryLogicList(data, srcFile="?"):
         rv["ArchitectureName"] = data[2]
         rv["CUCount"] = None
 
-    # TODOBEN: figure out what to do with these...
     rv["ExactLogic"] = data[7]
-    rv["RangeLogic"] = data[8]
+    # data[8] previously contained range logic, which has been retired
 
     # optional fields
     if len(data) > 10 and data[10]:
@@ -276,9 +276,9 @@ def rawLibraryLogic(data):
             problemTypeState, solutionStates, indexOrder, exactLogic, rangeLogic, otherFields)
 
 
-#################
-# Other functions
-#################
+########################
+# Library logic creation
+########################
 def createLibraryLogic(schedulePrefix, architectureName, deviceNames, logicTuple, dictFormat):
     if not dictFormat:
         return createLibraryLogicList(schedulePrefix, architectureName, deviceNames, logicTuple)
@@ -299,13 +299,7 @@ def createLibraryLogic(schedulePrefix, architectureName, deviceNames, logicTuple
 
     # problem type
     problemTypeState = rawProblemType.state
-    problemTypeState["DataType"] = \
-            problemTypeState["DataType"].value
-    problemTypeState["DestDataType"] = \
-            problemTypeState["DestDataType"].value
-    problemTypeState["ComputeDataType"] = \
-            problemTypeState["ComputeDataType"].value
-
+    updateProblemDatatypes(problemTypeState)
     rv["ProblemType"] = problemTypeState
 
     # solutions
@@ -353,26 +347,18 @@ def createLibraryLogicList(schedulePrefix, architectureName, deviceNames, logicT
     data.append(architectureName)
     # schedule device names
     data.append(deviceNames)
+
     # problem type
     problemTypeState = problemType.state
-    problemTypeState["DataType"] = \
-            problemTypeState["DataType"].value
-    problemTypeState["DestDataType"] = \
-            problemTypeState["DestDataType"].value
-    problemTypeState["ComputeDataType"] = \
-            problemTypeState["ComputeDataType"].value
+    updateProblemDatatypes(problemTypeState)
     data.append(problemTypeState)
+
     # solutions
     solutionList = []
     for solution in solutions:
         solutionState = solution.getAttributes()
         solutionState["ProblemType"] = solutionState["ProblemType"].state
-        solutionState["ProblemType"]["DataType"] = \
-                solutionState["ProblemType"]["DataType"].value
-        solutionState["ProblemType"]["DestDataType"] = \
-                solutionState["ProblemType"]["DestDataType"].value
-        solutionState["ProblemType"]["ComputeDataType"] = \
-                solutionState["ProblemType"]["ComputeDataType"].value
+        updateProblemDatatypes(solutionState["ProblemType"])
         solutionList.append(solutionState)
 
     if tileSelection:
@@ -380,12 +366,7 @@ def createLibraryLogicList(schedulePrefix, architectureName, deviceNames, logicT
         for solution in tileSolutions:
             solutionState = solution.getAttributes()
             solutionState["ProblemType"] = solutionState["ProblemType"].state
-            solutionState["ProblemType"]["DataType"] = \
-                    solutionState["ProblemType"]["DataType"].value
-            solutionState["ProblemType"]["DestDataType"] = \
-                    solutionState["ProblemType"]["DestDataType"].value
-            solutionState["ProblemType"]["ComputeDataType"] = \
-                    solutionState["ProblemType"]["ComputeDataType"].value
+            updateProblemDatatypes(solutionState["ProblemType"])
             solutionList.append(solutionState)
 
     data.append(solutionList)

--- a/Tensile/LibraryIO.py
+++ b/Tensile/LibraryIO.py
@@ -189,6 +189,8 @@ def parseLibraryLogicData(data, srcFile="?"):
     # unpack solutions
     solutions = []
     for solutionState in data["Solutions"]:
+        if solutionState["ProblemType"] == "derive":
+            solutionState["ProblemType"] = problemType
         if solutionState["KernelLanguage"] == "Assembly":
             solutionState["ISA"] = Common.gfxArch(data["ArchitectureName"])
         else:
@@ -310,13 +312,7 @@ def createLibraryLogic(schedulePrefix, architectureName, deviceNames, logicTuple
     solutionList = []
     for solution in rawSolutions:
         solutionState = solution.getAttributes()
-        solutionState["ProblemType"] = solutionState["ProblemType"].state
-        solutionState["ProblemType"]["DataType"] = \
-                solutionState["ProblemType"]["DataType"].value
-        solutionState["ProblemType"]["DestDataType"] = \
-                solutionState["ProblemType"]["DestDataType"].value
-        solutionState["ProblemType"]["ComputeDataType"] = \
-                solutionState["ProblemType"]["ComputeDataType"].value
+        solutionState["ProblemType"] = "derive"
         solutionList.append(solutionState)
 
     rv["Solutions"] = solutionList

--- a/Tensile/LibraryLogic.py
+++ b/Tensile/LibraryLogic.py
@@ -1456,8 +1456,9 @@ def generateLogic(config, benchmarkDataPath, libraryLogicPath):
         "{}_{}".format(analysisParameters["ScheduleName"], str(problemType) + ".yaml"))
 
     print2("# writing library logic YAML {}".format(filename))
+    dictFormat = globalParameters["DictLibraryLogic"]
     data = LibraryIO.createLibraryLogic(analysisParameters["ScheduleName"], \
-        analysisParameters["ArchitectureName"], analysisParameters["DeviceNames"], logicTuple)
+        analysisParameters["ArchitectureName"], analysisParameters["DeviceNames"], logicTuple, dictFormat)
 
     LibraryIO.writeYAML(filename, data, explicit_start=False, explicit_end=False)
 


### PR DESCRIPTION
#1534 added support for a new dict format library logic. This PR adds the ability for Tensile to output library logics in the new format. This is part of an effort to eventually move the rocBLAS library logic files to this new format.

`globalParameters["DictLibraryLogic"] = True` is included for CI to test the new format; the default will be set to False before merging. If/when the library files in rocBLAS are updated to this new format the default will be set to True again.