### PR TITLE
Adding round near to zero mode for fp16alt implementation

### DIFF
--- a/Tensile/Components/Signature.py
+++ b/Tensile/Components/Signature.py
@@ -243,6 +243,9 @@ class SignatureDefault(Signature):
         kStr += self.addArgument(                   "WgmRemainder1",     '4', offset,      "by_value",        "u32"); offset += 4
         kStr += self.addArgument(        "MagicNumberWgmRemainder1",     '4', offset,      "by_value",        "u32"); offset += 4
 
+        if kernel["Fp16AltImpl"]:
+            kStr += self.addArgument(             "Fp16AltImplMode",     '4', offset,      "by_value",        "u32"); offset += 4
+
         kStr += self.addArgument(                         "padding",     '4', offset,      "by_value",        "u32"); offset += 4
         kStr += "    .group_segment_fixed_size:   %u%s" % ( group_segment_size, writer.endLine ) #XXXXXX
         kStr += "    .kernarg_segment_align:      %u%s" % ( 8, writer.endLine )

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -8808,8 +8808,8 @@ class KernelWriterAssembly(KernelWriter):
                   localWriteCode.addInst("v_cvt_f32_f16", vgpr("G2Lpipe0"), vgprsrc,"")
                   localWriteCode.addInst("v_cvt_f32_f16", vgpr("G2Lpipe1"), vgprsrc, "src0_sel:WORD_1", "")
 
-                  localWriteCode.addInst("v_add_f32", vgpr("G2Lpipe0"), sgpr("Fp16AltRound"), vgpr("G2Lpipe0"), "")
-                  localWriteCode.addInst("v_add_f32", vgpr("G2Lpipe1"), sgpr("Fp16AltRound"), vgpr("G2Lpipe1"), "")
+                  localWriteCode.addInst("v_add_u32", vgpr("G2Lpipe0"), sgpr("Fp16AltRound"), vgpr("G2Lpipe0"), "")
+                  localWriteCode.addInst("v_add_u32", vgpr("G2Lpipe1"), sgpr("Fp16AltRound"), vgpr("G2Lpipe1"), "")
 
                   localWriteCode.addInst("v_pack_b32_f16", vgprsrc, vgpr("G2Lpipe0"),vgpr("G2Lpipe1"), "op_sel:[1,1,0]","")
 

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -1507,7 +1507,7 @@ class KernelWriterAssembly(KernelWriter):
     if kernel["ProblemType"]["Fp16AltImpl"]:
       self.G2Lpipe0 = vgprIdx
       self.G2Lpipe1 = self.G2Lpipe0 + 1
-      self.fp16AltTmp = self.G2Lpipe1 + 1
+      self.Fp16AltTmp = self.G2Lpipe1 + 1
       vgprIdx += 3
 
     self.startVgprAddressDbg = vgprIdx

--- a/Tensile/Source/lib/include/Tensile/ContractionProblem.hpp
+++ b/Tensile/Source/lib/include/Tensile/ContractionProblem.hpp
@@ -913,7 +913,8 @@ namespace Tensile
                                D*       _d,
                                Alpha    _alpha,
                                Beta     _beta,
-                               void*    _ws = nullptr)
+                               void*    _ws = nullptr,
+                               int32_t  _fp16AltImplMode = 0)
             : TypedContractionInputs(
                 _a, _b, _c, _d, nullptr, nullptr, nullptr, nullptr, _alpha, _beta){};
 
@@ -927,7 +928,8 @@ namespace Tensile
                                D* const*       _batchD,
                                Alpha           _alpha,
                                Beta            _beta,
-                               void*           _ws = nullptr);
+                               void*           _ws = nullptr,
+                               int32_t         _fp16AltImplMode = 0);
 
         ~TypedContractionInputs();
 
@@ -945,6 +947,8 @@ namespace Tensile
 
         Alpha alpha = static_cast<Alpha>(0);
         Beta  beta  = static_cast<Beta>(0);
+
+        int32_t fp16AltImplMode = 0;
 
         constexpr static uint32_t TypeId()
         {

--- a/Tensile/Source/lib/include/Tensile/ContractionProblem.hpp
+++ b/Tensile/Source/lib/include/Tensile/ContractionProblem.hpp
@@ -913,7 +913,7 @@ namespace Tensile
                                D*       _d,
                                Alpha    _alpha,
                                Beta     _beta,
-                               void*    _ws = nullptr,
+                               void*    _ws              = nullptr,
                                int32_t  _fp16AltImplMode = 0)
             : TypedContractionInputs(
                 _a, _b, _c, _d, nullptr, nullptr, nullptr, nullptr, _alpha, _beta){};
@@ -928,7 +928,7 @@ namespace Tensile
                                D* const*       _batchD,
                                Alpha           _alpha,
                                Beta            _beta,
