### PR TITLE
Update Ubuntu version for static analysis job

### DIFF
--- a/.jenkins/staticanalysis.groovy
+++ b/.jenkins/staticanalysis.groovy
@@ -120,6 +120,6 @@ ci: {
 
     properties(auxiliary.addCommonProperties([pipelineTriggers([cron('0 6 * * 6')])]))
     stage(urlJobName) {
-        runCI([ubuntu18:['any']], urlJobName)
+        runCI([ubuntu20:['any']], urlJobName)
     }
 }


### PR DESCRIPTION
As of ROCm 5.3, Ubuntu 18 is no longer supported. Updating the Static Analysis job to Ubuntu 20 for CI compatibility.