### PR TITLE
Update cache library directly

### DIFF
--- a/HostLibraryTests/CachingLibrary_test.cpp
+++ b/HostLibraryTests/CachingLibrary_test.cpp
@@ -911,8 +911,7 @@ TEST(CachingLibrary, Insert)
     SolutionDefault->index  = 0;
     SolutionOverride->index = 1;
 
-    SolutionMap<ContractionSolution> map(
-        {{0, SolutionDefault}, {1, SolutionOverride}});
+    SolutionMap<ContractionSolution> map({{0, SolutionDefault}, {1, SolutionOverride}});
 
     auto LibraryDefault  = std::make_shared<SingleContractionLibrary>(SolutionDefault);
     auto LibraryOverride = std::make_shared<SingleContractionLibrary>(SolutionOverride);
@@ -993,9 +992,23 @@ TEST(CachingLibrary, Insert)
 TEST(CachingLibrary, Parsing)
 {
     using namespace Tensile;
-    
+
     // Non-strided
-    std::vector<std::string> entries0{"T","N","2304","256","1","1729","1","1","1729","1729","2304","f16_r","f16_r","f32_r","752"};
+    std::vector<std::string> entries0{"T",
+                                      "N",
+                                      "2304",
+                                      "256",
+                                      "1",
+                                      "1729",
+                                      "1",
+                                      "1",
+                                      "1729",
+                                      "1729",
+                                      "2304",
+                                      "f16_r",
+                                      "f16_r",
+                                      "f32_r",
+                                      "752"};
 
     auto probSol = problemFromEntries(entries0);
     EXPECT_EQ(probSol.first.transA(), true);
@@ -1015,7 +1028,24 @@ TEST(CachingLibrary, Parsing)
     EXPECT_EQ(probSol.second, 752);
 
     // Strided
-    std::vector<std::string> entries1{"N","T","104","104","1024","64","1","0","104","64","104","6656","6656","10816","f32_r","f32_r","f32_r","3976"};
+    std::vector<std::string> entries1{"N",
+                                      "T",
+                                      "104",
+                                      "104",
+                                      "1024",
+                                      "64",
+                                      "1",
+                                      "0",
+                                      "104",
+                                      "64",
+                                      "104",
+                                      "6656",
+                                      "6656",
+                                      "10816",
+                                      "f32_r",
+                                      "f32_r",
+                                      "f32_r",
+                                      "3976"};
 
     probSol = problemFromEntries(entries1);
     EXPECT_EQ(probSol.first.transA(), false);
@@ -1035,15 +1065,43 @@ TEST(CachingLibrary, Parsing)
     EXPECT_EQ(probSol.second, 3976);
 
     // Bad args
-    std::vector<std::string> entries2{"N","T","104"};
+    std::vector<std::string> entries2{"N", "T", "104"};
     probSol = problemFromEntries(entries2);
     EXPECT_EQ(probSol.second, -1);
 
-    std::vector<std::string> entries3{"T","N","2304","256","1","1729","1","1","1729","1729","2304","f1_r","f16_r","f32_r","752"};
+    std::vector<std::string> entries3{"T",
+                                      "N",
+                                      "2304",
+                                      "256",
+                                      "1",
+                                      "1729",
+                                      "1",
+                                      "1",
+                                      "1729",
+                                      "1729",
+                                      "2304",
+                                      "f1_r",
+                                      "f16_r",
+                                      "f32_r",
+                                      "752"};
     probSol = problemFromEntries(entries3);
     EXPECT_EQ(probSol.second, -1);
 
-    std::vector<std::string> entries4{"T","N","b","256","1","1729","1","1","1729","1729","2304","f16_r","f16_r","f32_r","752"};
+    std::vector<std::string> entries4{"T",
+                                      "N",
+                                      "b",
+                                      "256",
+                                      "1",
+                                      "1729",
+                                      "1",
+                                      "1",
+                                      "1729",
+                                      "1729",
+                                      "2304",
+                                      "f16_r",
+                                      "f16_r",
+                                      "f32_r",
+                                      "752"};
     probSol = problemFromEntries(entries4);
     EXPECT_EQ(probSol.second, -1);
 }

--- a/Tensile/Source/lib/CMakeLists.txt
+++ b/Tensile/Source/lib/CMakeLists.txt
@@ -47,6 +47,7 @@ set(tensile_sources  ${tensile_sources}
     source/TensorDescriptor.cpp
     source/TensorOps.cpp
     source/Tensile.cpp
+    source/UserDrivenTuningParser.cpp
     source/Utils.cpp
     )
 

--- a/Tensile/Source/lib/include/Tensile/CachingLibrary.hpp
+++ b/Tensile/Source/lib/include/Tensile/CachingLibrary.hpp
@@ -121,14 +121,14 @@ namespace Tensile
         template <typename SubMap, typename K>
         Value find_impl(SubMap& map, K const& key)
         {
-            Value *val = find_impl_ptr(map, key);
-            return val ? *val : m_nullValue; 
+            Value* val = find_impl_ptr(map, key);
+            return val ? *val : m_nullValue;
         }
 
         template <typename SubMap, typename K, typename... Ks>
         Value find_impl(SubMap& map, K const& key, Ks const&... ks)
         {
-            Value *val = find_impl_ptr(map, key, ks...);
+            Value* val = find_impl_ptr(map, key, ks...);
             return val ? *val : m_nullValue;
         }
 
