### PR TITLE
Fix solution index collisions

### DIFF
--- a/Tensile/SolutionLibrary.py
+++ b/Tensile/SolutionLibrary.py
@@ -458,7 +458,7 @@ class MasterSolutionLibrary:
     def merge(self, other, startIndex=0):
         assert self.__class__ == other.__class__
 
-        curIndex = max(startIndex, max(self.solutions.keys()) + 1) if self.solutions else 0
+        curIndex = max(startIndex, max(self.solutions.keys()) + 1 if self.solutions else 0)
         if self.lazyLibraries:
             curIndex = max(
                 curIndex,


### PR DESCRIPTION
Fixes a solution index collision that was happening with lazy-loading.

This current version still produces collisions between different architectures, which should probably be fixed at some point, but for now this fixes the main issue of collisions in the same architecture (or at least it does based on my testing).

