### PR TITLE
GlobalSplitU + SingleBuffer improvement + BufferLoad, BufferStore=0 issue fixes

### DIFF
--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -711,10 +711,11 @@ validParameters = {
     "Use64bShadowLimit":   [ True, False],
 
     # Attempt to vectorize atomics
-    # 1,2,4,8 : Number of elements to vectorize
-    # -1 : Maximum supported value.  Half=2, Single=1, Double=2, singleComplex=2, doubleComplex=1
-    # TODO: support larger width
-    "VectorAtomicWidth":          [ -1, 1, 2] ,
+    # 1,2,4 : Number of elements to vectorize
+    # -1 : Maximum supported value
+    # Wider VAW is effective only for C load of "load + atomic_cmpswap" case. Atomic operation itself is not vectorized
+    # TODO: support larger width for atomic_cmpswap
+    "VectorAtomicWidth":          [ -1, 1, 2, 4] ,
 
     # Assertion properties
     # These provide information or assertions that the problem size meets certain requirements

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -711,10 +711,10 @@ validParameters = {
     "Use64bShadowLimit":   [ True, False],
 
     # Attempt to vectorize atomics
-    # 1,2,4 : Number of elements to vectorize
-    # -1 : Maximum supported value.  Half=2, Single=1, Double=1
-    # Currently 32-bit CAS only, eventually might support more
-    "VectorAtomicWidth":          [ -1, 1, 2 ] ,
+    # 1,2,4,8 : Number of elements to vectorize
+    # -1 : Maximum supported value.  Half=2, Single=1, Double=2, singleComplex=2, doubleComplex=1
+    # TODO: support larger width
+    "VectorAtomicWidth":          [ -1, 1, 2] ,
 
     # Assertion properties
     # These provide information or assertions that the problem size meets certain requirements

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -755,7 +755,11 @@ class KernelWriterAssembly(KernelWriter):
       kernel["LocalWriteUseSgprA"] = False # Requires DirectToLdsA
       kernel["LocalWriteUseSgprB"] = False # Requires DirectToLdsB
 
-    self.useAtomicAdd = self.asmCaps["HasAtomicAdd"] and (kernel["_GlobalAccumulation"] == 'SingleBuffer')
+    # set up useAtomicAdd
+    # limit to f32 + BufferStore + VAW=1 only
+    # applicable as long as ComputeDataType is single, but limited to _GlobalAccumulation=SingleBuffer so far
+    self.useAtomicAdd = self.asmCaps["HasAtomicAdd"] and (kernel["_GlobalAccumulation"] == 'SingleBuffer') and \
+                        kernel["BufferStore"] and kernel["VectorAtomicWidth"] == 1
 
     # OptPreLoopVmcnt for PAP:
     # the vmcnt for _ds_store in pre-loop can be optimized to skip the store of prev PKLoop
@@ -2306,14 +2310,15 @@ class KernelWriterAssembly(KernelWriter):
       origin  = f'{t}'
       replace = f'{t}' if self.archCaps["InstRename"] else f'{type_list[t]}'
       # use global_load/store instead of flat instructions
-      kStr += self.generalMacro('global_load_', origin, replace, 'dst', 'base', 'src', 'md0', 'md1', 'md2') + self.endLine
+      kStr += self.generalMacro('global_load_', origin, replace, 'dst', 'base', 'src', 'ioffset', 'md0', 'md1', 'md2') + self.endLine
       kStr += self.generalMacro('global_store_', origin, replace, 'base', 'src', 'src2', 'md0', 'md1', 'md2') + self.endLine
 
-    type_list = {'_b32': ''}
+    type_list = {'_b32': '',
+                 '_b64': '_x2'}
     for t in type_list:
         origin  = f'{t}'
         replace = f'{t}' if self.archCaps["InstRename"] else f'{type_list[t]}'
-        kStr += self.generalMacro('global_atomic_cmpswap', origin, replace, 'tmp', 'base', 'data', 'src', 'md') + self.endLine
+        kStr += self.generalMacro('global_atomic_cmpswap', origin, replace, 'tmp', 'base', 'data', 'src', 'ioffset', 'md') + self.endLine
 
     return kStr
 
@@ -2829,12 +2834,13 @@ class KernelWriterAssembly(KernelWriter):
             "add prepad for pointer shift")
 
       # addr *= bytes/element
+      bpe = self.bpeCexternal if tc == "C" else self.bpeAB
       if justOffset32:
-        kStr += staticMultiply("v[\\vgprAddr+0]", "v[\\vgprAddr+0]", self.bpeAB, None, "offset *= bytes/element")
+        kStr += staticMultiply("v[\\vgprAddr+0]", "v[\\vgprAddr+0]", bpe, None, "offset *= bytes/element")
       else:
         kStr += inst("v_lshlrev_b64", \
             "v[\\vgprAddr+0:\\vgprAddr+1]", \
-            hex(log2(self.bpeAB)), \
+            hex(log2(bpe)), \
             "v[\\vgprAddr+0:\\vgprAddr+1]", \
             "offset *= bytes/element")
       #kStr += "s_endpgm\n"
@@ -7352,6 +7358,14 @@ class KernelWriterAssembly(KernelWriter):
     g2lIdx = 0
     loadWidth = tP["globalReadInstruction"].totalWidth
 
+    # need numElementsPerLoad to calculate address increment for BufferLoad=0
+    numElementsPerLoad = 1
+    if kernel["ProblemType"]["DataType"].isHalf() or \
+       kernel["ProblemType"]["DataType"].isBFloat16():
+      if tP["glvw"]>1 and kernel["AssertSummationElementMultiple"] % 2 == 0:
+      # Pack two FP16 values into a single load dword x2
+        numElementsPerLoad = 2
+
     ########################################
     # Calculate Max Addr
     ########################################
@@ -7407,7 +7421,7 @@ class KernelWriterAssembly(KernelWriter):
       activeMask = "0xFFFFFFFF" if (waveSize == 32) else "0xFFFFFFFFFFFFFFFF"
       kStr += inst("s_mov_b{}".format(waveSize), sgpr(fullExec,sgprCnt), activeMask, "to restore all threads active")
       bpeVgpr = self.vgprPool.checkOut(1, "bpeVgpr")
-      kStr += inst("v_mov_b32", vgpr(bpeVgpr), hex(tP["bpe"]), "bpe")
+      kStr += inst("v_mov_b32", vgpr(bpeVgpr), hex(tP["bpe"]*numElementsPerLoad), "bpe*numElementsPerLoad")
 
       # can remove this?
       zeroVgpr = self.vgprPool.checkOut(1,"zeroVgpr")
@@ -7507,6 +7521,8 @@ class KernelWriterAssembly(KernelWriter):
 
               hi8 = 0
               hi16 = 0
+              bpl = numElementsPerLoad*self.bpeAB # bytesPerLoad
+
               if kernel["BufferLoad"]:
                 # Use buffer limit to stay in-bounds - the limit was set to edge when SRD initialized
                 # and each increment of SRD base in the unroll loop does a corresponding decrement
@@ -7618,8 +7634,6 @@ class KernelWriterAssembly(KernelWriter):
                     hi16 = (loopCnt%4)//2 if tP["glvw"]==1 else (r%4)//2
                     comment="load one buffer value"
 
-                bpl = numElementsPerLoad*self.bpeAB # bytesPerLoad
-
                 # if hi8=1 or hi16=1 (component 1,2,3 for int8) or (component 1 for half), use the temp destVgprHi
                 # but only when hi16=1 we use the _d16_hi version instruction, see the below visualized int8 comment
                 loadVgpr = destVgprHi if ((hi16 or hi8) and destVgprHi != None) else destVgpr
@@ -7667,18 +7681,22 @@ class KernelWriterAssembly(KernelWriter):
 
                 destVgpr="G2L%s+%u+%u"%(tc, g2lIdx, regIdx)
                 loadVgpr = destVgprHi if ((hi16 or hi8) and destVgprHi != None) else destVgpr
-                if kernel["ProblemType"]["DataType"].isInt8() and (not self.archCaps["HasEccHalf"]):
-                  kStr += inst("v_mov_b32", vgpr(loadVgpr), 0, "set to zero to avoid unexpected value")
+                if bpl < 4:
+                  # Not bufferLoad case, need to initialize dest vgpr for global load if bpl < 4
+                  # bpl < 4 case, we need to use multiple loads + or operation(s)
+                  # In that case, we need to ensure that register value of out of range is 0
+                  # Not buffer load case, we use exec flag and register value is unchanged if exec flag is 0.
+                  # If we do not initialize dest register here, some uninitialized value can be used for or operation
+                  kStr += inst("v_mov_b32", vgpr(loadVgpr), 0, "set to zero to set out of range load 0 for byte per load < 4")
 
                 kStr += inst("_v_cmpx_lt_u64", self.vcc, \
                     vgpr("GlobalReadAddr%s+%u"%(tc, graIdx),2), \
                     vgpr(maxAddrVgpr,2), \
                     "addr < maxAddr")
 
-
                 # load one element from address
                 kStr += self.chooseGlobalRead(False, \
-                          self.bpeAB, destVgpr=loadVgpr, \
+                          bpl, destVgpr=loadVgpr, \
                           addr0=vgpr("GlobalReadAddr%s+%u"%(tc,graIdx),2), addr1="", \
                           soffset=0, offset=0, \
                           extraFields=extraFields, \
@@ -9624,16 +9642,10 @@ class KernelWriterAssembly(KernelWriter):
     return kStr
 
   ##############################################################################
-  # LocalSplitU: Global Write Indices
+  # Global Write Indices common
   ##############################################################################
-  def localSplitUGlobalWriteIndices(self, kernel):
+  def globalWriteIndicesCommon(self, kernel):
     kStr = ""
-
-    # lr0 = serial % SG0
-    kStr += self.computeStoreVgprs(kernel, \
-              divisor = kernel["MacroTile0"] // kernel["GlobalWriteVectorWidth"], \
-              tid0Scale=kernel["GlobalWriteVectorWidth"], \
-              tid1Scale=1)
 
     if kernel["BufferStore"]:
       #print "----AddressC-LocalSplitU"
@@ -9650,15 +9662,55 @@ class KernelWriterAssembly(KernelWriter):
           vgpr(self.addrD+1), \
           sgpr("AddressD+1"), \
           "sgpr -> vgpr")
-      self.addrC = self.vgprPool.checkOut(2)
-      kStr += inst("v_mov_b32", \
-          vgpr(self.addrC+0), \
-          sgpr("AddressC+0"), \
-          "sgpr -> vgpr")
-      kStr += inst("v_mov_b32", \
-          vgpr(self.addrC+1), \
-          sgpr("AddressC+1"), \
-          "sgpr -> vgpr")
+      if kernel["_GlobalAccumulation"] == 'MultipleBuffer':
+        # (code from computeStoreSrdStart)
+        # GSU algorithm 2: adjust output buffer address to per GSU buffer
+        indices = list(range(0, kernel["ProblemType"]["NumIndicesC"]))
+        numDim = len(indices)
+        tmpSgpr = self.getTmpSgpr(5).idx()
+        kStr += "// GSU Output Buffer offset: Free0 + (Free1-1)*StrideC1J + (Free2-1)*StrideCK * GSUIdx * bpe%s" % self.endLine
+        kStr += self.s_mul_u64_u32(sgpr(tmpSgpr+0), sgpr(tmpSgpr+1), sgpr("SizesFree+0"), sgpr("GSUSumIdx"), "Free0")
+        for i in range(1, numDim):
+          kStr += inst("s_sub_u32",  sgpr(tmpSgpr+4), sgpr("SizesFree+%u"%i), 1, "Free%u" % i)
+          kStr += inst("s_mul_i32",  sgpr(tmpSgpr+4), sgpr(tmpSgpr+4), sgpr("GSUSumIdx"), "Free%u" % i)
+          kStr += self.s_mul_u64_u32(sgpr(tmpSgpr+2), sgpr(tmpSgpr+3), sgpr(tmpSgpr+4), sgpr("StrideC%s"%self.indexChars[i]), "Free%u" % i)
+          kStr += inst("s_add_u32",  sgpr(tmpSgpr+0), sgpr(tmpSgpr+0), sgpr(tmpSgpr+2), "Free%u" % i)
+          kStr += inst("s_addc_u32", sgpr(tmpSgpr+1), sgpr(tmpSgpr+1), sgpr(tmpSgpr+3), "Free%u" % i)
+        kStr += inst("s_lshl_b64", sgpr(tmpSgpr+0,2), sgpr(tmpSgpr+0,2), log2(self.bpeCexternal), "scale by bpe")
+        tmpVgpr = self.vgprPool.checkOut(2)
+        kStr += inst("v_mov_b32", vgpr(tmpVgpr+0), sgpr(tmpSgpr+0), "sgpr -> vgpr")
+        kStr += inst("v_mov_b32", vgpr(tmpVgpr+1), sgpr(tmpSgpr+1), "sgpr -> vgpr")
+        kStr += inst("_v_add_co_u32",  vgpr(self.addrD+0), self.vcc, vgpr(tmpVgpr+0), vgpr(self.addrD+0), "add lo GSU offset to SRD")
+        kStr += inst("_v_addc_co_u32", vgpr(self.addrD+1), self.vcc, vgpr(tmpVgpr+1), vgpr(self.addrD+1), self.vcc, "add hi GSU offset to SRD")
+        self.vgprPool.checkIn(tmpVgpr)
+        # addrC is not used for MultipleBuffer
+        self.addrC = -1
+      else:
+        self.addrC = self.vgprPool.checkOut(2)
+        kStr += inst("v_mov_b32", \
+            vgpr(self.addrC+0), \
+            sgpr("AddressC+0"), \
+            "sgpr -> vgpr")
+        kStr += inst("v_mov_b32", \
+            vgpr(self.addrC+1), \
+            sgpr("AddressC+1"), \
+            "sgpr -> vgpr")
+
+    return kStr
+
+  ##############################################################################
+  # LocalSplitU: Global Write Indices
+  ##############################################################################
+  def localSplitUGlobalWriteIndices(self, kernel):
+    kStr = ""
+
+    # lr0 = serial % SG0
+    kStr += self.computeStoreVgprs(kernel, \
+              divisor = kernel["MacroTile0"] // kernel["GlobalWriteVectorWidth"], \
+              tid0Scale=kernel["GlobalWriteVectorWidth"], \
+              tid1Scale=1)
+
+    kStr += self.globalWriteIndicesCommon(kernel)
 
     return kStr
 
@@ -9687,30 +9739,8 @@ class KernelWriterAssembly(KernelWriter):
               tid0Scale=kernel["VectorWidth"], \
               tid1Scale=kernel["VectorWidth"])
 
