### PR TITLE
joblib dependency as apt-get instead of pip

### DIFF
--- a/docker/dockerfile-build-ubuntu-rock
+++ b/docker/dockerfile-build-ubuntu-rock
@@ -46,6 +46,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     python3-pip \
     python3-pytest \
     python3-setuptools \
+    python3-joblib \
     python3-yaml \
     libnuma1 \
     libboost-all-dev \
@@ -63,7 +64,7 @@ RUN dpkg -i libmsgpack-dev_3.0.1-3_amd64.deb libmsgpackc2_3.0.1-3_amd64.deb
 
 RUN pip3 install setuptools --upgrade && \
     pip3 install wheel && \
-    pip3 install tox pyyaml msgpack joblib
+    pip3 install tox pyyaml msgpack
 
 # docker pipeline runs containers with particular uid
 # create a jenkins user with this specific uid so it can use sudo privileges


### PR DESCRIPTION
A recent change to setuptools has caused issues with some packages. When installing Tensile via the modified dockerfile, this causes an issue with devscripts. This change sidesteps the issue for now.

For detailed discussion see:
- https://github.com/pypa/setuptools/issues/3772
- https://bugs.launchpad.net/ubuntu/+source/devscripts/+bug/1991606

Note that the issue is not related to joblib itself. All other deps in the `pip3 install ... ` section are already installed and skipped. New deps, however, trigger devscripts and cause the issue. Changing joblib to any other (uninstalled) python packages causes the same error (e.g. pandas). 