@@ -169,8 +169,8 @@ namespace Tensile
         template <typename SubMap, typename K>
         void add_or_replace_impl(SubMap& map, Value const& value, K const& key)
         {
-            Value *current_value = find_impl_ptr(map, key);
-            if (current_value)
+            Value* current_value = find_impl_ptr(map, key);
+            if(current_value)
             {
                 *current_value = value;
             }
@@ -183,8 +183,8 @@ namespace Tensile
         template <typename SubMap, typename K, typename... Ks>
         void add_or_replace_impl(SubMap& map, Value const& value, K const& key, Ks const&... ks)
         {
-            Value *current_value = find_impl_ptr(map, key, ks...);
-            if (current_value)
+            Value* current_value = find_impl_ptr(map, key, ks...);
+            if(current_value)
             {
                 *current_value = value;
             }
@@ -192,7 +192,6 @@ namespace Tensile
             {
                 add_impl(map, value, key, ks...);
             }
-
         }
 
         Map                     m_map;
@@ -274,13 +273,14 @@ namespace Tensile
         {
             try
             {
-                auto const& amdgpu   = dynamic_cast<AMDGPU const&>(hardware);
-                double cachedFitness = std::numeric_limits<double>::max();
-                fitness              = (fitness) ? fitness : &cachedFitness;
+                auto const& amdgpu        = dynamic_cast<AMDGPU const&>(hardware);
+                double      cachedFitness = std::numeric_limits<double>::max();
+                fitness                   = (fitness) ? fitness : &cachedFitness;
 
                 if(solution)
                 {
-                    m_cache.add_or_replace(std::make_tuple(solution, cachedFitness), problem, amdgpu);
+                    m_cache.add_or_replace(
+                        std::make_tuple(solution, cachedFitness), problem, amdgpu);
                     return true;
                 }
                 else

--- a/Tensile/Source/lib/include/Tensile/CachingLibrary.hpp
+++ b/Tensile/Source/lib/include/Tensile/CachingLibrary.hpp
@@ -109,27 +109,49 @@ namespace Tensile
             add_impl(m_map, value, ks...);
         }
 
+        template <typename... Ks>
+        void add_or_replace(Value const& value, Ks const&... ks)
+        {
+            std::lock_guard<std::shared_timed_mutex> lock(m_mutex);
+
+            add_or_replace_impl(m_map, value, ks...);
+        }
+
     private:
         template <typename SubMap, typename K>
-        Value find_impl(SubMap const& map, K const& key)
+        Value find_impl(SubMap& map, K const& key)
         {
-            auto iter = map.find(key);
-
-            if(iter == map.end())
-                return m_nullValue;
-
-            return iter->second;
+            Value *val = find_impl_ptr(map, key);
+            return val ? *val : m_nullValue; 
         }
 
         template <typename SubMap, typename K, typename... Ks>
-        Value find_impl(SubMap const& map, K const& key, Ks const&... ks)
+        Value find_impl(SubMap& map, K const& key, Ks const&... ks)
+        {
+            Value *val = find_impl_ptr(map, key, ks...);
+            return val ? *val : m_nullValue;
+        }
+
+        template <typename SubMap, typename K>
+        Value* find_impl_ptr(SubMap& map, K const& key)
         {
             auto iter = map.find(key);
 
             if(iter == map.end())
-                return m_nullValue;
+                return nullptr;
 
-            return find_impl(iter->second, ks...);
+            return &(iter->second);
+        }
+
+        template <typename SubMap, typename K, typename... Ks>
+        Value* find_impl_ptr(SubMap& map, K const& key, Ks const&... ks)
+        {
+            auto iter = map.find(key);
+
+            if(iter == map.end())
+                return nullptr;
+
+            return find_impl_ptr(iter->second, ks...);
         }
 
         template <typename SubMap, typename K>
@@ -142,6 +164,35 @@ namespace Tensile
         void add_impl(SubMap& map, Value const& value, K const& key, Ks const&... ks)
         {
             add_impl(map[key], value, ks...);
+        }
+
+        template <typename SubMap, typename K>
+        void add_or_replace_impl(SubMap& map, Value const& value, K const& key)
+        {
+            Value *current_value = find_impl_ptr(map, key);
+            if (current_value)
+            {
+                *current_value = value;
+            }
+            else
+            {
+                add_impl(map, value, key);
+            }
+        }
+
+        template <typename SubMap, typename K, typename... Ks>
+        void add_or_replace_impl(SubMap& map, Value const& value, K const& key, Ks const&... ks)
+        {
+            Value *current_value = find_impl_ptr(map, key, ks...);
+            if (current_value)
+            {
+                *current_value = value;
+            }
+            else
+            {
+                add_impl(map, value, key, ks...);
+            }
+
         }
 
         Map                     m_map;
@@ -214,6 +265,33 @@ namespace Tensile
             auto const& amdgpu = dynamic_cast<AMDGPU const&>(hardware);
 
             return std::get<std::shared_ptr<MySolution>>(m_cache.find(problem, amdgpu));
+        }
+
+        bool add(MyProblem const&            problem,
+                 Hardware const&             hardware,
+                 std::shared_ptr<MySolution> solution,
+                 double*                     fitness = nullptr)
+        {
+            try
+            {
+                auto const& amdgpu   = dynamic_cast<AMDGPU const&>(hardware);
+                double cachedFitness = std::numeric_limits<double>::max();
+                fitness              = (fitness) ? fitness : &cachedFitness;
+
+                if(solution)
+                {
+                    m_cache.add_or_replace(std::make_tuple(solution, cachedFitness), problem, amdgpu);
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+            catch(std::bad_cast const& exc)
+            {
+                return false;
+            }
         }
 
         virtual std::string type() const override

--- a/Tensile/Source/lib/include/Tensile/CachingLibrary.hpp
+++ b/Tensile/Source/lib/include/Tensile/CachingLibrary.hpp
@@ -210,7 +210,9 @@ namespace Tensile
     public:
         using Library = SolutionLibrary<MyProblem, MySolution>;
         using Cache = CacheMap<std::tuple<std::shared_ptr<MySolution>, double>, AMDGPU, MyProblem>;
-        using Override = CacheMap<std::tuple<std::shared_ptr<MySolution>, double>, AMDGPU, ProblemOverride<ContractionProblem>>;
+        using Override = CacheMap<std::tuple<std::shared_ptr<MySolution>, double>,
+                                  AMDGPU,
+                                  ProblemOverride<ContractionProblem>>;
 
         CachingLibrary(std::shared_ptr<Library> subLibrary)
             : m_subLibrary(subLibrary)
@@ -277,10 +279,10 @@ namespace Tensile
             return std::get<std::shared_ptr<MySolution>>(m_cache.find(problem, amdgpu));
         }
 
-        bool addToOverride(ProblemOverride<MyProblem> const&  po,
-                           Hardware const&                    hardware,
-                           std::shared_ptr<MySolution>        solution,
-                           double*                            fitness = nullptr)
+        bool addToOverride(ProblemOverride<MyProblem> const& po,
+                           Hardware const&                   hardware,
+                           std::shared_ptr<MySolution>       solution,
+                           double*                           fitness = nullptr)
         {
             try
             {
@@ -289,9 +291,8 @@ namespace Tensile
                 fitness                   = (fitness) ? fitness : &cachedFitness;
 
                 if(solution)
-                {   
-                    m_override.add_or_replace(
-                        std::make_tuple(solution, *fitness), po, amdgpu);
+                {
+                    m_override.add_or_replace(std::make_tuple(solution, *fitness), po, amdgpu);
                     return true;
                 }
                 else

--- a/Tensile/Source/lib/include/Tensile/MasterSolutionLibrary.hpp
+++ b/Tensile/Source/lib/include/Tensile/MasterSolutionLibrary.hpp
@@ -27,9 +27,9 @@
 #pragma once
 
 #include <chrono>
-#include <string>
 #include <map>
 #include <memory>
+#include <string>
 #include <vector>
 
 #include <Tensile/CachingLibrary.hpp>
@@ -183,16 +183,16 @@ namespace Tensile
             }
         }
 
-        bool getSolutionMapsFromFile(Hardware const& hardware,
-                                     const std::string& file_path)
+        bool setOverridesFromFile(Hardware const& hardware, const std::string& file_path)
         {
             try
             {
                 // Early exit if no caching library
                 auto& lib = dynamic_cast<CachingLibrary<MyProblem, MySolution>&>(*library);
 
-                auto probSols = getContractionProblemsFromFile(file_path);
-                if(probSols.size() == 0) return false;
+                auto probSols = getContractionProblemsFromFile<MyProblem>(file_path);
+                if(probSols.size() == 0)
+                    return false;
 
                 bool success = true;
 
@@ -202,7 +202,7 @@ namespace Tensile
                     std::shared_ptr<MySolution> solution = getSolutionByIndex(ps.second);
 
                     // Update cache
-                    success &= lib.add(ps.first, hardware, solution);
+                    success &= lib.addToOverride(ps.first, hardware, solution);
                 }
 
                 return success;
@@ -226,5 +226,4 @@ namespace Tensile
             return library->findAllSolutionsMatchingType(problem, hardware);
         }
     };
-
 } // namespace Tensile

--- a/Tensile/Source/lib/include/Tensile/UserDrivenTuningParser.hpp
+++ b/Tensile/Source/lib/include/Tensile/UserDrivenTuningParser.hpp
@@ -1,3 +1,28 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
 #pragma once
 
 #include <Tensile/ContractionProblem.hpp>

--- a/Tensile/Source/lib/include/Tensile/UserDrivenTuningParser.hpp
+++ b/Tensile/Source/lib/include/Tensile/UserDrivenTuningParser.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <Tensile/ContractionProblem.hpp>
+
+#include <string>
+#include <vector>
+
+namespace Tensile
+{
+    std::pair<ContractionProblem, int> problemFromEntries(std::vector<std::string> entries);
+    std::vector<std::pair<ContractionProblem, int>> getContractionProblemsFromFile(std::string path);
+};

--- a/Tensile/Source/lib/include/Tensile/UserDrivenTuningParser.hpp
+++ b/Tensile/Source/lib/include/Tensile/UserDrivenTuningParser.hpp
@@ -8,5 +8,6 @@
 namespace Tensile
 {
     std::pair<ContractionProblem, int> problemFromEntries(std::vector<std::string> entries);
-    std::vector<std::pair<ContractionProblem, int>> getContractionProblemsFromFile(std::string path);
+    std::vector<std::pair<ContractionProblem, int>>
+        getContractionProblemsFromFile(std::string path);
 };

--- a/Tensile/Source/lib/include/Tensile/UserDrivenTuningParser.hpp
+++ b/Tensile/Source/lib/include/Tensile/UserDrivenTuningParser.hpp
@@ -11,60 +11,108 @@ namespace Tensile
     template <typename MyProblem>
     class ProblemOverride
     {
-        public:
-            ProblemOverride();
-            ProblemOverride(bool     transA,
-                            bool     transB,
-                            DataType inputType,
-                            DataType outputType,
-                            bool     HPA,
-                            size_t   m,
-                            size_t   n,
-                            size_t   k,
-                            size_t   batchSize,
-                            double   beta,
-                            size_t   ldA,
-                            size_t   strideA,
-                            size_t   ldB,
-                            size_t   strideB,
-                            size_t   ldC,
-                            size_t   strideC);
-            ProblemOverride(const MyProblem& problem);
+    public:
+        ProblemOverride();
+        ProblemOverride(bool     transA,
+                        bool     transB,
+                        DataType inputType,
+                        DataType outputType,
+                        bool     HPA,
+                        size_t   m,
+                        size_t   n,
+                        size_t   k,
+                        size_t   batchSize,
+                        double   beta,
+                        size_t   ldA,
+                        size_t   strideA,
+                        size_t   ldB,
+                        size_t   strideB,
+                        size_t   ldC,
+                        size_t   strideC);
+        ProblemOverride(const MyProblem& problem);
 
-            inline bool transA() const { return m_transA; }
-            inline bool transB() const { return m_transB; }
-            inline DataType inputType() const { return m_inputType; }
-            inline DataType outputType() const { return m_outputType; }
-            inline bool HPA() const { return m_HPA; }
-            inline size_t m() const { return m_m; }
-            inline size_t n() const { return m_n; }
-            inline size_t k() const { return m_k; }
-            inline size_t batchSize() const { return m_batchSize; }
-            inline double beta() const { return m_beta; }
-            inline size_t ldA() const { return m_ldA; }
-            inline size_t strideA() const { return m_strideA; }
-            inline size_t ldB() const { return m_ldB; }
-            inline size_t strideB() const { return m_strideB; }
-            inline size_t ldC() const { return m_ldC; }
-            inline size_t strideC() const { return m_strideC; }
-        
-        private:
-            bool     m_transA;
-            bool     m_transB;
-            DataType m_inputType;
-            DataType m_outputType;
-            bool     m_HPA;
-            size_t   m_m;
-            size_t   m_n;
-            size_t   m_k;
-            size_t   m_batchSize;
-            double   m_beta;
-            size_t   m_ldA;
-            size_t   m_strideA;
-            size_t   m_ldB;
-            size_t   m_strideB;
-            size_t   m_ldC;
-            size_t   m_strideC;
+        inline bool transA() const
+        {
+            return m_transA;
+        }
+        inline bool transB() const
+        {
+            return m_transB;
+        }
+        inline DataType inputType() const
+        {
+            return m_inputType;
+        }
+        inline DataType outputType() const
+        {
+            return m_outputType;
+        }
+        inline bool HPA() const
+        {
+            return m_HPA;
+        }
+        inline size_t m() const
+        {
+            return m_m;
+        }
+        inline size_t n() const
+        {
+            return m_n;
+        }
+        inline size_t k() const
+        {
+            return m_k;
+        }
+        inline size_t batchSize() const
+        {
+            return m_batchSize;
+        }
+        inline double beta() const
+        {
+            return m_beta;
+        }
+        inline size_t ldA() const
+        {
+            return m_ldA;
+        }
+        inline size_t strideA() const
+        {
+            return m_strideA;
+        }
+        inline size_t ldB() const
+        {
+            return m_ldB;
+        }
+        inline size_t strideB() const
+        {
+            return m_strideB;
+        }
+        inline size_t ldC() const
+        {
+            return m_ldC;
+        }
+        inline size_t strideC() const
+        {
+            return m_strideC;
+        }
+
+    private:
+        bool     m_transA;
+        bool     m_transB;
+        DataType m_inputType;
+        DataType m_outputType;
+        bool     m_HPA;
+        size_t   m_m;
+        size_t   m_n;
+        size_t   m_k;
+        size_t   m_batchSize;
+        double   m_beta;
+        size_t   m_ldA;
+        size_t   m_strideA;
+        size_t   m_ldB;
+        size_t   m_strideB;
+        size_t   m_ldC;
+        size_t   m_strideC;
     };
 
     template <>
@@ -78,7 +126,8 @@ namespace Tensile
             implemented = true
         };
 
