### PR TITLE
Clean up LLVM dependency code

### DIFF
--- a/HostLibraryTests/CMakeLists.txt
+++ b/HostLibraryTests/CMakeLists.txt
@@ -139,13 +139,7 @@ set(test_sources ${test_sources}
 )
 
 if(TENSILE_USE_LLVM)
-    find_package(LLVM 13.0 QUIET CONFIG)
-    if(NOT LLVM_FOUND)
-        find_package(LLVM 12.0 QUIET CONFIG)
-        if(NOT LLVM_FOUND)
-            find_package(LLVM REQUIRED CONFIG)
-        endif()
-    endif()
+    find_package(LLVM REQUIRED CONFIG)
 
     set(test_sources ${test_sources}
         ContractionLibraryLoading_test.cpp

--- a/Tensile/Source/lib/CMakeLists.txt
+++ b/Tensile/Source/lib/CMakeLists.txt
@@ -51,13 +51,7 @@ set(tensile_sources  ${tensile_sources}
     )
 
 if(TENSILE_USE_LLVM)
-    find_package(LLVM 13.0 QUIET CONFIG)
-    if(NOT LLVM_FOUND)
-        find_package(LLVM 12.0 QUIET CONFIG)
-        if(NOT LLVM_FOUND)
-            find_package(LLVM REQUIRED CONFIG)
-        endif()
-    endif()
+    find_package(LLVM REQUIRED CONFIG)
 
     set(tensile_sources ${tensile_sources}
         source/llvm/YAML.cpp

--- a/pytest.ini
+++ b/pytest.ini
@@ -53,6 +53,7 @@ markers =
  convolution
  convolution-vs-contraction
  direct_to_lds
+ direct_to_vgpr
  dot2
  double_complex
  fast


### PR DESCRIPTION
Remove searches for specific versions of llvm. Tensile can be built using LLVM bundled with ROCm as long as other dependencies are met. I'll update the wiki with new instructions. Separate LLVM installations still work, and cmake seems to prefer finding stand-alone LLVM libs, with the ROCm one being a fallback.

Also added a tag to fix some pytest warnings.