-    if kernel["BufferStore"]:
-      #print "----AddressC-nonLSU-----"
-      #print self.vgprPool.state()
-      self.addrD = -1
-      self.addrC = -1
-    else:
-      self.addrD = self.vgprPool.checkOut(2, 'addrD')
-      kStr += inst("v_mov_b32", \
-          vgpr(self.addrD+0), \
-          sgpr("AddressD+0"), \
-          "sgpr -> vgpr")
-      kStr += inst("v_mov_b32", \
-          vgpr(self.addrD+1), \
-          sgpr("AddressD+1"), \
-          "sgpr -> vgpr")
-      self.addrC = self.vgprPool.checkOut(2, 'addrC')
-      kStr += inst("v_mov_b32", \
-          vgpr(self.addrC+0), \
-          sgpr("AddressC+0"), \
-          "sgpr -> vgpr")
-      kStr += inst("v_mov_b32", \
-          vgpr(self.addrC+1), \
-          sgpr("AddressC+1"), \
-          "sgpr -> vgpr")
+    kStr += self.globalWriteIndicesCommon(kernel)
+
     return kStr
 
   ##############################################################################
@@ -9728,8 +9758,9 @@ class KernelWriterAssembly(KernelWriter):
     if kernel["BufferStore"]:
       self.vgprPool.checkIn(self.cinRowPtr)
       self.vgprPool.checkIn(self.coutRowPtr)
-    if not kernel["BufferStore"]:
+    if self.addrD >= 0:
       self.vgprPool.checkIn(self.addrD)
+    if self.addrC >= 0:
       self.vgprPool.checkIn(self.addrC)
 
     if self.betaVgpr != None:
@@ -10177,7 +10208,16 @@ class KernelWriterAssembly(KernelWriter):
           self.numMaskSgprPerBatch   = kernelWriter.laneSGPRCount
           self.numTempSgprPerBatch   = 2 * kernelWriter.laneSGPRCount
         else:
-          self.numMaskSgprPerElement = kernelWriter.laneSGPRCount
+          # calculate number of instructions per gwvw
+          # a separate mask is necessary for each single atomic instruction to avoid adding same value more than once
+          numAtomic = 1
+          if atomic:
+            bytePerGwvw = kernelWriter.bpeCexternal * gwvw
+            # TODO: enable wider VectorAtomicWidth
+            #atomicW = min(gwvw, kernel["VectorAtomicWidth"])
+            bytePerAtomicW = (2 if kernelWriter.bpeCexternal > kernelWriter.bpr else 1) * kernelWriter.bpr
+            numAtomic = bytePerGwvw // bytePerAtomicW
+          self.numMaskSgprPerElement = kernelWriter.laneSGPRCount * numAtomic # need 1 lane per atomic
           self.numMaskSgprPerBatch   = 0
           self.numTempSgprPerBatch   = 2 * kernelWriter.laneSGPRCount
 
@@ -10201,7 +10241,7 @@ class KernelWriterAssembly(KernelWriter):
 
         if atomic:
           # flat atomics have another VGPR to allow different data for return#
-          regsPerElement = 2 if kernel["BufferStore"] else (3 + 1) # + 1 for alignment
+          regsPerElement = 2
           # The atomic loop processes multiple elements in single instruction
           # so will use VGPR from consec elements? TODO
           self.numVgprsPerDataPerVI = (1.0 * regsPerElement * kernelWriter.bpeCexternal) / kernelWriter.bpr
@@ -10340,7 +10380,7 @@ class KernelWriterAssembly(KernelWriter):
     #
     # Also create an AddrCalc for each memory operation.
     ##############################################################################
-    def setupStoreElementsForBatch(self, kernel, gwvw, batchElements, batchElementSgprs, isOptNLL, allowLRVWBforTLUandMI, lrvwB):
+    def setupStoreElementsForBatch(self, kernel, gwvw, batchElements, batchElementSgprs, preventOverflow, allowLRVWBforTLUandMI, lrvwB):
 
       self.elementAddr = []
       self.elementData = []  # VGPR to use for element data, needed for atomic or beta
@@ -10436,11 +10476,12 @@ class KernelWriterAssembly(KernelWriter):
           #print ("d0=", d0, "vc0=", vc0, "elementCol=", elementCol)
         else:
           # allocate new VGPR for each element:
+          # need to allow expanding register pool (set preventOverflow=false)
           addrDVgpr = kw.vgprPool.checkOutAligned(self.cfg.numVgprsPerAddr, \
-              int(ceil(self.cfg.numVgprsPerAddr)), "writeDBatch-addr for ei=%u"%(elementIdx), preventOverflow=not isOptNLL)
+              int(ceil(self.cfg.numVgprsPerAddr)), "writeDBatch-addr for ei=%u"%(elementIdx), preventOverflow=False)
           if kernel["GroupLoadStore"] and kernel["ProblemType"]["UseBeta"]:
             addrCVgpr = kw.vgprPool.checkOutAligned(self.cfg.numVgprsPerAddr, \
-                int(ceil(self.cfg.numVgprsPerAddr)), "loadCBatch-addr for ei=%u"%(elementIdx), preventOverflow=not isOptNLL)
+                int(ceil(self.cfg.numVgprsPerAddr)), "loadCBatch-addr for ei=%u"%(elementIdx), preventOverflow=False)
           else:
             addrCVgpr = addrDVgpr
 
@@ -10455,12 +10496,12 @@ class KernelWriterAssembly(KernelWriter):
             if kernel["ProblemType"]["HighPrecisionAccumulate"] and \
                (kernel["ProblemType"]["DataType"].isBFloat16() or kernel["ProblemType"]["DataType"].isHalf()):
               data = kw.vgprPool.checkOutAligned(int(2*self.cfg.numVgprsPerDataPerVI*self.cfg.gwvw), \
-                    int(ceil(int(2*self.cfg.numVgprsPerDataPerVI*self.cfg.gwvw))), "writeBatch-data for ei=%u and ei=%u"%(elementIdx,elementIdx+1), preventOverflow=not isOptNLL)
+                    int(ceil(int(2*self.cfg.numVgprsPerDataPerVI*self.cfg.gwvw))), "writeBatch-data for ei=%u and ei=%u"%(elementIdx,elementIdx+1), preventOverflow=preventOverflow)
             else:
               if elementIdx%2 == 0:
                 # allocate for two elements:
                 data = kw.vgprPool.checkOutAligned(int(2*self.cfg.numVgprsPerDataPerVI*self.cfg.gwvw), \
-                       int(ceil(int(2*self.cfg.numVgprsPerDataPerVI*self.cfg.gwvw))), "writeBatch-data for ei=%u and ei=%u"%(elementIdx,elementIdx+1), preventOverflow=not isOptNLL)
+                       int(ceil(int(2*self.cfg.numVgprsPerDataPerVI*self.cfg.gwvw))), "writeBatch-data for ei=%u and ei=%u"%(elementIdx,elementIdx+1), preventOverflow=preventOverflow)
                 lastData = data
               else:
                 data = lastData
@@ -10828,23 +10869,6 @@ class KernelWriterAssembly(KernelWriter):
       updateCoord1 = (edge or len(kernel["PackedC1IndicesX"]) > 1)
       kStr += self.emitAddressCoordIncrement(kernel, ss, tmpVgpr, tmpS01, updateCoord1)
 
-      # calculate global load offset
-      if not kernel["BufferStore"]:
-        # global: in-bounds exec mask
-        # global offset macro (requires 3 tmpVgpr)
-        # final address = C + index*bytes
-        kStr += "GLOBAL_OFFSET_C %u" % addrVgpr
-        for i in range(0, kernel["ProblemType"]["NumIndicesC"]):
-          if i == kernel["ProblemType"]["Index0"]:
-            kStr += ", %s" % (self.coord0Vgpr)
-          elif i == kernel["ProblemType"]["Index1"]:
-            kStr += ", %s" % (self.coord1Vgpr)
-          else: # just a group index
-            kStr += ", sgprWorkGroup%u"%i
-        kStr += ", %s%s" % ((tmpVgpr+2), kw.endLine)
-        kStr += inst("v_mov_b32", vgpr(tmpVgpr+2), vgpr(addrVgpr+0), "temp store offset 0")
-        kStr += inst("v_mov_b32", vgpr(tmpVgpr+3), vgpr(addrVgpr+1), "temp store offset 1")
-
       # Move the row ptr VGPR
       # optSrdIncForRow moves the SRD so don't move here
       if not ss.optSrdIncForRow and kernel["BufferStore"]:
@@ -10915,6 +10939,24 @@ class KernelWriterAssembly(KernelWriter):
                           sgpr(sTmp1,sgprCnt), "set new rowStart if meet conditions" )
 
           kStr += "\n"
+
+      # calculate global load offset
+      # this has to be done after calculating new coord1
+      if not kernel["BufferStore"]:
+        # global: in-bounds exec mask
+        # global offset macro (requires 3 tmpVgpr)
+        # final address = C + index*bytes
+        kStr += "GLOBAL_OFFSET_C %u" % addrVgpr
+        for i in range(0, kernel["ProblemType"]["NumIndicesC"]):
+          if i == kernel["ProblemType"]["Index0"]:
+            kStr += ", %s" % (self.coord0Vgpr)
+          elif i == kernel["ProblemType"]["Index1"]:
+            kStr += ", %s" % (self.coord1Vgpr)
+          else: # just a group index
+            kStr += ", sgprWorkGroup%u"%i
+        kStr += ", %s%s" % ((tmpVgpr+2), kw.endLine)
+        kStr += inst("v_mov_b32", vgpr(tmpVgpr+2), vgpr(addrVgpr+0), "temp store offset 0")
+        kStr += inst("v_mov_b32", vgpr(tmpVgpr+3), vgpr(addrVgpr+1), "temp store offset 1")
 
       return kStr
 
