### PR TITLE
Changing Documentation Template - Tensile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ Tensile.egg-info
 build*
 dist
 .cache
-/*.yaml
 /*.txt
 /*log*
 


### PR DESCRIPTION
Changing Documentation Template - Tensile - Allow files with 'yaml' extension