### PR TITLE
Update kernels to have 64-bit offset arguments

### DIFF
--- a/Tensile/Components/Signature.py
+++ b/Tensile/Components/Signature.py
@@ -174,6 +174,11 @@ class SignatureDefault(Signature):
         kStr += self.addArgument(                               'A',     '8', offset, "global_buffer", srcValueType, "generic"); offset += 8
         kStr += self.addArgument(                               'B',     '8', offset, "global_buffer", srcValueType, "generic"); offset += 8
 
+        kStr += self.addArgument("OffsetD", '8', offset, "by_value", "u64"); offset += 8
+        kStr += self.addArgument("OffsetC", '8', offset, "by_value", "u64"); offset += 8
+        kStr += self.addArgument("OffsetA", '8', offset, "by_value", "u64"); offset += 8
+        kStr += self.addArgument("OffsetB", '8', offset, "by_value", "u64"); offset += 8
+
         useSize = max(4, cptByte)
         kStr += self.addArgument(                             "alpha", useSize, offset,      "by_value", cptValueType); offset += useSize
         if kernel["ProblemType"]["UseBeta"]:
@@ -237,11 +242,6 @@ class SignatureDefault(Signature):
         kStr += self.addArgument(                   "NumFullBlocks",     '4', offset,      "by_value",        "u32"); offset += 4
         kStr += self.addArgument(                   "WgmRemainder1",     '4', offset,      "by_value",        "u32"); offset += 4
         kStr += self.addArgument(        "MagicNumberWgmRemainder1",     '4', offset,      "by_value",        "u32"); offset += 4
-
-        kStr += self.addArgument("OffsetD", '4', offset, "by_value", "u32"); offset += 4
-        kStr += self.addArgument("OffsetC", '4', offset, "by_value", "u32"); offset += 4
-        kStr += self.addArgument("OffsetA", '4', offset, "by_value", "u32"); offset += 4
-        kStr += self.addArgument("OffsetB", '4', offset, "by_value", "u32"); offset += 4
 
         kStr += self.addArgument(                         "padding",     '4', offset,      "by_value",        "u32"); offset += 4
         kStr += "    .group_segment_fixed_size:   %u%s" % ( group_segment_size, writer.endLine ) #XXXXXX

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -1591,10 +1591,10 @@ class KernelWriterAssembly(KernelWriter):
       self.numSgprStridesB -= 1
     self.numSgprSizesSum = kernel["ProblemType"]["NumIndicesSummation"]
     self.numSgprSizesFree = kernel["ProblemType"]["NumIndicesC"]
-    self.numSgprOffsetD = 1
-    self.numSgprOffsetC = 1
-    self.numSgprOffsetA = 1
-    self.numSgprOffsetB = 1
+    self.numSgprOffsetD = 2
+    self.numSgprOffsetC = 2
+    self.numSgprOffsetA = 2
+    self.numSgprOffsetB = 2
     self.numSgprAddressDbg = self.rpga if globalParameters["DebugKernel"] else 0
 
     ####################################
@@ -1716,6 +1716,14 @@ class KernelWriterAssembly(KernelWriter):
     self.defineSgpr("AddressC", numSgprAddressC)
     self.defineSgpr("AddressA", numSgprAddressA)
     self.defineSgpr("AddressB", numSgprAddressB)
+
+    self.argOffsetOffset = self.argAddressOffset + (numSgprAddressD + numSgprAddressC + numSgprAddressA + numSgprAddressB) * 4
+
+    self.defineSgpr("OffsetD", self.numSgprOffsetD)
+    self.defineSgpr("OffsetC", self.numSgprOffsetC)
+    self.defineSgpr("OffsetA", self.numSgprOffsetA)
+    self.defineSgpr("OffsetB", self.numSgprOffsetB)
+
     self.defineSgpr("Alpha", numSgprAlpha, numSgprAlpha)
     if kernel["ProblemType"]["UseBeta"]:
       self.defineSgpr("Beta", numSgprBeta, numSgprBeta)
@@ -1780,11 +1788,6 @@ class KernelWriterAssembly(KernelWriter):
     self.defineSgpr("WgmRemainder1", 1) # Magic number to use for div by (NumWorkGroups1 % WGM)
     self.defineSgpr("MagicNumberWgmRemainder1", 1) # Magic number to use for div by (NumWorkGroups1 % WGM)
 
