### PR TITLE
Fix for rocblas precheckin test fail due to the previous tail loop optimization

### DIFF
--- a/Tensile/Tests/extended/direct_to_vgpr/dtv_dgemm_a1b0.yaml
+++ b/Tensile/Tests/extended/direct_to_vgpr/dtv_dgemm_a1b0.yaml
@@ -1,0 +1,953 @@
+TestParameters:
+  marks: [skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102] # not supported by arch
+
+GlobalParameters:
+  MinimumRequiredVersion: 4.33.0
+  NumElementsToValidate: -1
+  #BoundsCheck: True
+  KernelTime: True
+  #PrintSolutionRejectionReason: True
+  #MaxFileName: 256
+  DataInitTypeAlpha: 1
+  DataInitTypeBeta : 0
+
+BenchmarkProblems:
+  ########################################
+  # NT - DTVA + max load width for TailLoop
+  ########################################
+  - # dgemm NT
+    - # ProblemType
+      OperationType: GEMM
+      DataType: D
+      TransposeA: False
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - MatrixInstruction:
+          # - [16, 16, 4, 1]
+          - [16, 16, 4, 1, 1, 1,4, 4,1]  # 64x64
+          - [16, 16, 4, 1, 1, 2,4, 4,1]  # 128x64
+          - [16, 16, 4, 1, 1, 1,8, 4,1]  # 64x128
+          - [16, 16, 4, 1, 1, 2,8, 4,1]  # 128x128
+          - [16, 16, 4, 1, 1, 4,4, 4,1]  # 256x64
+        - ThreadTile:
+          - [  8, 32 ]
+        - WorkGroup:
+          - [ 16, 16, 1 ]
+        - SourceSwap: [True]
+        - PrefetchGlobalRead: [1,2]
+        - AssertFree0ElementMultiple: [2]
+        - AssertFree1ElementMultiple: [2]
+        - AssertSummationElementMultiple: [2]
+        - DepthU:  [8,16]
+        - PrefetchLocalRead: [3,5]
+        - GlobalSplitU: [1]
+        - VectorWidth: [1,2]
+        - GlobalReadVectorWidth: [1,2]
+        - LocalReadVectorWidth: [1,2]
+        - DirectToVgprA: [True]
+        - ScheduleIterAlg: [3]
+        - FractionalLoad: [0,2]
+        - BufferLoad: [True, False]
+        - StaggerU: [0,32]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          #- Exact: [ M, N, B, K, ldc, ldc, lda, ldb ]
+          - Range: [ [510], [510], [1], [2036, 8, 2044] ]
+
+  ########################################
+  # NT - DTVA + min load width for TailLoop
+  ########################################
+  - # dgemm NT
+    - # ProblemType
+      OperationType: GEMM
+      DataType: D
+      TransposeA: False
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - MatrixInstruction:
+          # - [16, 16, 4, 1]
+          - [16, 16, 4, 1, 1, 1,4, 4,1]  # 64x64
+          - [16, 16, 4, 1, 1, 2,4, 4,1]  # 128x64
+          - [16, 16, 4, 1, 1, 1,8, 4,1]  # 64x128
+          #- [16, 16, 4, 1, 1, 2,8, 4,1]  # 128x128
+          #- [16, 16, 4, 1, 1, 4,4, 4,1]  # 256x64
+        - ThreadTile:
+          - [  8, 32 ]
+        - WorkGroup:
+          - [ 16, 16, 1 ]
+        - SourceSwap: [0,1]
+        - PrefetchGlobalRead: [1]#[1,2]
+        - AssertFree0ElementMultiple: [1]
+        - AssertFree1ElementMultiple: [1]
+        - AssertSummationElementMultiple: [1]
+        - DepthU:  [8,16]
+        - PrefetchLocalRead: [3,5]
+        - GlobalSplitU: [1,3]
+        - GlobalSplitUAlgorithm: ["SingleBuffer"]
+        - VectorWidth: [1,2]
+        - GlobalReadVectorWidth: [1,2]
+        - LocalReadVectorWidth: [1,2]
+        - DirectToVgprA: [True]
+        - ScheduleIterAlg: [3]
+        #- FractionalLoad: [0,2]
+        #- BufferLoad: [True, False]
+        - StaggerU: [0,32]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          #- Exact: [ M, N, B, K, ldc, ldc, lda, ldb ]
+          - Range: [ [511], [511], [1], [2039, 8, 2047] ]
+          - Range: [ [511], [511], [1], [1, 2, 33] ]
+
+  ########################################
+  # NT - DTVB + max load width for TailLoop
+  ########################################
+  - # dgemm NT
+    - # ProblemType
+      OperationType: GEMM
+      DataType: D
+      TransposeA: False
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - MatrixInstruction:
+          # - [16, 16, 4, 1]
+          - [16, 16, 4, 1, 1, 4,1, 1,4]  # 64x64
+          - [16, 16, 4, 1, 1, 4,2, 1,4]  # 64x128
+          - [16, 16, 4, 1, 1, 8,1, 1,4]  # 128x64
+          - [16, 16, 4, 1, 1, 8,2, 1,4]  # 128x128
+          - [16, 16, 4, 1, 1, 4,4, 1,4]  # 64x256
+        - ThreadTile:
+          - [  8, 32 ]
+        - WorkGroup:
+          - [ 16, 16, 1 ]
+        - SourceSwap: [True]
+        - PrefetchGlobalRead: [1,2]
+        - AssertFree0ElementMultiple: [2]
+        - AssertFree1ElementMultiple: [2]
+        - AssertSummationElementMultiple: [2]
+        - DepthU:  [8,16]
+        - PrefetchLocalRead: [3,5]
+        - GlobalSplitU: [1]
+        - VectorWidth: [1,2]
+        - GlobalReadVectorWidth: [1,2]
+        - LocalReadVectorWidth: [1,2]
+        - DirectToVgprB: [True]
+        - ScheduleIterAlg: [3]
+        - FractionalLoad: [0,2]
+        - BufferLoad: [True, False]
+        - StaggerU: [0,32]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          #- Exact: [ M, N, B, K, ldc, ldc, lda, ldb ]
+          - Range: [ [510], [510], [1], [2036, 8, 2044] ]
+
+  ########################################
+  # NT - DTVB + min load width for TailLoop
+  ########################################
+  - # dgemm NT
+    - # ProblemType
+      OperationType: GEMM
+      DataType: D
+      TransposeA: False
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - MatrixInstruction:
+          # - [16, 16, 4, 1]
+          - [16, 16, 4, 1, 1, 4,1, 1,4]  # 64x64
+          - [16, 16, 4, 1, 1, 4,2, 1,4]  # 64x128
+          - [16, 16, 4, 1, 1, 8,1, 1,4]  # 128x64
+          #- [16, 16, 4, 1, 1, 8,2, 1,4]  # 128x128
+          #- [16, 16, 4, 1, 1, 4,4, 1,4]  # 64x256
+        - ThreadTile:
+          - [  8, 32 ]
+        - WorkGroup:
+          - [ 16, 16, 1 ]
+        - SourceSwap: [0,1]
+        - PrefetchGlobalRead: [1]#[1,2]
+        - AssertFree0ElementMultiple: [1]
+        - AssertFree1ElementMultiple: [1]
+        - AssertSummationElementMultiple: [1]
+        - DepthU:  [8,16]
+        - PrefetchLocalRead: [3,5]
+        - GlobalSplitU: [1]
+        - VectorWidth: [1,2]
+        - GlobalReadVectorWidth: [1,2]
+        - LocalReadVectorWidth: [1,2]
+        - DirectToVgprB: [True]
+        - ScheduleIterAlg: [3]
+        #- FractionalLoad: [0,2]
+        #- BufferLoad: [True, False]
+        - WaveSeparateGlobalReadA: [0,1]
+        - StaggerU: [0,32]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          #- Exact: [ M, N, B, K, ldc, ldc, lda, ldb ]
+          - Range: [ [511], [511], [1], [2039, 8, 2047] ]
+
+  ########################################
+  # NN - DTVA + max load width for TailLoop
+  ########################################
+  - # dgemm NN
+    - # ProblemType
+      OperationType: GEMM
+      DataType: D
+      TransposeA: False
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - MatrixInstruction:
+          # - [16, 16, 4, 1]
+          - [16, 16, 4, 1, 1, 1,4, 4,1]  # 64x64
+          - [16, 16, 4, 1, 1, 2,4, 4,1]  # 128x64
+          - [16, 16, 4, 1, 1, 1,8, 4,1]  # 64x128
+          - [16, 16, 4, 1, 1, 2,8, 4,1]  # 128x128
+          - [16, 16, 4, 1, 1, 4,4, 4,1]  # 256x64
+        - ThreadTile:
+          - [  8, 32 ]
+        - WorkGroup:
+          - [ 16, 16, 1 ]
+        - SourceSwap: [True]
+        - PrefetchGlobalRead: [1,2]
+        - AssertFree0ElementMultiple: [2]
+        - AssertFree1ElementMultiple: [2]
+        - AssertSummationElementMultiple: [2]
+        - DepthU:  [8,16]
+        - PrefetchLocalRead: [3,5]
+        - GlobalSplitU: [1]
+        - VectorWidth: [1,2]
+        - GlobalReadVectorWidth: [1,2]
+        - LocalReadVectorWidth: [1,2]
+        - DirectToVgprA: [True]
+        - ScheduleIterAlg: [3]
+        - FractionalLoad: [0,2]
+        - BufferLoad: [True, False]
+        - TransposeLDS: [1]
+        - WaveSeparateGlobalReadB: [0,1]
+        - StaggerU: [0,32]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          #- Exact: [ M, N, B, K, ldc, ldc, lda, ldb ]
+          - Range: [ [510], [510], [1], [2036, 8, 2044] ]
+
+  ########################################
+  # NN - DTVA + min load width for TailLoop
+  ########################################
+  - # dgemm NN
+    - # ProblemType
+      OperationType: GEMM
+      DataType: D
+      TransposeA: False
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - MatrixInstruction:
+          # - [16, 16, 4, 1]
+          - [16, 16, 4, 1, 1, 1,4, 4,1]  # 64x64
+          - [16, 16, 4, 1, 1, 2,4, 4,1]  # 128x64
+          - [16, 16, 4, 1, 1, 1,8, 4,1]  # 64x128
+          #- [16, 16, 4, 1, 1, 2,8, 4,1]  # 128x128
+          #- [16, 16, 4, 1, 1, 4,4, 4,1]  # 256x64
+        - ThreadTile:
+          - [  8, 32 ]
+        - WorkGroup:
+          - [ 16, 16, 1 ]
+        - SourceSwap: [0,1]
+        - PrefetchGlobalRead: [1]#[1,2]
+        - AssertFree0ElementMultiple: [1]
+        - AssertFree1ElementMultiple: [1]
+        - AssertSummationElementMultiple: [1]
+        - DepthU:  [8,16]
+        - PrefetchLocalRead: [3,5]
+        - GlobalSplitU: [1,3]
+        - GlobalSplitUAlgorithm: ["SingleBuffer"]
+        - VectorWidth: [1,2]
+        - GlobalReadVectorWidth: [1,2]
+        - LocalReadVectorWidth: [1,2]
+        - DirectToVgprA: [True]
+        - ScheduleIterAlg: [3]
+        #- FractionalLoad: [0,2]
+        #- BufferLoad: [True, False]
+        - TransposeLDS: [1]
+        - StaggerU: [0,32]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          #- Exact: [ M, N, B, K, ldc, ldc, lda, ldb ]
+          - Range: [ [511], [511], [1], [2039, 8, 2047] ]
+
+  ########################################
+  # NN - DTVB + max load width for TailLoop
+  ########################################
+  - # dgemm NN
+    - # ProblemType
+      OperationType: GEMM
+      DataType: D
+      TransposeA: False
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - MatrixInstruction:
+          # - [16, 16, 4, 1]
+          - [16, 16, 4, 1, 1, 4,1, 1,4]  # 64x64
+          - [16, 16, 4, 1, 1, 4,2, 1,4]  # 64x128
+          - [16, 16, 4, 1, 1, 8,1, 1,4]  # 128x64
+          - [16, 16, 4, 1, 1, 8,2, 1,4]  # 128x128
+          - [16, 16, 4, 1, 1, 4,4, 1,4]  # 64x256
+        - ThreadTile:
+          - [  8, 32 ]
+        - WorkGroup:
+          - [ 16, 16, 1 ]
+        - SourceSwap: [True]
+        - PrefetchGlobalRead: [1,2]
+        - AssertFree0ElementMultiple: [2]
+        - AssertFree1ElementMultiple: [2]
+        - AssertSummationElementMultiple: [2]
+        - DepthU:  [8,16]
+        - PrefetchLocalRead: [3,5]
+        - GlobalSplitU: [1]
+        - VectorWidth: [1,2]
+        - GlobalReadVectorWidth: [1,2]
+        - LocalReadVectorWidth: [1,2]
+        - DirectToVgprB: [True]
+        - ScheduleIterAlg: [3]
+        - FractionalLoad: [0,2]
+        - BufferLoad: [True, False]
+        - TransposeLDS: [1]
+        - StaggerU: [0,32]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          #- Exact: [ M, N, B, K, ldc, ldc, lda, ldb ]
+          - Range: [ [510], [510], [1], [2036, 8, 2044] ]
+
+  ########################################
+  # NN - DTVB + min load width for TailLoop
+  ########################################
+  - # dgemm NN
+    - # ProblemType
+      OperationType: GEMM
+      DataType: D
+      TransposeA: False
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - MatrixInstruction:
+          # - [16, 16, 4, 1]
+          - [16, 16, 4, 1, 1, 4,1, 1,4]  # 64x64
+          - [16, 16, 4, 1, 1, 4,2, 1,4]  # 64x128
+          - [16, 16, 4, 1, 1, 8,1, 1,4]  # 128x64
+          #- [16, 16, 4, 1, 1, 8,2, 1,4]  # 128x128
+          #- [16, 16, 4, 1, 1, 4,4, 1,4]  # 64x256
+        - ThreadTile:
+          - [  8, 32 ]
+        - WorkGroup:
+          - [ 16, 16, 1 ]
+        - SourceSwap: [0,1]
+        - PrefetchGlobalRead: [1]#[1,2]
+        - AssertFree0ElementMultiple: [1]
+        - AssertFree1ElementMultiple: [1]
+        - AssertSummationElementMultiple: [1]
+        - DepthU:  [8,16]
+        - PrefetchLocalRead: [3,5]
+        - GlobalSplitU: [1]
+        - VectorWidth: [1,2]
+        - GlobalReadVectorWidth: [1,2]
+        - LocalReadVectorWidth: [1,2]
+        - DirectToVgprB: [True]
+        - ScheduleIterAlg: [3]
+        #- FractionalLoad: [0,2]
+        #- BufferLoad: [True, False]
+        - TransposeLDS: [1]
+        - WaveSeparateGlobalReadA: [0,1]
+        - StaggerU: [0,32]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          #- Exact: [ M, N, B, K, ldc, ldc, lda, ldb ]
+          - Range: [ [511], [511], [1], [2039, 8, 2047] ]
+
+  ########################################
+  # TT - DTVA + max load width for TailLoop
+  ########################################
+  - # dgemm TT
+    - # ProblemType
+      OperationType: GEMM
+      DataType: D
+      TransposeA: True
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - MatrixInstruction:
+          # - [16, 16, 4, 1]
+          - [16, 16, 4, 1, 1, 1,4, 4,1]  # 64x64
+          - [16, 16, 4, 1, 1, 2,4, 4,1]  # 128x64
+          - [16, 16, 4, 1, 1, 1,8, 4,1]  # 64x128
+          - [16, 16, 4, 1, 1, 2,8, 4,1]  # 128x128
+          - [16, 16, 4, 1, 1, 4,4, 4,1]  # 256x64
+        - ThreadTile:
+          - [  8, 32 ]
+        - WorkGroup:
+          - [ 16, 16, 1 ]
+        - SourceSwap: [True]
+        - PrefetchGlobalRead: [1,2]
+        - AssertFree0ElementMultiple: [2]
+        - AssertFree1ElementMultiple: [2]
+        - AssertSummationElementMultiple: [2]
+        - DepthU:  [8,16]
+        - PrefetchLocalRead: [3,5]
+        - GlobalSplitU: [1]
+        - VectorWidth: [1,2]
+        - GlobalReadVectorWidth: [1,2]
+        - LocalReadVectorWidth: [1,2]
+        - DirectToVgprA: [True]
+        - ScheduleIterAlg: [3]
+        - FractionalLoad: [0,2]
+        - BufferLoad: [True, False]
+        - StaggerU: [0,32]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          #- Exact: [ M, N, B, K, ldc, ldc, lda, ldb ]
+          - Range: [ [510], [510], [1], [2036, 8, 2044] ]
+
+  ########################################
+  # TT - DTVA + min load width for TailLoop
+  ########################################
+  - # dgemm TT
+    - # ProblemType
+      OperationType: GEMM
+      DataType: D
+      TransposeA: True
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - MatrixInstruction:
+          # - [16, 16, 4, 1]
+          - [16, 16, 4, 1, 1, 1,4, 4,1]  # 64x64
+          - [16, 16, 4, 1, 1, 2,4, 4,1]  # 128x64
+          - [16, 16, 4, 1, 1, 1,8, 4,1]  # 64x128
+          #- [16, 16, 4, 1, 1, 2,8, 4,1]  # 128x128
+          #- [16, 16, 4, 1, 1, 4,4, 4,1]  # 256x64
+        - ThreadTile:
+          - [  8, 32 ]
+        - WorkGroup:
+          - [ 16, 16, 1 ]
+        - SourceSwap: [0,1]
+        - PrefetchGlobalRead: [1]#[1,2]
+        - AssertFree0ElementMultiple: [1]
+        - AssertFree1ElementMultiple: [1]
+        - AssertSummationElementMultiple: [1]
+        - DepthU:  [8,16]
+        - PrefetchLocalRead: [3,5]
+        - GlobalSplitU: [1,3]
+        - GlobalSplitUAlgorithm: ["SingleBuffer"]
+        - VectorWidth: [1,2]
+        - GlobalReadVectorWidth: [1,2]
+        - LocalReadVectorWidth: [1,2]
+        - DirectToVgprA: [True]
+        - ScheduleIterAlg: [3]
+        #- FractionalLoad: [0,2]
+        #- BufferLoad: [True, False]
+        - TransposeLDS: [1]
+        - WaveSeparateGlobalReadB: [0,1]
+        - StaggerU: [0,32]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          #- Exact: [ M, N, B, K, ldc, ldc, lda, ldb ]
+          - Range: [ [511], [511], [1], [2039, 8, 2047] ]
+
+  ########################################
+  # TT - DTVB + max load width for TailLoop
+  ########################################
+  - # dgemm TT
+    - # ProblemType
+      OperationType: GEMM
+      DataType: D
+      TransposeA: True
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - MatrixInstruction:
+          # - [16, 16, 4, 1]
+          - [16, 16, 4, 1, 1, 4,1, 1,4]  # 64x64
+          - [16, 16, 4, 1, 1, 4,2, 1,4]  # 64x128
+          - [16, 16, 4, 1, 1, 8,1, 1,4]  # 128x64
+          - [16, 16, 4, 1, 1, 8,2, 1,4]  # 128x128
+          - [16, 16, 4, 1, 1, 4,4, 1,4]  # 64x256
+        - ThreadTile:
+          - [  8, 32 ]
+        - WorkGroup:
+          - [ 16, 16, 1 ]
+        - SourceSwap: [True]
+        - PrefetchGlobalRead: [1,2]
+        - AssertFree0ElementMultiple: [2]
+        - AssertFree1ElementMultiple: [2]
+        - AssertSummationElementMultiple: [2]
+        - DepthU:  [8,16]
+        - PrefetchLocalRead: [3,5]
+        - GlobalSplitU: [1]
+        - VectorWidth: [1,2]
+        - GlobalReadVectorWidth: [1,2]
+        - LocalReadVectorWidth: [1,2]
+        - DirectToVgprB: [True]
+        - ScheduleIterAlg: [3]
+        - FractionalLoad: [0,2]
+        - BufferLoad: [True, False]
+        - TransposeLDS: [1]
+        - StaggerU: [0,32]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          #- Exact: [ M, N, B, K, ldc, ldc, lda, ldb ]
+          - Range: [ [510], [510], [1], [2036, 8, 2044] ]
+
+  ########################################
+  # TT - DTVB + min load width for TailLoop
+  ########################################
+  - # dgemm TT
+    - # ProblemType
+      OperationType: GEMM
+      DataType: D
+      TransposeA: True
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - MatrixInstruction:
+          # - [16, 16, 4, 1]
+          - [16, 16, 4, 1, 1, 4,1, 1,4]  # 64x64
+          - [16, 16, 4, 1, 1, 4,2, 1,4]  # 64x128
+          - [16, 16, 4, 1, 1, 8,1, 1,4]  # 128x64
+          #- [16, 16, 4, 1, 1, 8,2, 1,4]  # 128x128
+          #- [16, 16, 4, 1, 1, 4,4, 1,4]  # 64x256
+        - ThreadTile:
+          - [  8, 32 ]
+        - WorkGroup:
+          - [ 16, 16, 1 ]
+        - SourceSwap: [0,1]
+        - PrefetchGlobalRead: [1]#[1,2]
+        - AssertFree0ElementMultiple: [1]
+        - AssertFree1ElementMultiple: [1]
+        - AssertSummationElementMultiple: [1]
+        - DepthU:  [8,16]
+        - PrefetchLocalRead: [3,5]
+        - GlobalSplitU: [1]
+        - VectorWidth: [1,2]
+        - GlobalReadVectorWidth: [1,2]
+        - LocalReadVectorWidth: [1,2]
+        - DirectToVgprB: [True]
+        - ScheduleIterAlg: [3]
+        #- FractionalLoad: [0,2]
+        #- BufferLoad: [True, False]
+        - TransposeLDS: [1]
+        - WaveSeparateGlobalReadA: [0,1]
+        - StaggerU: [0,32]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          #- Exact: [ M, N, B, K, ldc, ldc, lda, ldb ]
+          - Range: [ [511], [511], [1], [2039, 8, 2047] ]
+
+  ########################################
+  # TN - DTVA + max load width for TailLoop
+  ########################################
+  - # dgemm TN
+    - # ProblemType
+      OperationType: GEMM
+      DataType: D
+      TransposeA: True
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - MatrixInstruction:
+          # - [16, 16, 4, 1]
+          - [16, 16, 4, 1, 1, 1,4, 4,1]  # 64x64
+          - [16, 16, 4, 1, 1, 2,4, 4,1]  # 128x64
+          - [16, 16, 4, 1, 1, 1,8, 4,1]  # 64x128
+          - [16, 16, 4, 1, 1, 2,8, 4,1]  # 128x128
+          - [16, 16, 4, 1, 1, 4,4, 4,1]  # 256x64
+        - ThreadTile:
+          - [  8, 32 ]
+        - WorkGroup:
+          - [ 16, 16, 1 ]
+        - SourceSwap: [True]
+        - PrefetchGlobalRead: [1,2]
+        - AssertFree0ElementMultiple: [2]
+        - AssertFree1ElementMultiple: [2]
+        - AssertSummationElementMultiple: [2]
+        - DepthU:  [8,16]
+        - PrefetchLocalRead: [3,5]
+        - GlobalSplitU: [1]
+        - VectorWidth: [1,2]
+        - GlobalReadVectorWidth: [1,2]
+        - LocalReadVectorWidth: [1,2]
+        - DirectToVgprA: [True]
+        - ScheduleIterAlg: [3]
+        - FractionalLoad: [0,2]
+        - BufferLoad: [True, False]
+        - WaveSeparateGlobalReadB: [0,1]
+        - StaggerU: [0,32]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          #- Exact: [ M, N, B, K, ldc, ldc, lda, ldb ]
+          - Range: [ [510], [510], [1], [2036, 8, 2044] ]
+
+  ########################################
+  # TN - DTVA + min load width for TailLoop
+  ########################################
+  - # dgemm TN
+    - # ProblemType
+      OperationType: GEMM
+      DataType: D
+      TransposeA: True
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - MatrixInstruction:
+          # - [16, 16, 4, 1]
+          - [16, 16, 4, 1, 1, 1,4, 4,1]  # 64x64
+          - [16, 16, 4, 1, 1, 2,4, 4,1]  # 128x64
+          - [16, 16, 4, 1, 1, 1,8, 4,1]  # 64x128
+          #- [16, 16, 4, 1, 1, 2,8, 4,1]  # 128x128
+          #- [16, 16, 4, 1, 1, 4,4, 4,1]  # 256x64
+        - ThreadTile:
+          - [  8, 32 ]
+        - WorkGroup:
+          - [ 16, 16, 1 ]
+        - SourceSwap: [0,1]
+        - PrefetchGlobalRead: [1]#[1,2]
+        - AssertFree0ElementMultiple: [1]
+        - AssertFree1ElementMultiple: [1]
+        - AssertSummationElementMultiple: [1]
+        - DepthU:  [8,16]
+        - PrefetchLocalRead: [3,5]
+        - GlobalSplitU: [1,3]
+        - GlobalSplitUAlgorithm: ["SingleBuffer"]
+        - VectorWidth: [1,2]
+        - GlobalReadVectorWidth: [1,2]
+        - LocalReadVectorWidth: [1,2]
+        - DirectToVgprA: [True]
+        - ScheduleIterAlg: [3]
+        #- FractionalLoad: [0,2]
+        #- BufferLoad: [True, False]
+        - TransposeLDS: [1]
+        - StaggerU: [0,32]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          #- Exact: [ M, N, B, K, ldc, ldc, lda, ldb ]
+          - Range: [ [511], [511], [1], [2039, 8, 2047] ]
+
+  ########################################
+  # TN - DTVB + max load width for TailLoop
+  ########################################
+  - # dgemm TN
+    - # ProblemType
+      OperationType: GEMM
+      DataType: D
+      TransposeA: True
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - MatrixInstruction:
+          # - [16, 16, 4, 1]
+          - [16, 16, 4, 1, 1, 4,1, 1,4]  # 64x64
+          - [16, 16, 4, 1, 1, 4,2, 1,4]  # 64x128
+          - [16, 16, 4, 1, 1, 8,1, 1,4]  # 128x64
+          - [16, 16, 4, 1, 1, 8,2, 1,4]  # 128x128
+          - [16, 16, 4, 1, 1, 4,4, 1,4]  # 64x256
+        - ThreadTile:
+          - [  8, 32 ]
+        - WorkGroup:
+          - [ 16, 16, 1 ]
+        - SourceSwap: [True]
+        - PrefetchGlobalRead: [1,2]
+        - AssertFree0ElementMultiple: [2]
+        - AssertFree1ElementMultiple: [2]
+        - AssertSummationElementMultiple: [2]
+        - DepthU:  [8,16]
+        - PrefetchLocalRead: [3,5]
+        - GlobalSplitU: [1]
+        - VectorWidth: [1,2]
+        - GlobalReadVectorWidth: [1,2]
+        - LocalReadVectorWidth: [1,2]
+        - DirectToVgprB: [True]
+        - ScheduleIterAlg: [3]
+        - FractionalLoad: [0,2]
+        - BufferLoad: [True, False]
+        - TransposeLDS: [1]
+        - WaveSeparateGlobalReadA: [0,1]
+        - StaggerU: [0,32]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          #- Exact: [ M, N, B, K, ldc, ldc, lda, ldb ]
+          - Range: [ [510], [510], [1], [2036, 8, 2044] ]
+
+  ########################################
+  # TN - DTVB + min load width for TailLoop
+  ########################################
+  - # dgemm TN
+    - # ProblemType
+      OperationType: GEMM
+      DataType: D
+      TransposeA: True
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - MatrixInstruction:
+          # - [16, 16, 4, 1]
+          - [16, 16, 4, 1, 1, 4,1, 1,4]  # 64x64
+          - [16, 16, 4, 1, 1, 4,2, 1,4]  # 64x128
+          - [16, 16, 4, 1, 1, 8,1, 1,4]  # 128x64
+          #- [16, 16, 4, 1, 1, 8,2, 1,4]  # 128x128
+          #- [16, 16, 4, 1, 1, 4,4, 1,4]  # 64x256
+        - ThreadTile:
+          - [  8, 32 ]
+        - WorkGroup:
+          - [ 16, 16, 1 ]
+        - SourceSwap: [0,1]
+        - PrefetchGlobalRead: [1]#[1,2]
+        - AssertFree0ElementMultiple: [1]
+        - AssertFree1ElementMultiple: [1]
+        - AssertSummationElementMultiple: [1]
+        - DepthU:  [4,8,16]
+        - PrefetchLocalRead: [2,3,5]
+        - GlobalSplitU: [1]
+        - VectorWidth: [1,2]
+        - GlobalReadVectorWidth: [1,2]
+        - LocalReadVectorWidth: [1,2]
+        - DirectToVgprB: [False, True]
+        - ScheduleIterAlg: [0,2,3]
+        #- FractionalLoad: [0,2]
+        #- BufferLoad: [True, False]
+        - TransposeLDS: [1]
+        - StaggerU: [0,32]
+        - InnerUnroll: [1,2]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          #- Exact: [ M, N, B, K, ldc, ldc, lda, ldb ]
+          - Range: [ [511], [511], [1], [2033, 1, 2047] ]
+
+  ########################################
+  # NT - MI4x4
+  ########################################
+  - # dgemm NT
+    - # ProblemType
+      OperationType: GEMM
+      DataType: D
+      TransposeA: False
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - MatrixInstruction:
+          # - [16, 16, 4, 1]
+          - [4, 4, 4, 4, 1, 2,2, 2,2] # 16x64
+          - [4, 4, 4, 4, 2, 2,2, 2,2] # 32x32
+          - [4, 4, 4, 4, 4, 2,2, 2,2] # 64x16
+          - [4, 4, 4, 4, 1, 4,2, 1,4] # 16x128
+          - [4, 4, 4, 4, 2, 4,2, 1,4] # 32x64
+          - [4, 4, 4, 4, 4, 4,2, 1,4] # 64x32
+          - [4, 4, 4, 4, 1, 2,4, 4,1] # 32x16
+          - [4, 4, 4, 4, 2, 2,4, 4,1] # 64x32
+          - [4, 4, 4, 4, 4, 2,4, 4,1] # 128x16
+          - [4, 4, 4, 4, 1, 4,4, 2,2] # 32x128
+          - [4, 4, 4, 4, 2, 4,4, 2,2] # 64x64
+          - [4, 4, 4, 4, 4, 4,4, 2,2] # 128x32
+        - SourceSwap: [0,1]
+        - PrefetchGlobalRead: [0,1,2]
+        - ThreadTile:
+          - [  8, 32 ]
+        - WorkGroup:
+          - [ 16, 16, 1 ]
+        #- AssertFree0ElementMultiple: [1,2]
+        #- AssertFree1ElementMultiple: [1,2]
+        - AssertSummationElementMultiple: [1]
+        - PrefetchLocalRead: [1]
+        - GlobalSplitU: [1]
+        - DepthU:  [16]
+        - GlobalReadVectorWidth: [1,2]
+        - VectorWidth: [1,2]
+        - StoreVectorWidth: [1,2]
+        #- LocalReadVectorWidth: [1,2]
+        #- DirectToLds: [False, True]
+        #- DirectToVgprA: [False, True] # MI4x4 + DTV not supported yet
+        #- DirectToVgprB: [True, False] # MI4x4 + DTV not supported yet
+        #- WaveSeparateGlobalReadA: [0,1]
+        #- WaveSeparateGlobalReadB: [0,1]
+        #- NumLoadsCoalescedA: [1,2]
+        #- NumLoadsCoalescedB: [1,2]
+        - ScheduleIterAlg: [3]#[0,2,3]
+        #- FractionalLoad: [0,1,2]
+        #- BufferLoad: [True, False]
+        - StaggerU: [0,32]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          #- Exact: [ M, N, B, K, ldc, ldc, lda, ldb ]
+          #- Exact: [1024, 1024, 1, 512]
+          - Exact: [1022, 1022, 1, 511]
+

