### PR TITLE
DirectToVgpr support for small data types + TN

### DIFF
--- a/Tensile/KernelWriter.py
+++ b/Tensile/KernelWriter.py
@@ -1539,7 +1539,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
         # how many localreads can skip is based on how many iterations we prefetch.
         localReadsA = 0 if kernel["DirectToVgprA"] else self.numReadsPerIterA * skipReadsIterA
         localReadsB = 0 if kernel["DirectToVgprB"] else self.numReadsPerIterB * skipReadsIterB
-        localReads += localReadsA + localReads + localReadsB
+        localReads += localReadsA + localReadsB
         # some of localReads is interleaved after waitcnt in SIA3
         if kernel["ScheduleIterAlg"] == 3 and self.numItersPLR and\
           (iteration < numReadsIterA or iteration < numReadsIterB or numPrefetchIter) and \

--- a/Tensile/KernelWriter.py
+++ b/Tensile/KernelWriter.py
@@ -1537,14 +1537,16 @@ class KernelWriter(metaclass=abc.ABCMeta):
         skipReadsIterB += numPrefetchIter
         # here the reads are prefetches so can skip them in the waitcnt
         # how many localreads can skip is based on how many iterations we prefetch.
-        localReads += self.numReadsPerIterA * skipReadsIterA + localReads + self.numReadsPerIterB * skipReadsIterB
+        localReadsA = 0 if kernel["DirectToVgprA"] else self.numReadsPerIterA * skipReadsIterA
+        localReadsB = 0 if kernel["DirectToVgprB"] else self.numReadsPerIterB * skipReadsIterB
+        localReads += localReadsA + localReads + localReadsB
         # some of localReads is interleaved after waitcnt in SIA3
         if kernel["ScheduleIterAlg"] == 3 and self.numItersPLR and\
           (iteration < numReadsIterA or iteration < numReadsIterB or numPrefetchIter) and \
           self.enable["LocalRead"]:
-          if (iteration < numReadsIterA and not dataAtIterA < max(dataAtIterA,dataAtIterB)) or numPrefetchIter:
+          if ((iteration < numReadsIterA and not dataAtIterA < max(dataAtIterA,dataAtIterB)) or numPrefetchIter) and (not kernel["DirectToVgprA"]):
             localReads -= self.numReadsPerIterA
-          if (iteration < numReadsIterB and not dataAtIterB < max(dataAtIterA,dataAtIterB)) or numPrefetchIter:
+          if ((iteration < numReadsIterB and not dataAtIterB < max(dataAtIterA,dataAtIterB)) or numPrefetchIter) and (not kernel["DirectToVgprB"]):
             localReads -= self.numReadsPerIterB
           localReads += localReadsWaitcnt
         lgkmcnt += localReads
@@ -1890,10 +1892,8 @@ class KernelWriter(metaclass=abc.ABCMeta):
     # no need local read wait if LocalReadVectorWidth==2 and u is odd.
     # In that case, Prefetch local read covers both u = 0 and 1 (limit to MFMA+double+DirectToVgpr only)
     # (The other side of numReadsIterCoalesced must be 0 to skip local read wait)
-    condSkip = kernel["LocalReadVectorWidth"]==2 and (u%2 != 0) and kernel["EnableMatrixInstruction"] and \
-               kernel["ProblemType"]["DataType"].isDouble() and \
-              (kernel["DirectToVgprA"] and self.numReadsIterCoalescedB % 2 == 0 or \
-               kernel["DirectToVgprB"] and self.numReadsIterCoalescedA % 2 == 0)
+    condSkip = (u%self.numReadsIterCoalescedB != 0) and kernel["EnableMatrixInstruction"] and \
+              (kernel["DirectToVgprA"] or kernel["DirectToVgprB"])
     # no local write wait is necessary in DirectToVgprA + DirectToVgprB case
     cond2 = not (kernel["DirectToVgprA"] and kernel["DirectToVgprB"])
     return cond1 and (not condSkip) and cond2
@@ -3627,10 +3627,10 @@ class KernelWriter(metaclass=abc.ABCMeta):
       else:
         self.lrvwB = 1
 
