### PR TITLE
Fixed issues with large array sizes

### DIFF
--- a/Tensile/Components/ComputeStoreVgprs.py
+++ b/Tensile/Components/ComputeStoreVgprs.py
@@ -144,8 +144,8 @@ class ComputeStoreVgprsMFMA(ComputeStoreVgprs):
 
         # writer.coord0
         # writer.coord1
-        # writer.cinRowPtr  : C buffer coulmn offset
-        # writer.coutRowPtr : D buffer coulmn offset
+        # writer.cinRowPtr  : C buffer column offset
+        # writer.coutRowPtr : D buffer column offset
 
         # alloc resources
         tid0 = writer.vgprPool.checkOut(1)
@@ -179,12 +179,13 @@ class ComputeStoreVgprsMFMA(ComputeStoreVgprs):
         kStr += vectorStaticRemainder(dummy, tmpVgpr0, "Serial", matrixInstN, tmpVgpr1, tmpSgpr)
         kStr += inst("_v_add_u32", vgpr(tid1), vgpr(tmpVgpr0), vgpr(tid1), "coordination 1 = wave_id1 + tid1")
 
-        # coord 1 : offset part
-        packedC1 = kernel["PackedC1IndicesX"]
-        strideC1 = "StrideC%s" % (writer.indexChars[packedC1[0]])
-        strideD1 = "StrideD%s" % (writer.indexChars[packedC1[0]])
-        kStr += inst("v_mul_lo_u32", vgpr(writer.cinRowPtr), vgpr(tid1), sgpr(strideC1), " offset 1")
-        kStr += inst("v_mul_lo_u32", vgpr(writer.coutRowPtr), vgpr(tid1), sgpr(strideD1), " offset 1")
+        if kernel["BufferStore"]:
+          # coord 1 : offset part
+          packedC1 = kernel["PackedC1IndicesX"]
+          strideC1 = "StrideC%s" % (writer.indexChars[packedC1[0]])
+          strideD1 = "StrideD%s" % (writer.indexChars[packedC1[0]])
+          kStr += inst("v_mul_lo_u32", vgpr(writer.cinRowPtr), vgpr(tid1), sgpr(strideC1), " offset 1")
+          kStr += inst("v_mul_lo_u32", vgpr(writer.coutRowPtr), vgpr(tid1), sgpr(strideD1), " offset 1")
 
         # coord 0 : wave part
         kStr += vectorStaticRemainder(dummy, tmpVgpr0, wave_id, kernel["MIWaveGroup"][0], tmpVgpr1, tmpSgpr)
@@ -248,8 +249,8 @@ class ComputeStoreVgprsMFMASwap(ComputeStoreVgprs):
 
         # writer.coord0
         # writer.coord1
-        # writer.cinRowPtr  : C buffer coulmn offset
-        # writer.coutRowPtr : D buffer coulmn offset
+        # writer.cinRowPtr  : C buffer column offset
+        # writer.coutRowPtr : D buffer column offset
 
         # alloc resources
         tid0 = writer.vgprPool.checkOut(1)
@@ -288,12 +289,13 @@ class ComputeStoreVgprsMFMASwap(ComputeStoreVgprs):
         if (writer.allowLRVWBforTLUandMI or kernel["DirectToVgprB"]) and writer.lrvwB > 1:
           kStr += staticMultiply(vgpr(tid1), vgpr(tid1), writer.lrvwB, sgpr(tmpSgpr), "coordination 1 *= lrvwB")
 
-        # coord 1 : offset part
-        packedC1 = kernel["PackedC1IndicesX"]
-        strideC1 = "StrideC%s" % (writer.indexChars[packedC1[0]])
-        strideD1 = "StrideD%s" % (writer.indexChars[packedC1[0]])
-        kStr += inst("v_mul_lo_u32", vgpr(writer.cinRowPtr), vgpr(tid1), sgpr(strideC1), " offset 1")
-        kStr += inst("v_mul_lo_u32", vgpr(writer.coutRowPtr), vgpr(tid1), sgpr(strideD1), " offset 1")
+        if kernel["BufferStore"]:
+          # coord 1 : offset part
+          packedC1 = kernel["PackedC1IndicesX"]
+          strideC1 = "StrideC%s" % (writer.indexChars[packedC1[0]])
+          strideD1 = "StrideD%s" % (writer.indexChars[packedC1[0]])
+          kStr += inst("v_mul_lo_u32", vgpr(writer.cinRowPtr), vgpr(tid1), sgpr(strideC1), " offset 1")
+          kStr += inst("v_mul_lo_u32", vgpr(writer.coutRowPtr), vgpr(tid1), sgpr(strideD1), " offset 1")
 
         # coord 0 : wave part
         kStr += vectorStaticRemainder(dummy, tid0, wave_id, kernel["MIWaveGroup"][0], tmpVgpr1, tmpSgpr)

