### PR TITLE
Fixed invalid parameters in dtv_dgemm.yaml

### DIFF
--- a/Tensile/Tests/extended/direct_to_vgpr/dtv_dgemm.yaml
+++ b/Tensile/Tests/extended/direct_to_vgpr/dtv_dgemm.yaml
@@ -77,8 +77,8 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           #- Exact: [ M, N, B, K, ldc, ldc, lda, ldb ]
-          - Exact: [1024, 1024, 1, 512]
-          - Exact: [1022, 1022, 1, 511]
+          #- Exact: [1024, 1024, 1, 512]
+          - Exact: [1023, 1022, 1, 511]
 
   ########################################
   # NT - standard
@@ -125,7 +125,7 @@ BenchmarkProblems:
           - [ 16, 16, 1 ]
         - AssertFree0ElementMultiple: [1,2]
         - AssertFree1ElementMultiple: [1,2]
-        - AssertSummationElementMultiple: [1,32]
+        #- AssertSummationElementMultiple: [1,32]
         - WorkGroupMapping: [8]
         - PrefetchLocalRead: [1,3]
         - GlobalSplitU: [1]
@@ -145,8 +145,8 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           #- Exact: [ M, N, B, K, ldc, ldc, lda, ldb ]
-          - Exact: [1024, 1024, 1, 512]
-          - Exact: [1023, 1023, 1, 511]
+          #- Exact: [1024, 1024, 1, 512]
+          #- Exact: [1023, 1023, 1, 511]
           - Exact: [1022, 1022, 1, 511]
 
   ########################################
@@ -167,8 +167,8 @@ BenchmarkProblems:
         - KernelLanguage: ["Assembly"]
         - EdgeType: ["ShiftPtr"]
         - AtomicAddC: [False] 
-        - AssertBetaValue: [1]
-        - AssertCEqualsD: [True]
+        #- AssertBetaValue: [1]
+        #- AssertCEqualsD: [True]
         - AssertSizeGreaterThan: [{},{3: 32}]
       ForkParameters:
         - MatrixInstruction:
@@ -221,9 +221,9 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           #- Exact: [ M, N, B, K, ldc, ldc, lda, ldb ]
-          - Exact: [2048, 2048, 1, 512]
-          - Exact: [2047, 2047, 1, 511]
-          - Exact: [2046, 2046, 1, 511]
+          #- Exact: [2048, 2048, 1, 512]
+          #- Exact: [2047, 2047, 1, 511]
+          - Exact: [2046, 2046, 1, 512]
 
   ########################################
   # NN - standard
@@ -291,8 +291,8 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           #- Exact: [ M, N, B, K, ldc, ldc, lda, ldb ]
-          - Exact: [1024, 1024, 1, 512]
-          - Exact: [1022, 1022, 1, 511]
+          #- Exact: [1024, 1024, 1, 512]
+          - Exact: [1023, 1023, 1, 511]
 
   ########################################
   # TT - standard
@@ -361,7 +361,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           #- Exact: [ M, N, B, K, ldc, ldc, lda, ldb ]
-          - Exact: [1024, 1024, 1, 512]
+          #- Exact: [1024, 1024, 1, 512]
           - Exact: [1022, 1022, 1, 511]
 
   ########################################
@@ -421,15 +421,15 @@ BenchmarkProblems:
         #- NumLoadsCoalescedA: [1,2]
         #- NumLoadsCoalescedB: [1,2]#[2,4]
         - ScheduleIterAlg: [3]
-        - FractionalLoad: [0,11]
+        - FractionalLoad: [0,1,2]
         - BufferLoad: [True, False]
-        - TransposeLDS: [11]
+        - TransposeLDS: [1]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
           #- Exact: [ M, N, B, K, ldc, ldc, lda, ldb ]
-          - Exact: [1024, 1024, 1, 512]
+          #- Exact: [1024, 1024, 1, 512]
           - Exact: [1022, 1022, 1, 511]
 


### PR DESCRIPTION
* Fixed invalid parameters(FractionalLoad, TransposeLDS) in dtv_dgemm.yaml
* Removed unnecessary assert checks
* Use only 1 size for BoundsCheck