### PR TITLE
Lanuch more workgroups in x dimenstion rathern than in y dimension forr skinny matrix multiplication.

### DIFF
--- a/Tensile/KernelWriterSource.py
+++ b/Tensile/KernelWriterSource.py
@@ -1195,21 +1195,21 @@ class KernelWriterSource(KernelWriter):
       kStr += "  unsigned int n%s = %s(%u);%s" \
           % ( wg1, self.getNumGroupsStr, n1, self.endLine)
       if kernel["GlobalSplitU"] > 1:
-        kStr += "  n%s /= GLOBAL_SPLITU;%s" % (wg1, self.endLine)
+        kStr += "  n%s /= GLOBAL_SPLITU;%s" % (wg0, self.endLine)
 
     # split up work-group grid
     if kernel["GlobalSplitU"] > 1:
       kStr += "  unsigned int gsuSumIdx;%s" % self.endLine
       if kernel["GlobalSplitUWorkGroupMappingRoundRobin"]:
         kStr += "  gsuSumIdx = %s / n%s;%s" \
-            % (wg1, wg1, self.endLine)
+            % (wg0, wg0, self.endLine)
         kStr += "  %s = %s %% n%s;%s" \
-            % (wg1, wg1, wg1, self.endLine)
+            % (wg0, wg0, wg0, self.endLine)
       else:
         kStr += "  gsuSumIdx = %s %% GLOBAL_SPLITU;%s" \
-            % (wg1, self.endLine)
+            % (wg0, self.endLine)
         kStr += "  %s = %s / GLOBAL_SPLITU;%s" \
-            % (wg1, wg1, self.endLine)
+            % (wg0, wg0, self.endLine)
 
       ########################################
       # Blocked rows or columns

--- a/Tensile/Source/lib/source/ContractionSolution.cpp
+++ b/Tensile/Source/lib/source/ContractionSolution.cpp
@@ -308,7 +308,8 @@ namespace Tensile
         // used only when persistent kernel along batch
         uint32_t problemNumGroupTiles2 = rv.numWorkGroups.z;
 
-        rv.numWorkGroups.y *= sizeMapping.globalSplitU;
+        rv.numWorkGroups.x *= sizeMapping.globalSplitU;
+        // rv.numWorkGroups.y *= sizeMapping.globalSplitU;
 
         if(sizeMapping.persistentKernel != 0)
         {


### PR DESCRIPTION
[](url)This is a prototype implementation of launching workgroup in x dimension rather in y dimension for skinny matrix multiplication, which participate in accumulate the partial summation results. It is a just prototype which only launching more workgroups in x direction which is only suitable for skinny matrix. Ideally, the implementation should support launching workgroups in both x and y dimension which depends on input matrix shape.

A sample yaml file for skinny matrix multiplication: A is a 2048x9217 matrix, B 9217X1, C 2048X1.
The performance of new implementation on MI200 is 474.038GFlops, the performance of original implementation is 472.726GFlops.

GlobalParameters:
  PrintLevel: 1
  ForceRedoBenchmarkProblems: True
  ForceRedoLibraryLogic: True
  ForceRedoLibraryClient: True
  CMakeBuildType: Release
  EnqueuesPerSync: 1
  SyncsPerBenchmark: 1
  LibraryPrintDebug: False
  NumElementsToValidate: 128
  ValidationMaxToPrint: 16
  ValidationPrintValids: False
  ShortNames: False
  MergeFiles: True
  PlatformIdx: 0
  DeviceIdx: 0
  #  DataInitTypeAB: 0
  PrintSolutionRejectionReason: True

BenchmarkProblems:
  - # sgemm NN
    - # ProblemType
      OperationType: GEMM
      DataType: H
      DestDataType: H
      ComputeDataType: S
      HighPrecisionAccumulate: True
      TransposeA: False
      TransposeB: False
      UseBeta: True
      Batched: True

    - # BenchmarkProblemSizeGroup
      InitialSolutionParameters:
      BenchmarkCommonParameters:
        - LoopTail: [True]
        - NumLoadsCoalescedA: [1]
        - NumLoadsCoalescedB: [1]
        - PrefetchGlobalRead: [False]
        - AssertFree0ElementMultiple : [4]
        - KernelLanguage: ["Source"]
      ForkParameters:
        - LoopDoWhile: [True,False]
        - GlobalSplitUAlgorithm: ["MultipleBuffer"]
        - GlobalSplitU: [4,8,16]
        - GlobalSplitUWorkGroupMappingRoundRobin: [False]
        - GlobalSplitUSummationAssignmentRoundRobin:  [True]
        - ThreadTile:
          - [ 8, 1 ]
            #          - [ 4, 2 ]
        - WorkGroup:
          - [8, 1, 8]
            #- [8, 1, 8]
        - EdgeType: ["ShiftPtr"]
        - DepthU: [ 64 ]
        - VectorWidth: [1]
        - LocalDotLayout: [1,2,4]
        - WorkGroupMapping: [1]
      #BenchmarkForkParameters: # obsolete
      BenchmarkJoinParameters:
      BenchmarkFinalParameters:
        - ProblemSizes:
            - Exact: [ 2048, 1, 1, 9217 ]
            #            - Exact: [ 2048, 1, 1, 9217, 2048, 2048, 2048, 9217 ]
            #- Exact: [ 1, 2048, 1, 9217 ]
              #- Exact: [ 1, 2048, 1, 9217, 1, 1, 1, 9217 ]

LibraryLogic:
    ScheduleName: "aldebaran"
    DeviceNames: ["Device 7400", "Device 7408", "Device 740c"]
    ArchitectureName: "gfx90a"

LibraryClient:

