### PR TITLE
Fix for gfx908 CI test failure

### DIFF
--- a/Tensile/Tests/extended/local_split_u/bfloat16_lsu_mfma.yaml
+++ b/Tensile/Tests/extended/local_split_u/bfloat16_lsu_mfma.yaml
@@ -1,5 +1,5 @@
 TestParameters:
-  marks: [skip-gfx900, skip-gfx906, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102] # not supported by arch
+  marks: [skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102] # not supported by arch
 
 GlobalParameters:
   NumElementsToValidate: -1


### PR DESCRIPTION
* added skip for gfx908 in bfloat16_lsu_mfma.yaml (not supported by arch)