### PR TITLE
TailLoop optimization for source kernels.

### DIFF
--- a/Tensile/KernelWriter.py
+++ b/Tensile/KernelWriter.py
@@ -3127,6 +3127,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
         if self.enable["GlobalRead"]:
           # tail: global read
           kl.append(self.calculateLoopNumIter(kernel, -1, False))
+          kl.append(self.openPreTailLoop(kernel))
           if self.staggerU and self.actualSummationLoops==1:
             kl.append(self.comment("remove stagger offsets for tail loop"))
             kl.append(self.removeStagger(kernel, tensorParametersA))
@@ -3154,6 +3155,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
           kl.append(self.comment("global read %s"%tc2))
           vregSetIdx = 0
           kl.append(str(self.globalReadDo(kernel, 2, tensorParameters2nd, vregSetIdx)))
+          kl.append(self.closePreTailLoop(kernel))
         if self.enable["Wait"]:
           kl.append(self.wait(kernel, tensorParametersA, tensorParametersB, 0, -1, -1, "2wait for global read"))
         if self.enable["Sync"]:
@@ -4016,6 +4018,18 @@ class KernelWriter(metaclass=abc.ABCMeta):
   ##############################################################################
   @abc.abstractmethod
   def graWorkGroup(self, kernel, isPap):
+    return ""
+
+  ##############################################################################
+  #  
+  ##############################################################################
+  def openPreTailLoop(self, kernel):
+    return ""
+
+  ##############################################################################
+  # 
+  ##############################################################################
+  def closePreTailLoop(self, kernel):
     return ""
 
   ##############################################################################

--- a/Tensile/KernelWriterSource.py
+++ b/Tensile/KernelWriterSource.py
@@ -1263,6 +1263,28 @@ class KernelWriterSource(KernelWriter):
     #      % (wg0, wg1)+ self.endLine
     return kStr
 
+  ##############################################################################
+  # openPreTailLoop
+  ##############################################################################
+  def openPreTailLoop(self, kernel):
+    kStr = ""
+    loopIdx = self.unrollIdx
+    loopChar = self.indexChars[kernel["ProblemType"]["IndicesSummation"][loopIdx]]
+    kStr += "%sif (numIter%s)%s" %(self.indent,loopChar,self.endLine)
+    kStr += "%s{%s" %(self.indent,self.endLine)
+    self.indent += "  "
+    return kStr
+
+
+  ##############################################################################
+  # closePreTailLoop
+  ##############################################################################
+  def closePreTailLoop(self, kernel):
+    kStr = ""
+    self.indent = self.indent[2:]
+    kStr += "%s}%s" %(self.indent,self.endLine)
+    return kStr
+    
 
   ##############################################################################
   # Global Read Addresses: Tile Assignment A/B
@@ -1943,8 +1965,8 @@ class KernelWriterSource(KernelWriter):
                   % (tP["tensorChar"], para, sPara, perp, sPerp)
 
             if self.staggerU:
-              kStr += "  %s += ((origNumIter - (staggerUIter - %u)) * globalReadInc%s%s); // remove stagger offset%s" \
-                      % (gr, kernel["PrefetchGlobalRead"], tc, loopChar, self.endLine)
+              kStr += "%s%s += ((origNumIter - (staggerUIter - %u)) * globalReadInc%s%s); // remove stagger offset%s" \
+                      % (self.indent,gr, kernel["PrefetchGlobalRead"], tc, loopChar, self.endLine)
 
               if self.db["PrintStagger"]:
                 kStr += "if (%s(2)==0 && %s(1)==0 && %s(0) <= 8)%s" % \


### PR DESCRIPTION
TailLoop is necessary if K is not a multiple of (DepthU*GlobalSplitU). However, the GEMM performance of current Tensile drops 5-10% when K is a multiple of (DepthU*GlobalSplitU). Some operations should be put in a conditional statement to avoid redundant operations in case that K is a multiple of (DepthU*GlobalSplitU). 