### PR TITLE
Turn off merge files to speed up some slow pre_checkin tests

### DIFF
--- a/Tensile/Tests/pre_checkin/bfloat16/bfloat16_hpa_source_nn.yaml
+++ b/Tensile/Tests/pre_checkin/bfloat16/bfloat16_hpa_source_nn.yaml
@@ -3,6 +3,7 @@ GlobalParameters:
   MinimumRequiredVersion: 4.2.0
   NumElementsToValidate: -1
   KernelTime: True
+  MergeFiles: False
 
 BenchmarkProblems:
 

--- a/Tensile/Tests/pre_checkin/bfloat16/bfloat16_hpa_source_nt.yaml
+++ b/Tensile/Tests/pre_checkin/bfloat16/bfloat16_hpa_source_nt.yaml
@@ -3,6 +3,7 @@ GlobalParameters:
   MinimumRequiredVersion: 4.2.0
   NumElementsToValidate: -1
   KernelTime: True
+  MergeFiles: False
 
 BenchmarkProblems:
   - # hgemm TN

--- a/Tensile/Tests/pre_checkin/bfloat16/bfloat16_hpa_source_tn.yaml
+++ b/Tensile/Tests/pre_checkin/bfloat16/bfloat16_hpa_source_tn.yaml
@@ -3,6 +3,7 @@ GlobalParameters:
   MinimumRequiredVersion: 4.2.0
   NumElementsToValidate: -1
   KernelTime: True
+  MergeFiles: False
 
 BenchmarkProblems:
 

--- a/Tensile/Tests/pre_checkin/bfloat16/bfloat16_hpa_source_tt.yaml
+++ b/Tensile/Tests/pre_checkin/bfloat16/bfloat16_hpa_source_tt.yaml
@@ -2,6 +2,7 @@ GlobalParameters:
   MinimumRequiredVersion: 4.2.0
   NumElementsToValidate: -1
   KernelTime: True
+  MergeFiles: False
 
 BenchmarkProblems:
   - # hgemm TT

--- a/Tensile/Tests/pre_checkin/bfloat16/bfloat16s_hpa_source_nn.yaml
+++ b/Tensile/Tests/pre_checkin/bfloat16/bfloat16s_hpa_source_nn.yaml
@@ -3,6 +3,7 @@ GlobalParameters:
   MinimumRequiredVersion: 4.2.0
   NumElementsToValidate: -1
   KernelTime: True
+  MergeFiles: False
 
 BenchmarkProblems:
 

--- a/Tensile/Tests/pre_checkin/bfloat16/bfloat16s_hpa_source_nt.yaml
+++ b/Tensile/Tests/pre_checkin/bfloat16/bfloat16s_hpa_source_nt.yaml
@@ -3,6 +3,7 @@ GlobalParameters:
   MinimumRequiredVersion: 4.2.0
   NumElementsToValidate: -1
   KernelTime: True
+  MergeFiles: False
 
 BenchmarkProblems:
   - # hgemm TN

--- a/Tensile/Tests/pre_checkin/bfloat16/bfloat16s_hpa_source_tn.yaml
+++ b/Tensile/Tests/pre_checkin/bfloat16/bfloat16s_hpa_source_tn.yaml
@@ -3,6 +3,7 @@ GlobalParameters:
   MinimumRequiredVersion: 4.2.0
   NumElementsToValidate: -1
   KernelTime: True
+  MergeFiles: False
 
 BenchmarkProblems:
 

--- a/Tensile/Tests/pre_checkin/bfloat16/bfloat16s_hpa_source_tt.yaml
+++ b/Tensile/Tests/pre_checkin/bfloat16/bfloat16s_hpa_source_tt.yaml
@@ -2,6 +2,7 @@ GlobalParameters:
   MinimumRequiredVersion: 4.2.0
   NumElementsToValidate: -1
   KernelTime: True
+  MergeFiles: False
 
 BenchmarkProblems:
   - # hgemm TT

--- a/Tensile/Tests/pre_checkin/igemm_hpa_hip_nn.yaml
+++ b/Tensile/Tests/pre_checkin/igemm_hpa_hip_nn.yaml
@@ -4,6 +4,7 @@ GlobalParameters:
   NumElementsToValidate: -1
   BoundsCheck: True
   KernelTime: True
+  MergeFiles: False
 
 BenchmarkProblems:
   -


### PR DESCRIPTION
igemm_hpa_hip_nn drops from > 12 minutes to < 4 minutes
bfloat16s_hpa_source_tt drops from ~ 2.5 minutes to < 1 minute