### PR TITLE
Hotfix: updating CXX_STANDARD to 17

### DIFF
--- a/HostLibraryTests/CMakeLists.txt
+++ b/HostLibraryTests/CMakeLists.txt
@@ -26,7 +26,7 @@ cmake_minimum_required(VERSION 3.13)
 
 project(TensileHostLibraryTest)
 
-set( CMAKE_CXX_STANDARD 14 )
+set( CMAKE_CXX_STANDARD 17 )
 set( CMAKE_CXX_EXTENSIONS OFF )
 
 list(APPEND CMAKE_PREFIX_PATH $ENV{ROCM_PATH} /opt/rocm)

--- a/Tensile/Source/client/CMakeLists.txt
+++ b/Tensile/Source/client/CMakeLists.txt
@@ -51,7 +51,7 @@ add_library(TensileClient STATIC ${client_sources})
 
 set_target_properties(TensileClient
                       PROPERTIES
-                      CXX_STANDARD 14
+                      CXX_STANDARD 17
                       CXX_STANDARD_REQUIRED ON
                       CXX_EXTENSIONS OFF)
 
@@ -83,7 +83,7 @@ endif()
 add_executable(tensile_client main.cpp)
 set_target_properties(tensile_client
                       PROPERTIES
-                      CXX_STANDARD 14
+                      CXX_STANDARD 17
                       CXX_STANDARD_REQUIRED ON
                       CXX_EXTENSIONS OFF)
 

--- a/Tensile/Source/lib/CMakeLists.txt
+++ b/Tensile/Source/lib/CMakeLists.txt
@@ -86,7 +86,7 @@ add_library (TensileHost STATIC ${tensile_sources})
 
 set_target_properties(TensileHost
                       PROPERTIES
-                      CXX_STANDARD 14
+                      CXX_STANDARD 17
                       CXX_STANDARD_REQUIRED ON
                       CXX_EXTENSIONS OFF)
 


### PR DESCRIPTION
updating CXX_STANDARD to 17 due to YAML lib dependencies now requiring C++17 support [#1652](https://github.com/ROCmSoftwarePlatform/Tensile/pull/1652)