### PR TITLE
Re-enable integration tests

### DIFF
--- a/Tensile/Tests/integration/test_integration.py
+++ b/Tensile/Tests/integration/test_integration.py
@@ -102,22 +102,20 @@ def getLogicFileDir(tmp_path_factory, worker_id):
   return destDir
 
 def isSkippedTest(testYamls, mergeFiles, libraryFormat, shortNames, legacyComponents):
-  # Random failures on latest ROCm build, re-enable when passing
-  return True
-  # if testYamls == "pre_checkin":
-  #   # for more extensive tests,
-  #   # we run only on single combination of build params
-  #   if (mergeFiles           == True
-  #       and shortNames       == False
-  #       and libraryFormat    == "yaml"
-  #       and legacyComponents == False):
-  #     return False
-  #   else:
-  #     return True
-  # elif testYamls == "quick":
-  #   return False
-  # else:
-  #   assert(False) # should've caught all params already
+  if testYamls == "pre_checkin":
+    # for more extensive tests,
+    # we run only on single combination of build params
+    if (mergeFiles           == True
+        and shortNames       == False
+        and libraryFormat    == "yaml"
+        and legacyComponents == False):
+      return False
+    else:
+      return True
+  elif testYamls == "quick":
+    return False
+  else:
+    assert(False) # should've caught all params already
 
 def str2bool(mergeFiles, shortNames, legacyComponents):
   return (True if mergeFiles=="mergeFiles" else False,


### PR DESCRIPTION
Integration tests can be run again now that rocm-5.5 has been tagged.