### PR TITLE
Small fixes for ThreadSeparateGlobalRead and DirectToLds

### DIFF
--- a/Tensile/Tests/extended/direct_to_lds/dtl_tsgr_hgemm.yaml
+++ b/Tensile/Tests/extended/direct_to_lds/dtl_tsgr_hgemm.yaml
@@ -46,7 +46,7 @@ BenchmarkProblems:
         - WorkGroup:
           - [ 16, 16, 1 ]
         - SourceSwap: [True]
-        - PrefetchGlobalRead: [1]
+        - PrefetchGlobalRead: [1, 2]
         #- AssertFree0ElementMultiple: [2]
         # - AssertFree1ElementMultiple: [2]
         - WorkGroupMapping: [8]
@@ -98,7 +98,7 @@ BenchmarkProblems:
         - WorkGroup:
           - [ 16, 16, 1 ]
         - SourceSwap: [True]
-        - PrefetchGlobalRead: [1]
+        - PrefetchGlobalRead: [1, 2]
         #- AssertFree0ElementMultiple: [2]
         # - AssertFree1ElementMultiple: [2]
         - WorkGroupMapping: [8]

--- a/Tensile/Tests/extended/direct_to_lds/dtl_tsgr_sgemm.yaml
+++ b/Tensile/Tests/extended/direct_to_lds/dtl_tsgr_sgemm.yaml
@@ -49,7 +49,7 @@ BenchmarkProblems:
         - WorkGroup:
           - [ 16, 16, 1 ]
         - SourceSwap: [True]
-        - PrefetchGlobalRead: [1] # [1, 2]
+        - PrefetchGlobalRead: [1, 2]
         #- AssertFree0ElementMultiple: [2]
         # - AssertFree1ElementMultiple: [2]
         - WorkGroupMapping: [8]
@@ -111,7 +111,7 @@ BenchmarkProblems:
         - WorkGroup:
           - [ 16, 16, 1 ]
         - SourceSwap: [True]
-        - PrefetchGlobalRead: [1] # [1, 2]
+        - PrefetchGlobalRead: [1, 2]
         #- AssertFree0ElementMultiple: [2]
         # - AssertFree1ElementMultiple: [2]
         - WorkGroupMapping: [8]
@@ -173,7 +173,7 @@ BenchmarkProblems:
         - WorkGroup:
           - [ 16, 16, 1 ]
         - SourceSwap: [True]
-        - PrefetchGlobalRead: [1] #[1,2]
+        - PrefetchGlobalRead: [1,2]
         #- AssertFree0ElementMultiple: [2]
         # - AssertFree1ElementMultiple: [2]
         - WorkGroupMapping: [8]
@@ -229,7 +229,7 @@ BenchmarkProblems:
         - WorkGroup:
           - [ 16, 16, 1 ]
         - SourceSwap: [True]
-        - PrefetchGlobalRead: [1] # [1, 2]
+        - PrefetchGlobalRead: [1, 2]
         #- AssertFree0ElementMultiple: [2]
         # - AssertFree1ElementMultiple: [2]
         - WorkGroupMapping: [8]
@@ -303,7 +303,7 @@ BenchmarkProblems:
         - WorkGroup:
           - [ 16, 16, 1 ]
         - SourceSwap: [True]
-        - PrefetchGlobalRead: [1] # [1, 2]
+        - PrefetchGlobalRead: [1, 2]
         #- AssertFree0ElementMultiple: [2]
         # - AssertFree1ElementMultiple: [2]
         - WorkGroupMapping: [8]
@@ -366,7 +366,7 @@ BenchmarkProblems:
         - WorkGroup:
           - [ 16, 16, 1 ]
         - SourceSwap: [True]
-        - PrefetchGlobalRead: [1] # [1, 2]
+        - PrefetchGlobalRead: [1, 2]
         #- AssertFree0ElementMultiple: [2]
         # - AssertFree1ElementMultiple: [2]
         - WorkGroupMapping: [8]
@@ -429,7 +429,7 @@ BenchmarkProblems:
         - WorkGroup:
           - [ 16, 16, 1 ]
         - SourceSwap: [True]
-        - PrefetchGlobalRead: [1] #[1,2]
+        - PrefetchGlobalRead: [1,2]
         #- AssertFree0ElementMultiple: [2]
         # - AssertFree1ElementMultiple: [2]
         - WorkGroupMapping: [8]
@@ -486,7 +486,7 @@ BenchmarkProblems:
         - WorkGroup:
           - [ 16, 16, 1 ]
         - SourceSwap: [True]
-        - PrefetchGlobalRead: [1] # [1, 2]
+        - PrefetchGlobalRead: [1, 2]
         #- AssertFree0ElementMultiple: [2]
         # - AssertFree1ElementMultiple: [2]
         - WorkGroupMapping: [8]
@@ -561,7 +561,7 @@ BenchmarkProblems:
         - WorkGroup:
           - [ 16, 16, 1 ]
         - SourceSwap: [True]
-        - PrefetchGlobalRead: [1] # [1, 2]
+        - PrefetchGlobalRead: [1, 2]
         #- AssertFree0ElementMultiple: [2]
         # - AssertFree1ElementMultiple: [2]
         - WorkGroupMapping: [8]
@@ -624,7 +624,7 @@ BenchmarkProblems:
         - WorkGroup:
           - [ 16, 16, 1 ]
         - SourceSwap: [True]
-        - PrefetchGlobalRead: [1] # [1, 2]
+        - PrefetchGlobalRead: [1, 2]
         #- AssertFree0ElementMultiple: [2]
         # - AssertFree1ElementMultiple: [2]
         - WorkGroupMapping: [8]
@@ -687,7 +687,7 @@ BenchmarkProblems:
         - WorkGroup:
           - [ 16, 16, 1 ]
         - SourceSwap: [True]
-        - PrefetchGlobalRead: [1] #[1,2]
+        - PrefetchGlobalRead: [1,2]
         #- AssertFree0ElementMultiple: [2]
         # - AssertFree1ElementMultiple: [2]
         - WorkGroupMapping: [8]
@@ -744,7 +744,7 @@ BenchmarkProblems:
         - WorkGroup:
           - [ 16, 16, 1 ]
         - SourceSwap: [True]
-        - PrefetchGlobalRead: [1] # [1, 2]
+        - PrefetchGlobalRead: [1, 2]
         #- AssertFree0ElementMultiple: [2]
         # - AssertFree1ElementMultiple: [2]
         - WorkGroupMapping: [8]


### PR DESCRIPTION
* Fixed DirectToLds + PrefetchGlobalRead=2 mismatch and removed the reject condition (HGEMM, SGEMM only)
* Modified reject condition for minimum lanes of ThreadSeparateGlobalRead from 2 to 1 (SGEMM or larger data type only)
* Removed unnecessary reject conditions
* Updated ThreadSeparateGlobalRead test cases for PrefetchGlobalRead=2