-    self.defineSgpr("OffsetD", self.numSgprOffsetD)
-    self.defineSgpr("OffsetC", self.numSgprOffsetC)
-    self.defineSgpr("OffsetA", self.numSgprOffsetA)
-    self.defineSgpr("OffsetB", self.numSgprOffsetB)
-
     # dedicated sgpr(S) for storeC VGPR indexing
     # sgpr semaphore for message synchronization between different part of code section
     if kernel["StoreCInUnroll"]:
@@ -1825,8 +1828,6 @@ class KernelWriterAssembly(KernelWriter):
       pkArgumentToLoad + \
       3 + \
       self.numSgprOffsetD + self.numSgprOffsetC + self.numSgprOffsetA + self.numSgprOffsetB
-
-    self.argOffsetOffset = (self.numSgprToLoad + 2 - (self.numSgprOffsetD + self.numSgprOffsetC + self.numSgprOffsetA + self.numSgprOffsetB)) * 4
 
     # Get kernel argument end here
     ###################################
@@ -3114,34 +3115,22 @@ class KernelWriterAssembly(KernelWriter):
       kStr += ".if 0\n"
 
     # add offset to buffer
-    tmpOffset = self.sgprPool.checkOutAligned(2, 2, preventOverflow=0)
-
     if not kernel["_GlobalAccumulation"]:
-      kStr += inst("s_mov_b32", sgpr(tmpOffset), sgpr("OffsetD"), "copy to temp b64 to prevent overflow with large offset")
-      kStr += inst("s_mov_b32", sgpr(tmpOffset + 1), 0, "init to 0")
-      kStr += inst("s_lshl_b64", sgpr(tmpOffset, 2), sgpr(tmpOffset, 2), hex(log2(self.bpeCexternal)), "elements offset to bytes offset")
-      kStr += inst("s_add_u32",  sgpr("AddressD+0"), sgpr("AddressD+0"), sgpr(tmpOffset), "add offset to buffer address")
-      kStr += inst("s_addc_u32", sgpr("AddressD+1"), sgpr("AddressD+1"), sgpr(tmpOffset + 1), "add offset to buffer address")
+      kStr += inst("s_lshl_b64", sgpr("OffsetD", 2), sgpr("OffsetD", 2), hex(log2(self.bpeCexternal)), "elements offset to bytes offset")
+      kStr += inst("s_add_u32",  sgpr("AddressD+0"), sgpr("AddressD+0"), sgpr("OffsetD"), "add offset to buffer address")
+      kStr += inst("s_addc_u32", sgpr("AddressD+1"), sgpr("AddressD+1"), sgpr("OffsetD+1"), "add offset to buffer address")
 
-      kStr += inst("s_mov_b32", sgpr(tmpOffset), sgpr("OffsetC"), "copy to temp b64 to prevent overflow with large offset")
-      kStr += inst("s_mov_b32", sgpr(tmpOffset + 1), 0, "init to 0")
-      kStr += inst("s_lshl_b64", sgpr(tmpOffset, 2), sgpr(tmpOffset, 2), hex(log2(self.bpeCexternal)), "elements offset to bytes offset")
-      kStr += inst("s_add_u32",  sgpr("AddressC+0"), sgpr("AddressC+0"), sgpr(tmpOffset), "add offset to buffer address")
-      kStr += inst("s_addc_u32", sgpr("AddressC+1"), sgpr("AddressC+1"), sgpr(tmpOffset + 1), "add offset to buffer address")
+      kStr += inst("s_lshl_b64", sgpr("OffsetC", 2), sgpr("OffsetC", 2), hex(log2(self.bpeCexternal)), "elements offset to bytes offset")
+      kStr += inst("s_add_u32",  sgpr("AddressC+0"), sgpr("AddressC+0"), sgpr("OffsetC"), "add offset to buffer address")
+      kStr += inst("s_addc_u32", sgpr("AddressC+1"), sgpr("AddressC+1"), sgpr("OffsetC+1"), "add offset to buffer address")
 
-    kStr += inst("s_mov_b32", sgpr(tmpOffset), sgpr("OffsetA"), "copy to temp b64 to prevent overflow with large offset")
-    kStr += inst("s_mov_b32", sgpr(tmpOffset + 1), 0, "init to 0")
-    kStr += inst("s_lshl_b64", sgpr(tmpOffset, 2), sgpr(tmpOffset, 2), hex(log2(self.bpeAB)), "elements offset to bytes offset")
-    kStr += inst("s_add_u32",  sgpr("AddressA+0"), sgpr("AddressA+0"), sgpr(tmpOffset), "add offset to buffer address")
-    kStr += inst("s_addc_u32", sgpr("AddressA+1"), sgpr("AddressA+1"), sgpr(tmpOffset + 1), "add offset to buffer address")
+    kStr += inst("s_lshl_b64", sgpr("OffsetA", 2), sgpr("OffsetA", 2), hex(log2(self.bpeAB)), "elements offset to bytes offset")
+    kStr += inst("s_add_u32",  sgpr("AddressA+0"), sgpr("AddressA+0"), sgpr("OffsetA"), "add offset to buffer address")
+    kStr += inst("s_addc_u32", sgpr("AddressA+1"), sgpr("AddressA+1"), sgpr("OffsetA+1"), "add offset to buffer address")
 