-                               void*           _ws = nullptr,
+                               void*           _ws              = nullptr,
                                int32_t         _fp16AltImplMode = 0);
 
         ~TypedContractionInputs();

--- a/Tensile/Source/lib/include/Tensile/ContractionSolution.hpp
+++ b/Tensile/Source/lib/include/Tensile/ContractionSolution.hpp
@@ -264,8 +264,7 @@ namespace Tensile
             int    persistentKernel           = 0;
             bool   persistentKernelAlongBatch = false;
 
-            bool   sourceKernel = false;
-
+            bool   sourceKernel          = false;
             int    globalAccumulation    = 0;
             size_t workspaceSizePerElemC = 0;
         };

--- a/Tensile/Source/lib/include/Tensile/ContractionSolution.hpp
+++ b/Tensile/Source/lib/include/Tensile/ContractionSolution.hpp
@@ -264,7 +264,7 @@ namespace Tensile
             int    persistentKernel           = 0;
             bool   persistentKernelAlongBatch = false;
 
-            bool sourceKernel = false;
+            bool   sourceKernel = false;
 
             int    globalAccumulation    = 0;
             size_t workspaceSizePerElemC = 0;

--- a/Tensile/Source/lib/source/ContractionProblem.cpp
+++ b/Tensile/Source/lib/source/ContractionProblem.cpp
@@ -1246,18 +1246,19 @@ namespace Tensile
     TypedContractionInputs<A, B, C, D, Alpha, Beta>::~TypedContractionInputs() = default;
 
     template <typename A, typename B, typename C, typename D, typename Alpha, typename Beta>
-    TypedContractionInputs<A, B, C, D, Alpha, Beta>::TypedContractionInputs(A const*        _a,
-                                                                            B const*        _b,
-                                                                            C const*        _c,
-                                                                            D*              _d,
-                                                                            A const* const* _batchA,
-                                                                            B const* const* _batchB,
-                                                                            C const* const* _batchC,
-                                                                            D* const*       _batchD,
-                                                                            Alpha           _alpha,
-                                                                            Beta            _beta,
-                                                                            void*           _ws,
-                                                                            int32_t         _fp16AltImplMode)
+    TypedContractionInputs<A, B, C, D, Alpha, Beta>::TypedContractionInputs(
+        A const*        _a,
+        B const*        _b,
+        C const*        _c,
+        D*              _d,
+        A const* const* _batchA,
+        B const* const* _batchB,
+        C const* const* _batchC,
+        D* const*       _batchD,
+        Alpha           _alpha,
+        Beta            _beta,
+        void*           _ws,
+        int32_t         _fp16AltImplMode)
         : a(_a)
         , b(_b)
         , c(_c)

--- a/Tensile/Source/lib/source/ContractionProblem.cpp
+++ b/Tensile/Source/lib/source/ContractionProblem.cpp
@@ -1256,7 +1256,8 @@ namespace Tensile
                                                                             D* const*       _batchD,
                                                                             Alpha           _alpha,
                                                                             Beta            _beta,
-                                                                            void*           _ws)
+                                                                            void*           _ws,
+                                                                            int32_t         _fp16AltImplMode)
         : a(_a)
         , b(_b)
         , c(_c)
@@ -1268,6 +1269,7 @@ namespace Tensile
         , ws(_ws)
         , alpha(_alpha)
         , beta(_beta)
+        , fp16AltImplMode(_fp16AltImplMode)
     {
     }
 

--- a/Tensile/Source/lib/source/ContractionSolution.cpp
+++ b/Tensile/Source/lib/source/ContractionSolution.cpp
@@ -584,6 +584,11 @@ namespace Tensile
             rv.args.append<uint32_t>("magicNumberWgmRemainder1", magicNumberWgmRemainder1);
         }
 
+        if(problemType.fp16AltImpl)
+        {
+            rv.args.append<uint32_t>("fp16AltImplMode", inputs.fp16AltImplMode);
+        }
+
         if(!isSourceKernel())
         {
             rv.args.append<uint32_t>("pad", 0);

--- a/Tensile/Source/lib/source/ContractionSolution.cpp
+++ b/Tensile/Source/lib/source/ContractionSolution.cpp
@@ -584,7 +584,7 @@ namespace Tensile
             rv.args.append<uint32_t>("magicNumberWgmRemainder1", magicNumberWgmRemainder1);
         }
 
-        if(problemType.fp16AltImpl)
+        if(problem.fp16AltImpl())
         {
             rv.args.append<uint32_t>("fp16AltImplMode", inputs.fp16AltImplMode);
         }


### PR DESCRIPTION
Adding a second rounding mode for fp16alt implementation. Original implementation truncates on internal conversion, adding round nearest to zero option. Tests are added to rocBLAS companion PR