@@ -11082,7 +11124,7 @@ class KernelWriterAssembly(KernelWriter):
     # write possibilities and labels
     # if beta/edge combo not specified fall back to global param definition
     if betas is None:
-      hasBeta = kernel["ProblemType"]["UseBeta"] and (kernel["_GlobalAccumulation"] != 'MultipleBuffer')
+      hasBeta = kernel["ProblemType"]["UseBeta"] and (kernel["GlobalSplitU"] == 1)
       betas = [False, True] if hasBeta else [False]
     if edges is None:
       edges = [False, True] if self.do["EdgeWrite"] else [False]
@@ -11481,20 +11523,27 @@ class KernelWriterAssembly(KernelWriter):
     else:
       # use global_load instructions (instead of flat_load) for useBuffer=0
       # specify "off" to disable optional saddr
+      # global_load uses offset13s (offset:{-4096..4095})
+      # TODO: use saddr if offset is out of offset13s
+      if offset > 4095 or offset < -4096:
+          assert 0, "offset out of range for global_load"
+      tailFields = "offset:%u"%offset
+      if extraFields != "":
+        tailFields += ", %s"% extraFields
       if bpl==1 and hi16:
-        return Code.GlobalReadInst("_global_load_d16_hi_u8", vgpr(destVgpr, rpv*4), addr0, "off", extraFields, comment )
+        return Code.GlobalReadInst("_global_load_d16_hi_u8", vgpr(destVgpr, rpv*4), addr0, "off", tailFields, comment )
       elif bpl==1 and not hi16:
-        return Code.GlobalReadInst("_global_load_d16_u8", vgpr(destVgpr, rpv*4), addr0, "off", extraFields, comment )
+        return Code.GlobalReadInst("_global_load_d16_u8", vgpr(destVgpr, rpv*4), addr0, "off", tailFields, comment )
       elif bpl==2 and hi16:
-        return Code.GlobalReadInst("_global_load_d16_hi_b16", vgpr(destVgpr, rpv*2), addr0, "off", extraFields, comment )
+        return Code.GlobalReadInst("_global_load_d16_hi_b16", vgpr(destVgpr, rpv*2), addr0, "off", tailFields, comment )
       elif bpl==2 and not hi16:
-        return Code.GlobalReadInst("_global_load_d16_b16", vgpr(destVgpr, rpv*2), addr0, "off", extraFields, comment )
+        return Code.GlobalReadInst("_global_load_d16_b16", vgpr(destVgpr, rpv*2), addr0, "off", tailFields, comment )
       elif bpl==4:
-        return Code.GlobalReadInst("_global_load_b32", vgpr(destVgpr, rpv), addr0, "off", extraFields, comment )
+        return Code.GlobalReadInst("_global_load_b32", vgpr(destVgpr, rpv), addr0, "off", tailFields, comment )
       elif bpl==8:
-        return Code.GlobalReadInst("_global_load_b64", vgpr(destVgpr, rpv), addr0, "off", extraFields, comment )
+        return Code.GlobalReadInst("_global_load_b64", vgpr(destVgpr, rpv), addr0, "off", tailFields, comment )
       elif bpl==16:
-        return Code.GlobalReadInst("_global_load_b128", vgpr(destVgpr, rpv), addr0, "off", extraFields, comment )
+        return Code.GlobalReadInst("_global_load_b128", vgpr(destVgpr, rpv), addr0, "off", tailFields, comment )
       else:
         assert 0, "chooseGlobalRead: bad bpl"
 
@@ -11623,37 +11672,55 @@ class KernelWriterAssembly(KernelWriter):
   # choose the ADD instruction for combining external C with internal C
   # used in atomic=1 case to compute expected external data
   ##############################################################################
-  def chooseAddForAtomic(self, kernel, dst, src0, src1, comment):
+  def chooseAddForAtomic(self, kernel, dst, src0, sumIdxV, comment, atomicOpW):
     kStr = ""
-    if kernel["ProblemType"]["DataType"].isBFloat16():
-      if kernel["_GlobalAccumulation"]:
-        kStr += inst("v_add_f32", dst, src0, src1, comment)
-    elif kernel["ProblemType"]["DataType"].isHalf():
-      if kernel["_GlobalAccumulation"]:
-        kStr += inst("v_add_f32", dst, src0, src1, comment)
-      elif kernel["ProblemType"]["HighPrecisionAccumulate"]:
-        kStr += inst("v_mad_mix need madmix bozo", \
-                  dst, src0, src1, \
-                  comment)
-      else:
-        kStr += inst("v_pk_add_f16", \
-                  dst, src0, src1, \
-                  comment)
-    elif kernel["ProblemType"]["DataType"].isInt8x4() or kernel["ProblemType"]["DataType"].isInt8():
+    regNum = 1
+    if kernel["ProblemType"]["ComputeDataType"].isSingle() or kernel["ProblemType"]["ComputeDataType"].isSingleComplex():
+      addInst = "v_add_f32"
+    elif kernel["ProblemType"]["ComputeDataType"].isHalf():
+      addInst = "v_pk_add_f16"
+    elif kernel["ProblemType"]["ComputeDataType"].isInt32():
       # assume v_add_i32 can be used in place of v_add_f32
       # need to add saturation directive to v_add_i32 instruction to clamp integer arithmetic
-      kStr += inst("_v_add_i32", \
-                dst, src0, src1, \
-                comment)
-    elif kernel["ProblemType"]["DataType"].isSingle():
-      kStr += inst("v_add_f32", \
-                dst, src0, src1, \
-                comment)
+      addInst = "_v_add_i32"
+    elif kernel["ProblemType"]["ComputeDataType"].isDouble() or kernel["ProblemType"]["ComputeDataType"].isDoubleComplex():
+      addInst = "v_add_f64"
+      regNum = 2
     else:
-       #support for double
-      kStr += inst("v_add_f64", \
-                 dst, src0, src1, \
-                 comment)
+      assert(0) # unsupported data type,
+
+    for idx in range(0,atomicOpW, regNum):
+      kStr += inst(addInst, vgpr(dst+idx, regNum), vgpr(src0+idx, regNum), vgpr("ValuC+%u"%(sumIdxV+idx), regNum), comment)
+
+    return kStr
+
+  ##############################################################################
+  # choose the atomic_cmpswap instruction for write attempt
+  # used in atomic=1 case
+  ##############################################################################
+  def chooseAtomicCmpswap(self, kernel, addrCalc, addDst, offset, atomicOpW):
+    kStr = ""
+    # attempt write
+    if self.do["GlobalWrite"]:
+      # use cmpswap_b64 for DGEMM or cmpswap_b32 for DGEMM in CAS loop
+      bits = 32 * atomicOpW
+      if kernel["BufferStore"]:
+        kStr += "_buffer_atomic_cmpswap_b%u %s, %s, %s %s    // %s%s" % \
+            (bits, \
+            vgpr(addDst,atomicOpW*2), \
+            vgpr(addrCalc.addrDVgpr,1), \
+            sgpr("SrdD", 4),  \
+            "0 offen offset:%u glc" % (addrCalc.globalOffset + offset), \
+            "attempt write", self.endLine )
+      else:
+        # not BufferStore case
+        kStr += "_global_atomic_cmpswap_b%u %s, %s, %s, %s, %s, %s    // %s%s" % \
+            (bits, vgpr(addDst,atomicOpW), vgpr(addrCalc.addrDVgpr,2), \
+            vgpr(addDst,atomicOpW*2), "off", "offset:%u"%offset, "glc", "attempt write", self.endLine )
+    else:
+       # Fake successful CAS swap:
+       for idx in range(atomicOpW):
+         kStr += inst("v_mov_b32", vgpr(addDst+idx), vgpr(addDst+atomicOpW+idx), "Fake successful CAS" )
 
     return kStr
 
@@ -11789,9 +11856,8 @@ class KernelWriterAssembly(KernelWriter):
     if atomic:
       # all kinds of code relies on this assumption:
       assert(atomicW <= gwvw)
-      if (kernel["ProblemType"]["DataType"].isHalf() or kernel["ProblemType"]["DataType"].isBFloat16()) \
-         and not kernel["_GlobalAccumulation"]:
-        assert(atomicW >= 2)
+      # atomicW * numBytes should be >= self.bpr
+      assert((atomicW * kernel["ProblemType"]["ComputeDataType"].numBytes()) >= self.bpr)
 
     # comment tt1, tt0, vc1, vc0
     # tt = thread tile, vc=vector component
@@ -11808,7 +11874,9 @@ class KernelWriterAssembly(KernelWriter):
     # print(self.kernelName)
     # print(commentStr)
 