-    kStr += inst("s_mov_b32", sgpr(tmpOffset), sgpr("OffsetB"), "copy to temp b64 to prevent overflow with large offset")
-    kStr += inst("s_mov_b32", sgpr(tmpOffset + 1), 0, "init to 0")
-    kStr += inst("s_lshl_b64", sgpr(tmpOffset, 2), sgpr(tmpOffset, 2), hex(log2(self.bpeAB)), "elements offset to bytes offset")
-    kStr += inst("s_add_u32",  sgpr("AddressB+0"), sgpr("AddressB+0"), sgpr(tmpOffset), "add offset to buffer address")
-    kStr += inst("s_addc_u32", sgpr("AddressB+1"), sgpr("AddressB+1"), sgpr(tmpOffset + 1), "add offset to buffer address")
-
-    self.sgprPool.checkIn(tmpOffset)
+    kStr += inst("s_lshl_b64", sgpr("OffsetB", 2), sgpr("OffsetB", 2), hex(log2(self.bpeAB)), "elements offset to bytes offset")
+    kStr += inst("s_add_u32",  sgpr("AddressB+0"), sgpr("AddressB+0"), sgpr("OffsetB"), "add offset to buffer address")
+    kStr += inst("s_addc_u32", sgpr("AddressB+1"), sgpr("AddressB+1"), sgpr("OffsetB+1"), "add offset to buffer address")
 
     # self.groOffsetInMacroTile == 1 case, subtract pre-pad here
     if self.groOffsetInMacroTile:
@@ -3385,7 +3374,7 @@ class KernelWriterAssembly(KernelWriter):
     kStr = ""
 
     if kernel["PersistentKernel"]:
-      stmpRef = self.getTmpSgpr(4, 4)
+      stmpRef = self.getTmpSgpr(8, 4)
       stmp = stmpRef.idx()
       # Always reset pointers to handle odd-exit case which moves LRO to the upper bank
       if not self.prefetchAcrossPersistent and kernel["PrefetchGlobalRead"]:
@@ -3415,37 +3404,25 @@ class KernelWriterAssembly(KernelWriter):
             kStr += inst("_s_load_b256", sgpr("AddressD", 8), sgpr("KernArgAddress",2), hex(self.argAddressOffset), "reload DCAB address")
             kStr += inst("s_waitcnt", "lgkmcnt(0)", "wait for reload DCAB address")
             kStr += self.loadBatchedAddress(kernel, "WGKSerial", stmp)
-            kStr += inst("_s_load_b128", sgpr(stmp, 4), sgpr("KernArgAddress",2), hex(self.argOffsetOffset),  "reload DCAB Offset")
+            kStr += inst("_s_load_b256", sgpr(stmp, 8), sgpr("KernArgAddress",2), hex(self.argOffsetOffset),  "reload DCAB Offset")
             kStr += inst("s_waitcnt", "lgkmcnt(0)", "wait global buffer adress ready")
 
-            tmpOffset = self.sgprPool.checkOutAligned(2, 2, preventOverflow=0)
-
             if not kernel["_GlobalAccumulation"]:
-              kStr += inst("s_mov_b32", sgpr(tmpOffset), sgpr(stmp+0), "copy to temp b64 to prevent overflow with large offset")
-              kStr += inst("s_mov_b32", sgpr(tmpOffset + 1), 0, "init to 0")
-              kStr += inst("s_lshl_b64", sgpr(tmpOffset, 2), sgpr(tmpOffset, 2), hex(log2(self.bpeCexternal)), "elements offset to bytes offset")
-              kStr += inst("s_add_u32",  sgpr("AddressD+0"), sgpr("AddressD+0"), sgpr(tmpOffset), "add offset to buffer address")
-              kStr += inst("s_addc_u32", sgpr("AddressD+1"), sgpr("AddressD+1"), sgpr(tmpOffset + 1), "add offset to buffer address")
+              kStr += inst("s_lshl_b64", sgpr(stmp+0, 2), sgpr(stmp+0, 2), hex(log2(self.bpeCexternal)), "elements offset to bytes offset")
+              kStr += inst("s_add_u32",  sgpr("AddressD+0"), sgpr("AddressD+0"), sgpr(stmp + 0), "add offset to buffer address")
+              kStr += inst("s_addc_u32", sgpr("AddressD+1"), sgpr("AddressD+1"), sgpr(stmp + 1), "add offset to buffer address")
 