--- a/Tensile/Contractions.py
+++ b/Tensile/Contractions.py
@@ -375,7 +375,7 @@ class ProblemPredicate(Properties.Predicate):
 
         # if bufferload is performed, we output some predication info for host side,
         # to prevent from some extremely large problems from launching and causing bufferload offset limit < 2^32
-        # thoses cases will not satisfy the assertion thus won't use the kernel.
+        # those cases will not satisfy the assertion thus won't use the kernel.
         # See Common.py for more details, we will need four values:
         # TODO - haven't been fully tested for FP16 and BF, need to verify the false-positive
         if 'BufferLoad' in state and state['BufferLoad'] == True:
@@ -388,18 +388,18 @@ class ProblemPredicate(Properties.Predicate):
             subrv['ShiftPtrElemA'] = state['GlobalLoadVectorWidthA'] if MayShiftA else 0
             subrv['DUorMT1'] = state['DepthU'] if TLUB else state['MacroTile1']
             subrv['DUorMT0'] = state['DepthU'] if TLUA else state['MacroTile0']
-            # value is also a dict for better readibility, client side need to handel the serialization
+            # value is also a dict for better readability, client side need to handel the serialization
             rv += [cls('BufferLoadOffsetLimitCheck', value=subrv)]
 
-        # When doing globol write, may need to load matrix C if beta !=0
-        if 'BufferLoad' in state and state['BufferLoad'] == True:
-            rv += [cls('BufferLoadOffsetLimitCheck_Beta', value=state['MacroTile1'])]
-
-        # similiar check is applied for bufferstore,
+        # similar check is applied for bufferstore,
         # for bufferstore offset, test if the bot-right offset < 2^32,
         # it should be StrideA*MT1, so we need to output MT1 and use the StrideA of problem in host-side for predication
         if 'BufferStore' in state and state['BufferStore'] == True:
-            rv += [cls('BufferStoreOffsetLimitCheck', value=state['MacroTile1'])]
+            val = state['MacroTile1']
+            if (1 in state["AssertSizeLessThan"].keys()):
+                # use smaller value if array size assert is enabled
+                val = min(val, state["AssertSizeLessThan"][1] - 1)
+            rv += [cls('BufferStoreOffsetLimitCheck', value=val)]
 
         if '_GlobalAccumulation' in state and state['_GlobalAccumulation'] != None:
             value = globalParameters['MinKForGSU'] * state['GlobalSplitU']

--- a/Tensile/KernelWriter.py
+++ b/Tensile/KernelWriter.py
@@ -1544,7 +1544,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
         iterCode.addComment0("dataAtIterB=%u numReadsIterB=%u skipReadsIterB=%u readsPerIterB=%u" % (dataAtIterB, numReadsIterB, skipReadsIterB, self.numReadsPerIterB))
         if kernel["ScheduleIterAlg"] == 0 or kernel["ScheduleIterAlg"] == 1:
           # adjust the initial value of loop counter for DirectToVgpr
-          adj = 1 if (kernel["DirectToVpgrA"] or kernel["DirectToVpgrB"]) else 0
+          adj = 1 if (kernel["DirectToVgprA"] or kernel["DirectToVgprB"]) else 0
           for i in range (max(dataAtIterA,dataAtIterB)+adj,iteration+1):
             localWrites += self.perIterLocalWriteCode[i].countType(Code.LocalWriteInst)
         # ScheduleIterAlg=2, localwrite is after waitCnt, no need to count it's current iteration.

--- a/Tensile/KernelWriter.py
+++ b/Tensile/KernelWriter.py
@@ -2788,7 +2788,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
       kl.append(self.comment3("Unrolled Loop - End"))
 
     oddLabel = lc == 0
-    kl.append(self.closeLoop(kernel, self.unrollIdx, finalLoop, oddLabel=oddLabel))
+    kl.append(self.closeLoop(kernel, self.unrollIdx, finalLoop, loopCopies, oddLabel=oddLabel))
 
   ##############################################################################
   # Kernel Body
@@ -3267,9 +3267,9 @@ class KernelWriter(metaclass=abc.ABCMeta):
                 kl.append(self.macIter(kernel, 0, tailLoopInnerUnroll, True, True))
 
             finalLoop = mValue == mEnd - 1
