### PR TITLE
Trees match bill features

### DIFF
--- a/Tensile/SolutionLibrary.py
+++ b/Tensile/SolutionLibrary.py
@@ -130,11 +130,11 @@ class MatchingLibrary:
 
 class DecisionTreeLibrary:
     Tag = "DecisionTree"
-    StateKeys = [("type", "tag"), "properties", "trees"]
+    StateKeys = [("type", "tag"), "features", "trees"]
 
     @classmethod
     def FromOriginalState(cls, d, solutions):
-        properties = d["properties"]
+        features = d["features"]
         origTrees = d["trees"]
 
         trees = []
@@ -146,7 +146,7 @@ class DecisionTreeLibrary:
             entry = {"tree": tree["tree"], "value": value}
             trees.append(entry)
 
-        return cls(properties, trees)
+        return cls(features, trees)
 
     @property
     def tag(self):
@@ -160,8 +160,8 @@ class DecisionTreeLibrary:
     def remapSolutionIndices(self, indexMap):
         pass
 
-    def __init__(self, properties, trees):
-        self.properties = properties
+    def __init__(self, features, trees):
+        self.features = features
         self.trees = trees
 
 

--- a/Tensile/Source/lib/CMakeLists.txt
+++ b/Tensile/Source/lib/CMakeLists.txt
@@ -41,6 +41,7 @@ set(tensile_sources  ${tensile_sources}
     source/EmbeddedLibrary.cpp
     source/KernelArguments.cpp
     source/KernelLanguageTypes.cpp
+    source/MLFeatures.cpp
     source/PerformanceMetricTypes.cpp
     source/ScalarValueTypes.cpp
     source/TensorDescriptor.cpp

--- a/Tensile/Source/lib/include/Tensile/ContractionSolution.hpp
+++ b/Tensile/Source/lib/include/Tensile/ContractionSolution.hpp
@@ -281,14 +281,6 @@ namespace Tensile
             bool        fp16AltImpl             = false;
         };
 
-        /* Scale factors used for partially calculating granularities */
-        struct GranularityScaleFactors
-        {
-            float mt0_scale; // 1/mt0
-            float mt1_scale; // 1/mt1
-            float devSolScale; // General (non-problem related) scaling
-        };
-
         struct LinearModel
         {
             double slope     = 1.0;
@@ -332,6 +324,4 @@ namespace Tensile
     std::ostream& operator<<(std::ostream&                                    stream,
                              ContractionSolution::ProjectedPerformance const& spm);
     std::ostream& operator<<(std::ostream& stream, BufferLoadCheckPacket const& st);
-    std::ostream& operator<<(std::ostream&                                       stream,
-                             ContractionSolution::GranularityScaleFactors const& gsf);
 } // namespace Tensile

--- a/Tensile/Source/lib/include/Tensile/MLFeatures.hpp
+++ b/Tensile/Source/lib/include/Tensile/MLFeatures.hpp
@@ -46,23 +46,23 @@ namespace Tensile
         /* Scale factors used for partially calculating granularities */
         struct CUGranularityScaleFactors
         {
-            float mt0_scale; // 1/mt0
-            float mt1_scale; // 1/mt1
-            float cu_scale;
+            float mt0Scale; // 1/mt0
+            float mt1Scale; // 1/mt1
+            float cuScale;
         };
 
         struct WaveGranularityScaleFactors
         {
-            CUGranularityScaleFactors cu_factors;
-            float wave_scale;
+            CUGranularityScaleFactors cuFactors;
+            float                     waveScale;
         };
-        
-        float tilesPerCU(ContractionProblem const& problem, CUGranularityScaleFactors const& cu_factors);
-        std::ostream& operator<<(std::ostream&                    stream,
-                                 CUGranularityScaleFactors const& cugsf);
-        std::ostream& operator<<(std::ostream&                      stream,
-                                 WaveGranularityScaleFactors const& wgsf);
-        
+
+        float tilesPerCU(ContractionProblem const&        problem,
+                         CUGranularityScaleFactors const& cuFactors);
+
+        std::ostream& operator<<(std::ostream& stream, CUGranularityScaleFactors const& cugsf);
+        std::ostream& operator<<(std::ostream& stream, WaveGranularityScaleFactors const& wgsf);
+
         /**
          * @brief A Property whose value is of type `float`.
          */
