### PR TITLE
Add option for GSU+ SingleBuffer + AtomicAdd and small improvement on width of load C for GSU

### DIFF
--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -537,6 +537,11 @@ validParameters = {
     # GSUSARR=True means the 4 workgroups round robin split up the chunks of the summation: k=0 -> DU-1, 4DU -> 5DU-1, ...; k=1DU -> 2DU-1, 5DU -> 6DU-1...; ...
     "GlobalSplitUSummationAssignmentRoundRobin":  [ False, True ],
 
+    # Enable atomic_add instruction for GlobalSplitU with SingleBuffer
+    # So far, f32 only.
+    # NOTE: This is not recommended
+    "GlobalSplitUAtomicAdd":      [ False, True ],
+
     # in opencl for some compilers, performance improved by putting a memfence after each sub-iteration; it prevented the loads of one sub-iteration from being moved
     # into a prior iteration, which would help latency but it consumed more vgprs which was a net loss
     "UnrollMemFence":             [ False, True ],
@@ -711,11 +716,11 @@ validParameters = {
     "Use64bShadowLimit":   [ True, False],
 
     # Attempt to vectorize atomics
-    # 1,2,4 : Number of elements to vectorize
+    # 1,2 : Number of elements to vectorize
     # -1 : Maximum supported value
-    # Wider VAW is effective only for C load of "load + atomic_cmpswap" case. Atomic operation itself is not vectorized
-    # TODO: support larger width for atomic_cmpswap
-    "VectorAtomicWidth":          [ -1, 1, 2, 4] ,
+    # This defines width of atomic_cmpswap (bpe(external) * VAW * 32bit = width of atomic_cmpswap (b32 or b64))
+    # AtomicAdd case, only 1 supported
+    "VectorAtomicWidth":          [ -1, 1, 2] ,
 
     # Assertion properties
     # These provide information or assertions that the problem size meets certain requirements
@@ -1375,6 +1380,7 @@ defaultBenchmarkCommonParameters = [
     {"GlobalSplitUAlgorithm":     [ "SingleBuffer" ] },
     {"GlobalSplitUSummationAssignmentRoundRobin": [ True ] },
     {"GlobalSplitUWorkGroupMappingRoundRobin":    [ False ] },
+    {"GlobalSplitUAtomicAdd":     [ False ] },
     {"MacroTileShapeMin":         [ 1 ] },
     {"MacroTileShapeMax":         [ 64 ] },
     {"PersistentKernel":          [ 0 ] },

--- a/Tensile/Tests/extended/global_split_u/hgemm_gsu.yaml
+++ b/Tensile/Tests/extended/global_split_u/hgemm_gsu.yaml
@@ -107,7 +107,7 @@ BenchmarkProblems:
         - WorkGroupMapping: [64]
         - DepthU: [ 16 ]
         - VectorWidth: [2,4,8]
-        - VectorAtomicWidth: [-1,2]#[-1,2,4,8]
+        - VectorAtomicWidth: [-1,2]#[-1,2,4]
         - AssertFree0ElementMultiple: [8]  # so we can test GRVW sweep
         - AssertSummationElementMultiple: [1,2]  # so we can test GRVW sweep
         - BufferLoad: [0,1]

--- a/Tensile/Tests/extended/local_split_u/bfloat16_lsu_mfma.yaml
+++ b/Tensile/Tests/extended/local_split_u/bfloat16_lsu_mfma.yaml
@@ -62,13 +62,14 @@ BenchmarkProblems:
         #- TransposeLDS: [0,1]
         - GlobalReadVectorWidth: [4]
         - VectorWidth: [2,4]
-        - VectorAtomicWidth: [-1,1,2,4]
+        - VectorAtomicWidth: [-1,1,2]
         #- WaveSeparateGlobalReadB: [1]
         #- MIArchVgpr: [True, False]
         - NumElementsPerBatchStore: [4]
         - UseSgprForGRO: [0]
         - BufferLoad: [0,1]
         - BufferStore: [0,1]
+        - GlobalSplitUAtomicAdd: [0,1]
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
@@ -127,13 +128,14 @@ BenchmarkProblems:
         #- TransposeLDS: [0,1]
         - GlobalReadVectorWidth: [4]
         - VectorWidth: [2,4]
-        - VectorAtomicWidth: [-1,1,2,4]
+        - VectorAtomicWidth: [-1,1,2]
         #- WaveSeparateGlobalReadB: [1]
         #- MIArchVgpr: [True, False]
         - NumElementsPerBatchStore: [0]
         - UseSgprForGRO: [0]
         - BufferLoad: [0,1]
         - BufferStore: [0,1]
+        - GlobalSplitUAtomicAdd: [0,1]
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:

--- a/Tensile/Tests/extended/local_split_u/cgemm_lsu_mfma.yaml
+++ b/Tensile/Tests/extended/local_split_u/cgemm_lsu_mfma.yaml
@@ -116,7 +116,7 @@ BenchmarkProblems:
         - DepthU:  [16]#[16,32]#[ 8, 16 ]
         #- StoreVectorWidth: [1,2]
         - VectorWidth: [1,2]
-        - VectorAtomicWidth: [-1,1,2]
+        - VectorAtomicWidth: [-1,1]
         #- LocalReadVectorWidth: [1,2]
         #- DirectToVgprB: [False, True]
         - ScheduleIterAlg: [3]

--- a/Tensile/Tests/extended/local_split_u/dgemm_lsu_mfma.yaml
+++ b/Tensile/Tests/extended/local_split_u/dgemm_lsu_mfma.yaml
@@ -198,7 +198,7 @@ BenchmarkProblems:
         - DepthU:  [16]
         #- StoreVectorWidth: [1,2]#[2]
         - VectorWidth: [1,2] #[1,2]
-        - VectorAtomicWidth: [-1,1,2]
+        - VectorAtomicWidth: [-1,1]
         #- GlobalReadVectorWidth: [1,2]
         #- LocalReadVectorWidth: [1,2]
         #- DirectToVgprA: [False, True]

--- a/Tensile/Tests/extended/local_split_u/hgemm_lsu_mfma.yaml
+++ b/Tensile/Tests/extended/local_split_u/hgemm_lsu_mfma.yaml
@@ -111,13 +111,14 @@ BenchmarkProblems:
         #- TransposeLDS: [0,1]
         - GlobalReadVectorWidth: [4]
         - VectorWidth: [2,4]
-        - VectorAtomicWidth: [-1,1,2,4]
+        - VectorAtomicWidth: [-1,1,2]
         #- WaveSeparateGlobalReadB: [1]
         #- MIArchVgpr: [True, False]
         - NumElementsPerBatchStore: [4]
         - UseSgprForGRO: [0]
         - BufferLoad: [0,1]
         - BufferStore: [0,1]
+        - GlobalSplitUAtomicAdd: [0,1]
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
@@ -176,13 +177,14 @@ BenchmarkProblems:
         #- TransposeLDS: [0,1]
         - GlobalReadVectorWidth: [4]
         - VectorWidth: [2,4]
-        - VectorAtomicWidth: [-1,1,2,4]
+        - VectorAtomicWidth: [-1,1,2]
         #- WaveSeparateGlobalReadB: [1]
         #- MIArchVgpr: [True, False]
         - NumElementsPerBatchStore: [4]
         - UseSgprForGRO: [0]
         - BufferLoad: [0,1]
         - BufferStore: [0,1]
+        - GlobalSplitUAtomicAdd: [0,1]
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:

--- a/Tensile/Tests/extended/local_split_u/igemm_lsu_mfma.yaml
+++ b/Tensile/Tests/extended/local_split_u/igemm_lsu_mfma.yaml
@@ -65,7 +65,7 @@ BenchmarkProblems:
         #- TransposeLDS: [0,1]
         - GlobalReadVectorWidth: [4,8]
         - VectorWidth: [2,4]
-        - VectorAtomicWidth: [-1,1,2,4]
+        - VectorAtomicWidth: [-1,1,2]
         #- WaveSeparateGlobalReadB: [1]
         #- MIArchVgpr: [True, False]
         - NumElementsPerBatchStore: [4]

--- a/Tensile/Tests/extended/local_split_u/sgemm_lsu_mfma.yaml
+++ b/Tensile/Tests/extended/local_split_u/sgemm_lsu_mfma.yaml
@@ -111,7 +111,7 @@ BenchmarkProblems:
         - TransposeLDS: [1]
         #- GlobalReadVectorWidth: [1,2,4]
         - VectorWidth: [1,2,4]
-        - VectorAtomicWidth: [-1,1,2,4]
+        - VectorAtomicWidth: [-1,1,2]
         #- LocalReadVectorWidth: [1,2,4]
         #- DirectToVgprA: [True, False]
         #- MIArchVgpr: [False, True]


### PR DESCRIPTION
* added an option to enable/disable AtomicAdd for GlobalSplitU (default disabled)
* optimized width of load C for GlobalSplitU to use GlobalWriteVectorWidth and removed redundant loop and counter
* added more test cases for AtomicAdd and removed VectorAtomicWidth=4 based on the changes for width of load C
* added warning message when GlobalSplitUAtomicAdd is used