-            kl.append(self.closeLoop(kernel, -1, finalLoop, uDu if kernel.enabledSplitLDS else None))
+            kl.append(self.closeLoop(kernel, -1, finalLoop, loopCopies, uDu if kernel.enabledSplitLDS else None))
       # always emit the skip-tail-loop label
-      kl.append(self.closeLoop(kernel, -1, None, emitEndLabelOnly=True))
+      kl.append(self.closeLoop(kernel, -1, None, loopCopies, emitEndLabelOnly=True))
       # tail: close
       self.inTailLoop = False
 
@@ -3277,7 +3277,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
     for i in reversed(range(self.otherSummationLoops)):
       kl.append(self.comment("global read inc AB"))
       kl.append(self.globalReadIncrementAB(kernel, i, 0))
-      kl.append(self.closeLoop(kernel, i, True))
+      kl.append(self.closeLoop(kernel, i, True, loopCopies))
 
     if self.prefetchAcrossPersistent and kernel["PrefetchAcrossPersistentMode"] != 1:
       kl.append(str(self.openPrefetchAcrossPersistent(kernel, isOptNLL=False)))
@@ -4358,7 +4358,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
   # Close Loop
   ##############################################################################
   @abc.abstractmethod
-  def closeLoop(self, kernel, loopIdx, finalLoop, uDu, emitEndLabelOnly, oddLabel=False):
+  def closeLoop(self, kernel, loopIdx, finalLoop, loopCopies, uDu, emitEndLabelOnly, oddLabel=False):
     return ""
 
   ##############################################################################

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -5889,7 +5889,7 @@ class KernelWriterAssembly(KernelWriter):
   # uDu: 'None' means not generating branching label which decides which part of G2L
   #      buffer to write to LDS
   ##############################################################################
-  def closeLoop(self, kernel, loopIdx, finalLoop, uDu=None, emitEndLabelOnly=False, oddLabel=False):
+  def closeLoop(self, kernel, loopIdx, finalLoop, loopCopies, uDu=None, emitEndLabelOnly=False, oddLabel=False):
     kStr = ""
     if emitEndLabelOnly:
       loopIdx = self.unrollIdx
@@ -5994,9 +5994,9 @@ class KernelWriterAssembly(KernelWriter):
           #  In endCounter % 2 == 0 case, exit at lc % 2 == 1 (= not oddLabel). It means no exit if oddLabel
           # No exit case, no code is necessary except for final Loop
 
-          # decrement by 2 if PGR=2 and StaggerU == 0 and not one loop case, else 1
+          # decrement by loopCopies if PGR=2 and StaggerU == 0, else 1
           oneLoop = loopIdx==0 and finalLoop