@@ -226,10 +226,10 @@ namespace Tensile
 
             virtual float operator()(ContractionProblem const& problem) const
             {
-                return ceil(tilesPerCU(problem, value.cu_factors)) * value.wave_scale;
+                return ceil(tilesPerCU(problem, value.cuFactors)) * value.waveScale;
             }
         };
-        
+
         /**
          * @}
          */

--- a/Tensile/Source/lib/include/Tensile/Serialization/ContractionSolution.hpp
+++ b/Tensile/Source/lib/include/Tensile/Serialization/ContractionSolution.hpp
@@ -124,20 +124,6 @@ namespace Tensile
         };
 
         template <typename IO>
-        struct MappingTraits<ContractionSolution::GranularityScaleFactors, IO>
-        {
-            using iot = IOTraits<IO>;
-            static void mapping(IO& io, ContractionSolution::GranularityScaleFactors& gsf)
-            {
-                iot::mapRequired(io, "mt0", gsf.mt0_scale);
-                iot::mapRequired(io, "mt1", gsf.mt1_scale);
-                iot::mapRequired(io, "gsc", gsf.devSolScale);
-            }
-
-            const static bool flow = true;
-        };
-
-        template <typename IO>
         struct MappingTraits<ContractionSolution::LinearModel, IO>
         {
             using iot = IOTraits<IO>;

--- a/Tensile/Source/lib/include/Tensile/Serialization/MLFeatures.hpp
+++ b/Tensile/Source/lib/include/Tensile/Serialization/MLFeatures.hpp
@@ -57,9 +57,9 @@ namespace Tensile
             using iot = IOTraits<IO>;
             static void mapping(IO& io, MLFeatures::WaveGranularityScaleFactors& wgsf)
             {
-                iot::mapRequired(io, "mt0", wgsf.cu_factors.mt0Scale);
-                iot::mapRequired(io, "mt1", wgsf.cu_factors.mt1Scale);
-                iot::mapRequired(io, "cus", wgsf.cu_factors.cuScale);
+                iot::mapRequired(io, "mt0", wgsf.cuFactors.mt0Scale);
+                iot::mapRequired(io, "mt1", wgsf.cuFactors.mt1Scale);
+                iot::mapRequired(io, "cus", wgsf.cuFactors.cuScale);
                 iot::mapRequired(io, "ws", wgsf.waveScale);
             }
 

--- a/Tensile/Source/lib/include/Tensile/Serialization/MLFeatures.hpp
+++ b/Tensile/Source/lib/include/Tensile/Serialization/MLFeatures.hpp
@@ -43,9 +43,9 @@ namespace Tensile
             using iot = IOTraits<IO>;
             static void mapping(IO& io, MLFeatures::CUGranularityScaleFactors& cugsf)
             {
-                iot::mapRequired(io, "mt0", cugsf.mt0_scale);
-                iot::mapRequired(io, "mt1", cugsf.mt1_scale);
-                iot::mapRequired(io, "cus", cugsf.cu_scale);
+                iot::mapRequired(io, "mt0", cugsf.mt0Scale);
+                iot::mapRequired(io, "mt1", cugsf.mt1Scale);
+                iot::mapRequired(io, "cus", cugsf.cuScale);
             }
 
             const static bool flow = true;
@@ -57,15 +57,15 @@ namespace Tensile
             using iot = IOTraits<IO>;
             static void mapping(IO& io, MLFeatures::WaveGranularityScaleFactors& wgsf)
             {
-                iot::mapRequired(io, "mt0", wgsf.cu_factors.mt0_scale);
-                iot::mapRequired(io, "mt1", wgsf.cu_factors.mt1_scale);
-                iot::mapRequired(io, "cus", wgsf.cu_factors.cu_scale);
-                iot::mapRequired(io, "ws",  wgsf.wave_scale);
+                iot::mapRequired(io, "mt0", wgsf.cu_factors.mt0Scale);
+                iot::mapRequired(io, "mt1", wgsf.cu_factors.mt1Scale);
+                iot::mapRequired(io, "cus", wgsf.cu_factors.cuScale);
+                iot::mapRequired(io, "ws", wgsf.waveScale);
             }
 
             const static bool flow = true;
         };
