### PR TITLE
Fix CI issue on gfx1030 temporarily

### DIFF
--- a/Tensile/KernelWriterSource.py
+++ b/Tensile/KernelWriterSource.py
@@ -3317,11 +3317,13 @@ class KernelWriterSource(KernelWriter):
   # SyncThreads
   ##############################################################################
   def syncThreads(self, kernel, comment=""):
-    if kernel["NumThreads"] > kernel["WavefrontSize"]:
-        return self.indent + self.syncStr + " //" + comment + self.endLine
-    else:
-        return self.indent + "// Skip barrier: NumThreads=%s"%(kernel["NumThreads"]) + \
-               self.endLine
+    return self.indent + self.syncStr + " //" + comment + self.endLine
+# TODO: can be uncommented once source kernels support WavefrontSize=32
+#    if kernel["NumThreads"] > kernel["WavefrontSize"]:
+#        return self.indent + self.syncStr + " //" + comment + self.endLine
+#    else:
+#        return self.indent + "// Skip barrier: NumThreads=%s"%(kernel["NumThreads"]) + \
+#               self.endLine
 
   ##############################################################################
   # MapAcctoArch


### PR DESCRIPTION
Comment out the conditional statement in function syncThreads. The WavefrontSize is 32 on gfx1030.

In SolutionStructs.py, the following statement cause CI issue on gfx1030 because the
WavefrontSize is 32 on gfx1030.

if state["WavefrontSize"] == 32 and state["KernelLanguage"] == "Source":
   reject(state, "WavefrontSize=32 not yet supported for source kernels.")