### PR TITLE
Fix AssertSummationElementMultiple + GlobalSplitU issues, the issue with InitAccVgprOpt improvement

### DIFF
--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -735,6 +735,12 @@ validParameters = {
     #     - Enables asm kernels on V20
     #     - Can use DirectToLds for both unroll and tail loops
     #  - Tail loop can be unrolled up to InnerUnroll amount if AssertSummationElementMultiple%InnerUnroll==0
+    #  - GlobalSplitU>1 case:
+    #   - Optimizations enabled by AssertSummationElementMultiple>1 will be adjusted as follows.
+    #     ASEM%GSU == 0 and ASEM//GSU will be used for optimizations instead of ASEM
+    #     For example, if ASEM is 8 and GSU is 2, K is multiple of 8 but K is divided by GSU.
+    #     In that case, we can still guarantee K/GSU is multiple of 4 (= ASEM/GSU) and 
+    #     we can use ASEM//GSU=4 for optimizations
     #
     # 1 indicates no assertion (since all sizes are multiples of 1)
     "AssertSummationElementMultiple": [1,2,4,8,16,32,64,128,256],

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -737,7 +737,7 @@ validParameters = {
     #  - Tail loop can be unrolled up to InnerUnroll amount if AssertSummationElementMultiple%InnerUnroll==0
     #
     # 1 indicates no assertion (since all sizes are multiples of 1)
-    "AssertSummationElementMultiple": [1,2,4,8,16,32,64],
+    "AssertSummationElementMultiple": [1,2,4,8,16,32,64,128,256],
 
     # Kernel generator will assume that the FreeIndex[0] size is some multiple of the element size
     # and uses this to optimize the kernel.

--- a/Tensile/KernelWriter.py
+++ b/Tensile/KernelWriter.py
@@ -2203,8 +2203,10 @@ class KernelWriter(metaclass=abc.ABCMeta):
       if self.enable["Sync"]:
         kl.append(self.syncThreads(kernel))
 
-    # if DirectToVgpr and  ASEM is not multiple of DepthU*2, generate noLoadLoopBody twice for odd and even exit separately
-    if ( kernel["DirectToVgprA"] or  kernel["DirectToVgprB"]) and (kernel["AssertSummationElementMultiple"] % (kernel["DepthU"] * 2) != 0):
+    # if DirectToVgpr and  ASEM/GSU is not multiple of DepthU*2, generate noLoadLoopBody twice for odd and even exit separately
+    asem = kernel["AssertSummationElementMultiple"]
+    gsu = kernel["GlobalSplitU"]
+    if ( kernel["DirectToVgprA"] or  kernel["DirectToVgprB"]) and ((asem%gsu != 0) or (asem//gsu) % (kernel["DepthU"] * 2) != 0):
       # generate additional No Load Loop Body code for odd case (to use the other Vreg set for DirectToVgpr)
       # 1. generate odd check
       name = ""
@@ -3213,7 +3215,9 @@ class KernelWriter(metaclass=abc.ABCMeta):
             KinInnerUnroll *= kernel["MatrixInstK"]
 
           tailLoopInnerUnroll = 1
-          if (kernel["AssertSummationElementMultiple"] % KinInnerUnroll == 0):
+          asem = kernel["AssertSummationElementMultiple"]
+          gsu = kernel["GlobalSplitU"]
+          if ((asem%gsu == 0) and (asem//gsu) % KinInnerUnroll == 0):
             tailLoopInnerUnroll = kernel["InnerUnroll"]
           elif (kernel["LocalDotLayout"] > 1) and (kernel["InnerUnroll"] == kernel["LocalDotLayout"]):
             tailLoopInnerUnroll = kernel["InnerUnroll"]

--- a/Tensile/KernelWriter.py
+++ b/Tensile/KernelWriter.py
@@ -3905,7 +3905,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
     tensorParametersA["PackedIndices"] = kernel["PackedC%uIndicesX"%self.tPA["tile01Idx"]]
     tensorParametersB["PackedIndices"] = kernel["PackedC%uIndicesX"%self.tPB["tile01Idx"]]
 
-    # condition(s) to enable init accvgpr opt (initialize only the last set of accvgpr instead of whole accvgpr)
+    # condition(s) to enable init accvgpr opt (use const "0" as an operand instead of initializing whole accvgpr)
     self.useInitAccVgprOpt = False
     # enable for the following conditions
     if kernel["StoreCInUnroll"]:


### PR DESCRIPTION
* fixed hang issue with PersistentKernel + InitAccVgprOpt caused by previous commit
* fixed mismatch with ASEM + GSU + NoTailLoop opt
* fixed issue with ASEM + GSU + no odd exit opt
* fixed ASEM + GSU + TailLoop inner unroll
* simplified and improved the reject conditions for ASEM + DirectToLds + Half/Bfloat16
* increased the maximum of ASEM to 256