-              kStr += inst("s_mov_b32", sgpr(tmpOffset), sgpr(stmp+1), "copy to temp b64 to prevent overflow with large offset")
-              kStr += inst("s_mov_b32", sgpr(tmpOffset + 1), 0, "init to 0")
-              kStr += inst("s_lshl_b64", sgpr(tmpOffset, 2), sgpr(tmpOffset, 2), hex(log2(self.bpeCexternal)), "elements offset to bytes offset")
-              kStr += inst("s_add_u32",  sgpr("AddressC+0"), sgpr("AddressC+0"), sgpr(tmpOffset), "add offset to buffer address")
-              kStr += inst("s_addc_u32", sgpr("AddressC+1"), sgpr("AddressC+1"), sgpr(tmpOffset + 1), "add offset to buffer address")
+              kStr += inst("s_lshl_b64", sgpr(stmp+2, 2), sgpr(stmp+2, 2), hex(log2(self.bpeCexternal)), "elements offset to bytes offset")
+              kStr += inst("s_add_u32",  sgpr("AddressC+0"), sgpr("AddressC+0"), sgpr(stmp + 2), "add offset to buffer address")
+              kStr += inst("s_addc_u32", sgpr("AddressC+1"), sgpr("AddressC+1"), sgpr(stmp + 3), "add offset to buffer address")
 
-            kStr += inst("s_mov_b32", sgpr(tmpOffset), sgpr(stmp+2), "copy to temp b64 to prevent overflow with large offset")
-            kStr += inst("s_mov_b32", sgpr(tmpOffset + 1), 0, "init to 0")
-            kStr += inst("s_lshl_b64", sgpr(tmpOffset, 2), sgpr(tmpOffset, 2), hex(log2(self.bpeAB)), "elements offset to bytes offset")
-            kStr += inst("s_add_u32",  sgpr("AddressA+0"), sgpr("AddressA+0"), sgpr(tmpOffset), "add offset to buffer address")
-            kStr += inst("s_addc_u32", sgpr("AddressA+1"), sgpr("AddressA+1"), sgpr(tmpOffset + 1), "add offset to buffer address")
+            kStr += inst("s_lshl_b64", sgpr(stmp+4, 2), sgpr(stmp+4, 2), hex(log2(self.bpeAB)), "elements offset to bytes offset")
+            kStr += inst("s_add_u32",  sgpr("AddressA+0"), sgpr("AddressA+0"), sgpr(stmp + 4), "add offset to buffer address")
+            kStr += inst("s_addc_u32", sgpr("AddressA+1"), sgpr("AddressA+1"), sgpr(stmp + 5), "add offset to buffer address")
 
-            kStr += inst("s_mov_b32", sgpr(tmpOffset), sgpr(stmp+3), "copy to temp b64 to prevent overflow with large offset")
-            kStr += inst("s_mov_b32", sgpr(tmpOffset + 1), 0, "init to 0")
-            kStr += inst("s_lshl_b64", sgpr(tmpOffset, 2), sgpr(tmpOffset, 2), hex(log2(self.bpeAB)), "elements offset to bytes offset")
-            kStr += inst("s_add_u32",  sgpr("AddressB+0"), sgpr("AddressB+0"), sgpr(tmpOffset), "add offset to buffer address")
-            kStr += inst("s_addc_u32", sgpr("AddressB+1"), sgpr("AddressB+1"), sgpr(tmpOffset + 1), "add offset to buffer address")
-
-            self.sgprPool.checkIn(tmpOffset)
+            kStr += inst("s_lshl_b64", sgpr(stmp+6, 2), sgpr(stmp+6, 2), hex(log2(self.bpeAB)), "elements offset to bytes offset")
+            kStr += inst("s_add_u32",  sgpr("AddressB+0"), sgpr("AddressB+0"), sgpr(stmp + 6), "add offset to buffer address")
+            kStr += inst("s_addc_u32", sgpr("AddressB+1"), sgpr("AddressB+1"), sgpr(stmp + 7), "add offset to buffer address")
 
             if self.groOffsetInMacroTile:
               prePad = self.srdShiftLeft["A"] * self.tPA["bpe"] # leave room in case we have to pointer shift

