### PR TITLE
Fix unescaped $PATH variable

### DIFF
--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -61,7 +61,7 @@ def runCompileCommand(platform, project, jobName, boolean debug=false)
             mkdir build
             pushd build
 
-            export PATH=/opt/rocm/bin:$PATH
+            export PATH=/opt/rocm/bin:\$PATH
             cmake -DCMAKE_BUILD_TYPE=${buildType} -DCMAKE_CXX_COMPILER=${compiler} -DTensile_ROOT=\$(pwd)/../Tensile ../HostLibraryTests
             make -j\$(nproc)
 


### PR DESCRIPTION
This was causing Tensile to build using the wrong version of Python, as it was using the PATH from the host Groovy environment instead of the local Docker environment.