### PR TITLE
Lazy loading hotfix

### DIFF
--- a/Tensile/Source/lib/include/Tensile/ContractionSolution.hpp
+++ b/Tensile/Source/lib/include/Tensile/ContractionSolution.hpp
@@ -37,6 +37,7 @@
 #include <Tensile/ContractionProblem_fwd.hpp>
 #include <Tensile/DataTypes.hpp>
 #include <Tensile/Predicates.hpp>
+#include <Tensile/Utils.hpp>
 
 namespace Tensile
 {
@@ -286,11 +287,11 @@ namespace Tensile
             double max       = 1000.0;
         };
 
-        int         index = 0;
-        std::string kernelName;
-        std::string codeObjectFilename;
-        bool        debugKernel   = false;
-        bool        kernelArgsLog = false;
+        int                          index = 0;
+        std::string                  kernelName;
+        ThreadSafeValue<std::string> codeObjectFilename;
+        bool                         debugKernel   = false;
+        bool                         kernelArgsLog = false;
 
         std::shared_ptr<Predicates::Predicate<Problem>> problemPredicate
             = std::make_shared<Predicates::True<Problem>>();

--- a/Tensile/Source/lib/include/Tensile/PlaceholderLibrary.hpp
+++ b/Tensile/Source/lib/include/Tensile/PlaceholderLibrary.hpp
@@ -57,7 +57,7 @@ namespace Tensile
     struct PlaceholderLibrary : public SolutionLibrary<MyProblem, MySolution>
     {
         mutable std::shared_ptr<SolutionLibrary<MyProblem, MySolution>> library;
-        mutable SolutionMap<MySolution>*                                solutions;
+        mutable SolutionMap<MySolution>*                                masterSolutions;
         mutable std::mutex*                                             solutionsGuard;
         mutable std::mutex                                              lazyLoadingGuard;
         std::string                                                     filePrefix;
@@ -78,7 +78,7 @@ namespace Tensile
                     = static_cast<MasterSolutionLibrary<MyProblem, MySolution>*>(newLibrary.get());
                 library = mLibrary->library;
                 std::lock_guard<std::mutex> lock(*solutionsGuard);
-                solutions->insert(mLibrary->solutions.begin(), mLibrary->solutions.end());
+                masterSolutions->insert(mLibrary->solutions.begin(), mLibrary->solutions.end());
 
                 return mLibrary;
             }