-          decValue = 2 if kernel["PrefetchGlobalRead"]==2 and kernel["StaggerU"] == 0 and not oneLoop else 1
+          decValue = loopCopies if kernel["PrefetchGlobalRead"]==2 and kernel["StaggerU"] == 0 else 1
           decCode = inst("s_sub_u32", \
               loopCounter, loopCounter, \
               decValue, \

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -1877,6 +1877,11 @@ class KernelWriterAssembly(KernelWriter):
     else:
       numB = kernel["InnerUnroll"]*(kernel["ThreadTile1"] // kernel["VectorWidth"]) // tPB["localReadInstruction"].numOffsets
       numA = kernel["InnerUnroll"]*(kernel["ThreadTile0"] // kernel["VectorWidth"]) // tPA["localReadInstruction"].numOffsets
+    # set numA/B=0 if DirectToVgprA/B is true
+    if kernel["DirectToVgprA"]:
+      numA = 0
+    if kernel["DirectToVgprB"]:
+      numB = 0
     self.numReadsPerIterA = numA
     self.numReadsPerIterB = numB
     self.localReadDoCntA   = 0
@@ -2542,7 +2547,9 @@ class KernelWriterAssembly(KernelWriter):
       #TODO-64 : This is max 32-bit negative value, the tail loop
       # does incrementally step through the GRO and increment GRO
       # which are initialized with this value
-      kStr += self.macroRegister("BufferOOB", "0x80000000")
+      #strOOB = "0xfffff000" if self.noTailLoop else "0x80000000" # use 32bit max (minus offset 12bit) in noTailLoop case
+      strOOB = "0xfffff000" # use 32bit max (minus offset 12bit)
+      kStr += self.macroRegister("BufferOOB", strOOB)
 
       srdUpperValue = Code.SrdUpperValue(self.version)
       kStr += self.comment3("Bits 127:96 of SRD.\n" + srdUpperValue.desc())
@@ -7238,34 +7245,24 @@ class KernelWriterAssembly(KernelWriter):
     # Calculate Max Addr
     ########################################
 
-    tmpSgpr = self.getTmpSgpr(2).idx()
-    maxAddrSgpr = tmpSgpr
-
     if not kernel["BufferLoad"]:
-      kStr += self.comment1("flat addressing - max read address = size[n] * stride[n-1]")
-      dim = len(tP["ia"])-1 # dim
-      sizeIdx = tP["ia"][dim]
-      sizeIdxIsSum = sizeIdx in kernel["ProblemType"]["IndicesSummation"]
-      if sizeIdxIsSum:
-        sizeIdx -= kernel["ProblemType"]["NumIndicesC"]
-      # TODO-multiply by largest stride
-      kStr += self.s_mul_u64_u32(sgpr(maxAddrSgpr+0), sgpr(maxAddrSgpr+1),  \
-                  sgpr("Sizes%s+%u"%("Sum" if sizeIdxIsSum else "Free", sizeIdx)),  \
-                  sgpr("Stride%s%s"%(tc, self.indexChars[tP['ia'][-1]])), \
-                  "64b tensor%s size in elements"%tc)
+      tmpSgpr = self.getTmpSgpr(2).idx()
+      maxAddrSgpr = tmpSgpr
+
+      kStr += self.comment1("flat addressing - max read address = Tensor2dSize%s"%tc)
       kStr += inst("s_lshl_b64", \
         sgpr(maxAddrSgpr,2), \
-        sgpr(maxAddrSgpr,2), \
+        sgpr("Tensor2dSize%s"%tc,2), \
         hex(log2(tP["bpe"])), "<- tensor%s size in bytes"%tc)
 
       kStr += inst("s_add_u32", \
           sgpr(maxAddrSgpr+0), \
-          sgpr(self.sgprs["AddressA"] if tP["isA"] else self.sgprs["AddressB"]), \
+          sgpr(self.sgprs["Address%s"%tc]), \
           sgpr(maxAddrSgpr+0), \
           "prepend address lower")
       kStr += inst("s_addc_u32", \
           sgpr(maxAddrSgpr+1), \
-          sgpr((self.sgprs["AddressA"] if tP["isA"] else self.sgprs["AddressB"])+1), \
+          sgpr(self.sgprs["Address%s"%tc] +1), \
           sgpr(maxAddrSgpr+1), \
           "prepend address upper")
       # sgpr->vgpr
@@ -7400,7 +7397,7 @@ class KernelWriterAssembly(KernelWriter):
 
                 if problemType["ZeroPad%s"%tc] and not (kernel["DirectToLds%s"%tc] and kernel["UseInstOffsetForGRO"]):
                   codeMod = Code.Module("guardZeroPad%u"%loopCnt)
-                  offsetVgpr = self.guardZeroPad(kernel, tP, codeMod, offsetVgpr, soffset, tmpSgpr, addrV, perp, sPerp, para, sPara)
+                  offsetVgpr = self.guardZeroPad(kernel, tP, codeMod, offsetVgpr, soffset, addrV, perp, sPerp, para, sPara)
                   kStr += str(codeMod)
 
                 unrollMirrorWithSoffset = kernel["ProblemType"]["IndicesSummation"][self.unrollIdx] in problemType["MirrorDims%s"%tc] and soffset != "0"
@@ -7519,7 +7516,7 @@ class KernelWriterAssembly(KernelWriter):
               else: # Not buffer load, ie 'flat' load
                 # mask if current address if in bounds
                 kStr += inst("_v_cmpx_lt_u64", self.vcc, \
-                    vgpr("GlobalReadAddr%s+%u"%(tP["tensorChar"], graIdx),2), \
+                    vgpr("GlobalReadAddr%s+%u"%(tc, graIdx),2), \
                     vgpr(maxAddrVgpr,2), \
                     "addr < maxAddr")
                 hi16=(kernel["ProblemType"]["DataType"].isHalf() or kernel["ProblemType"]["DataType"].isBFloat16()) and r%2==1
@@ -7540,14 +7537,14 @@ class KernelWriterAssembly(KernelWriter):
 
                 # increment address by 1 element (BPE)
                 kStr += inst("_v_add_co_u32", \
-                    vgpr("GlobalReadAddr%s+%u+0"%(tP["tensorChar"], graIdx)), \
+                    vgpr("GlobalReadAddr%s+%u+0"%(tc, graIdx)), \
                     self.vcc, \
-                    vgpr("GlobalReadAddr%s+%u+0"%(tP["tensorChar"], graIdx)),  \
+                    vgpr("GlobalReadAddr%s+%u+0"%(tc, graIdx)),  \
                     vgpr(bpeVgpr), "gra += 1 (lower)")
                 kStr += inst("_v_addc_co_u32", \
-                    vgpr("GlobalReadAddr%s+%u+1"%(tP["tensorChar"], graIdx)), \
+                    vgpr("GlobalReadAddr%s+%u+1"%(tc, graIdx)), \
                     self.vcc, \
-                    vgpr("GlobalReadAddr%s+%u+1"%(tP["tensorChar"], graIdx)), \
+                    vgpr("GlobalReadAddr%s+%u+1"%(tc, graIdx)), \
                     vgpr(zeroVgpr), \
                     self.vcc, \
                     "gra += 1 (upper)")
@@ -7632,7 +7629,8 @@ class KernelWriterAssembly(KernelWriter):
   # Outputs:
   #  - addrV is temp vgpr, returns the guarded address (OOB lanes return -1)
   ##############################################################################
-  def guardZeroPad(self, kernel, tP, codeMod, offsetVgpr, soffset, tmpSgpr, addrV, perp, sPerp, para, sPara):
+  def guardZeroPad(self, kernel, tP, codeMod, offsetVgpr, soffset, addrV, perp, sPerp, para, sPara):
+    tmpSgpr = self.getTmpSgpr(2).idx()
     tc = tP["tensorChar"]
     zps = [zpr for zpr in self.zeroPadRegs[tc].values() if zpr.isMatch(perp, sPerp, para, sPara)]
     for i, zpr in enumerate(zps):
@@ -7750,7 +7748,7 @@ class KernelWriterAssembly(KernelWriter):
               0,
               "Set limit to 0 for last iteration")
 
-    tmpSgpr = self.getTmpSgpr(2).idx()
+    #tmpSgpr = self.getTmpSgpr(2).idx()
     # TODO - clean up here:
     # +0,+1 - general purpose tmp. i + 2 is the offset for zero-pad index X
     #tmpSgpr = self.getTmpSgpr(2+len(problemType["ZeroPad%s"%tc])).idx()
@@ -7840,7 +7838,7 @@ class KernelWriterAssembly(KernelWriter):
 
               if problemType["ZeroPad%s"%tc] and not (kernel["DirectToLds%s"%tc] and kernel["UseInstOffsetForGRO"]):
                 codeMod = Code.Module("guardZeroPad%u"%loopCnt)
-                offsetVgpr = self.guardZeroPad(kernel, tP, codeMod, offsetVgpr, soffset, tmpSgpr, addrV, perp, sPerp, para, sPara)
+                offsetVgpr = self.guardZeroPad(kernel, tP, codeMod, offsetVgpr, soffset, addrV, perp, sPerp, para, sPara)
                 loadModule.addCode(codeMod)
 
               unrollMirrorWithSoffset = kernel["ProblemType"]["IndicesSummation"][self.unrollIdx] in problemType["MirrorDims%s"%tc] and soffset != "0"
@@ -9268,7 +9266,7 @@ class KernelWriterAssembly(KernelWriter):
     # Buffer-load uses one base read pointer stored in the SRD - set it here:
     kStr += inst("s_mov_b32", sgpr("Srd%s+0"%ch), sgpr("Address%s+0"%ch), "init SRD base address (lower)" )
     kStr += inst("s_mov_b32", sgpr("Srd%s+1"%ch), sgpr("Address%s+1"%ch), "init SRD base address (upper) + other fields" )
-    kStr += inst("s_mov_b32", sgpr("Srd%s+2"%ch), hex(0x80000000), "")
+    kStr += inst("s_mov_b32", sgpr("Srd%s+2"%ch), "BufferOOB", "")
     kStr += inst("s_mov_b32", sgpr("Srd%s+3"%ch), "Srd127_96", "Set bits 127_96 in post-loop SRD")
     kStr += "\n"
     return kStr
@@ -13227,68 +13225,61 @@ class KernelWriterAssembly(KernelWriter):
       # jump to end
       kStr += inst("s_cbranch_scc1 %s"%(self.getNamedLabel(EndLabelName)), "jump to StoreCInUnrollPostLoopEnd")
 
-      if isOptNLL:
-        # OptNLL case, generate PostLoop code
-        kStrPL = ""
+      # generate PostLoop code (non OptNLL (means Ord NLL) case are merged into OptNLL)
+      kStrPL = ""
 
-        # decrement StoreCEnableCount
-        kStrPL += inst("s_sub_u32",  sgpr("StoreCEnableCount"), sgpr("StoreCEnableCount"), hex(1), \
-                       "decrement StoreCEnableCount.")
+      # decrement StoreCEnableCount
+      kStrPL += inst("s_sub_u32",  sgpr("StoreCEnableCount"), sgpr("StoreCEnableCount"), hex(1), \
+                     "decrement StoreCEnableCount.")
 
-        backupSgpr = self.getTmpSgpr(2).idx()  # allocate all tmp register here
-        tmpSgprWork = backupSgpr + 1
-        loopCount = self.getAddrGprIdxIncrementFrequencyForStoreCInUnroll(kernel)
-        for lc in range(loopCount):
-          # generate LoadC code
-          needAddrC = (not kernel["AssertCEqualsD"]) and kernel["ProblemType"]["UseBeta"]
-          for x in self.LoadCTemplate.items():
-            kStrPL += str(x)
-          # Addr C increment code
-          if needAddrC:
-            kStrPL += self.generateCorDaddrIncrementForStoreCInUnroll(kernel, "C", (lc % 2) == 0, tmpSgprWork)
+      backupSgpr = self.getTmpSgpr(2).idx()  # allocate all tmp register here
+      tmpSgprWork = backupSgpr + 1
+      loopCount = self.getAddrGprIdxIncrementFrequencyForStoreCInUnroll(kernel)
+      for lc in range(loopCount):
+        # generate LoadC code
+        needAddrC = (not kernel["AssertCEqualsD"]) and kernel["ProblemType"]["UseBeta"]
+        for x in self.LoadCTemplate.items():
+          kStrPL += str(x)
+        # Addr C increment code
+        if needAddrC:
+          kStrPL += self.generateCorDaddrIncrementForStoreCInUnroll(kernel, "C", (lc % 2) == 0, tmpSgprWork)
 
-          # these 3 items need to be in the same set
-          #  open gpr indexing
-          #  accVgpr (need gpr indexing)
-          #  close gpr indexing
-          kStrPL += self.openmovaccVgpr(kernel, backupSgpr)
-          # odd case, use + (1 iteration) for gpr index, but not necessary if index frequency is 1
-          odd = (lc % 2) != 0 and (self.getAddrGprIdxIncrementFrequencyForStoreCInUnroll(kernel) > 1)
-          kStrPL += self.getAccVgprCode(kernel, odd)
-          first, second = self.closemovaccVgpr(kernel, backupSgpr)
-          kStrPL += first
-          kStrPL += second
-          # Alpha
-          for x in self.AlphaOpTemplate.items():
-            kStrPL += str(x)
-          # Beta
-          for x in self.BetaOpTemplate.items():
-            kStrPL += str(x)
+        # these 3 items need to be in the same set
+        #  open gpr indexing
+        #  accVgpr (need gpr indexing)
+        #  close gpr indexing
+        kStrPL += self.openmovaccVgpr(kernel, backupSgpr)
+        # odd case, use + (1 iteration) for gpr index, but not necessary if index frequency is 1
+        odd = (lc % 2) != 0 and (self.getAddrGprIdxIncrementFrequencyForStoreCInUnroll(kernel) > 1)
+        kStrPL += self.getAccVgprCode(kernel, odd)
+        first, second = self.closemovaccVgpr(kernel, backupSgpr)
+        kStrPL += first
+        kStrPL += second
+        # Alpha
+        for x in self.AlphaOpTemplate.items():
+          kStrPL += str(x)
+        # Beta
+        for x in self.BetaOpTemplate.items():
+          kStrPL += str(x)
 
-          # StoreC
+        # StoreC
 
-          # generate post process for StoreCInUnroll loop
-          # 1) increment gpr indexing (new value in tmp). Put this as separate item in StoreCUnrollCode
-          # 2-1) increment StoreC address  (new value in tmp)
-          # 2-2) check enable count and apply new values when necessary
-          needPost = (lc % 2) != 0 or (self.getAddrGprIdxIncrementFrequencyForStoreCInUnroll(kernel) == 1)
-          postProcessList, finalAddrIncList = self.generatePostProcessForStoreCInUnrollLoop(kernel, needPost)
+        # generate post process for StoreCInUnroll loop
+        # 1) increment gpr indexing (new value in tmp). Put this as separate item in StoreCUnrollCode
+        # 2-1) increment StoreC address  (new value in tmp)
+        # 2-2) check enable count and apply new values when necessary
+        needPost = (lc % 2) != 0 or (self.getAddrGprIdxIncrementFrequencyForStoreCInUnroll(kernel) == 1)
+        postProcessList, finalAddrIncList = self.generatePostProcessForStoreCInUnrollLoop(kernel, needPost)
 
-          for x in self.StoreCTemplate.items():
-            kStrPL += str(x)
-          # StorSyncOpt
-          if kernel["StoreSyncOpt"]:
-            kStrPL += "s_sleep %d // optimization: sync and wait\n" %(kernel["StoreSyncOpt"]-1)
-            kStrPL += "s_barrier\n"
-          # add all finalAddrInc code after the last StoreC (in the same item)
-          for item in (postProcessList + finalAddrIncList):
-            kStrPL += item
-
-        # keep PostLoop code for Ord NLL
-        self.StoreCInUnrollPostLoop = kStrPL
-      else:
-        # not OptNLL (means Ord NLL) case, put same code as OptNLL
-        kStrPL = self.StoreCInUnrollPostLoop
+        for x in self.StoreCTemplate.items():
+          kStrPL += str(x)
+        # StorSyncOpt
+        if kernel["StoreSyncOpt"]:
+          kStrPL += "s_sleep %d // optimization: sync and wait\n" %(kernel["StoreSyncOpt"]-1)
+          kStrPL += "s_barrier\n"
+        # add all finalAddrInc code after the last StoreC (in the same item)
+        for item in (postProcessList + finalAddrIncList):
+          kStrPL += item
 
       # add PostLoop code
       kStr += kStrPL

--- a/Tensile/KernelWriterSource.py
+++ b/Tensile/KernelWriterSource.py
@@ -2108,7 +2108,7 @@ class KernelWriterSource(KernelWriter):
   ##############################################################################
   # Close Loop
   ##############################################################################
-  def closeLoop(self, kernel, loopIdx, finalLoop, uDu=0, emitEndLabelOnly=False, oddLabel=False):
+  def closeLoop(self, kernel, loopIdx, finalLoop, loopCopies, uDu=0, emitEndLabelOnly=False, oddLabel=False):
     kStr = ""
     if emitEndLabelOnly:
       return kStr

--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -3300,7 +3300,9 @@ class Solution(collections.abc.Mapping):
       VectorWidthB = state["VectorWidth"]
     elif state["DirectToVgprA"]:
       VectorWidthB = state["LocalReadVectorWidth"]
-    state["allowLRVWBforTLUandMI"] = (state["DirectToVgprB"] and state["LocalReadVectorWidth"] == 1 or \
+    state["allowLRVWBforTLUandMI"] = (state["DirectToVgprB"] and \
+                                       (state["ProblemType"]["TLUA"] and state["LocalReadVectorWidth"] == 1 or \
+                                        not state["ProblemType"]["TLUA"]) or \
                                       state["DirectToVgprA"] and not state["DirectToLds"]) and \
                                 state["EnableMatrixInstruction"] and state["ProblemType"]["TLUB"] and \
                                 state["VectorWidth"] >= state["LocalReadVectorWidth"] and \

--- a/Tensile/Source/lib/include/Tensile/ContractionProblemPredicates.hpp
+++ b/Tensile/Source/lib/include/Tensile/ContractionProblemPredicates.hpp
@@ -1113,59 +1113,6 @@ namespace Tensile
                 }
             };
 
-            struct BufferLoadOffsetLimitCheck_Beta
-                : public Predicate_CRTP<BufferLoadOffsetLimitCheck_Beta, ContractionProblem>
-            {
-                enum
-                {
-                    HasIndex = false,
-                    HasValue = true
-                };
-                size_t value;
-
-                BufferLoadOffsetLimitCheck_Beta() = default;
-                BufferLoadOffsetLimitCheck_Beta(size_t value)
-                    : value(value)
-                {
-                }
-
-                static std::string Type()
-                {
-                    return "BufferLoadOffsetLimitCheck_Beta";
-                }
-
-                virtual bool operator()(ContractionProblem const& problem) const override
-                {
-                    if(problem.c().empty() || problem.beta() == 0)
-                    {
-                        return true;
-                    }
-                    else
-                    {
-                        const uint64_t TWO_POW_32 = 4294967296;
-                        return problem.c().strides()[1] * problem.c().elementBytes() * value
-                               < TWO_POW_32;
-                    }
-                }
-
-                virtual std::string toString() const override
-                {
-                    return concatenate(this->type(), "(MT1:", value, ")");
-                }
-
-                virtual bool debugEval(ContractionProblem const& problem,
-                                       std::ostream&             stream) const override
-                {
-                    bool rv = (*this)(problem);
-
-                    stream << *this << ": (" << problem.c().strides()[1] << " * "
-                           << problem.c().elementBytes() << " * " << value << " < 4294967296"
-                           << ") == " << rv;
-
-                    return rv;
-                }
-            };
-
             struct BufferStoreOffsetLimitCheck
                 : public Predicate_CRTP<BufferStoreOffsetLimitCheck, ContractionProblem>
             {

--- a/Tensile/Source/lib/include/Tensile/Serialization/ContractionPredicates.hpp
+++ b/Tensile/Source/lib/include/Tensile/Serialization/ContractionPredicates.hpp
@@ -85,7 +85,6 @@ namespace Tensile
                     Base::template Pair<Predicates::Contraction::TypesEqual>(),
                     Base::template Pair<Predicates::Contraction::OperationIdentifierEqual>(),
                     Base::template Pair<Predicates::Contraction::BufferLoadOffsetLimitCheck>(),
-                    Base::template Pair<Predicates::Contraction::BufferLoadOffsetLimitCheck_Beta>(),
                     Base::template Pair<Predicates::Contraction::BufferStoreOffsetLimitCheck>(),
                     Base::template Pair<Predicates::Contraction::WorkspaceCheck>(),
                     Base::template Pair<Predicates::Contraction::PersistentKernelCheck>(),
@@ -286,12 +285,6 @@ namespace Tensile
         template <typename IO>
         struct MappingTraits<Predicates::Contraction::BufferLoadOffsetLimitCheck, IO>
             : public AutoMappingTraits<Predicates::Contraction::BufferLoadOffsetLimitCheck, IO>
-        {
-        };
-
-        template <typename IO>
-        struct MappingTraits<Predicates::Contraction::BufferLoadOffsetLimitCheck_Beta, IO>
-            : public AutoMappingTraits<Predicates::Contraction::BufferLoadOffsetLimitCheck_Beta, IO>
         {
         };
 

--- a/Tensile/Tests/extended/direct_to_vgpr/dtv_cgemm.yaml
+++ b/Tensile/Tests/extended/direct_to_vgpr/dtv_cgemm.yaml
@@ -1,6 +1,5 @@
 TestParameters:
-  marks: [xfail, skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102] # not supported by arch
-  # Failing on latest ROCm build, re-enable when passing
+  marks: [skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102] # not supported by arch
 
 GlobalParameters:
   MinimumRequiredVersion: 4.33.0

--- a/Tensile/Tests/extended/direct_to_vgpr/dtv_dgemm.yaml
+++ b/Tensile/Tests/extended/direct_to_vgpr/dtv_dgemm.yaml
@@ -1,6 +1,5 @@
 TestParameters:
-  marks: [xfail, skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102] # not supported by arch
-  # Failing on latest ROCm build, re-enable when passing
+  marks: [skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102] # not supported by arch
 
 GlobalParameters:
   MinimumRequiredVersion: 4.33.0

--- a/Tensile/Tests/pre_checkin/direct_to_vgpr/dtv_sgemm_lite.yaml
+++ b/Tensile/Tests/pre_checkin/direct_to_vgpr/dtv_sgemm_lite.yaml
@@ -1,6 +1,5 @@
 TestParameters:
-  marks: [xfail, skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102] # not supported by arch
-  # Failing on latest ROCm build, re-enable when passing
+  marks: [skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102] # not supported by arch
 
 GlobalParameters:
   MinimumRequiredVersion: 4.33.0


### PR DESCRIPTION
* Fixed mismatch issue with BufferLoad=0 + TailLoop for large array sizes Use Tensor2dSize to calculate max read address (instead of using StrideA1(or B1))
* Fixed code generation error with BufferStore=0
* Fixed code generation error with StoreCInUnrollPostLoop
* Removed unnecessary check (BufferLoadOffsetLimitCheck_Beta) (Reverted the previous change for BufferLoadOffsetLimitCheck_Beta)
* Enhanced bufferOOB to 0xfffff000 to improve the coverage of BufferStore=1
* Use AssertSizeLessThan for BufferStoreOffsetLimitCheck if it is smaller than MT1 (To improve the coverage of BufferStore=1)
* Added reject condition for StoreCInUnroll + BufferStore=0
* Added reject condition for DirectToVgpr + ScheduleIterAlg<3 + PrefetchGlobalRead==2
* Fixed issues with DirectToVgpr + ScheduleIterAlg<3
* Fixed typo
* Removed xfail from direct_to_vgpr cases
* Fixed mismatch issue with DGEMM TT + LocalReadVectorWidth=2
* Fixed mismatch issue with PrefetchGlobalRead=2