### PR TITLE
Remove reject condition for BF16 + VectorAtomicWidth>=2

### DIFF
--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -3064,7 +3064,7 @@ class Solution(collections.abc.Mapping):
         state["VectorAtomicWidth"] = 2
 
     if state["VectorAtomicWidth"] >= 2 \
-       and not state["ProblemType"]["DataType"].isHalf():
+       and not (state["ProblemType"]["DataType"].isHalf() or state["ProblemType"]["DataType"].isBFloat16()):
          reject (state, "VectorAtomicWidth>=2 only supported for half")
 
     if state["ProblemType"]["DataType"].isHalf() and state["KernelLanguage"] == "Assembly":


### PR DESCRIPTION
I tried to run Tensile test with the yaml file converted from a rocblas logic file (aldebaran_Cijk_Ailk_Bjlk_BBS_BH.yaml solution index=106). 
However, it was rejected.
We should remove the reject condition for BF16 + VectorAtomicWidth>=2 (treat it same as fp16)