-        
+
         // Set Flow
         template <typename IO>
         struct MappingTraits<std::shared_ptr<MLFeatures::MLFeature<ContractionProblem>>, IO>

--- a/Tensile/Source/lib/include/Tensile/Serialization/MLFeatures.hpp
+++ b/Tensile/Source/lib/include/Tensile/Serialization/MLFeatures.hpp
@@ -37,6 +37,35 @@ namespace Tensile
 {
     namespace Serialization
     {
+        template <typename IO>
+        struct MappingTraits<MLFeatures::CUGranularityScaleFactors, IO>
+        {
+            using iot = IOTraits<IO>;
+            static void mapping(IO& io, MLFeatures::CUGranularityScaleFactors& cugsf)
+            {
+                iot::mapRequired(io, "mt0", cugsf.mt0_scale);
+                iot::mapRequired(io, "mt1", cugsf.mt1_scale);
+                iot::mapRequired(io, "cus", cugsf.cu_scale);
+            }
+
+            const static bool flow = true;
+        };
+
+        template <typename IO>
+        struct MappingTraits<MLFeatures::WaveGranularityScaleFactors, IO>
+        {
+            using iot = IOTraits<IO>;
+            static void mapping(IO& io, MLFeatures::WaveGranularityScaleFactors& wgsf)
+            {
+                iot::mapRequired(io, "mt0", wgsf.cu_factors.mt0_scale);
+                iot::mapRequired(io, "mt1", wgsf.cu_factors.mt1_scale);
+                iot::mapRequired(io, "cus", wgsf.cu_factors.cu_scale);
+                iot::mapRequired(io, "ws",  wgsf.wave_scale);
+            }
+
+            const static bool flow = true;
+        };
+        
         // Set Flow
         template <typename IO>
         struct MappingTraits<std::shared_ptr<MLFeatures::MLFeature<ContractionProblem>>, IO>

--- a/Tensile/Source/lib/source/ContractionSolution.cpp
+++ b/Tensile/Source/lib/source/ContractionSolution.cpp
@@ -1359,11 +1359,4 @@ namespace Tensile
                       << " shiftPtrElemB=" << st.shiftPtrElemB << " depthUorMT0=" << st.depthUorMT0
                       << " depthUorMT1=" << st.depthUorMT1;
     }
-
-    std::ostream& operator<<(std::ostream&                                       stream,
-                             ContractionSolution::GranularityScaleFactors const& gsf)
-    {
-        return stream << " mt0=" << gsf.mt0_scale << " mt1=" << gsf.mt1_scale
-                      << " gsc=" << gsf.devSolScale;
-    }
 } // namespace Tensile

--- a/Tensile/Source/lib/source/MLFeatures.cpp
+++ b/Tensile/Source/lib/source/MLFeatures.cpp
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <Tensile/MLFeatures.hpp>
+
+namespace Tensile
+{
+    namespace MLFeatures
+    {
+        float tilesPerCU(ContractionProblem const& problem, CUGranularityScaleFactors const& cu_factors)
+        {
+            float NumBatches = 1; // TODO: Higher batch sizes
+            float numTilesM  = problem.freeSizeA(0) * cu_factors.mt0_scale; // M / MT0
+            float numTilesN  = problem.freeSizeB(0) * cu_factors.mt1_scale; // N / MT1
+            float totalTiles = NumBatches * ceil(numTilesM) * ceil(numTilesN);
+            return totalTiles * cu_factors.cu_scale;
+        };
+        
+        std::ostream& operator<<(std::ostream&                  stream,
+                                 CUGranularityScaleFactors const& cugsf)
+        {
+            return stream << " mt0=" << cugsf.mt0_scale << " mt1=" << cugsf.mt1_scale
+                        << " cus=" << cugsf.cu_scale;
+        };
+
+        std::ostream& operator<<(std::ostream&                      stream,
+                                 WaveGranularityScaleFactors const& wgsf)
+        {
+            return stream << wgsf.cu_factors << " ws=" << wgsf.wave_scale;
+        };
+    } // namespace Tensile
+}

