### PR TITLE
Update python versions for CI builds

### DIFF
--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -30,7 +30,7 @@ def runCompileCommand(platform, project, jobName, boolean debug=false)
     project.paths.construct_build_prefix()
 
     String compiler = 'hipcc'
-    String pythonVersion = 'py36'
+    String pythonVersion = 'py3'
     String cov = "V3"
     // Do release build of HostLibraryTests on CI until it is upgraded to rocm 5.3 to
     // avoid bug causing long build times of certain files.
@@ -112,7 +112,7 @@ def runTestCommand (platform, project, jobName, test_marks, boolean skipHostTest
     def test_dir =  "Tensile/Tests"
 
     String compiler = 'hipcc'
-    String pythonVersion = 'py36'
+    String pythonVersion = 'py3'
     String markSkipHostTest = skipHostTest ? "#" : ""
     String markSkipExtendedTest = !test_marks.contains("extended") ? "--gtest_filter=-\"*Extended*\"" : ""
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py35,py36,py27}{,-win},lint
+envlist = {py35,py36,py38,py27}{,-win},lint
 
 
 [testenv]
@@ -17,7 +17,7 @@ commands =
     py.test -v --basetemp={envtmpdir} --junit-xml={toxinidir}/python_tests.xml --junit-prefix={envname} --color=yes -n 4 --prebuilt-client={envdir}/client/0_Build/client/tensile_client {posargs}
 
 
-[testenv:{py35,py36,py27}-win]
+[testenv:{py35,py36,py38,py27}-win]
 platform = win32
 passenv = *
 deps =


### PR DESCRIPTION
Ubuntu 20.04 installs python 3.8 by default