-    ss.setupStoreElementsForBatch(kernel, gwvw, batchElements, batchElementSgprs, isOptNLL=False, \
+    # allow expanding vgpr pool for OptNLL
+    preventOverflow = (not isOptNLL)
+    ss.setupStoreElementsForBatch(kernel, gwvw, batchElements, batchElementSgprs, preventOverflow=preventOverflow, \
                                   allowLRVWBforTLUandMI=self.allowLRVWBforTLUandMI, lrvwB=self.lrvwB)
 
     loadsIssued = 0
@@ -11818,6 +11886,12 @@ class KernelWriterAssembly(KernelWriter):
 
     wavelen = self.kernel["WavefrontSize"]
     laneSGPRC = self.laneSGPRCount
+    bpm = self.bpeCexternal * atomicW
+    vgprLoadDW = 1*(bpm//4)
+    # cmpswap_b64 is applicable only for bpe>4 data types due to alignment restriction
+    # atomicAdd case, W=1 only.
+    # TODO: add atomicOpW=2 support for smaller data types by introducing alignment assertion
+    atomicOpW = 2 if (self.bpeCexternal > 4 and (not self.useAtomicAdd)) else 1
 
     ########################################
     # calculate addr and masks
@@ -11926,7 +12000,6 @@ class KernelWriterAssembly(KernelWriter):
         # iterate over number of atomic operations to perform, each of width atomicW
         for avi in range(0, gwvw//atomicW):
           dataV = ss.elementData[elementIdx] + int(avi*ss.cfg.numVgprsPerDataPerVI)
-          bpm = self.bpeCexternal * atomicW
           useBuffer = kernel["BufferStore"]
           if kernel["BufferStore"]: # yes, BufferStore here - use same addressing regs for this load
             addr0 = vgpr(addrDVgpr)
@@ -11936,8 +12009,7 @@ class KernelWriterAssembly(KernelWriter):
             addr1 = ""
           # Calculate vgpr Index for 32-bit/64-bit instruction
           # DGEMM use SRCS[2] register
-          vgprIdx = 1*(bpm//4)
-          kStr += self.chooseGlobalRead(useBuffer, bpm, dataV+vgprIdx, \
+          kStr += self.chooseGlobalRead(useBuffer, bpm, dataV+vgprLoadDW, \
                     addr0, addr1, soffset=0, offset=addrCalc.globalOffset, extraFields="",
                     dtlNoDestVgpr=False, \
                     comment="load D (atomic) bpm=%u vaw=%u"%(bpm,atomicW)).toStr()
@@ -12047,31 +12119,34 @@ class KernelWriterAssembly(KernelWriter):
         # first attempt write
         kStr += self.comment("issue first atomic writes")
         for elementIdx in range(0, len(batchElements)):
-          element  = batchElements[elementIdx]
           addrCalc = ss.elementAddr[elementIdx]
           mask     = ss.elementMask[elementIdx]
-          d1       = element[0]
-          d0       = element[1]
-          vc1      = element[2]
-          vc0      = element[3]
 
-          # apply in-bounds exec mask
-          if edge:
-            kStr += inst("s_mov_b{}".format(wavelen), self.exec, sgpr(mask,laneSGPRC), "sgprs -> exec (before atomic)" )
+          loopCount = 0
+          for avi in range(0, gwvw, atomicW):
+            for compIdx in range(vgprLoadDW // atomicOpW):
+              maskIdx = mask + loopCount * laneSGPRC
+              compOffset = compIdx * atomicOpW
+              compDstRegOffset = compOffset * 2
+              sumIdxV = ss.elementSumIdx[elementIdx] + avi
+              sumIdxV = int(sumIdxV * kernel["ProblemType"]["ComputeDataType"].numRegisters())
+              sumIdxV += compOffset
 
-          for avi in range(0, gwvw//atomicW):
-            dataV = ss.elementData[elementIdx] + int(avi*ss.cfg.numVgprsPerDataPerVI)
-            sumIdxV = ss.elementSumIdx[elementIdx] + avi
-            if self.do["GlobalWrite"]:
-              if kernel["BufferStore"]:
-                kStr += "buffer_atomic_add_f32 %s, %s, %s, %s    // %s%s" % \
-                    (vgpr("ValuC+%u"%sumIdxV), \
-                     vgpr(addrCalc.addrDVgpr,1), \
-                     sgpr("SrdD", 4), \
-                     "0 offen offset:%u" % addrCalc.globalOffset, \
-                     "attempt write avi=%u" % (avi), self.endLine )
-              else:
-                pass # TODO:
+              # apply in-bounds exec mask
+              if edge:
+                kStr += inst("s_mov_b{}".format(wavelen), self.exec, sgpr(maskIdx,laneSGPRC), "sgprs -> exec (before atomic)" )
+
+              if self.do["GlobalWrite"]:
+                if kernel["BufferStore"]:
+                  kStr += "buffer_atomic_add_f%u %s, %s, %s, %s    // %s%s" % \
+                      (atomicOpW * 32, \
+                       vgpr("ValuC+%u"%sumIdxV,atomicOpW), \
+                       vgpr(addrCalc.addrDVgpr,1), \
+                       sgpr("SrdD", 4), \
+                       "0 offen offset:%u" % (addrCalc.globalOffset + compOffset), \
+                       "attempt write avi=%u" % (avi), self.endLine )
+                else:
+                  pass # TODO:
 
         if edge:
           kStr += inst("s_mov_b{}".format(wavelen), self.exec, -1, "full mask -> exec" )
@@ -12087,62 +12162,66 @@ class KernelWriterAssembly(KernelWriter):
         # first attempt write
         kStr += self.comment("issue first atomic writes")
         for elementIdx in range(0, len(batchElements)):
-          element = batchElements[elementIdx]
           addrCalc = ss.elementAddr[elementIdx]
           mask = ss.elementMask[elementIdx]
-          d1 = element[0]
-          d0 = element[1]
-          vc1 = element[2]
-          vc0 = element[3]
 
           # apply in-bounds exec mask
           if edge:
             kStr += inst("s_mov_b{}".format(wavelen), self.exec, sgpr(mask,laneSGPRC), "sgprs -> exec (before atomic)" )
 
-          for avi in range(0, gwvw//atomicW):
+          for avi in range(0, gwvw, atomicW):
             dataV = ss.elementData[elementIdx] + int(avi*ss.cfg.numVgprsPerDataPerVI)
-            sumIdxV = ss.elementSumIdx[elementIdx] + avi
-            ## number of src[s]/dst[s] register for DGEMM / SGEMM HGEMM
-            vgprCnt = 2 if kernel["ProblemType"]["DestDataType"].isDouble() else 1
-            if kernel["ProblemType"]["DestDataType"].numRegisters() < 1 and not kernel["_GlobalAccumulation"]:
-              sumIdxV //= 2
-            if kernel["ProblemType"]["DestDataType"].isDouble(): sumIdxV = sumIdxV * 2
-            bpm = self.bpeCexternal * atomicW
-            # Calculate vgpr Index for 32-bit/64-bit instruction
-            # DGEMM use SRCS[2] register
-            vgprIdx = 1*(bpm//4)
-            # for atomic, data[1] = original c, data[0] = new c
-            kStr += self.chooseAddForAtomic(kernel, \
-                      vgpr(dataV+0,vgprCnt), vgpr(dataV+1*vgprIdx,vgprCnt), vgpr("ValuC+%u"%sumIdxV,vgprCnt), \
-                      "desired value avi=%u"%avi)
+            # vgprLoadDW > atomicOpW case, we use wider load
+            # In this case, we need to move loaded data to use multiple cmpswap instructions
+            #  ex.) vgprLoadDW=4, atomicOpW=2 case
+            #   before move (after load b128) :
+            #         dataV + 0-3: empty
+            #         dataV + 4-7: loaded data
+            #   after move (4-5 to 2-3):
+            #         dataV + 0-1: empty (for add data)
+            #         dataV + 2-3: loaded data (first 8Byte)  -> need to move
+            #         dataV + 4-5: empty (for add data)
+            #         dataV + 6-7: loaded data (second 8Byte) -> no move
+            # adjust cmpswapWidth (no b128 instruction)
+            if vgprLoadDW > atomicOpW:
+              for idx1 in range((vgprLoadDW//atomicOpW) - 1):
+                for idx0 in range(atomicOpW):
+                  dst = dataV + (2*atomicOpW) * idx1 + atomicOpW + idx0
+                  src = dataV + vgprLoadDW + atomicOpW * idx1 + idx0
+                  kStr += inst("v_mov_b32", vgpr(dst), vgpr(src), "v_mov for reordering loaded data" )
 
-            # attempt write
-            atomicDestVgpr = dataV if kernel["BufferStore"] else dataV+2
-            if self.do["GlobalWrite"]:
-              if kernel["BufferStore"]:
-                # use cmpswap_x2 for DGEMM in CAS loop
-                if kernel["ProblemType"]["DestDataType"].isDouble():
-                  kStr += "_buffer_atomic_cmpswap_b64 %s, %s, %s %s    // %s%s" % \
-                      (vgpr(dataV,4), \
-                      vgpr(addrCalc.addrDVgpr,1), \
-                      sgpr("SrdD", 4),  \
-                      "0 offen offset:%u glc" % addrCalc.globalOffset, \
-                      "attempt write avi=%u"%(avi), self.endLine )
-                else:
-                # use cmpswap for SGEMM in CAS loop
-                  kStr += "_buffer_atomic_cmpswap_b32 %s, %s, %s %s    // %s%s" % \
-                      (vgpr(dataV,2), \
-                      vgpr(addrCalc.addrDVgpr,1), \
-                      sgpr("SrdD", 4),  \
-                      "0 offen offset:%u glc" % addrCalc.globalOffset, \
-                      "attempt write avi=%u"%(avi), self.endLine )
-              else:
-                kStr += "_global_atomic_cmpswap_b32 %s, %s, %s, %s %s    // %s%s" % \
-                    (vgpr(atomicDestVgpr), vgpr(addrCalc.addrDVgpr,2), \
-                    vgpr(dataV,2), "off", "glc", "attempt write", self.endLine )
-            else:
-               kStr += inst("v_mov_b32", vgpr(atomicDestVgpr), vgpr(dataV+1), "Fake successful CAS" )
-               # Fake successful CAS swap:
+            for compIdx in range(vgprLoadDW // atomicOpW):
+              compOffset = compIdx * atomicOpW
+              compDstRegOffset = compOffset * 2
+              sumIdxV = ss.elementSumIdx[elementIdx] + avi
+              ## number of src[s]/dst[s] register for DGEMM / SGEMM HGEMM
+              sumIdxV = int(sumIdxV * kernel["ProblemType"]["ComputeDataType"].numRegisters())
+              sumIdxV += compOffset
+              # Calculate vgpr Index for 32-bit/64-bit instruction
+              # DGEMM use SRCS[2] register
+              addDst = dataV + compDstRegOffset
+              addSrc0 = addDst + atomicOpW
+              comment = "desired value avi=%u"%avi
+              # for atomic, data[1] = original c, data[0] = new c
+              kStr += self.chooseAddForAtomic(kernel, addDst, addSrc0, sumIdxV, comment, atomicOpW)
+              # attempt write
+              kStr += self.chooseAtomicCmpswap(kernel, addrCalc, addDst, compOffset * self.bpr, atomicOpW)
+
+        ########################################
+        # edge case only, copy out of range mask to all masks for each atomic instruction
+        if edge:
+          for elementIdx in range(0, len(batchElements)):
+            mask = ss.elementMask[elementIdx]
+            # calculate new masks
+            loopCount = 0
+            for avi in range(0, gwvw, atomicW):
+              for compIdx in range(vgprLoadDW // atomicOpW):
+                maskIdx = mask + loopCount * laneSGPRC
+                if loopCount > 0:
+                  # copy out of range mask from the first one
+                  kStr += inst("s_mov_b{}".format(wavelen),  sgpr(maskIdx,laneSGPRC), sgpr(mask,laneSGPRC), "copy out of range mask from the first one" )
+                #increment loopCount
+                loopCount += 1
 
         ########################################
         # wait for first attempt write
@@ -12154,64 +12233,43 @@ class KernelWriterAssembly(KernelWriter):
         # check first attempt
         kStr += self.comment("check success of writes, update masks")
         for elementIdx in range(0, len(batchElements)):
-          element = batchElements[elementIdx]
           mask = ss.elementMask[elementIdx]
-          d1 = element[0]
-          d0 = element[1]
-          vc1 = element[2]
-          vc0 = element[3]
-
-          # calculate new masks
-          if edge:
-            kStr += inst("s_mov_b{}".format(wavelen), self.exec, sgpr(mask,laneSGPRC), "sgprs -> exec" )
-            for avi in range(0, gwvw//atomicW):
+          loopCount = 0
+          for avi in range(0, gwvw, atomicW):
+            for compIdx in range(vgprLoadDW // atomicOpW):
+              maskIdx = mask + loopCount * laneSGPRC
+              compOffset = compIdx * atomicOpW
+              compDstRegOffset = compOffset * 2
               dataV = ss.elementData[elementIdx] + int(avi*ss.cfg.numVgprsPerDataPerVI)
-              atomicDestVgpr = dataV if kernel["BufferStore"] else dataV+2
-              # need to apply element mask before comparison
-              # so that all valid lanes are doing the cmp
-              if avi == 0:
-                # use u64 for DGEMM
-                if kernel["ProblemType"]["DestDataType"].isDouble():
-                  kStr += inst("v_cmp_ne_u64", sgpr(tmpS01,laneSGPRC), vgpr(atomicDestVgpr,2), \
-                      vgpr(dataV+2,2), "c read during atomic == c read during prior load (avi=%u, first)"%avi )
-                else:
-                  kStr += inst("v_cmp_ne_u32", sgpr(tmpS01,laneSGPRC), vgpr(atomicDestVgpr), \
-                      vgpr(dataV+1), "c read during atomic == c read during prior load (avi=%u, first)"%avi )
-              else:
-                if kernel["ProblemType"]["DestDataType"].isDouble():
-                  kStr += inst("v_cmp_ne_u64", sgpr(tmpS23,laneSGPRC), vgpr(atomicDestVgpr,2), \
-                      vgpr(dataV+2,2), "c read during atomic != c read during prior load" )
-                else:
-                  kStr += inst("v_cmp_ne_u32", sgpr(tmpS23,laneSGPRC), vgpr(atomicDestVgpr), \
-                      vgpr(dataV+1), "c read during atomic == c read during prior load (avi=%u)"%avi )
-                kStr += inst("s_or_b{}".format(wavelen), sgpr(tmpS01,laneSGPRC), \
-                      sgpr(tmpS01,laneSGPRC), sgpr(tmpS23,laneSGPRC), "combine with tmp mask")
+              atomicDestVgpr = dataV + compDstRegOffset
+              dstSgpr = tmpS01 if edge else maskIdx
+              comment = "c read during atomic != c read during prior load (avi=%u)"%avi
 
-            if kernel["DisableAtomicFail"]:
-              kStr += inst("s_mov_b{}".format(wavelen),  sgpr(mask,laneSGPRC), 0, "DisableAtomicFail, force 0" )
-            else:
-              kStr += inst("s_and_b{}".format(wavelen),  sgpr(mask,laneSGPRC), sgpr(tmpS01,laneSGPRC), sgpr(mask,laneSGPRC), "inBounds & must try again" )
+              if edge:
+                # edge case only, set exec flag
+                kStr += inst("s_mov_b{}".format(wavelen), self.exec, sgpr(maskIdx,laneSGPRC), "sgprs -> exec" )
+              kStr += inst("v_cmp_ne_u%u"%(32 * atomicOpW), sgpr(dstSgpr,laneSGPRC), vgpr(atomicDestVgpr,atomicOpW), \
+                  vgpr(atomicDestVgpr+atomicOpW,atomicOpW), comment )
 
-          else:
-            for avi in range(0, gwvw//atomicW):
-              dataV = ss.elementData[elementIdx] + int(avi*ss.cfg.numVgprsPerDataPerVI)
-              atomicDestVgpr = dataV if kernel["BufferStore"] else dataV+2
               if kernel["DisableAtomicFail"]:
-                kStr += inst("s_mov_b{}".format(wavelen),  sgpr(mask,laneSGPRC), 0, "DisableAtomicFail, force 0" )
-              else:
-                if kernel["ProblemType"]["DestDataType"].isDouble():
-                  kStr += inst("v_cmp_ne_u64", sgpr(mask,laneSGPRC), vgpr(atomicDestVgpr,2), \
-                      vgpr(dataV+2,2), "c read during atomic != c read during prior load" )
-                else:
-                  kStr += inst("v_cmp_ne_u32", sgpr(mask,laneSGPRC), vgpr(atomicDestVgpr), \
-                      vgpr(dataV+1), "c read during atomic != c read during prior load" )
+                kStr += inst("s_mov_b{}".format(wavelen),  sgpr(maskIdx,laneSGPRC), 0, "DisableAtomicFail, force 0" )
+              elif edge:
+                kStr += inst("s_and_b{}".format(wavelen),  sgpr(maskIdx,laneSGPRC), sgpr(tmpS01,laneSGPRC), sgpr(maskIdx,laneSGPRC), "inBounds & must try again" )
+              #increment loopCount
+              loopCount += 1
 
         # or masks together to check early exit
         kStr += self.comment("or masks to check for exit")
         kStr += inst("s_mov_b{}".format(wavelen), sgpr(tmpS01,laneSGPRC), hex(0), "empty mask" )
         for elementIdx in range(0, len(batchElements)):
           mask = ss.elementMask[elementIdx]
-          kStr += inst("s_or_b{}".format(wavelen), sgpr(tmpS01,laneSGPRC), sgpr(mask,laneSGPRC), sgpr(tmpS01,laneSGPRC), "or to add threads" )
+          loopCount = 0
+          for avi in range(0, gwvw, atomicW):
+            for compIdx in range(vgprLoadDW // atomicOpW):
+              maskIdx = mask + loopCount * laneSGPRC
+              kStr += inst("s_or_b{}".format(wavelen), sgpr(tmpS01,laneSGPRC), sgpr(maskIdx,laneSGPRC), sgpr(tmpS01,laneSGPRC), "or to add threads" )
+              #increment loopCount
+              loopCount += 1
         kStr += inst("s_or_saveexec_b{}".format(wavelen), sgpr(tmpS23,laneSGPRC), sgpr(tmpS01,laneSGPRC), "apply combined mask" )
         kStr += inst("s_cbranch_execz", "label_%04u" % labelAfterAtomicLoop, "if exec is zero skip loop" )
 
@@ -12221,54 +12279,34 @@ class KernelWriterAssembly(KernelWriter):
 
         kStr += self.comment("apply updated masks and issue writes again")
         for elementIdx in range(0, len(batchElements)):
-          element = batchElements[elementIdx]
           addrCalc = ss.elementAddr[elementIdx]
-          addr = ss.elementAddr[elementIdx].addrDVgpr
           mask = ss.elementMask[elementIdx]
-          vgprCnt = 2 if kernel["ProblemType"]["DestDataType"].isDouble() else 1   # number of registers for f32/f64
-          bpm = self.bpeCexternal * atomicW
-          vgprIdx = 1*(bpm//4)   # index register
 
-          for avi in range(0, gwvw//atomicW):
-            dataV = ss.elementData[elementIdx] + int(avi*ss.cfg.numVgprsPerDataPerVI)
-            atomicDestVgpr = dataV if kernel["BufferStore"] else dataV+2
-            sumIdxV = ss.elementSumIdx[elementIdx] + avi
-            if kernel["ProblemType"]["DestDataType"].numRegisters() < 1 and not kernel["_GlobalAccumulation"]:
-              sumIdxV //= 2
-            if kernel["ProblemType"]["DestDataType"].isDouble():  sumIdxV =  sumIdxV * 2
+          loopCount = 0
+          for avi in range(0, gwvw, atomicW):
+            for compIdx in range(vgprLoadDW // atomicOpW):
+              maskIdx = mask + loopCount * laneSGPRC
+              compOffset = compIdx * atomicOpW
+              compDstRegOffset = compOffset * 2
+              dataV = ss.elementData[elementIdx] + int(avi*ss.cfg.numVgprsPerDataPerVI)
+              sumIdxV = ss.elementSumIdx[elementIdx] + avi
+              sumIdxV = int(sumIdxV * kernel["ProblemType"]["ComputeDataType"].numRegisters())
+              sumIdxV += compOffset
+              addDst = dataV + compDstRegOffset
+              addSrc0 = addDst + atomicOpW
+              comment = "newC = rC + originalC"
 
-            # apply mask for element
-            kStr += inst("s_mov_b{}".format(wavelen), self.exec, sgpr(mask,laneSGPRC), "must try again" )
-            if kernel["ProblemType"]["DestDataType"].isDouble():
-              #64-bit C val move by 2 32-bit instructions
-              kStr += inst("v_mov_b32", vgpr(dataV+2), vgpr(atomicDestVgpr), "dataV+2 = tmp (new original C)" )
-              kStr += inst("v_mov_b32", vgpr(dataV+3), vgpr(atomicDestVgpr+1), "dataV+3 = tmp (new original C)" )
-            else:
-              kStr += inst("v_mov_b32", vgpr(dataV+1), vgpr(atomicDestVgpr), "dataV+1 = tmp (new original C)" )
-            kStr += self.chooseAddForAtomic(kernel, \
-                      vgpr(dataV+0,vgprCnt), vgpr(dataV+1*vgprIdx,vgprCnt), vgpr("ValuC+%u"%sumIdxV,vgprCnt), \
-                      "newC = rC + originalC")
-            if self.do["GlobalWrite"]:
-              if kernel["BufferStore"]:
-                # Using no-ret version here?
-                # cmpswap_x2 for DGEMM
-                if kernel["ProblemType"]["DestDataType"].isDouble():
-                  kStr += "_buffer_atomic_cmpswap_b64 %s, %s, %s %s    // %s%s" % \
-                    (vgpr(dataV,4), \
-                     vgpr(addr,1), \
-                     sgpr("SrdD", 4), \
-                     "0 offen offset:%u glc" % (addrCalc.globalOffset), \
-                     "try again", self.endLine )
-                else:
-                  kStr += "_buffer_atomic_cmpswap_b32 %s, %s, %s %s    // %s%s" % \
-                      (vgpr(dataV,2), \
-                       vgpr(addr,1), \
-                       sgpr("SrdD", 4), \
-                       "0 offen offset:%u glc" % (addrCalc.globalOffset), \
-                       "try again", self.endLine )
-              else:
-                kStr += "_global_atomic_cmpswap_b32 %s, %s, %s, %s %s    // %s%s" % ( vgpr(atomicDestVgpr), \
-                    vgpr(addr,2), vgpr(dataV,2), "off", "glc", "try again", self.endLine)
+              # apply mask for element
+              kStr += inst("s_mov_b{}".format(wavelen), self.exec, sgpr(maskIdx,laneSGPRC), "must try again" )
+              # copy previous load data
+              for idx in range(atomicOpW):
+                movDst = addDst+atomicOpW
+                kStr += inst("v_mov_b32", vgpr(movDst+idx), vgpr(addDst+idx), "dataV+%u = tmp (new original C)"%(atomicOpW+idx) )
+              kStr += self.chooseAddForAtomic(kernel, addDst, addSrc0, sumIdxV, comment, atomicOpW)
+              # attempt write
+              kStr += self.chooseAtomicCmpswap(kernel, addrCalc, addDst, compOffset * self.bpr, atomicOpW)
+              #increment loopCount
+              loopCount += 1
 
         # wait for batched write
         kStr += inst("s_waitcnt vmcnt(0)", "wait for atomic writes" )
@@ -12278,32 +12316,38 @@ class KernelWriterAssembly(KernelWriter):
         # check batched write success
         kStr += self.comment("apply masks and check for success")
         for elementIdx in range(0, len(batchElements)):
-          element = batchElements[elementIdx]
           data = ss.elementData[elementIdx]
           mask = ss.elementMask[elementIdx]
-          for avi in range(0, gwvw//atomicW):
-            dataV = ss.elementData[elementIdx] + int(avi*ss.cfg.numVgprsPerDataPerVI)
-            atomicDestVgpr = dataV if kernel["BufferStore"] else dataV+2
-
-            # apply mask for element
-            kStr += inst("s_mov_b{}".format(wavelen), self.exec, sgpr(mask,laneSGPRC), "must try again" )
-
-            # compare success
-            if kernel["ProblemType"]["DestDataType"].isDouble():
-              kStr += inst("v_cmp_ne_u64", sgpr(tmpS01,laneSGPRC), vgpr(data+2,2), vgpr(atomicDestVgpr,2), \
-                  "c read during atomic != c read during prior load" )
-            else:
-              kStr += inst("v_cmp_ne_u32", sgpr(tmpS01,laneSGPRC), vgpr(data+1), vgpr(atomicDestVgpr), \
-                  "c read during atomic == c read during prior load" )
-            # update element mask
-            kStr += inst("s_and_b{}".format(wavelen),  sgpr(mask,laneSGPRC), sgpr(tmpS01,laneSGPRC), sgpr(mask,laneSGPRC), "inBounds & must try again" )
+          loopCount = 0
+          for avi in range(0, gwvw, atomicW):
+            for compIdx in range(vgprLoadDW // atomicOpW):
+              maskIdx = mask + loopCount * laneSGPRC
+              compOffset = compIdx * vgprLoadDW
+              dataV = ss.elementData[elementIdx] + int(avi*ss.cfg.numVgprsPerDataPerVI)
+              atomicDestVgpr = dataV + compOffset
+              comment = "c read during atomic != c read during prior load (avi=%u)"%avi
+              # apply mask for element
+              kStr += inst("s_mov_b{}".format(wavelen), self.exec, sgpr(maskIdx,laneSGPRC), "must try again" )
+              # compare success
+              kStr += inst("v_cmp_ne_u%u"%(32 * atomicOpW), sgpr(tmpS01,laneSGPRC), vgpr(atomicDestVgpr,atomicOpW), \
+                  vgpr(atomicDestVgpr+atomicOpW,atomicOpW), comment )
+              # update element mask
+              kStr += inst("s_and_b{}".format(wavelen),  sgpr(maskIdx,laneSGPRC), sgpr(tmpS01,laneSGPRC), sgpr(maskIdx,laneSGPRC), "inBounds & must try again" )
+              #increment loopCount
+              loopCount += 1
 
         # or masks together
         kStr += self.comment("or masks to check for exit")
         kStr += inst("s_mov_b{}".format(wavelen), sgpr(tmpS01,laneSGPRC), hex(0), "empty mask" )
         for elementIdx in range(0, len(batchElements)):
           mask = ss.elementMask[elementIdx]
-          kStr += inst("s_or_b{}".format(wavelen), sgpr(tmpS01,laneSGPRC), sgpr(mask,laneSGPRC), sgpr(tmpS01,laneSGPRC), "or to add threads" )
+          loopCount = 0
+          for avi in range(0, gwvw, atomicW):
+            for compIdx in range(vgprLoadDW // atomicOpW):
+              maskIdx = mask + loopCount * laneSGPRC
+              kStr += inst("s_or_b{}".format(wavelen), sgpr(tmpS01,laneSGPRC), sgpr(maskIdx,laneSGPRC), sgpr(tmpS01,laneSGPRC), "or to add threads" )
+              #increment loopCount
+              loopCount += 1
 
         # apply combined masks and exit
         kStr += inst("s_or_saveexec_b{}".format(wavelen), sgpr(tmpS23,laneSGPRC), sgpr(tmpS01,laneSGPRC), "apply combined mask" )

--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -3075,11 +3075,7 @@ class Solution(collections.abc.Mapping):
     # set minimum and maximum of VectorAtomicWidth
     minVectorAtomicWidth = 2 if (state["ProblemType"]["ComputeDataType"].numBytes() == 2) else 1
     #  TODO: enable wider VectorAtomicWidth
-    # maxVectorAtomicWidth = max(state["GlobalWriteVectorWidth"], minVectorAtomicWidth)
-    maxVectorAtomicWidth = minVectorAtomicWidth
-    if (state["ProblemType"]["ComputeDataType"].numBytes() == 8):
-      # numBytes=8 only (DGEMM, CGEMM), we can use VectorAtomicWidth to use b128 load
-      maxVectorAtomicWidth = 2
+    maxVectorAtomicWidth = max(state["GlobalWriteVectorWidth"], minVectorAtomicWidth)
     useAtomic = state["GlobalSplitU"] > 1 and state["GlobalSplitUAlgorithm"] == 'SingleBuffer'
     if state["VectorAtomicWidth"] == -1:
       if useAtomic:

--- a/Tensile/Tests/extended/global_split_u/hgemm_gsu.yaml
+++ b/Tensile/Tests/extended/global_split_u/hgemm_gsu.yaml
@@ -82,3 +82,39 @@ BenchmarkProblems:
           ##- Range: [[56,8,72], [56,8,72], [1,1,2], [66, 64, 34, 1024]]
           - Range: [[56,8,72], 0, [1,1,2], [64, 64, 34, 1024]]
           - Range: [[56,8,72], 0, [1,1,2], [66, 64, 34, 1024]]
+
+  ########################################
+  # NN - MI workloads (DeepBench, ResNet, etc)
+  ########################################
+    -
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - PrefetchGlobalRead: [ False]
+        - PrefetchLocalRead: [ False]
+        - ThreadTile:
+          #- [ 4, 8 ]
+          - [ 8, 8 ]
+        - WorkGroup:
+          #- [ 8, 16, 1 ] # control
+          - [ 8, 4, 2 ] # LSU case
+          - [ 8, 8, 1 ]
+          - [ 8, 16, 1 ]
+        - GlobalSplitU: [16,32]
+        - WorkGroupMapping: [64]
+        - DepthU: [ 16 ]
+        - VectorWidth: [2,4,8]
+        - VectorAtomicWidth: [-1,2]#[-1,2,4,8]
+        - AssertFree0ElementMultiple: [8]  # so we can test GRVW sweep
+        - AssertSummationElementMultiple: [1,2]  # so we can test GRVW sweep
+        - BufferLoad: [0,1]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          # Note for K>1024 the operation order change with LSU doesn't consistently match CPU
+          - Range: [[56,8,72], 0, [1,2], [4097]]

--- a/Tensile/Tests/extended/local_split_u/bfloat16_lsu_mfma.yaml
+++ b/Tensile/Tests/extended/local_split_u/bfloat16_lsu_mfma.yaml
@@ -38,16 +38,14 @@ BenchmarkProblems:
             - [16, 16, 16, 1, 1, 2, 2, 1,2]  # 32x64
             - [16, 16, 16, 1, 1, 2, 2, 2,1]  # 64x32
             - [16, 16, 16, 1, 1, 2, 2, 4,1]  # 128x32
-            - [32, 32, 8, 1, 1, 2, 2, 1,1]  # 64x64
-            - [32, 32, 8, 1, 1, 2, 1, 1,2]  # 64x64
-            - [32, 32, 8, 1, 1, 2, 1, 1,4]  # 64x128
+            - [16, 16, 16, 1, 1, 4, 2, 2,2]  # 128x64
         #- ThreadTile:
         #  - [ 2, 2 ]
         - WorkGroup:
           - [ 64, 1, 1 ] # only WG2 is effective for 9 parameter MI
           - [ 64, 1, 2 ] # only WG2 is effective for 9 parameter MI
           - [ 64, 1, 4 ] # only WG2 is effective for 9 parameter MI
-        - AssertFree0ElementMultiple : [2]
+        - AssertFree0ElementMultiple : [2,4]
         - AssertFree1ElementMultiple : [2]
         - AssertSummationElementMultiple: [2]
         - DepthU: [32]#[8,16,32]
@@ -61,19 +59,20 @@ BenchmarkProblems:
         - ScheduleIterAlg: [3]
         - StaggerU: [0]
         - SourceSwap: [0,1]
-        - TransposeLDS: [0,1]
+        #- TransposeLDS: [0,1]
         - GlobalReadVectorWidth: [4]
         - VectorWidth: [2,4]
-        - VectorAtomicWidth: [-1,1,2]#[-1,1,2,4]
+        - VectorAtomicWidth: [-1,1,2,4]
         #- WaveSeparateGlobalReadB: [1]
         #- MIArchVgpr: [True, False]
         - NumElementsPerBatchStore: [4]
         - UseSgprForGRO: [0]
+        - BufferLoad: [0,1]
         - BufferStore: [0,1]
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [ 254, 254, 1, 2050]
+          - Exact: [ 252, 254, 1, 2050]
 
   ########################################
   # BSS NT - standard
@@ -104,16 +103,14 @@ BenchmarkProblems:
             - [16, 16, 16, 1, 1, 2, 2, 1,2]  # 32x64
             - [16, 16, 16, 1, 1, 2, 2, 2,1]  # 64x32
             - [16, 16, 16, 1, 1, 2, 2, 4,1]  # 128x32
-            - [32, 32, 8, 1, 1, 2, 2, 1,1]  # 64x64
-            - [32, 32, 8, 1, 1, 2, 1, 1,2]  # 64x64
-            - [32, 32, 8, 1, 1, 2, 1, 1,4]  # 64x128
+            - [16, 16, 16, 1, 1, 4, 2, 2,2]  # 128x64
         #- ThreadTile:
         #  - [ 2, 2 ]
         - WorkGroup:
           - [ 64, 1, 1 ] # only WG2 is effective for 9 parameter MI
           - [ 64, 1, 2 ] # only WG2 is effective for 9 parameter MI
           - [ 64, 1, 4 ] # only WG2 is effective for 9 parameter MI
-        - AssertFree0ElementMultiple : [2]
+        - AssertFree0ElementMultiple : [2,4]
         - AssertFree1ElementMultiple : [2]
         - AssertSummationElementMultiple: [2]
         - DepthU: [32]#[8,16,32]
@@ -127,18 +124,19 @@ BenchmarkProblems:
         - ScheduleIterAlg: [3]
         - StaggerU: [0]
         - SourceSwap: [0,1]
-        - TransposeLDS: [0,1]
+        #- TransposeLDS: [0,1]
         - GlobalReadVectorWidth: [4]
         - VectorWidth: [2,4]
-        - VectorAtomicWidth: [-1,1,2]#[-1,1,2,4]
+        - VectorAtomicWidth: [-1,1,2,4]
         #- WaveSeparateGlobalReadB: [1]
         #- MIArchVgpr: [True, False]
-        - NumElementsPerBatchStore: [4]
+        - NumElementsPerBatchStore: [0]
         - UseSgprForGRO: [0]
+        - BufferLoad: [0,1]
         - BufferStore: [0,1]
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [ 254, 254, 1, 2050]
+          - Exact: [ 252, 254, 1, 2050]
 
 

--- a/Tensile/Tests/extended/local_split_u/bfloat16_lsu_mfma.yaml
+++ b/Tensile/Tests/extended/local_split_u/bfloat16_lsu_mfma.yaml
@@ -10,13 +10,13 @@ GlobalParameters:
 
 BenchmarkProblems:
   ########################################
-  # HHS NT - standard
+  # BBS NT - standard
   ########################################
   -
     - # ProblemType
       OperationType: GEMM
-      DataType: H
-      DestDataType: H
+      DataType: B
+      DestDataType: B
       ComputeDataType: S
       HighPrecisionAccumulate: True
       TransposeA: False
@@ -25,56 +25,7 @@ BenchmarkProblems:
       Batched: True
 
   ########################################
-  # HHS NT - LSU
-  ########################################
-    -
-      InitialSolutionParameters:
-      BenchmarkCommonParameters:
-        - EdgeType: ["ShiftPtr"]
-        - LoopTail: [True]
-        - KernelLanguage: ["Assembly"]
-      ForkParameters:
-        - MatrixInstruction:
-            - [16, 16, 16, 1, 1, 2, 2, 1,1]  # 32x32
-            - [16, 16, 16, 1, 1, 2, 1, 1,2]  # 32x32
-            - [16, 16, 16, 1, 1, 2, 2, 1,2]  # 32x64
-            - [16, 16, 16, 1, 1, 2, 2, 2,1]  # 64x32
-            - [32, 32, 8, 1, 1, 2, 1, 1,1]  # 64x32
-            - [32, 32, 8, 1, 1, 2, 2, 1,1]  # 64x64
-            - [32, 32, 8, 1, 1, 2, 1, 1,2]  # 64x64
-            - [32, 32, 8, 1, 1, 2, 2, 1,2]  # 64x128
-        #- ThreadTile:
-        #  - [ 2, 2 ]
-        - WorkGroup:
-          - [ 64, 1, 1 ] # only WG2 is effective for 9 parameter MI
-          - [ 64, 1, 2 ] # only WG2 is effective for 9 parameter MI
-          - [ 64, 1, 4 ] # only WG2 is effective for 9 parameter MI
-        - AssertFree0ElementMultiple : [2]
-        - AssertFree1ElementMultiple : [2]
-        - AssertSummationElementMultiple: [1,2]
-        - DepthU: [32,64]#[8,16,32]
-        - 1LDSBuffer: [0,1]
-        - LoopTail: [True]
-        - OptNoLoadLoop: [1]
-        - PrefetchGlobalRead: [2]
-        - PrefetchLocalRead: [1]
-        - ScheduleIterAlg: [3]
-        - StaggerU: [0]
-        - SourceSwap: [0,1]
-        - TransposeLDS: [0,1]
-        - GlobalReadVectorWidth: [4]
-        - VectorWidth: [1,2,4]
-        - WaveSeparateGlobalReadB: [1]
-        - MIArchVgpr: [True, False]
-        - NumElementsPerBatchStore: [4]
-        - UseSgprForGRO: [0]
-      BenchmarkJoinParameters:
-      BenchmarkFinalParameters:
-        - ProblemSizes:
-          - Exact: [ 254, 254, 1, 2050]
-
-  ########################################
-  # HHS NT - LSU + GSU + VAW + BS[0,1]
+  # BBS NT - LSU + GSU + VAW + BS[0,1]
   ########################################
     -
       InitialSolutionParameters:
@@ -118,7 +69,6 @@ BenchmarkProblems:
         #- MIArchVgpr: [True, False]
         - NumElementsPerBatchStore: [4]
         - UseSgprForGRO: [0]
-        - BufferLoad: [0,1]
         - BufferStore: [0,1]
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
@@ -126,12 +76,12 @@ BenchmarkProblems:
           - Exact: [ 254, 254, 1, 2050]
 
   ########################################
-  # HSS NT - standard
+  # BSS NT - standard
   ########################################
   -
     - # ProblemType
       OperationType: GEMM
-      DataType: H
+      DataType: B
       DestDataType: S
       ComputeDataType: S
       HighPrecisionAccumulate: True
@@ -141,7 +91,7 @@ BenchmarkProblems:
       Batched: True
 
   ########################################
-  # HSS NT - LSU + GSU + VAW + BS[0,1]
+  # BSS NT - LSU + GSU + VAW + BS[0,1]
   ########################################
     -
       InitialSolutionParameters:
@@ -185,7 +135,6 @@ BenchmarkProblems:
         #- MIArchVgpr: [True, False]
         - NumElementsPerBatchStore: [4]
         - UseSgprForGRO: [0]
-        - BufferLoad: [0,1]
         - BufferStore: [0,1]
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:

--- a/Tensile/Tests/extended/local_split_u/cgemm_lsu_mfma.yaml
+++ b/Tensile/Tests/extended/local_split_u/cgemm_lsu_mfma.yaml
@@ -6,6 +6,7 @@ GlobalParameters:
   BoundsCheck: True
   KernelTime: True
   #PrintSolutionRejectionReason: True
+  #MaxFileName: 256
 
 BenchmarkProblems:
   ########################################
@@ -69,4 +70,68 @@ BenchmarkProblems:
         - ProblemSizes:
           #- Exact: [ M, N, B, K, ldc, ldc, lda, ldb ]
           - Exact: [1020, 1020, 1, 2052]
+
+  ########################################
+  # CN - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: c
+      DestDataType: c
+      TransposeA: True
+      TransposeB: False
+      ComplexConjugateA: True
+      ComplexConjugateB: False
+      UseBeta: True
+      Batched: True
+
+  ########################################
+  # CN - LSU + GSU + VAW + BS[0,1]
+  ########################################
+    -
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [16, 16, 4, 1, 1, 4,2, 1,1]  # 64x32
+          - [16, 16, 4, 1, 1, 2,2, 2,1]  # 64x32
+          - [16, 16, 4, 1, 1, 2,2, 1,2]  # 32x64
+          - [16, 16, 4, 1, 1, 2,1, 2,2]  # 64x32
+        - SourceSwap: [True, False]
+        - PrefetchGlobalRead: [2]
+        - ThreadTile:
+          - [  8, 32 ]
+        - WorkGroup:
+          - [ 64, 1, 1 ] # only WG2 is effective for 9 parameter MI
+          - [ 64, 1, 2 ] # only WG2 is effective for 9 parameter MI
+          - [ 64, 1, 4 ] # only WG2 is effective for 9 parameter MI
+        #- AssertFree1ElementMultiple: [1,2]
+        - PrefetchLocalRead: [3,5,9]
+        - GlobalSplitU: [1,4]
+        - GlobalSplitUAlgorithm: ["SingleBuffer","MultipleBuffer"]
+        - DepthU:  [16]#[16,32]#[ 8, 16 ]
+        #- StoreVectorWidth: [1,2]
+        - VectorWidth: [1,2]
+        - VectorAtomicWidth: [-1,1,2]
+        #- LocalReadVectorWidth: [1,2]
+        #- DirectToVgprB: [False, True]
+        - ScheduleIterAlg: [3]
+        - PersistentKernel: [0]
+        - StaggerU: [0]
+        #- MIArchVgpr: [True, False]
+        - NumElementsPerBatchStore: [0]
+        - TransposeLDS: [1]#[0,1]
+        - BufferStore: [0,1]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          #- Exact: [ M, N, B, K, ldc, ldc, lda, ldb ]
+          - Exact: [1021, 1021, 1, 2051]
+
 

--- a/Tensile/Tests/extended/local_split_u/dgemm_lsu_mfma.yaml
+++ b/Tensile/Tests/extended/local_split_u/dgemm_lsu_mfma.yaml
@@ -6,6 +6,7 @@ GlobalParameters:
   BoundsCheck: True
   KernelTime: True
   #PrintSolutionRejectionReason: True
+  #MaxFileName: 256
 
 BenchmarkProblems:
   ########################################
@@ -160,6 +161,54 @@ BenchmarkProblems:
         - NumElementsPerBatchStore: [0]
         - GlobalSplitU: [1,2]
         - GlobalSplitUAlgorithm: ["SingleBuffer","MultipleBuffer"]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          #- Exact: [ M, N, B, K, ldc, ldc, lda, ldb ]
+          - Exact: [1022, 1022, 1, 2050]
+
+
+  ########################################
+  # NT - LSU + GSU + VAW + BS[0,1]
+  ########################################
+    -
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [16, 16, 4, 1, 1, 4,2, 1,1]  # 64x32
+          - [16, 16, 4, 1, 1, 2,2, 2,1]  # 64x32
+          - [16, 16, 4, 1, 1, 2,2, 1,2]  # 32x64
+          - [16, 16, 4, 1, 1, 2,2, 2,2]  # 64x64
+        - SourceSwap: [True, False]
+        - PrefetchGlobalRead: [1]
+        - ThreadTile:
+          - [  8, 32 ]
+        - WorkGroup:
+          - [ 64, 1, 1 ] # only WG2 is effective for 9 parameter MI
+          - [ 64, 1, 2 ] # only WG2 is effective for 9 parameter MI
+          - [ 64, 1, 4 ] # only WG2 is effective for 9 parameter MI
+        #- AssertFree1ElementMultiple: [1,2]
+        - PrefetchLocalRead: [1]
+        - DepthU:  [16]
+        #- StoreVectorWidth: [1,2]#[2]
+        - VectorWidth: [1,2] #[1,2]
+        - VectorAtomicWidth: [-1,1,2]
+        #- GlobalReadVectorWidth: [1,2]
+        #- LocalReadVectorWidth: [1,2]
+        #- DirectToVgprA: [False, True]
+        #- DirectToVgprB: [True, False]
+        - ScheduleIterAlg: [3]
+        #- MIArchVgpr: [True, False]
+        - NumElementsPerBatchStore: [0]
+        - GlobalSplitU: [1,4]
+        - GlobalSplitUAlgorithm: ["SingleBuffer","MultipleBuffer"]
+        - BufferStore: [0,1]
       BenchmarkForkParameters:
       JoinParameters:
       BenchmarkJoinParameters:

--- a/Tensile/Tests/extended/local_split_u/hgemm_lsu_mfma.yaml
+++ b/Tensile/Tests/extended/local_split_u/hgemm_lsu_mfma.yaml
@@ -51,7 +51,7 @@ BenchmarkProblems:
           - [ 64, 1, 4 ] # only WG2 is effective for 9 parameter MI
         - AssertFree0ElementMultiple : [2]
         - AssertFree1ElementMultiple : [2]
-        - AssertSummationElementMultiple: [1,2]
+        - AssertSummationElementMultiple: [2]#[1,2]
         - DepthU: [32,64]#[8,16,32]
         - 1LDSBuffer: [0,1]
         - LoopTail: [True]
@@ -61,7 +61,7 @@ BenchmarkProblems:
         - ScheduleIterAlg: [3]
         - StaggerU: [0]
         - SourceSwap: [0,1]
-        - TransposeLDS: [0,1]
+        #- TransposeLDS: [0,1]
         - GlobalReadVectorWidth: [4]
         - VectorWidth: [1,2,4]
         - WaveSeparateGlobalReadB: [1]
@@ -87,16 +87,14 @@ BenchmarkProblems:
             - [16, 16, 16, 1, 1, 2, 2, 1,2]  # 32x64
             - [16, 16, 16, 1, 1, 2, 2, 2,1]  # 64x32
             - [16, 16, 16, 1, 1, 2, 2, 4,1]  # 128x32
-            - [32, 32, 8, 1, 1, 2, 2, 1,1]  # 64x64
-            - [32, 32, 8, 1, 1, 2, 1, 1,2]  # 64x64
-            - [32, 32, 8, 1, 1, 2, 1, 1,4]  # 64x128
+            - [16, 16, 16, 1, 1, 4, 2, 2,2]  # 128x64
         #- ThreadTile:
         #  - [ 2, 2 ]
         - WorkGroup:
           - [ 64, 1, 1 ] # only WG2 is effective for 9 parameter MI
           - [ 64, 1, 2 ] # only WG2 is effective for 9 parameter MI
           - [ 64, 1, 4 ] # only WG2 is effective for 9 parameter MI
-        - AssertFree0ElementMultiple : [2]
+        - AssertFree0ElementMultiple : [2,4]
         - AssertFree1ElementMultiple : [2]
         - AssertSummationElementMultiple: [2]
         - DepthU: [32]#[8,16,32]
@@ -110,10 +108,10 @@ BenchmarkProblems:
         - ScheduleIterAlg: [3]
         - StaggerU: [0]
         - SourceSwap: [0,1]
-        - TransposeLDS: [0,1]
+        #- TransposeLDS: [0,1]
         - GlobalReadVectorWidth: [4]
         - VectorWidth: [2,4]
-        - VectorAtomicWidth: [-1,1,2]#[-1,1,2,4]
+        - VectorAtomicWidth: [-1,1,2,4]
         #- WaveSeparateGlobalReadB: [1]
         #- MIArchVgpr: [True, False]
         - NumElementsPerBatchStore: [4]
@@ -123,7 +121,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [ 254, 254, 1, 2050]
+          - Exact: [ 252, 254, 1, 2050]
 
   ########################################
   # HSS NT - standard
@@ -154,16 +152,14 @@ BenchmarkProblems:
             - [16, 16, 16, 1, 1, 2, 2, 1,2]  # 32x64
             - [16, 16, 16, 1, 1, 2, 2, 2,1]  # 64x32
             - [16, 16, 16, 1, 1, 2, 2, 4,1]  # 128x32
-            - [32, 32, 8, 1, 1, 2, 2, 1,1]  # 64x64
-            - [32, 32, 8, 1, 1, 2, 1, 1,2]  # 64x64
-            - [32, 32, 8, 1, 1, 2, 1, 1,4]  # 64x128
+            - [16, 16, 16, 1, 1, 4, 2, 2,2]  # 128x64
         #- ThreadTile:
         #  - [ 2, 2 ]
         - WorkGroup:
           - [ 64, 1, 1 ] # only WG2 is effective for 9 parameter MI
           - [ 64, 1, 2 ] # only WG2 is effective for 9 parameter MI
           - [ 64, 1, 4 ] # only WG2 is effective for 9 parameter MI
-        - AssertFree0ElementMultiple : [2]
+        - AssertFree0ElementMultiple : [2,4]
         - AssertFree1ElementMultiple : [2]
         - AssertSummationElementMultiple: [2]
         - DepthU: [32]#[8,16,32]
@@ -177,10 +173,10 @@ BenchmarkProblems:
         - ScheduleIterAlg: [3]
         - StaggerU: [0]
         - SourceSwap: [0,1]
-        - TransposeLDS: [0,1]
+        #- TransposeLDS: [0,1]
         - GlobalReadVectorWidth: [4]
         - VectorWidth: [2,4]
-        - VectorAtomicWidth: [-1,1,2]#[-1,1,2,4]
+        - VectorAtomicWidth: [-1,1,2,4]
         #- WaveSeparateGlobalReadB: [1]
         #- MIArchVgpr: [True, False]
         - NumElementsPerBatchStore: [4]
@@ -190,6 +186,6 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [ 254, 254, 1, 2050]
+          - Exact: [ 252, 254, 1, 2050]
 
 

--- a/Tensile/Tests/extended/local_split_u/igemm_lsu_mfma.yaml
+++ b/Tensile/Tests/extended/local_split_u/igemm_lsu_mfma.yaml
@@ -1,0 +1,77 @@
+TestParameters:
+  marks: [skip-gfx900, skip-gfx906, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102] # not supported by arch
+
+GlobalParameters:
+  NumElementsToValidate: -1
+  BoundsCheck: True
+  KernelTime: True
+  #PrintSolutionRejectionReason: True
+  #MaxFileName: 256
+
+BenchmarkProblems:
+  ########################################
+  # I8II NT - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: I8
+      DestDataType: I
+      ComputeDataType: I
+      HighPrecisionAccumulate: True
+      TransposeA: False
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+
+  ########################################
+  # I8II NT - LSU + GSU + VAW + BS[0,1]
+  ########################################
+    -
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+            - [16, 16, 16, 1, 1, 2, 2, 1,2]  # 32x64
+            - [16, 16, 16, 1, 1, 2, 2, 2,1]  # 64x32
+            - [16, 16, 16, 1, 1, 2, 2, 4,1]  # 128x32
+            - [32, 32, 8, 1, 1, 2, 2, 1,1]  # 64x64
+            - [32, 32, 8, 1, 1, 2, 1, 1,2]  # 64x64
+            - [32, 32, 8, 1, 1, 2, 1, 1,4]  # 64x128
+        #- ThreadTile:
+        #  - [ 2, 2 ]
+        - WorkGroup:
+          - [ 64, 1, 1 ] # only WG2 is effective for 9 parameter MI
+          - [ 64, 1, 2 ] # only WG2 is effective for 9 parameter MI
+          - [ 64, 1, 4 ] # only WG2 is effective for 9 parameter MI
+        - AssertFree0ElementMultiple : [2]
+        - AssertFree1ElementMultiple : [2]
+        - AssertSummationElementMultiple: [2]
+        - DepthU: [32]#[8,16,32]
+        - GlobalSplitU: [1,4]
+        - GlobalSplitUAlgorithm: ["SingleBuffer","MultipleBuffer"]
+        - 1LDSBuffer: [0]
+        - LoopTail: [True]
+        - OptNoLoadLoop: [1]
+        - PrefetchGlobalRead: [2]
+        - PrefetchLocalRead: [1]
+        - ScheduleIterAlg: [3]
+        - StaggerU: [0]
+        - SourceSwap: [0,1]
+        - TransposeLDS: [0,1]
+        - GlobalReadVectorWidth: [4,8]
+        - VectorWidth: [2,4,8]
+        - VectorAtomicWidth: [-1,1,2]#[-1,1,2,4]
+        #- WaveSeparateGlobalReadB: [1]
+        #- MIArchVgpr: [True, False]
+        - NumElementsPerBatchStore: [4]
+        - UseSgprForGRO: [0]
+        - BufferStore: [0,1]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [ 254, 254, 1, 2050]
+

--- a/Tensile/Tests/extended/local_split_u/igemm_lsu_mfma.yaml
+++ b/Tensile/Tests/extended/local_split_u/igemm_lsu_mfma.yaml
@@ -38,6 +38,7 @@ BenchmarkProblems:
             - [16, 16, 16, 1, 1, 2, 2, 1,2]  # 32x64
             - [16, 16, 16, 1, 1, 2, 2, 2,1]  # 64x32
             - [16, 16, 16, 1, 1, 2, 2, 4,1]  # 128x32
+            - [16, 16, 16, 1, 1, 4, 2, 2,2]  # 128x64
             - [32, 32, 8, 1, 1, 2, 2, 1,1]  # 64x64
             - [32, 32, 8, 1, 1, 2, 1, 1,2]  # 64x64
             - [32, 32, 8, 1, 1, 2, 1, 1,4]  # 64x128
@@ -47,7 +48,7 @@ BenchmarkProblems:
           - [ 64, 1, 1 ] # only WG2 is effective for 9 parameter MI
           - [ 64, 1, 2 ] # only WG2 is effective for 9 parameter MI
           - [ 64, 1, 4 ] # only WG2 is effective for 9 parameter MI
-        - AssertFree0ElementMultiple : [2]
+        - AssertFree0ElementMultiple : [2,4]
         - AssertFree1ElementMultiple : [2]
         - AssertSummationElementMultiple: [2]
         - DepthU: [32]#[8,16,32]
@@ -61,17 +62,18 @@ BenchmarkProblems:
         - ScheduleIterAlg: [3]
         - StaggerU: [0]
         - SourceSwap: [0,1]
-        - TransposeLDS: [0,1]
+        #- TransposeLDS: [0,1]
         - GlobalReadVectorWidth: [4,8]
-        - VectorWidth: [2,4,8]
-        - VectorAtomicWidth: [-1,1,2]#[-1,1,2,4]
+        - VectorWidth: [2,4]
+        - VectorAtomicWidth: [-1,1,2,4]
         #- WaveSeparateGlobalReadB: [1]
         #- MIArchVgpr: [True, False]
         - NumElementsPerBatchStore: [4]
         - UseSgprForGRO: [0]
+        - BufferLoad: [0,1]
         - BufferStore: [0,1]
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [ 254, 254, 1, 2050]
+          - Exact: [ 252, 254, 1, 2050]
 

--- a/Tensile/Tests/extended/local_split_u/sgemm_lsu_mfma.yaml
+++ b/Tensile/Tests/extended/local_split_u/sgemm_lsu_mfma.yaml
@@ -85,8 +85,7 @@ BenchmarkProblems:
           - [16, 16, 4, 1, 1, 4,2, 1,1]  # 64x32
           - [16, 16, 4, 1, 1, 2,2, 2,1]  # 64x32
           - [16, 16, 4, 1, 1, 2,2, 1,2]  # 32x64
-          - [16, 16, 4, 1, 1, 2,2, 2,2]  # 64x64
-        #- ThreadTile:
+          - [16, 16, 4, 1, 1, 4,2, 2,2]  # 128x64
         #  - [ 2, 2 ]
         - WorkGroup:
           - [ 64, 1, 1 ] # only WG2 is effective for 9 parameter MI
@@ -112,11 +111,12 @@ BenchmarkProblems:
         - TransposeLDS: [1]
         #- GlobalReadVectorWidth: [1,2,4]
         - VectorWidth: [1,2,4]
-        - VectorAtomicWidth: [-1,1,2]#[-1,1,2,4]
+        - VectorAtomicWidth: [-1,1,2,4]
         #- LocalReadVectorWidth: [1,2,4]
         #- DirectToVgprA: [True, False]
         #- MIArchVgpr: [False, True]
-        - NumElementsPerBatchStore: [2]
+        - NumElementsPerBatchStore: [0]
+        - BufferLoad: [0,1]
         - BufferStore: [0,1]
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:

--- a/Tensile/Tests/extended/local_split_u/sgemm_lsu_mfma.yaml
+++ b/Tensile/Tests/extended/local_split_u/sgemm_lsu_mfma.yaml
@@ -6,6 +6,7 @@ GlobalParameters:
   BoundsCheck: True
   KernelTime: True
   #PrintSolutionRejectionReason: True
+  #MaxFileName: 256
 
 BenchmarkProblems:
   ########################################
@@ -69,6 +70,58 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [1020, 1020, 1, 2052]
+
+  ########################################
+  # NN - LSU + GSU + VAW + BS[0,1]
+  ########################################
+    -
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [16, 16, 4, 1, 1, 4,2, 1,1]  # 64x32
+          - [16, 16, 4, 1, 1, 2,2, 2,1]  # 64x32
+          - [16, 16, 4, 1, 1, 2,2, 1,2]  # 32x64
+          - [16, 16, 4, 1, 1, 2,2, 2,2]  # 64x64
+        #- ThreadTile:
+        #  - [ 2, 2 ]
+        - WorkGroup:
+          - [ 64, 1, 1 ] # only WG2 is effective for 9 parameter MI
+          - [ 64, 1, 2 ] # only WG2 is effective for 9 parameter MI
+          - [ 64, 1, 4 ] # only WG2 is effective for 9 parameter MI
+        - DepthU: [16]
+        - GlobalSplitU: [1,4]
+        - GlobalSplitUAlgorithm: ["SingleBuffer","MultipleBuffer"]
+        - GlobalSplitUWorkGroupMappingRoundRobin: [False]
+        - GlobalSplitUSummationAssignmentRoundRobin:  [True]
+        - 1LDSBuffer: [0]
+        #- AssertFree0ElementMultiple : [8]
+        #- AssertFree1ElementMultiple : [1,4]
+        - ExpandPointerSwap: [1] # 1 for DirectToVgpr
+        - PrefetchGlobalRead: [2]
+        - PrefetchLocalRead: [1]
+        - SuppressNoLoadLoop: [0]
+        - ScheduleLocalWrite: [1]
+        - ScheduleGlobalRead: [1]
+        - ScheduleIterAlg: [3]#[0]
+        - StaggerU: [0]
+        - SourceSwap: [0,1]
+        - TransposeLDS: [1]
+        #- GlobalReadVectorWidth: [1,2,4]
+        - VectorWidth: [1,2,4]
+        - VectorAtomicWidth: [-1,1,2]#[-1,1,2,4]
+        #- LocalReadVectorWidth: [1,2,4]
+        #- DirectToVgprA: [True, False]
+        #- MIArchVgpr: [False, True]
+        - NumElementsPerBatchStore: [2]
+        - BufferStore: [0,1]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [1021, 1021, 1, 2051]
 
   ########################################
   # NT - standard

--- a/Tensile/Tests/extended/local_split_u/zgemm_lsu_mfma.yaml
+++ b/Tensile/Tests/extended/local_split_u/zgemm_lsu_mfma.yaml
@@ -6,10 +6,11 @@ GlobalParameters:
   BoundsCheck: True
   KernelTime: True
   #PrintSolutionRejectionReason: True
+  #MaxFileName: 256
 
 BenchmarkProblems:
   ########################################
-  # NN - standard
+  # NT - standard
   ########################################
   -
     - # ProblemType
@@ -63,4 +64,62 @@ BenchmarkProblems:
         - ProblemSizes:
           #- Exact: [ M, N, B, K, ldc, ldc, lda, ldb ]
           - Exact: [1022, 1022, 1, 2050]
+
+  ########################################
+  # NN - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: z
+      DestDataType: z
+      TransposeA: False
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+
+  ########################################
+  # NN - LSU + GSU + BS[0,1]
+  ########################################
+    -
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [16, 16, 4, 1, 1, 4,2, 1,1]  # 64x32
+          - [16, 16, 4, 1, 1, 2,2, 2,1]  # 64x32
+          - [16, 16, 4, 1, 1, 2,2, 1,2]  # 32x64
+          - [16, 16, 4, 1, 1, 2,1, 2,2]  # 64x32
+        - ThreadTile:
+          - [ 1, 32 ]
+        - WorkGroup:
+          - [ 64, 1, 1 ] # only WG2 is effective for 9 parameter MI
+          - [ 64, 1, 2 ] # only WG2 is effective for 9 parameter MI
+          - [ 64, 1, 4 ] # only WG2 is effective for 9 parameter MI
+        - SourceSwap: [0,1]
+        - DepthU: [8,16]
+        - VectorWidth: [1]
+        - PrefetchGlobalRead: [2]
+        - PrefetchLocalRead: [1]
+        - GlobalReadVectorWidth: [1]
+        #- WaveSeparateGlobalReadA: [0,1]
+        #- WaveSeparateGlobalReadB: [0,1]
+        - GlobalSplitU: [1,4]
+        - GlobalSplitUAlgorithm: ["SingleBuffer","MultipleBuffer"]
+        - StaggerU: [0]
+        - ScheduleIterAlg: [3]
+        #- DirectToVgprA: [False, True] #[True, False]
+        #- DirectToVgprB: [False, True] #[True, False]
+        - NumElementsPerBatchStore: [2]
+        - 1LDSBuffer: [0]
+        #- MIArchVgpr: [0,1]
+        - BufferStore: [0,1]
+      BenchmarkForkParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          #- Exact: [ M, N, B, K, ldc, ldc, lda, ldb ]
+          - Exact: [1021, 1021, 1, 2051]
 


### PR DESCRIPTION
* GlobalSplitU + SingleBuffer improvement
    * ZGEMM/CGEMM support for GlobalSplitU + SingleBuffer
    * refactored and unified atomic_cmpswap code generation and result check for all data types and BufferStore=0,1
    * supported atomic_cmpswap_b64 + BufferStore=0
    * supported wider C load for GlobalSplitU + SingleBuffer
    * optimized hasBeta condition to avoid generating unnecessary beta code for GlobalSplitU + SingleBuffer
    * optimized the condition for _GlobalAccumulation=SingleBuffer
        * set SingleBuffer only when ComputeDataType!=DestDataType
        * previously, SingleBuffer is set for HSS and BSS (no need to set) as well as HHS and BBS
    * restricted the usage of AtomicAdd for BufferStore + VectorAtomicWidth=1 only
    * allowed growing vgpr allocation for loadCBatch-addr/writeDBatch-addr(preventOverflow=False)
* BufferLoad=0, BufferStore=0 issue fixes
    * fixed mismatch issue with GlobalSplitU + SingleBuffer + BufferStore=0 + edge
        * moved GLOBAL_OFFSET_C after caclulation of new coord1 for edge case
    * fixed mismatch issue with GlobalSplitU + MultipleBuffer + BufferStore=0
        * added missing address calculation
    * fixed mismatch issue with HSS data type + BufferStore=0
        * fixed incorrect bpe in address calculation macro
    * fixed mismatch issue with HHS, HSS data type + BufferLoad=0 + TailLoop
        * fixed incorrect offset calculation