--- a/Tensile/Source/lib/source/MLFeatures.cpp
+++ b/Tensile/Source/lib/source/MLFeatures.cpp
@@ -30,26 +30,25 @@ namespace Tensile
 {
     namespace MLFeatures
     {
-        float tilesPerCU(ContractionProblem const& problem, CUGranularityScaleFactors const& cu_factors)
+        float tilesPerCU(ContractionProblem const&        problem,
+                         CUGranularityScaleFactors const& cuFactors)
         {
-            float NumBatches = 1; // TODO: Higher batch sizes
-            float numTilesM  = problem.freeSizeA(0) * cu_factors.mt0_scale; // M / MT0
-            float numTilesN  = problem.freeSizeB(0) * cu_factors.mt1_scale; // N / MT1
-            float totalTiles = NumBatches * ceil(numTilesM) * ceil(numTilesN);
-            return totalTiles * cu_factors.cu_scale;
-        };
-        
-        std::ostream& operator<<(std::ostream&                  stream,
-                                 CUGranularityScaleFactors const& cugsf)
-        {
-            return stream << " mt0=" << cugsf.mt0_scale << " mt1=" << cugsf.mt1_scale
-                        << " cus=" << cugsf.cu_scale;
+            float numBatches = 1; // TODO: Higher batch sizes
+            float numTilesM  = problem.freeSizeA(0) * cuFactors.mt0Scale; // M / MT0
+            float numTilesN  = problem.freeSizeB(0) * cuFactors.mt1Scale; // N / MT1
+            float totalTiles = numBatches * ceil(numTilesM) * ceil(numTilesN);
+            return totalTiles * cuFactors.cuScale;
         };
 
-        std::ostream& operator<<(std::ostream&                      stream,
-                                 WaveGranularityScaleFactors const& wgsf)
+        std::ostream& operator<<(std::ostream& stream, CUGranularityScaleFactors const& cugsf)
         {
-            return stream << wgsf.cu_factors << " ws=" << wgsf.wave_scale;
+            return stream << " mt0=" << cugsf.mt0Scale << " mt1=" << cugsf.mt1Scale
+                          << " cus=" << cugsf.cuScale;
+        };
+
+        std::ostream& operator<<(std::ostream& stream, WaveGranularityScaleFactors const& wgsf)
+        {
+            return stream << wgsf.cuFactors << " ws=" << wgsf.waveScale;
         };
     } // namespace Tensile
 }

--- a/Tensile/Tests/unit/test_LibraryIO.py
+++ b/Tensile/Tests/unit/test_LibraryIO.py
@@ -106,7 +106,7 @@ Library:
 treeLibrary = r"""
 LibraryType: DecisionTree
 Library:
-- properties:
+- features:
   - {index: 0, type: FreeSizeA}
   - {index: 0, type: BoundSize}
   trees:
@@ -120,7 +120,7 @@ Library:
   - {type: SizeInRange, index: 0, value: {min: 6000, max: 8000}}
   - {type: SizeInRange, index: 1, value: {min: 6000, max: 7000}}
 
-- properties:
+- features:
   - {index: 0, type: FreeSizeB}
   trees:
   - tree:


### PR DESCRIPTION
The features used be Bill are slightly different to the ones used in ContractionSolution::computeGranularities. This PR updates the dtree features to match Bill's.