--- a/Tensile/Source/lib/include/Tensile/Serialization/PlaceholderLibrary.hpp
+++ b/Tensile/Source/lib/include/Tensile/Serialization/PlaceholderLibrary.hpp
@@ -50,7 +50,7 @@ namespace Tensile
                 if(!iot::outputting(io))
                 {
                     auto ctx      = static_cast<LibraryIOContext<MySolution>*>(iot::getContext(io));
-                    lib.solutions = ctx->solutions;
+                    lib.masterSolutions = ctx->solutions;
                     lib.solutionsGuard = ctx->solutionsGuard;
 
                     //Extract directory where TensileLibrary.dat/yaml file is located

--- a/Tensile/Source/lib/include/Tensile/Utils.hpp
+++ b/Tensile/Source/lib/include/Tensile/Utils.hpp
@@ -37,6 +37,59 @@
 namespace Tensile
 {
 
+    // Type wrapper that can be copied or assigned to in a threadsafe manner. Value cannot be modified
+    template<typename T>
+    struct ThreadSafeValue
+    {
+    private:
+        mutable std::mutex access;
+        T                  value;
+    public:
+        ThreadSafeValue()
+        {
+
+        }
+
+        ThreadSafeValue(const ThreadSafeValue<T>& other)
+        {
+            std::lock_guard<std::mutex> lock (other.access);
+            value = other.value;
+        }
+
+        ThreadSafeValue(const T& other): value(other)
+        {
+
+        }
+
+        ThreadSafeValue<T>& operator=(const ThreadSafeValue<T>& other)
+        {
+            std::lock_guard<std::mutex> otherLock (other.access);
+            std::lock_guard<std::mutex> selfLock (access);
+            value = other.value;
+
+            return *this;
+        }
+
+        ThreadSafeValue<T>& operator=(const T& other)
+        {
+            std::lock_guard<std::mutex> lock (access);
+            value = other;
+
+            return *this;
+        }
+
+        T copy() const
+        {
+            std::lock_guard<std::mutex> lock(access);
+            return value;
+        }
+
+        T operator*() const
+        {
+            return copy();
+        }
+    };
+
     /**
  * \ingroup Tensile
  * \addtogroup Utilities

--- a/Tensile/Source/lib/source/ContractionSolution.cpp
+++ b/Tensile/Source/lib/source/ContractionSolution.cpp
@@ -589,7 +589,7 @@ namespace Tensile
             rv.args.append<uint32_t>("pad", 0);
         }
 
-        rv.codeObjectFile = codeObjectFilename.copy();
+        rv.codeObjectFile = codeObjectFilename.load();
 
         return rv;
     }
@@ -683,7 +683,7 @@ namespace Tensile
         rv.args.append<typename TypedInputs::BetaType>("beta", inputs.beta);
 
         //Pass along code object dependency
-        rv.codeObjectFile = codeObjectFilename.copy();
+        rv.codeObjectFile = codeObjectFilename.load();
 
         return rv;
     }
@@ -797,7 +797,7 @@ namespace Tensile
             rv.args.append<uint32_t>("gsu", sizeMapping.globalSplitU);
 
         //@TODO determine if this is needed, may not end up in the same code object file
-        rv.codeObjectFile = codeObjectFilename.copy();
+        rv.codeObjectFile = codeObjectFilename.load();
 
         return rv;
     }

--- a/Tensile/Source/lib/source/ContractionSolution.cpp
+++ b/Tensile/Source/lib/source/ContractionSolution.cpp
@@ -589,7 +589,7 @@ namespace Tensile
             rv.args.append<uint32_t>("pad", 0);
         }
 
-        rv.codeObjectFile = codeObjectFilename;
+        rv.codeObjectFile = codeObjectFilename.copy();
 
         return rv;
     }
@@ -683,7 +683,7 @@ namespace Tensile
         rv.args.append<typename TypedInputs::BetaType>("beta", inputs.beta);
 
         //Pass along code object dependency
-        rv.codeObjectFile = codeObjectFilename;
+        rv.codeObjectFile = codeObjectFilename.copy();
 
         return rv;
     }
@@ -797,7 +797,7 @@ namespace Tensile
             rv.args.append<uint32_t>("gsu", sizeMapping.globalSplitU);
 
         //@TODO determine if this is needed, may not end up in the same code object file
-        rv.codeObjectFile = codeObjectFilename;
+        rv.codeObjectFile = codeObjectFilename.copy();
 
         return rv;
     }

--- a/Tensile/Source/lib/source/hip/HipSolutionAdapter.cpp
+++ b/Tensile/Source/lib/source/hip/HipSolutionAdapter.cpp
@@ -34,8 +34,6 @@
 #include <Tensile/hip/HipSolutionAdapter.hpp>
 #include <Tensile/hip/HipUtils.hpp>
 
-#include <Tensile/Utils.hpp>
-
 //@TODO add alternative for windows
 #ifndef WIN32
 #include <glob.h>
@@ -92,7 +90,6 @@ namespace Tensile
 
             {
                 std::lock_guard<std::mutex> guard(m_access);
-
                 m_modules.push_back(module);
                 m_loadedModuleNames.push_back(concatenate("File ", path));
 

--- a/Tensile/Source/lib/source/hip/HipSolutionAdapter.cpp
+++ b/Tensile/Source/lib/source/hip/HipSolutionAdapter.cpp
@@ -273,6 +273,7 @@ namespace Tensile
                 m_access.lock();
                 bool loaded = m_loadedCOFiles.find(removeXnack(kernel.codeObjectFile))
                               != m_loadedCOFiles.end();
+                std::string codeObjectDir = m_codeObjectDirectory;
                 m_access.unlock();
 
                 if(!loaded)
@@ -285,7 +286,7 @@ namespace Tensile
                     {
                         std::string modifiedCOName = kernel.codeObjectFile;
                         modifiedCOName.insert(loc, ver);
-                        err = loadCodeObjectFile(m_codeObjectDirectory + modifiedCOName);
+                        err = loadCodeObjectFile(codeObjectDir + modifiedCOName);
 
                         if(err == hipSuccess)
                             break;

--- a/Tensile/Source/lib/source/hip/HipSolutionAdapter.cpp
+++ b/Tensile/Source/lib/source/hip/HipSolutionAdapter.cpp
@@ -35,7 +35,6 @@
 #include <Tensile/hip/HipUtils.hpp>
 
 #include <Tensile/Utils.hpp>
-#include <thread>
 
 //@TODO add alternative for windows
 #ifndef WIN32
@@ -74,8 +73,6 @@ namespace Tensile
 
         std::string removeXnack(std::string coFilename)
         {
-            //Tensile::DeferLogger::addLog("TLLL: remove xnack " + coFilename);
-
             std::string xnackVersion = "xnack"; //Extra character before and after xnack
             size_t      loc          = coFilename.find(xnackVersion);
             if(loc != std::string::npos)
@@ -86,8 +83,6 @@ namespace Tensile
 
         hipError_t SolutionAdapter::loadCodeObjectFile(std::string const& path)
         {
-            //Tensile::DeferLogger::addLog("TLLL: loading code object (enter) " + path);
-
             hipModule_t module;
 
             HIP_CHECK_RETURN(hipModuleLoad(&module, path.c_str()));
@@ -97,8 +92,6 @@ namespace Tensile
 
             {
                 std::lock_guard<std::mutex> guard(m_access);
-
-                //Tensile::DeferLogger::addLog("TLLL: loading code object (load) " + path);
 
                 m_modules.push_back(module);
                 m_loadedModuleNames.push_back(concatenate("File ", path));


### PR DESCRIPTION
Failures were detected when using multiple GPUs and using lazy loading. The source of these errors were narrowed down to a race condition that occurs when accessing/modifying codeObjectFilename in the Solution object when multiple threads are accessing the same solution. I've introduced a new class to wrap that variable and protect all instances where it is being assigned to or read from. The failure hasn't been observed with these changes, so I'm confident it fixes the issue.

It was also found that m_codeObjectDirectory could result in a race condition, I've moved the assignment and reading of that variable into a mutex protected area.