--- a/Tensile/Tests/extended/local_split_u/hgemm_lsu_mfma_a1b0.yaml
+++ b/Tensile/Tests/extended/local_split_u/hgemm_lsu_mfma_a1b0.yaml
@@ -3,10 +3,12 @@ TestParameters:
 
 GlobalParameters:
   NumElementsToValidate: -1
-  BoundsCheck: True
+  #BoundsCheck: True
   KernelTime: True
   #PrintSolutionRejectionReason: True
   #MaxFileName: 256
+  DataInitTypeAlpha: 1
+  DataInitTypeBeta : 0
 
 BenchmarkProblems:
   ########################################
@@ -72,6 +74,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [ 254, 254, 1, 2050]
+          - Range: [ [510], [510], [1], [2, 8, 66] ]
 
   ########################################
   # HHS NT - LSU + GSU + VAW + BS[0,1]
@@ -123,6 +126,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [ 252, 254, 1, 2050]
+          - Range: [ [510], [510], [1], [2, 8, 66] ]
 
   ########################################
   # HSS NT - standard


### PR DESCRIPTION
* added wait for prefetch read (local, global) at the end of Opt NoLoadLoop
   * this was already added for Ord NoLoadLoop, but missed for Opt NoLoadLoop
* added more test cases including test cases for alpha=1 + beta = 0