-        static int compare(ProblemOverride<ContractionProblem> const& lhs, ProblemOverride<ContractionProblem> const& rhs)
+        static int compare(ProblemOverride<ContractionProblem> const& lhs,
+                           ProblemOverride<ContractionProblem> const& rhs)
         {
             return LexicographicCompare(lhs.transA(),
                                         rhs.transA(),
@@ -116,11 +165,12 @@ namespace Tensile
     };
 
     template <typename MyProblem>
-    std::pair<ProblemOverride<MyProblem>, int> problemFromEntries(const std::vector<std::string>& entries);
+    std::pair<ProblemOverride<MyProblem>, int>
+        problemFromEntries(const std::vector<std::string>& entries);
 
     template <typename MyProblem>
     std::vector<std::pair<ProblemOverride<MyProblem>, int>>
-                getContractionProblemsFromFile(const std::string& path);
+        getContractionProblemsFromFile(const std::string& path);
 } // namespace Tensile
 
 namespace std
@@ -128,7 +178,8 @@ namespace std
     template <>
     struct hash<Tensile::ProblemOverride<Tensile::ContractionProblem>>
     {
-        inline size_t operator()(Tensile::ProblemOverride<Tensile::ContractionProblem> const& po) const
+        inline size_t
+            operator()(Tensile::ProblemOverride<Tensile::ContractionProblem> const& po) const
         {
             return Tensile::hash_combine(po.transA(),
                                          po.transB(),

--- a/Tensile/Source/lib/include/Tensile/UserDrivenTuningParser.hpp
+++ b/Tensile/Source/lib/include/Tensile/UserDrivenTuningParser.hpp
@@ -7,7 +7,7 @@
 
 namespace Tensile
 {
-    std::pair<ContractionProblem, int> problemFromEntries(std::vector<std::string> entries);
+    std::pair<ContractionProblem, int> problemFromEntries(const std::vector<std::string>& entries);
     std::vector<std::pair<ContractionProblem, int>>
-        getContractionProblemsFromFile(std::string path);
+        getContractionProblemsFromFile(const std::string& path);
 };

--- a/Tensile/Source/lib/include/Tensile/UserDrivenTuningParser.hpp
+++ b/Tensile/Source/lib/include/Tensile/UserDrivenTuningParser.hpp
@@ -1,13 +1,151 @@
 #pragma once
 
 #include <Tensile/ContractionProblem.hpp>
+#include <Tensile/DataTypes.hpp>
 
 #include <string>
 #include <vector>
 
 namespace Tensile
 {
-    std::pair<ContractionProblem, int> problemFromEntries(const std::vector<std::string>& entries);
-    std::vector<std::pair<ContractionProblem, int>>
-        getContractionProblemsFromFile(const std::string& path);
-};
+    template <typename MyProblem>
+    class ProblemOverride
+    {
+        public:
+            ProblemOverride();
+            ProblemOverride(bool     transA,
+                            bool     transB,
+                            DataType inputType,
+                            DataType outputType,
+                            bool     HPA,
+                            size_t   m,
+                            size_t   n,
+                            size_t   k,
+                            size_t   batchSize,
+                            double   beta,
+                            size_t   ldA,
+                            size_t   strideA,
+                            size_t   ldB,
+                            size_t   strideB,
+                            size_t   ldC,
+                            size_t   strideC);
+            ProblemOverride(const MyProblem& problem);
+
+            inline bool transA() const { return m_transA; }
+            inline bool transB() const { return m_transB; }
+            inline DataType inputType() const { return m_inputType; }
+            inline DataType outputType() const { return m_outputType; }
+            inline bool HPA() const { return m_HPA; }
+            inline size_t m() const { return m_m; }
+            inline size_t n() const { return m_n; }
+            inline size_t k() const { return m_k; }
+            inline size_t batchSize() const { return m_batchSize; }
+            inline double beta() const { return m_beta; }
+            inline size_t ldA() const { return m_ldA; }
+            inline size_t strideA() const { return m_strideA; }
+            inline size_t ldB() const { return m_ldB; }
+            inline size_t strideB() const { return m_strideB; }
+            inline size_t ldC() const { return m_ldC; }
+            inline size_t strideC() const { return m_strideC; }
+        
+        private:
+            bool     m_transA;
+            bool     m_transB;
+            DataType m_inputType;
+            DataType m_outputType;
+            bool     m_HPA;
+            size_t   m_m;
+            size_t   m_n;
+            size_t   m_k;
+            size_t   m_batchSize;
+            double   m_beta;
+            size_t   m_ldA;
+            size_t   m_strideA;
+            size_t   m_ldB;
+            size_t   m_strideB;
+            size_t   m_ldC;
+            size_t   m_strideC;
+    };
+
+    template <>
+    ProblemOverride<ContractionProblem>::ProblemOverride(const ContractionProblem& problem);
+
+    template <>
+    struct Comparison<ProblemOverride<ContractionProblem>>
+    {
+        enum
+        {
+            implemented = true
+        };
+
+        static int compare(ProblemOverride<ContractionProblem> const& lhs, ProblemOverride<ContractionProblem> const& rhs)
+        {
+            return LexicographicCompare(lhs.transA(),
+                                        rhs.transA(),
+                                        lhs.transB(),
+                                        rhs.transB(),
+                                        lhs.inputType(),
+                                        rhs.inputType(),
+                                        lhs.outputType(),
+                                        rhs.outputType(),
+                                        lhs.HPA(),
+                                        rhs.HPA(),
+                                        lhs.m(),
+                                        rhs.m(),
+                                        lhs.n(),
+                                        rhs.n(),
+                                        lhs.k(),
+                                        rhs.k(),
+                                        lhs.batchSize(),
+                                        rhs.batchSize(),
+                                        lhs.beta(),
+                                        rhs.beta(),
+                                        lhs.ldA(),
+                                        rhs.ldA(),
+                                        lhs.strideA(),
+                                        rhs.strideA(),
+                                        lhs.ldB(),
+                                        rhs.ldB(),
+                                        lhs.strideB(),
+                                        rhs.strideB(),
+                                        lhs.ldC(),
+                                        rhs.ldC(),
+                                        lhs.strideC(),
+                                        rhs.strideC());
+        }
+    };
+
+    template <typename MyProblem>
+    std::pair<ProblemOverride<MyProblem>, int> problemFromEntries(const std::vector<std::string>& entries);
+
+    template <typename MyProblem>
+    std::vector<std::pair<ProblemOverride<MyProblem>, int>>
+                getContractionProblemsFromFile(const std::string& path);
+} // namespace Tensile
+
+namespace std
+{
+    template <>
+    struct hash<Tensile::ProblemOverride<Tensile::ContractionProblem>>
+    {
+        inline size_t operator()(Tensile::ProblemOverride<Tensile::ContractionProblem> const& po) const
+        {
+            return Tensile::hash_combine(po.transA(),
+                                         po.transB(),
+                                         po.inputType(),
+                                         po.outputType(),
+                                         po.HPA(),
+                                         po.m(),
+                                         po.n(),
+                                         po.k(),
+                                         po.batchSize(),
+                                         po.beta(),
+                                         po.ldA(),
+                                         po.strideA(),
+                                         po.ldB(),
+                                         po.strideB(),
+                                         po.ldC(),
+                                         po.strideC());
+        }
+    };
+} // namespace std

--- a/Tensile/Source/lib/source/UserDrivenTuningParser.cpp
+++ b/Tensile/Source/lib/source/UserDrivenTuningParser.cpp
@@ -2,57 +2,50 @@
 
 #include <Tensile/DataTypes.hpp>
 
-#include <iostream>
-#include <functional>
 #include <fstream>
-#include <optional>
 #include <sstream>
 #include <utility>
-
 
 namespace Tensile
 {
     inline DataType convertToDataType(const std::string& DataTypeStr)
     {
-        return
-            DataTypeStr == "f16_r" || DataTypeStr == "h" ? DataType::Half          :
-            DataTypeStr == "f32_r" || DataTypeStr == "s" ? DataType::Float         :
-            DataTypeStr == "f64_r" || DataTypeStr == "d" ? DataType::Double        :
-            DataTypeStr == "bf16_r"                      ? DataType::BFloat16      :
-            DataTypeStr == "f16_c"                       ? DataType::None          :
-            DataTypeStr == "f32_c" || DataTypeStr == "c" ? DataType::ComplexFloat  :
-            DataTypeStr == "f64_c" || DataTypeStr == "z" ? DataType::ComplexDouble :
-            DataTypeStr == "bf16_c"                      ? DataType::None          :
-            DataTypeStr == "i8_r"                        ? DataType::Int8          :
-            DataTypeStr == "i32_r"                       ? DataType::Int32         :
-            DataTypeStr == "i8_c"                        ? DataType::None          :
-            DataTypeStr == "i32_c"                       ? DataType::None          :
-            DataTypeStr == "u8_r"                        ? DataType::None          :
-            DataTypeStr == "u32_r"                       ? DataType::None          :
-            DataTypeStr == "u8_c"                        ? DataType::None          :
-            DataTypeStr == "u32_c"                       ? DataType::None          :
-            DataType::None;
+        return DataTypeStr == "f16_r" || DataTypeStr == "h"   ? DataType::Half
+               : DataTypeStr == "f32_r" || DataTypeStr == "s" ? DataType::Float
+               : DataTypeStr == "f64_r" || DataTypeStr == "d" ? DataType::Double
+               : DataTypeStr == "bf16_r"                      ? DataType::BFloat16
+               : DataTypeStr == "f16_c"                       ? DataType::None
+               : DataTypeStr == "f32_c" || DataTypeStr == "c" ? DataType::ComplexFloat
+               : DataTypeStr == "f64_c" || DataTypeStr == "z" ? DataType::ComplexDouble
+               : DataTypeStr == "bf16_c"                      ? DataType::None
+               : DataTypeStr == "i8_r"                        ? DataType::Int8
+               : DataTypeStr == "i32_r"                       ? DataType::Int32
+               : DataTypeStr == "i8_c"                        ? DataType::None
+               : DataTypeStr == "i32_c"                       ? DataType::None
+               : DataTypeStr == "u8_r"                        ? DataType::None
+               : DataTypeStr == "u32_r"                       ? DataType::None
+               : DataTypeStr == "u8_c"                        ? DataType::None
+               : DataTypeStr == "u32_c"                       ? DataType::None
+                                                              : DataType::None;
     }
 
-
-
-    ContractionProblem ConstructTensileProblem( bool     transA,
-                                                bool     transB,
-                                                DataType inputType,
-                                                DataType outputType,
-                                                DataType computeType,
-                                                size_t   m,
-                                                size_t   n,
-                                                size_t   k,
-                                                size_t   b,
-                                                size_t   ldA,
-                                                size_t   strideA,
-                                                size_t   ldB,
-                                                size_t   strideB,
-                                                size_t   ldC,
-                                                size_t   strideC,
-                                                double   alpha,
-                                                double   beta)
+    ContractionProblem ConstructTensileProblem(bool     transA,
+                                               bool     transB,
+                                               DataType inputType,
+                                               DataType outputType,
+                                               DataType computeType,
+                                               size_t   m,
+                                               size_t   n,
+                                               size_t   k,
+                                               size_t   b,
+                                               size_t   ldA,
+                                               size_t   strideA,
+                                               size_t   ldB,
+                                               size_t   strideB,
+                                               size_t   ldC,
+                                               size_t   strideC,
+                                               double   alpha,
+                                               double   beta)
     {
         // Tensor descriptors for a, b
         TensorDescriptor tdA;
@@ -130,41 +123,27 @@ namespace Tensile
         // clang-format on
 
         // Descriptor for input matrix C
-        TensorDescriptor tdC{outputType,
-                            {m, n, b},
-                            {strideC, strideC, strideC},
-                            0};
+        TensorDescriptor tdC{outputType, {m, n, b}, {strideC, strideC, strideC}, 0};
 
         // Descriptor for output matrix D
-        TensorDescriptor tdD{outputType,
-                            {m, n, b},
-                            {strideC, strideC, strideC},
-                            0};
+        TensorDescriptor tdD{outputType, {m, n, b}, {strideC, strideC, strideC}, 0};
 
         // The ContractionProblem
-        ContractionProblem tensileProblem{tdA,
-                                            aops,
-                                            tdB,
-                                            bops,
-                                            tdC,
-                                            cops,
-                                            tdD,
-                                            dops,
-                                            freeIndex,
-                                            batchIndex,
-                                            boundIndex,
-                                            beta};
+        ContractionProblem tensileProblem{
+            tdA, aops, tdB, bops, tdC, cops, tdD, dops, freeIndex, batchIndex, boundIndex, beta};
 
         tensileProblem.setAlphaType(computeType);
         tensileProblem.setBetaType(computeType);
 
         // HPA is active iff sizeof(compute type) > sizeof(input type)
-        tensileProblem.setHighPrecisionAccumulate(((inputType == DataType::Half) || (inputType == DataType::BFloat16))
-                                                    && (computeType == DataType::Float));
+        tensileProblem.setHighPrecisionAccumulate(
+            ((inputType == DataType::Half) || (inputType == DataType::BFloat16))
+            && (computeType == DataType::Float));
 
         // Environment variable to force use of VALU for double precision gemm
         static bool force_valu_for_dgemm = std::getenv("ROCBLAS_INTERNAL_FORCE_VALU_FOR_DGEMM");
-        if((inputType == DataType::Double) && (outputType == DataType::Double) && (computeType == DataType::Double) && force_valu_for_dgemm)
+        if((inputType == DataType::Double) && (outputType == DataType::Double)
+           && (computeType == DataType::Double) && force_valu_for_dgemm)
         {
             tensileProblem.setArithmeticUnit(Tensile::ArithmeticUnit::VALU);
         }
@@ -177,7 +156,8 @@ namespace Tensile
         // If k==0, we do not need to dereference prob.alpha and can set tensileAlpha=0
         // Not positive if this is necessary here as well
         // typename AlphaBeta<Ti, To, Tc>::tensile_type tensileAlpha;
-        if(!k) alpha = 0.0;
+        if(!k)
+            alpha = 0.0;
         tensileProblem.setAlphaRestriction(Tensile::toScalarValueEnum(alpha));
 
         // Add problem predicates for CEqualsD
@@ -199,8 +179,6 @@ namespace Tensile
 
         return tensileProblem;
     }
-
-
 
     std::pair<ContractionProblem, int> problemFromEntries(std::vector<std::string> entries)
     {
@@ -275,30 +253,29 @@ namespace Tensile
             std::make_pair(ContractionProblem{}, -1);
         }
 
-        if(inputType == DataType::None ||
-           outputType == DataType::None ||
-           computeType == DataType::None)
+        if(inputType == DataType::None || outputType == DataType::None
+           || computeType == DataType::None)
         {
             return std::make_pair(ContractionProblem{}, -1);
         }
 
         ContractionProblem problem = ConstructTensileProblem(transA,
-                                                            transB,
-                                                            inputType,
-                                                            outputType,
-                                                            computeType,
-                                                            m,
-                                                            n,
-                                                            k,
-                                                            b,
-                                                            ldA,
-                                                            strideA,
-                                                            ldB,
-                                                            strideB,
-                                                            ldC,
-                                                            strideC,
-                                                            alpha,
-                                                            beta);
+                                                             transB,
+                                                             inputType,
+                                                             outputType,
+                                                             computeType,
+                                                             m,
+                                                             n,
+                                                             k,
+                                                             b,
+                                                             ldA,
+                                                             strideA,
+                                                             ldB,
+                                                             strideB,
+                                                             ldC,
+                                                             strideC,
+                                                             alpha,
+                                                             beta);
 
         return std::make_pair(problem, solution_idx);
     }
@@ -306,39 +283,42 @@ namespace Tensile
     std::vector<std::pair<ContractionProblem, int>> getContractionProblemsFromFile(std::string path)
     {
         std::vector<std::pair<ContractionProblem, int>> out;
-        
-        std::ifstream file(path);
-        std::string line, entry;
 
-        const auto delim = ',';
+        std::ifstream file(path);
+        std::string   line, entry;
+
+        const auto delim         = ',';
         const auto first_heading = "transA";
 
         int current_section = -1;
-        
-        while (std::getline(file, line))
+
+        while(std::getline(file, line))
         {
             // Ignore lines without delimiter
-            if (line.find(delim) == std::string::npos) {
+            if(line.find(delim) == std::string::npos)
+            {
                 continue;
             }
 
             // Check for section start
-            if (line.find(first_heading) != std::string::npos) {
+            if(line.find(first_heading) != std::string::npos)
+            {
                 // TODO: Get param index from headings?
                 current_section++;
                 continue;
             }
-            
+
             std::vector<std::string> entries{};
             entries.reserve((current_section == 0) ? 15 : 18);
 
             std::stringstream line_ss(line);
-            while(getline(line_ss, entry, delim)) {
+            while(getline(line_ss, entry, delim))
+            {
                 entries.push_back(entry);
             }
 
             auto problemSolution = problemFromEntries(entries);
-            if (problemSolution.second > 0)
+            if(problemSolution.second > 0)
             {
                 out.push_back(problemSolution);
             }

--- a/Tensile/Source/lib/source/UserDrivenTuningParser.cpp
+++ b/Tensile/Source/lib/source/UserDrivenTuningParser.cpp
@@ -1,0 +1,182 @@
+#include <Tensile/UserDrivenTuningParser.hpp>
+
+#include <Tensile/DataTypes.hpp>
+
+#include <iostream>
+#include <functional>
+#include <fstream>
+#include <optional>
+#include <sstream>
+#include <utility>
+
+
+namespace Tensile
+{
+    inline DataType convertToDataType(const std::string& DataTypeStr)
+    {
+        return
+            DataTypeStr == "f16_r" || DataTypeStr == "h" ? DataType::Half          :
+            DataTypeStr == "f32_r" || DataTypeStr == "s" ? DataType::Float         :
+            DataTypeStr == "f64_r" || DataTypeStr == "d" ? DataType::Double        :
+            DataTypeStr == "bf16_r"                      ? DataType::BFloat16      :
+            DataTypeStr == "f16_c"                       ? DataType::None          :
+            DataTypeStr == "f32_c" || DataTypeStr == "c" ? DataType::ComplexFloat  :
+            DataTypeStr == "f64_c" || DataTypeStr == "z" ? DataType::ComplexDouble :
+            DataTypeStr == "bf16_c"                      ? DataType::None          :
+            DataTypeStr == "i8_r"                        ? DataType::Int8          :
+            DataTypeStr == "i32_r"                       ? DataType::Int32         :
+            DataTypeStr == "i8_c"                        ? DataType::None          :
+            DataTypeStr == "i32_c"                       ? DataType::None          :
+            DataTypeStr == "u8_r"                        ? DataType::None          :
+            DataTypeStr == "u32_r"                       ? DataType::None          :
+            DataTypeStr == "u8_c"                        ? DataType::None          :
+            DataTypeStr == "u32_c"                       ? DataType::None          :
+            DataType::None;
+    }
+
+    std::pair<ContractionProblem, int> problemFromEntries(std::vector<std::string> entries)
+    {
+        const size_t entries_n = entries.size();
+        if((entries_n != 15) && (entries_n != 18))
+        {
+            return std::make_pair(ContractionProblem{}, -1);
+        }
+        
+        // Common
+        bool transA = (entries[0] != "N");
+        bool transB = (entries[1] != "N");
+
+        size_t m, n, b, k;
+        size_t ldA, ldB, ldC;
+        size_t strideA, strideB, strideC;
+        double beta;
+
+        DataType inputType   = DataType::None;
+        DataType outputType  = DataType::None;
+        DataType computeType = DataType::None;
+
+        int solution_idx = -1;
+
+        try
+        {
+            m = std::stol(entries[2]);
+            n = std::stol(entries[3]);
+            b = std::stol(entries[4]);
+            k = std::stol(entries[5]);
+
+            beta = std::stod(entries[7]);
+
+            ldA = std::stol(entries[8]);
+            ldB = std::stol(entries[9]);
+            ldC = std::stol(entries[10]);
+
+            strideA = 1;
+            strideB = 1;
+            strideC = 1;
+
+            if(entries_n == 15)
+            {
+                // Expected layout: transA,transB,M,N,batch_count,K,alpha,beta,lda,ldb,ldc,input_type,output_type,compute_type,solution_index
+                inputType   = convertToDataType(entries[11]);
+                outputType  = convertToDataType(entries[12]);
+                computeType = convertToDataType(entries[13]);
+
+                solution_idx = std::stoi(entries[14]);
+            }
+            else if(entries_n == 18)
+            {
+                // Expected layout: transA,transB,M,N,batch_count,K,alpha,beta,lda,ldb,ldc,stride_a,stride_b,stride_c,input_type,output_type,compute_type,solution_index
+                strideA = std::stol(entries[11]);
+                strideB = std::stol(entries[12]);
+                strideC = std::stol(entries[13]);
+
+                inputType   = convertToDataType(entries[14]);
+                outputType  = convertToDataType(entries[15]);
+                computeType = convertToDataType(entries[16]);
+
+                solution_idx = std::stoi(entries[17]);
+            }
+        }
+        catch(std::invalid_argument const& ex)
+        {
+            std::make_pair(ContractionProblem{}, -1);
+        }
+        catch(std::out_of_range const& ex)
+        {
+            std::make_pair(ContractionProblem{}, -1);
+        }
+
+        if(inputType == DataType::None ||
+           outputType == DataType::None ||
+           computeType == DataType::None)
+        {
+            return std::make_pair(ContractionProblem{}, -1);
+        }
+
+        ContractionProblem problem = ContractionProblem::GEMM_Strides(transA,
+                                                                        transB,
+                                                                        inputType,
+                                                                        inputType,
+                                                                        outputType,
+                                                                        outputType,
+                                                                        m,
+                                                                        n,
+                                                                        k,
+                                                                        b,
+                                                                        ldA,
+                                                                        strideA,
+                                                                        ldB,
+                                                                        strideB,
+                                                                        ldC,
+                                                                        strideC,
+                                                                        ldC,
+                                                                        strideC,
+                                                                        beta);
+        
+        return std::make_pair(problem, solution_idx);
+    }
+
+    std::vector<std::pair<ContractionProblem, int>> getContractionProblemsFromFile(std::string path)
+    {
+        std::vector<std::pair<ContractionProblem, int>> out;
+        
+        std::ifstream file(path);
+        std::string line, entry;
+
+        const auto delim = ',';
+        const auto first_heading = "transA";
+
+        int current_section = -1;
+        
+        while (std::getline(file, line))
+        {
+            // Ignore lines without delimiter
+            if (line.find(delim) == std::string::npos) {
+                continue;
+            }
+
+            // Check for section start
+            if (line.find(first_heading) != std::string::npos) {
+                // TODO: Get param index from headings?
+                current_section++;
+                continue;
+            }
+            
+            std::vector<std::string> entries{};
+            entries.reserve((current_section == 0) ? 15 : 18);
+
+            std::stringstream line_ss(line);
+            while(getline(line_ss, entry, delim)) {
+                entries.push_back(entry);
+            }
+
+            auto problemSolution = problemFromEntries(entries);
+            if (problemSolution.second > 0)
+            {
+                out.push_back(problemSolution);
+            }
+        }
+
+        return out;
+    }
+};

--- a/Tensile/Source/lib/source/UserDrivenTuningParser.cpp
+++ b/Tensile/Source/lib/source/UserDrivenTuningParser.cpp
@@ -8,32 +8,32 @@ namespace Tensile
 {
     int dataTypeSize(DataType dt)
     {
-        switch (dt)
+        switch(dt)
         {
-            case DataType::Int8:
-                return 1;
+        case DataType::Int8:
+            return 1;
 
-            case DataType::Half:
-            case DataType::BFloat16:
-                return 2;
+        case DataType::Half:
+        case DataType::BFloat16:
+            return 2;
 
-            case DataType::Float:
-            case DataType::Int32:
-                return 4;
+        case DataType::Float:
+        case DataType::Int32:
+            return 4;
 
-            case DataType::Double:
-            case DataType::ComplexFloat:
-                return 8;
+        case DataType::Double:
+        case DataType::ComplexFloat:
+            return 8;
 
-            case DataType::ComplexDouble:
-                return 18;
+        case DataType::ComplexDouble:
+            return 18;
 
-            default:
-            case DataType::None:
-                return 0;
+        default:
+        case DataType::None:
+            return 0;
         };
     }
-    
+
     DataType convertToDataType(const std::string& DataTypeStr)
     {
         return DataTypeStr == "f16_r" || DataTypeStr == "h"   ? DataType::Half
@@ -56,7 +56,8 @@ namespace Tensile
     }
 
     template <>
-    std::pair<ProblemOverride<ContractionProblem>, int> problemFromEntries(const std::vector<std::string>& entries)
+    std::pair<ProblemOverride<ContractionProblem>, int>
+        problemFromEntries(const std::vector<std::string>& entries)
     {
         const size_t entries_n = entries.size();
         if((entries_n != 15) && (entries_n != 18))
@@ -86,7 +87,7 @@ namespace Tensile
             b = std::stol(entries[4]);
             k = std::stol(entries[5]);
 
-            beta  = std::stod(entries[7]);
+            beta = std::stod(entries[7]);
 
             ldA = std::stol(entries[8]);
             ldB = std::stol(entries[9]);
@@ -137,44 +138,45 @@ namespace Tensile
         bool HPA = (dataTypeSize(computeType) > dataTypeSize(inputType));
 
         ProblemOverride<ContractionProblem> po(transA,
-                                                transB,
-                                                inputType,
-                                                outputType,
-                                                HPA,
-                                                m,
-                                                n,
-                                                k,
-                                                b,
-                                                beta,
-                                                ldA,
-                                                strideA,
-                                                ldB,
-                                                strideB,
-                                                ldC,
-                                                strideC
-                                                );
+                                               transB,
+                                               inputType,
+                                               outputType,
+                                               HPA,
+                                               m,
+                                               n,
+                                               k,
+                                               b,
+                                               beta,
+                                               ldA,
+                                               strideA,
+                                               ldB,
+                                               strideB,
+                                               ldC,
+                                               strideC);
 
         return std::make_pair(po, solution_idx);
     }
 
     template <typename MyProblem>
     ProblemOverride<MyProblem>::ProblemOverride()
-                            : m_transA(false) 
-                            , m_transB(false)
-                            , m_inputType(DataType::None)
-                            , m_outputType(DataType::None)
-                            , m_HPA(false)
-                            , m_m(0)
-                            , m_n(0)
-                            , m_k(0)
-                            , m_batchSize(0)
-                            , m_beta(0)
-                            , m_ldA(0)
-                            , m_strideA(0)
-                            , m_ldB(0)
-                            , m_strideB(0)
-                            , m_ldC(0)
-                            , m_strideC(0) {}
+        : m_transA(false)
+        , m_transB(false)
+        , m_inputType(DataType::None)
+        , m_outputType(DataType::None)
+        , m_HPA(false)
+        , m_m(0)
+        , m_n(0)
+        , m_k(0)
+        , m_batchSize(0)
+        , m_beta(0)
+        , m_ldA(0)
+        , m_strideA(0)
+        , m_ldB(0)
+        , m_strideB(0)
+        , m_ldC(0)
+        , m_strideC(0)
+    {
+    }
 
     template <typename MyProblem>
     ProblemOverride<MyProblem>::ProblemOverride(bool     transA,
@@ -193,42 +195,44 @@ namespace Tensile
                                                 size_t   strideB,
                                                 size_t   ldC,
                                                 size_t   strideC)
-                            : m_transA(transA) 
-                            , m_transB(transB)
-                            , m_inputType(inputType)
-                            , m_outputType(outputType)
-                            , m_HPA(HPA)
-                            , m_m(m)
-                            , m_n(n)
-                            , m_k(k)
-                            , m_batchSize(batchSize)
-                            , m_beta(beta)
-                            , m_ldA(ldA)
-                            , m_strideA(strideA)
-                            , m_ldB(ldB)
-                            , m_strideB(strideB)
-                            , m_ldC(ldC)
-                            , m_strideC(strideC) {}
+        : m_transA(transA)
+        , m_transB(transB)
+        , m_inputType(inputType)
+        , m_outputType(outputType)
+        , m_HPA(HPA)
+        , m_m(m)
+        , m_n(n)
+        , m_k(k)
+        , m_batchSize(batchSize)
+        , m_beta(beta)
+        , m_ldA(ldA)
+        , m_strideA(strideA)
+        , m_ldB(ldB)
+        , m_strideB(strideB)
+        , m_ldC(ldC)
+        , m_strideC(strideC)
+    {
+    }
 
     template <>
     ProblemOverride<ContractionProblem>::ProblemOverride(const ContractionProblem& problem)
     {
-        m_transA = problem.transA();
-        m_transB = problem.transB();
-        m_inputType = problem.a().dataType();
+        m_transA     = problem.transA();
+        m_transB     = problem.transB();
+        m_inputType  = problem.a().dataType();
         m_outputType = problem.c().dataType();
-        m_HPA = problem.highPrecisionAccumulate();
-        m_m = problem.freeSizeA(0);
-        m_n = problem.freeSizeB(0);
-        m_k = problem.boundSize(0);
-        m_batchSize = problem.batchSize(0);
-        m_beta = problem.beta();
-        m_ldA = problem.a().strides()[1];
-        m_strideA = problem.a().strides()[2];
-        m_ldB = problem.b().strides()[1];
-        m_strideB = problem.b().strides()[2];
-        m_ldC = problem.c().strides()[1];
-        m_strideC = problem.c().strides()[2];
+        m_HPA        = problem.highPrecisionAccumulate();
+        m_m          = problem.freeSizeA(0);
+        m_n          = problem.freeSizeB(0);
+        m_k          = problem.boundSize(0);
+        m_batchSize  = problem.batchSize(0);
+        m_beta       = problem.beta();
+        m_ldA        = problem.a().strides()[1];
+        m_strideA    = problem.a().strides()[2];
+        m_ldB        = problem.b().strides()[1];
+        m_strideB    = problem.b().strides()[2];
+        m_ldC        = problem.c().strides()[1];
+        m_strideC    = problem.c().strides()[2];
     }
 
     template <>
@@ -242,7 +246,7 @@ namespace Tensile
 
         const auto delim         = ',';
         const auto first_heading = "transA";
-        const int max_entries    = 18;
+        const int  max_entries   = 18;
 
         while(std::getline(file, line))
         {

--- a/Tensile/Source/lib/source/UserDrivenTuningParser.cpp
+++ b/Tensile/Source/lib/source/UserDrivenTuningParser.cpp
@@ -1,3 +1,28 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
 #include <Tensile/UserDrivenTuningParser.hpp>
 
 #include <fstream>

--- a/Tensile/Source/lib/source/UserDrivenTuningParser.cpp
+++ b/Tensile/Source/lib/source/UserDrivenTuningParser.cpp
@@ -48,8 +48,7 @@ namespace Tensile
                                                double   beta)
     {
         // Tensor descriptors for a, b
-        TensorDescriptor tdA;
-        TensorDescriptor tdB;
+        TensorDescriptor tdA, tdB;
 
         // Tensor ops for matrices, like complex conjugate
         TensorOps aops, bops, cops, dops;
@@ -78,7 +77,7 @@ namespace Tensile
             tdA = {
                     inputType,
                     {k, m, b},
-                    {strideA, strideA, strideA},
+                    {1, ldA, strideA},
                     0
                 };
             freeIndex[0].i  = 1;
@@ -89,7 +88,7 @@ namespace Tensile
             tdA = {
                     inputType,
                     {m, k, b},
-                    {strideA, strideA, strideA},
+                    {1, ldA, strideA},
                     0
                 };
             freeIndex[0].i  = 0;
@@ -102,7 +101,7 @@ namespace Tensile
             tdB = {
                     inputType,
                     {n, k, b},
-                    {strideB, strideB, strideB},
+                    {1, ldB, strideB},
                     0
                 };
             freeIndex[1].i  = 0;
@@ -113,7 +112,7 @@ namespace Tensile
             tdB = {
                     inputType,
                     {k, n, b},
-                    {strideB, strideB, strideB},
+                    {1, ldB, strideB},
                     0
                 };
             freeIndex[1].i  = 1;
@@ -123,10 +122,10 @@ namespace Tensile
         // clang-format on
 
         // Descriptor for input matrix C
-        TensorDescriptor tdC{outputType, {m, n, b}, {strideC, strideC, strideC}, 0};
+        TensorDescriptor tdC{outputType, {m, n, b}, {1, ldC, strideC}, 0};
 
         // Descriptor for output matrix D
-        TensorDescriptor tdD{outputType, {m, n, b}, {strideC, strideC, strideC}, 0};
+        TensorDescriptor tdD{outputType, {m, n, b}, {1, ldC, strideC}, 0};
 
         // The ContractionProblem
         ContractionProblem tensileProblem{
@@ -180,7 +179,7 @@ namespace Tensile
         return tensileProblem;
     }
 
-    std::pair<ContractionProblem, int> problemFromEntries(std::vector<std::string> entries)
+    std::pair<ContractionProblem, int> problemFromEntries(const std::vector<std::string>& entries)
     {
         const size_t entries_n = entries.size();
         if((entries_n != 15) && (entries_n != 18))
@@ -280,7 +279,8 @@ namespace Tensile
         return std::make_pair(problem, solution_idx);
     }
 
-    std::vector<std::pair<ContractionProblem, int>> getContractionProblemsFromFile(std::string path)
+    std::vector<std::pair<ContractionProblem, int>>
+        getContractionProblemsFromFile(const std::string& path)
     {
         std::vector<std::pair<ContractionProblem, int>> out;
 


### PR DESCRIPTION
Add a mechanism for updating the CachingLibrary with problem->solution maps directly: `add` method on CachingLibrary.

Also adds a parser for files generated by this PR: https://github.com/ROCmSoftwarePlatform/rocBLAS-internal/pull/1865

I'm not 100% sure about the GEMM generation part, it's mostly copied (and slightly modified) from the rocBLAS function, but my generated file has less information than the arguments struct that rocBLAS uses.