--- a/Tensile/Source/client/source/DataInitialization.cpp
+++ b/Tensile/Source/client/source/DataInitialization.cpp
@@ -379,11 +379,6 @@ namespace Tensile
                 m_maxBatch = std::max(m_maxBatch, numOfBatch);
             }
 
-            m_aMaxElements += m_aBufferOffset;
-            m_bMaxElements += m_bBufferOffset;
-            m_cMaxElements += m_cBufferOffset;
-            m_dMaxElements += m_dBufferOffset;
-
             if(m_curBoundsCheck == BoundsCheckMode::NaN)
             {
                 m_aMaxElements += 1024;

--- a/Tensile/Source/lib/source/ContractionSolution.cpp
+++ b/Tensile/Source/lib/source/ContractionSolution.cpp
@@ -392,6 +392,11 @@ namespace Tensile
             rv.args.append<typename TypedInputs::BType const* const*>("batchB", inputs.batchB);
         }
 
+        rv.args.append<uint64_t>("offsetD", d.offset());
+        rv.args.append<uint64_t>("offsetC", c.offset());
+        rv.args.append<uint64_t>("offsetA", a.offset());
+        rv.args.append<uint64_t>("offsetB", b.offset());
+
         rv.args.append<typename TypedInputs::AlphaType>("alpha", inputs.alpha);
         if(std::is_same<typename TypedInputs::AlphaType, Half>::value && !isSourceKernel())
             rv.args.append<typename TypedInputs::AlphaType>("alpha_2", inputs.alpha);
@@ -578,11 +583,6 @@ namespace Tensile
             rv.args.append<uint32_t>("wgmRemainder1", wgmRemainder1);
             rv.args.append<uint32_t>("magicNumberWgmRemainder1", magicNumberWgmRemainder1);
         }
-
-        rv.args.append<uint32_t>("offsetD", d.offset());
-        rv.args.append<uint32_t>("offsetC", c.offset());
-        rv.args.append<uint32_t>("offsetA", a.offset());
-        rv.args.append<uint32_t>("offsetB", b.offset());
 
         if(!isSourceKernel())
         {

--- a/Tensile/Tests/pre_checkin/mfma/dgemm_64bit_offset.yaml
+++ b/Tensile/Tests/pre_checkin/mfma/dgemm_64bit_offset.yaml
@@ -1,0 +1,64 @@
+TestParameters:
+  marks: [skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102] # not supported by arch
+
+GlobalParameters:
+  NumElementsToValidate: -1
+  BoundsCheck: True
+  KernelTime: True
+  # PrintSolutionRejectionReason: True
+  BufferOffsetB: 4294967296
+  PristineOnGPU: False
+
+BenchmarkProblems:
+  ########################################
+  # NT - standard
+  ########################################
+  - # sgemm TN
+    - # ProblemType
+      OperationType: GEMM
+      DataType: d
+      TransposeA: False
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+        - PrefetchLocalRead: [True]
+      ForkParameters:
+        - AssertMinApproxSize: [0]
+        - DepthU: [8]
+        - ExpandPointerSwap: [0]
+        - GroupLoadStore: [1]
+        - LocalReadVectorWidth: [1]
+        - MACInstruction: ["MAD"]
+        - NumElementsPerBatchStore: [4]
+        - PrefetchGlobalRead: [2]
+        - PrefetchLocalRead: [3]
+        - ScheduleIterAlg: [3]
+        - SourceSwap: [1]
+        - StaggerU: [0]
+        - StaggerUStride: [0]
+        - StorePriorityOpt: [1]
+        - StoreSyncOpt: [6]
+        - WorkGroupMapping: [11]
+        - MatrixInstruction:
+          # - [16, 16, 4, 1,  1,  8,2,  1,4]  # 128x128
+          # - [16, 16, 4, 1,  1,  4,4,  2,2]  # 128x128
+          # - [16, 16, 4, 1,  1,  1,1,  4,1]  # 128x128
+          - [16, 16, 4, 1]
+        - ThreadTile:
+          - [ 2, 16 ]
+        - WorkGroup:
+          - [  32, 4, 1 ]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          # - Exact: [1024, 1024, 1, 1024, 1048576, 524288, 524288, 524288]
+          - Exact: [1024, 1024, 1, 1024]
+


### PR DESCRIPTION
Also fix error in client code that allocated double the required GPU memory when using offset.
Added a new test case with a 64-bit offset