-    # DirectToVgprB case, set lrvwB = VW
+    # DirectToVgprB + TLU case, set lrvwB = VW
     # DirectToVgprB case, global load data directly goes to Vgpr.
     # If VW=2, it means lrwvB is 2.
-    if kernel["DirectToVgprB"]:
+    if kernel["DirectToVgprB"] and kernel["ProblemType"]["TLUB"]:
       self.lrvwB = kernel["VectorWidth"]
     # DirectToVgpr + TLU=False case
     # set lrvw = VW
@@ -3640,7 +3640,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
        kernel["DirectToVgprB"] and (not kernel["ProblemType"]["TLUB"]) and (not kernel["ProblemType"]["TLUA"]):
       self.lrvwA = max(self.lrvwA, self.lrvwB)
       self.lrvwB = self.lrvwA
-      if kernel["DepthU"] // kernel["MatrixInstK"] <= 2 and self.lrvwA > 1:
+      if kernel["DepthU"] // kernel["MatrixInstK"] <= 2 and self.lrvwA > kernel["MIInputPerThread"]:
         # need to double vgprValu to avoid local read overwritting vgprValu registers
         self.vgprValuDouble = True
  
@@ -5215,7 +5215,7 @@ for codeObjectFileName in codeObjectFileNames:
         numReadsIterCoalesced = self.numReadsIterCoalescedA if self.isSwapGlobalReadOrderForDirectToVgpr(kernel) else self.numReadsIterCoalescedB
         waitComment = "global read wait for DirectToVgpr"
         # delay DirectToVgpr global read (from previous iteration) which is not referred yet
