### PR TITLE
hotfix (prototype): using hipModuleLoadData instead of hipModuleLoad

### DIFF
--- a/Tensile/Source/lib/include/Tensile/hip/HipSolutionAdapter.hpp
+++ b/Tensile/Source/lib/include/Tensile/hip/HipSolutionAdapter.hpp
@@ -87,6 +87,7 @@ namespace Tensile
             std::mutex m_access;
 
             std::vector<hipModule_t>                       m_modules;
+            std::vector<std::unique_ptr<char[]>>           m_moduleBuffers;
             std::unordered_map<std::string, hipFunction_t> m_kernels;
             bool                                           m_debug           = false;
             bool                                           m_debugSkipLaunch = false;


### PR DESCRIPTION
Prototype of a fix for SWDEV-348341

### Cause of the crash
`hipModuleLoad` doesn't release file descriptors after loading. Since the new lazy-loading splits rocBLAS kernels into many more code object files than before, there are enough modules that if rocBLAS loads all the gfx90a ones on multiple GPUs the process will reach the limit for open file descriptors.

This behaviour of `hipModuleLoad` is intended and won't be changed (see SWDEV-353036 and SWDEV-304151). Thus, a workaround is up to us.

### Potential solutions
**1) Reduce the number of code object files lazy-loading splits kernels into**
Medium dev effort and only side steps the issue---the issue could still show up again in the future if the number of GPUs increases or file descriptors are needed for other purposes (e.g. other libraries loading modules, application needing files).

**2) Manage modules and unload modules using some heuristics when necessary**
Very high dev effort: not feasible for a quick fix. Might be worth exploring in the future.

**3) Use `hipModuleLoadData`**
This is the solution prototyped in this PR. This API also has an undocumented gotcha where the original memory buffer must outlive the module; the code to meet this requirement is also included in this PR.

### Feedback requested
We've tested this fix and it resolves the issue in SWDEV-348341, so it seems this is functionally sound. If possible, I'd like to know the impact this has on rocBLAS library initialization times (@JeremyAdamHart any help here would be appreciated). I'd also like to know if anyone has ideas for a more elegant way to accomplish what I've roughed out. Finally, I want to know if there are any unforeseen consequences that might result from these changes.