### PR TITLE
Functions for user-driven tuning

### DIFF
--- a/Tensile/Source/lib/include/Tensile/ContractionSolution.hpp
+++ b/Tensile/Source/lib/include/Tensile/ContractionSolution.hpp
@@ -242,6 +242,8 @@ namespace Tensile
                                                TypedInputs const& inputs,
                                                Hardware const&    hardware) const;
 
+        bool canSolve(Problem const& problem, Hardware const& hardware) const;
+
         struct SizeMapping
         {
             dim3 workGroupSize;

--- a/Tensile/Source/lib/include/Tensile/MasterSolutionLibrary.hpp
+++ b/Tensile/Source/lib/include/Tensile/MasterSolutionLibrary.hpp
@@ -130,11 +130,9 @@ namespace Tensile
                              "default behavior."
                           << std::endl;
                 {
-                    std::lock_guard<std::mutex> guard(solutionsGuard);
-                    auto                        selected_solution = solutions.at(solution_index);
+                    auto selected_solution = getSolutionByIndex(solution_index);
 
-                    if((*selected_solution->problemPredicate)(problem)
-                       && (*selected_solution->hardwarePredicate)(hardware))
+                    if(selected_solution->canSolve(problem, hardware))
                         rv = selected_solution;
                     else
                         return nullptr;
@@ -153,6 +151,14 @@ namespace Tensile
             }
             return rv;
         }
+
+        std::shared_ptr<MySolution> getSolutionByIndex(int index) const
+        {
+            // TODO add safegaurds related to lazy loading and other checks on the index
+            std::lock_guard<std::mutex> guard(solutionsGuard);
+            return solutions.at(index);
+        }
+
         virtual SolutionSet<MySolution> findAllSolutions(MyProblem const& problem,
                                                          Hardware const&  hardware) const override
         {

--- a/Tensile/Source/lib/include/Tensile/MasterSolutionLibrary.hpp
+++ b/Tensile/Source/lib/include/Tensile/MasterSolutionLibrary.hpp
@@ -38,8 +38,8 @@ namespace Tensile
 {
 
     /**
- * \ingroup SolutionLibrary
- */
+     * \ingroup SolutionLibrary
+     */
     template <typename MySolution>
     using SolutionMap = std::map<int, std::shared_ptr<MySolution>>;
 
@@ -54,11 +54,11 @@ namespace Tensile
     };
 
     /**
- * \ingroup SolutionLibrary
- *
- * Root level library object. Contains all individual solutions in a map
- * for serialization purposes.
- */
+     * \ingroup SolutionLibrary
+     *
+     * Root level library object. Contains all individual solutions in a map
+     * for serialization purposes.
+     */
     template <typename MyProblem, typename MySolution = typename MyProblem::Solution>
     struct MasterSolutionLibrary : public SolutionLibrary<MyProblem, MySolution>
     {
@@ -154,7 +154,7 @@ namespace Tensile
 
         std::shared_ptr<MySolution> getSolutionByIndex(int index) const
         {
-            // TODO add safegaurds related to lazy loading and other checks on the index
+            // will only return solution if already loaded; does not load solutions
             std::lock_guard<std::mutex> guard(solutionsGuard);
             if(solutions.find(index) != solutions.end())
             {

--- a/Tensile/Source/lib/include/Tensile/MasterSolutionLibrary.hpp
+++ b/Tensile/Source/lib/include/Tensile/MasterSolutionLibrary.hpp
@@ -156,7 +156,14 @@ namespace Tensile
         {
             // TODO add safegaurds related to lazy loading and other checks on the index
             std::lock_guard<std::mutex> guard(solutionsGuard);
-            return solutions.at(index);
+            if(solutions.find(index) != solutions.end())
+            {
+                return solutions.at(index);
+            }
+            else
+            {
+                return nullptr;
+            }
         }
 
         virtual SolutionSet<MySolution> findAllSolutions(MyProblem const& problem,

--- a/Tensile/Source/lib/include/Tensile/MasterSolutionLibrary.hpp
+++ b/Tensile/Source/lib/include/Tensile/MasterSolutionLibrary.hpp
@@ -132,7 +132,7 @@ namespace Tensile
                 {
                     auto selected_solution = getSolutionByIndex(solution_index);
 
-                    if(selected_solution->canSolve(problem, hardware))
+                    if(selected_solution && selected_solution->canSolve(problem, hardware))
                         rv = selected_solution;
                     else
                         return nullptr;

--- a/Tensile/Source/lib/source/ContractionSolution.cpp
+++ b/Tensile/Source/lib/source/ContractionSolution.cpp
@@ -802,6 +802,11 @@ namespace Tensile
         return rv;
     }
 
+    bool ContractionSolution::canSolve(Problem const& problem, Hardware const& hardware) const
+    {
+        return (*problemPredicate)(problem) && (*hardwarePredicate)(hardware);
+    }
+
     template <typename TypedInputs>
     std::string ContractionSolution::outputConversionKernelName(Problem const&     problem,
                                                                 TypedInputs const& inputs,


### PR DESCRIPTION
This PR adds the two functions needed in Tensile to enable user-driven tuning in rocBLAS

1. MasterSolutionLibrary::getSolutionByIndex
2. ContractionSolution::canSolve

getSolutionByIndex only returns loaded solutions; the caller (rocBLAS for now) is responsible for making sure the solution is already loaded