-        numRegsIn1set = (numGlobalRead // kernel["LoopIters"]) * numReadsIterCoalesced
+        numRegsIn1set = (numGlobalRead * numReadsIterCoalesced) // kernel["LoopIters"]
         numSet = (u + numReadsIterCoalesced) // numReadsIterCoalesced
         numSetMod = (u + numReadsIterCoalesced) % numReadsIterCoalesced
         if numSetMod > 0:

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -3664,16 +3664,25 @@ class KernelWriterAssembly(KernelWriter):
       # parameters
       tile01      = tP["tile01Idx"]
       waveWidth   = kernel["WavefrontSize"]
+      dividendForKId   = kernel["MatrixInstM"] * kernel["MatrixInstB"]
       num1DBlocks = kernel["MatrixInstBM"] if (tile01 == 0) else kernel["MatrixInstBN"]
       num1DWaves  = kernel["MIWaveGroup"][0] if (tile01 == 0) else kernel["MIWaveGroup"][1]
       vectorWidth = 1 # kernel["VectorWidth"] if ((tile01 == 0) and kernel["SourceSwap"]) else 1 # TODO: nonSwap VectorWidth
       strideTile  = 1 # tentative
       strideWave  = kernel["MatrixInstM"] * num1DBlocks * strideTile * vectorWidth
       # tile offset
-      kStr += vectorStaticRemainder(qReg, dividendReg, waveWidth, tmpSgpr)
-      kStr += vectorStaticRemainder(rReg, qReg, kernel["MatrixInstN"], tmpSgpr)
+      kStr += vectorStaticRemainder(qReg, dividendReg, waveWidth, tmpSgpr, \
+        "0. thread id in wave: wtid = tid %% wavelength(%u)" % waveWidth)
+      kStr += vectorStaticRemainder(rReg, qReg, kernel["MatrixInstN"], tmpSgpr, \
+        "1. N offset: nIdx = wtid %% MI_N(%u)" % kernel["MatrixInstN"])
+      kStr += staticMultiply(vgpr(rReg), vgpr(rReg), strideTile, sgpr(tmpSgpr), \
+        "1. N offset: nOffset = nIdx * nStride(%u)" % strideTile)
       # block offset (no code. assuming num1DBlocks == 1)
-      # unroll offset (no code here. This will be handled in GlobalOffset)
+      # unroll offset
+      # need division for qReg
+      kStr += vectorStaticDivide(qReg, qReg, dividendForKId, tmpSgpr, \
+          "5. K offset: kIdx = wtid / (MIN(%u) * MIBB(%u))" % (kernel["MatrixInstN"], kernel["MatrixInstB"]))
+
       # wave offset
       if num1DWaves > 1:
           # alloc vgpr
@@ -3686,9 +3695,6 @@ class KernelWriterAssembly(KernelWriter):
           # release register
           self.vgprPool.checkIn(wReg)
           self.vgprPool.checkIn(tmpVgpr)
-
-      # need division for qReg
-      kStr += vectorStaticDivide(qReg, qReg, kernel["MatrixInstN"], tmpSgpr)
 
       # localSplitU case. Calculate LSU offset here
       if kernel["LocalSplitU"] > 1:
@@ -3754,7 +3760,7 @@ class KernelWriterAssembly(KernelWriter):
       else:
         kStr += self.comment1("gro-unroll *= glvw")
         kStr += staticMultiply(vgpr(uReg), vgpr(uReg), tP["glvw"], sgpr(tmpSgpr))
-    if forceSwap:
+    if forceSwap and  tc == "A":
       # in this case, need to multiply vw to gro-tile
       kStr += self.comment1("gro-tile *= vw")
       kStr += staticMultiply(vgpr(tReg), vgpr(tReg), kernel["VectorWidth"], sgpr(tmpSgpr))
@@ -3866,11 +3872,12 @@ class KernelWriterAssembly(KernelWriter):
         tP["vgprPackedOffsets"] = self.vgprPool.checkOut(numExtraPackedOffsetsPerTile * numTileOffsets, "vgprPackedOffsets", self.preventVgprOverflowDuringNewTile)
       strideIdx = tP["lsc"] if tP["tlu"] else tP["lsp"]
       stride = kernel[strideIdx]
-      # adjustment for DirectToVgpr + tlu=False + VW > 1 case
+      # adjustment for DirectToVgpr + tlu=False + VW > 1 case (A only)
       strideInterleave = False
-      if kernel["DirectToVgpr%c"%tc] and (not tP["tlu"]) and kernel["VectorWidth"] > 1:
+      if kernel["DirectToVgpr%c"%tc] and (not tP["tlu"]) and kernel["VectorWidth"] > 1 and tc == "A":
         strideInterleave = True
         stride = stride * kernel["VectorWidth"] - (kernel["VectorWidth"] - 1)
+        strideMask = (kernel["VectorWidth"] - 1)
 
       if tP["rtc"]:
         assert(numExtraPackedOffsetsPerTile == 0) # not supported here
@@ -3884,7 +3891,7 @@ class KernelWriterAssembly(KernelWriter):
         for l in range(1, tP["nrt"]):
           # l>0, s=0
           strideValue = stride
-          if strideInterleave and (l & 1) != 0:
+          if strideInterleave and (l & strideMask) != 0:
             strideValue = 1
           kStr += inst("_v_add_co_u32", vgpr(v+l*tP["glvw"]), self.vcc, strideValue, \
               vgpr(v+(l-1)*tP["glvw"]), \
@@ -3900,7 +3907,7 @@ class KernelWriterAssembly(KernelWriter):
             vgpr(tP["gpr"]["tReg"]), "gro%s%s_%u"%(tP["tensorChar"], tP["tileChar"], 0) )
         for l in range(1, tP["nrt"]):
           strideValue = stride
-          if strideInterleave and (l & 1) != 0:
+          if strideInterleave and (l & strideMask) != 0:
             strideValue = 1
           kStr += inst("_v_add_co_u32", vgpr(v+l), self.vcc, strideValue, \
               vgpr(v+l-1), "gro%s%s_%u += %s"%(tP["tensorChar"], tP["tileChar"], l, strideIdx) )
@@ -13925,13 +13932,15 @@ class KernelWriterAssembly(KernelWriter):
 
     if skipLocalWrite > -1 or skipLocalRead > -1:
       if skipLocalWrite > -1:
-        numA = 0 if kernel["DirectToLdsA"] \
+        numA = 0 if (kernel["DirectToLdsA"] or  kernel["DirectToVgprA"])\
                else tPA["nrp"]*tPA["nrc"]*max(tPA["nwcv"],tPA["nwpv"])//tPA["nwcvpi"]
-        numB = 0 if kernel["DirectToLdsB"] \
+        numB = 0 if (kernel["DirectToLdsB"] or  kernel["DirectToVgprB"])\
                else tPB["nrp"]*tPB["nrc"]*max(tPB["nwcv"],tPB["nwpv"])//tPB["nwcvpi"]
         lgkmcnt += skipLocalWrite * (numA + numB)
       if skipLocalRead > -1:
-        readsPerIter = self.numReadsPerIterA + self.numReadsPerIterB
+        numReadsPerIterA = 0 if kernel["DirectToVgprA"] else self.numReadsPerIterA
+        numReadsPerIterB = 0 if kernel["DirectToVgprB"] else self.numReadsPerIterB
+        readsPerIter = numReadsPerIterA + numReadsPerIterB
         lgkmcnt += skipLocalRead * readsPerIter
 
     vmcnt = 0 if skipGlobalRead > -1 else -1

--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -2386,7 +2386,7 @@ class Solution(collections.abc.Mapping):
 
     # numBytes < 4 case
     if numBytes < 4:
-      # Does not work with TLU = True and numBytes < 4 SGEMM/CGEMM (not supported)
+      # Does not work with TLU = True and numBytes < 4 (not supported)
       if state["ProblemType"]["TLU%c"%tc]:
         reject(state, "DirectToVgpr%c does not supports TLU%c = True + numByte < 4"%(tc, tc))
         return False

--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -2346,8 +2346,8 @@ class Solution(collections.abc.Mapping):
   # determine if current datatype can support DirectToVgpr
   @staticmethod
   def isDirectToVgprSupportDataType(state):
-    # Single/Double/Complex only (tentative)
-    return (state["ProblemType"]["DataType"].isSingle() or state["ProblemType"]["DataType"].isDouble() or state["ProblemType"]["DataType"].isComplex())
+    return (state["ProblemType"]["DataType"].isSingle() or state["ProblemType"]["DataType"].isDouble() or state["ProblemType"]["DataType"].isComplex() or \
+            state["ProblemType"]["DataType"].isHalf() or state["ProblemType"]["DataType"].isBFloat16() or state["ProblemType"]["DataType"].isInt8())
 
   ########################################
   # determine can we use DirectToVgpr
@@ -2355,6 +2355,9 @@ class Solution(collections.abc.Mapping):
   def isDirectToVgprDoable(state, tc):
     tcOther = 'B' if tc == 'A' else 'A'
     MIindex = 0 if tc == 'A' else 1
+    numBytes = state["ProblemType"]["DataType"].numBytes()
+    asem = state["AssertSummationElementMultiple"]
+    gsu = state["GlobalSplitU"]
     # Does not support DirectToVgprA+DirectToVgprB+PrefetchGlobalRead=2
     # Need more than double-vgpr buffers to avoid overwritting loaded data on vgpr
     if state["DirectToVgprA"] and state["DirectToVgprB"] and state["PrefetchGlobalRead"]==2:
@@ -2380,6 +2383,17 @@ class Solution(collections.abc.Mapping):
     if (not state["ProblemType"]["TLU%c"%tc]) and (state["ProblemType"]["DataType"].isSingle() or state["ProblemType"]["DataType"].isSingleComplex()):
       reject(state, "DirectToVgpr%c does not supports TLU%c = False + SGEMM/CGEMM"%(tc, tc))
       return False
+
+    # numBytes < 4 case
+    if numBytes < 4:
+      # Does not work with TLU = True and numBytes < 4 SGEMM/CGEMM (not supported)
+      if state["ProblemType"]["TLU%c"%tc]:
+        reject(state, "DirectToVgpr%c does not supports TLU%c = True + numByte < 4"%(tc, tc))
+        return False
+      # Does not work with ASEM//GSU % DepthU != 0
+      if (asem % gsu != 0) or (asem//gsu) % state["DepthU"] != 0:
+        reject(state, "DirectToVgpr%c does not supports AssertSummationElementMultiple / GlobalSplitU is not multiple of DepthU"%(tc))
+        return False
 
     # MIWaveGroup check
     #  for A, MIWaveGroup should be [4, 1]
@@ -2423,9 +2437,9 @@ class Solution(collections.abc.Mapping):
       reject(state, "DirectToVgpr%c does not supports ExpandPointerSwap = False"%(tc))
       return False
 
-    # Does not work with VectorWidth != GlobalReadVectorWidth (VW = 2 + GRVW = 1 or VW = 1 + GRVW = 2 does not work)
-    if state["VectorWidth"] != state["GlobalLoadVectorWidth%c"%tc]:
-      reject(state, "DirectToVgpr%c does not supports VectorWidth(=%u) != GlobalReadVectorWidth%c(%u)"%(tc, state["VectorWidth"], tc, state["GlobalLoadVectorWidth%c"%tc]))
+    # Does not work with TLU + VectorWidth != GlobalReadVectorWidth (VW = 2 + GRVW = 1 or VW = 1 + GRVW = 2 does not work)
+    if state["ProblemType"]["TLU%c"%tc] and state["VectorWidth"] != state["GlobalLoadVectorWidth%c"%tc]:
+      reject(state, "DirectToVgpr%c does not supports TLU + VectorWidth(=%u) != GlobalReadVectorWidth%c(%u)"%(tc, state["VectorWidth"], tc, state["GlobalLoadVectorWidth%c"%tc]))
       return False
 
     # Does not work with AssertFree1ElementMultiple % VectorWidth != 0 (edge shift case) for B
@@ -2438,20 +2452,16 @@ class Solution(collections.abc.Mapping):
       reject(state, "DirectToVgpr%c does not supports FractionalLoad + TLU=False"%(tc))
       return False
 
-    # Does not work with TLU=False and PGR=2 and DepthU<=MatrixInstK*VW*LSU
-    if (not state["ProblemType"]["TLU%c"%tc]) and state["PrefetchGlobalRead"] == 2 and state["DepthU"] <= state["MatrixInstK"] * state["VectorWidth"] * state["LocalSplitU"]:
-      reject(state, "DirectToVgpr%c does not supports TLU=False and PrefetchGlobalRead==2 and DepthU<=MatrixInstK*VectorWidth*LocalSplitU"%(tc))
+    # Does not work with TLU=False and NumLoadsCoalesced != DepthU//(MatrixInstK*GRVW*LSU//MIInputPerThread)
+    if (not state["ProblemType"]["TLU%c"%tc]) and \
+        state["NumLoadsCoalesced%c"%tc] != state["DepthU"] // (state["MatrixInstK"] * state["GlobalLoadVectorWidth%c"%tc] * state["LocalSplitU"] // state["MIInputPerThread"]):
+      reject(state, "DirectToVgpr%c does not supports TLU=False and NumLoadsCoalesced%c != DepthU//(MatrixInstK*GlobalReadVectorWidth*LocalSplitU//MIInputPerThread(=%u))"%(tc, tc, state["MIInputPerThread"]))
       return False
 
-    # Does not work with TLU=False and NumLoadsCoalesced != DepthU//(MatrixInstK*VW*LSU)
-    if (not state["ProblemType"]["TLU%c"%tc]) and state["NumLoadsCoalesced%c"%tc] != state["DepthU"] // (state["MatrixInstK"] * state["VectorWidth"] * state["LocalSplitU"]):
-      reject(state, "DirectToVgpr%c does not supports TLU=False and NumLoadsCoalesced%c != DepthU//(MatrixInstK*VectorWidth*LocalSplitU)"%(tc, tc))
-      return False
-
-    # Both TLU=False + TransposeLDS case, need GlobalLoadVectorWidth == LocalReadVectorWidth
-    if (not state["ProblemType"]["TLU%c"%tc]) and (not state["ProblemType"]["TLU%c"%tcOther]) and state["TransposeLDS"] and \
+    # TLU=False case, need GlobalLoadVectorWidth == LocalReadVectorWidth
+    if (not state["ProblemType"]["TLU%c"%tc]) and \
        state["GlobalLoadVectorWidth%c"%tc] != state["LocalReadVectorWidth"]:
-      reject(state, "DirectToVgpr%c does not supports TLUA=False and TLUB=False and GlobalLoadVectorWidth%c != LocalReadVectorWidth"%(tc, tc))
+      reject(state, "DirectToVgpr%c does not supports TLU=False GlobalLoadVectorWidth%c != LocalReadVectorWidth"%(tc, tc))
       return False
 
     # Does not work with TLU=False and PrefetchLocalRead=1 and VectorWidth>1
@@ -4052,6 +4062,9 @@ class Solution(collections.abc.Mapping):
       if PLR != 0 and state["LoopIters"] - (PLR * wlrMultiple) <= 0 :
         reject(state, "with PrefetchLocalRead %u LoopIters %u LocalReadVectorWidth %u, not enough LoopIters to prefetch %ux%u iterations, " \
           % (state["PrefetchLocalRead"],state["LoopIters"],state["LocalReadVectorWidth"], PLR , wlrMultiple) )
+      if state["PrefetchLocalRead"] > 1 and PLR == 0:
+        reject(state, "not good performance with PrefetchLocalRead %u LoopIters %u" \
+          % (state["PrefetchLocalRead"],state["LoopIters"]) )
 
     # # reject conditions with lower performance
     # if state["ScheduleIterAlg"] == 2 and \
@@ -4078,7 +4091,7 @@ class Solution(collections.abc.Mapping):
       if state["PrefetchGlobalRead"] == 2:
         reject(state, "DepthULdsDivisor > 1 does not support PrefetchGlobalRead=2")
       if state["ScheduleIterAlg"] != 3:
-        reject(state, "DepthULdsDivisor > 1 does not support SchedulIterAlg other than 3")
+        reject(state, "DepthULdsDivisor > 1 does not support ScheduleIterAlg other than 3")
       if state["DirectToLds"] == True:
         reject(state, "DepthULdsDivisor > 1 does not support DirectToLds")
       if state["ProblemType"]["TLUA"] or state["ProblemType"]["TLUA"] or not state["TransposeLDS"]:

--- a/Tensile/Tests/extended/direct_to_vgpr/dtv_hgemm.yaml
+++ b/Tensile/Tests/extended/direct_to_vgpr/dtv_hgemm.yaml
@@ -1,0 +1,120 @@
+TestParameters:
+  marks: [skip-gfx900, skip-gfx906, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102] # not supported by arch
+
+GlobalParameters:
+  NumElementsToValidate: -1
+  BoundsCheck: True
+  KernelTime: True
+  #PrintSolutionRejectionReason: True
+  #MaxFileName: 256
+
+BenchmarkProblems:
+  ########################################
+  # HHS TN - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: H
+      DestDataType: H
+      ComputeDataType: S
+      HighPrecisionAccumulate: True
+      TransposeA: True
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+
+  ########################################
+  # HHS TN - DTVA + DTL
+  ########################################
+    -
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+            - [16, 16, 16, 1, 1, 4, 2, 4,1]  # 256x32
+            - [32, 32, 8, 1, 1, 4, 1, 4,1]  # 512x32
+            - [32, 32, 8, 1, 1, 2, 2, 4,1]  # 256x64
+        #- ThreadTile:
+        #  - [ 2, 2 ]
+        - WorkGroup:
+          - [ 64, 1, 1 ] # only WG2 is effective for 9 parameter MI
+          #- [ 64, 1, 2 ] # only WG2 is effective for 9 parameter MI
+          #- [ 64, 1, 4 ] # only WG2 is effective for 9 parameter MI
+        - AssertFree0ElementMultiple : [4]
+        - AssertFree1ElementMultiple : [4]
+        - AssertSummationElementMultiple: [64]
+        - DepthU: [16,32,64]
+        - 1LDSBuffer: [0]
+        - LoopTail: [True]
+        - OptNoLoadLoop: [1]
+        - PrefetchGlobalRead: [1,2]
+        - PrefetchLocalRead: [1,2,3,5,9]
+        - ScheduleIterAlg: [3]
+        - StaggerU: [0]
+        - SourceSwap: [0,1]
+        - TransposeLDS: [1]
+        - GlobalReadVectorWidth: [2,4,8]
+        - LocalReadVectorWidth: [2,4,8]
+        - VectorWidth: [1,2,4]
+        #- WaveSeparateGlobalReadB: [1]
+        - NumElementsPerBatchStore: [4]
+        - UseSgprForGRO: [0]
+        - DirectToVgprA: [1]
+        - DirectToLds: [0,1]
+        - NumLoadsCoalescedA: [1,2,4]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [ 508, 508, 1, 2048]
+
+  ########################################
+  # HHS TN - DTVB (+ DTL)
+  ########################################
+    -
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+            - [16, 16, 16, 1, 1, 4, 2, 1,4]  # 64x128
+            - [32, 32, 8, 1, 1, 2, 2, 1,4]  # 64x256
+            - [32, 32, 8, 1, 1, 4, 2, 1,4]  # 128x256
+        #- ThreadTile:
+        #  - [ 2, 2 ]
+        - WorkGroup:
+          - [ 64, 1, 1 ] # only WG2 is effective for 9 parameter MI
+          #- [ 64, 1, 2 ] # only WG2 is effective for 9 parameter MI
+          #- [ 64, 1, 4 ] # only WG2 is effective for 9 parameter MI
+        - AssertFree0ElementMultiple : [4]
+        - AssertFree1ElementMultiple : [4]
+        - AssertSummationElementMultiple: [64]
+        - DepthU: [16,32,64]
+        - 1LDSBuffer: [0]
+        - LoopTail: [True]
+        - OptNoLoadLoop: [1]
+        - PrefetchGlobalRead: [1,2]
+        - PrefetchLocalRead: [1,2,3,5,9]
+        - ScheduleIterAlg: [3]
+        - StaggerU: [0]
+        - SourceSwap: [0,1]
+        - TransposeLDS: [1]
+        - GlobalReadVectorWidth: [2,4,8]
+        - LocalReadVectorWidth: [2,4,8]
+        - VectorWidth: [1,2,4]
+        #- WaveSeparateGlobalReadB: [1]
+        - MIArchVgpr: [False]#[True, False]
+        - NumElementsPerBatchStore: [4]
+        - UseSgprForGRO: [0]
+        - DirectToVgprB: [1]
+        - DirectToLds: [0]#[0,1] # no valid scenario with DTL=1
+        - NumLoadsCoalescedB: [1,2,4]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [ 508, 508, 1, 2048]

--- a/Tensile/Tests/extended/direct_to_vgpr/dtv_igemm.yaml
+++ b/Tensile/Tests/extended/direct_to_vgpr/dtv_igemm.yaml
@@ -1,0 +1,125 @@
+TestParameters:
+  marks: [skip-gfx900, skip-gfx906, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102] # not supported by arch
+
+GlobalParameters:
+  NumElementsToValidate: -1
+  BoundsCheck: True
+  KernelTime: True
+  #PrintSolutionRejectionReason: True
+  #MaxFileName: 256
+
+BenchmarkProblems:
+  ########################################
+  # I8II TN - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: I8
+      DestDataType: I
+      ComputeDataType: I
+      HighPrecisionAccumulate: True
+      TransposeA: True
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+
+  ########################################
+  # I8II TN - DTVA + DTL
+  ########################################
+    -
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+            - [16, 16, 16, 1, 1, 4, 2, 4,1]  # 256x32
+            - [32, 32, 8, 1, 1, 4, 1, 4,1]  # 512x32
+            - [32, 32, 8, 1, 1, 2, 2, 4,1]  # 256x64
+        #- ThreadTile:
+        #  - [ 2, 2 ]
+        - WorkGroup:
+          - [ 64, 1, 1 ] # only WG2 is effective for 9 parameter MI
+          #- [ 64, 1, 2 ] # only WG2 is effective for 9 parameter MI
+          #- [ 64, 1, 4 ] # only WG2 is effective for 9 parameter MI
+        - AssertFree0ElementMultiple : [4]
+        - AssertFree1ElementMultiple : [4]
+        - AssertSummationElementMultiple: [128]
+        - DepthU: [16,32,64,128]
+        - 1LDSBuffer: [0]
+        - LoopTail: [True]
+        - OptNoLoadLoop: [1]
+        - PrefetchGlobalRead: [1,2]
+        - PrefetchLocalRead: [1,2,3,5,9,17]
+        - ScheduleIterAlg: [3]
+        - StaggerU: [0]
+        - SourceSwap: [0,1]
+        - TransposeLDS: [1]
+        - GlobalReadVectorWidth: [4,8,16]
+        - LocalReadVectorWidth: [4,8,16]
+        - VectorWidth: [1,2,4]
+        #- WaveSeparateGlobalReadB: [1]
+        - NumElementsPerBatchStore: [4]
+        - UseSgprForGRO: [0]
+        - DirectToVgprA: [1]
+        - DirectToLds: [0,1]
+        - NumLoadsCoalescedA: [1,2,4]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [ 508, 508, 1, 2048]
+
+  ########################################
+  # I8II TN - DTVB + DTL
+  ########################################
+    -
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+            - [16, 16, 16, 1, 1, 4, 2, 1,4]  # 64x128
+            - [32, 32, 8, 1, 1, 2, 2, 1,4]  # 64x256
+            - [32, 32, 8, 1, 1, 4, 2, 1,4]  # 128x256
+        #- ThreadTile:
+        #  - [ 2, 2 ]
+        - WorkGroup:
+          - [ 64, 1, 1 ] # only WG2 is effective for 9 parameter MI
+          #- [ 64, 1, 2 ] # only WG2 is effective for 9 parameter MI
+          #- [ 64, 1, 4 ] # only WG2 is effective for 9 parameter MI
+        - AssertFree0ElementMultiple : [4]
+        - AssertFree1ElementMultiple : [4]
+        - AssertSummationElementMultiple: [128]
+        - DepthU: [16,32,64,128]
+        - 1LDSBuffer: [0]
+        - LoopTail: [True]
+        - OptNoLoadLoop: [1]
+        - PrefetchGlobalRead: [1,2]
+        - PrefetchLocalRead: [1,2,3,5,9,17]
+        - ScheduleIterAlg: [3]
+        - StaggerU: [0]
+        - SourceSwap: [0,1]
+        - TransposeLDS: [1]
+        - GlobalReadVectorWidth: [4,8,16]
+        - LocalReadVectorWidth: [4,8,16]
+        - VectorWidth: [1,2,4]
+        #- WaveSeparateGlobalReadB: [1]
+        - MIArchVgpr: [False]#[True, False]
+        - NumElementsPerBatchStore: [4]
+        - UseSgprForGRO: [0]
+        - DirectToVgprB: [1]
+        - DirectToLds: [0,1]
+        - NumLoadsCoalescedB: [1,2,4]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [ 508, 508, 1, 2048]
+
+
+
+
+

--- a/Tensile/Tests/pre_checkin/mfma/hpa_hgemm_split_lds.yaml
+++ b/Tensile/Tests/pre_checkin/mfma/hpa_hgemm_split_lds.yaml
@@ -78,7 +78,7 @@ BenchmarkProblems:
         - DepthULdsDivisor: [2]
         - ScheduleIterAlg: [3]
         - GlobalReadVectorWidth: [4]
-        - LocalReadVectorWidth: [8]
+        - LocalReadVectorWidth: [4]
         - 1LDSBuffer: [0,1]
       JoinParameters:
       BenchmarkJoinParameters:


### PR DESCRIPTION
* enabled DirectToVgpr for small data types (HGEMM, I8) for TLU=False only
* removed restriction of VectorWidth=GlobalReadVectorWidth for DirectToVgpr+TLU=False
* fixed incorrect vmcnt values with DirecToVgpr+TN case
* fixed mismatch issue with DirectToVgprB + VectorWidth>1
* removed unnecessary wait in NumLoadsCoalesced= 4 case
* re-organized reject conditions for DirectToVgpr + TLU=False
* added reject condition for PrefetchLocalRead>1 and PrefetchLocalRead%LoopIters=0
    * no actual prefetch if PrefetchLocalRead%LoopIters=0 and performance is not good in this case
* added test cases for DirectToVgpr + HGEMM/I8 + TN
* fixed typo