### PR TITLE
Change the second kernel to improve the performance of multiple-buffer implementaion when GSU is enabled.…

### DIFF
--- a/Tensile/KernelWriterConversion.py
+++ b/Tensile/KernelWriterConversion.py
@@ -236,8 +236,8 @@ class KernelWriterConversion(KernelWriterBase):
       indexChar = self.indexChars[i]
       kStr += " + (size%s - 1) * strideW%s" % (indexChar, indexChar)
     kStr += ";" + self.endLine
-
     kStr += "  " + self.datatype + " accum = 0;%s" % self.endLine
+    kStr += "#pragma unroll%s" % self.endLine
     kStr += "  for (int i=0; i<gsu; i++) {%s" % self.endLine
     kStr += "    accum += W[idxW];%s" % self.endLine
     kStr += "    idxW  += strideW;%s" % self.endLine


### PR DESCRIPTION
The current multiple-buffer implementation of GSU is not optimal. Because the implementation of the second kernel  for accumulating the GSU partial summation results is simple. A tuned version with loop unroll is implemented.  The tuned version has better performance compared to old multiple-buffer and single-buffer implementation.

The tests are performed on MI250 in auto mode. The GEMM format is HSS. 
[PerfAtomicCASMB.xlsx](https://github.com/ROCmSoftwarePlatform/Tensile/files/10255420/PerfAtomicCASMB.xlsx)
