### PR TITLE
Fix boundary check for mirror dims

### DIFF
--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -7718,11 +7718,7 @@ class KernelWriterAssembly(KernelWriter):
                   # check for pre-padding
                   prePad = 0
                   if self.groOffsetInMacroTile:
-                    prePad = self.srdShiftLeft[tc]
-                    if tc == "A":
-                      prePad *= self.tPA["bpe"]
-                    elif tc == "B":
-                      prePad *= self.tPB["bpe"]
+                    prePad = self.srdShiftLeft[tc] * self.bpeAB
 
                   codeMod.addInst("v_max_i32", vgpr(offsetVgpr), prePad, vgpr(offsetVgpr), "clamp to beginning of buffer")
                   kStr += str(codeMod)

--- a/Tensile/TensileLibLogicToYaml.py
+++ b/Tensile/TensileLibLogicToYaml.py
@@ -75,12 +75,14 @@ def TensileLibLogicToYaml(userArgs):
       raise RuntimeError("Could not find the matching data for the solution index:{} from the library logic file, Try different solution index".format(solutionIndex))
     
     #Skip the MI calculation if 9 bit MI is not needed or MatrixInstruction field is disabled 
-    isMatrixInsEnabled = currentIndexSolution["EnableMatrixInstruction"]
+    isMatrixInsEnabled = False
+    if "EnableMatrixInstruction" in currentIndexSolution:
+      isMatrixInsEnabled = currentIndexSolution["EnableMatrixInstruction"]
     
-    if currentIndexSolution["EnableMatrixInstruction"] and currentIndexSolution["MatrixInstruction"]:
-      isMatrixInsEnabled = True
-    else:
-      print1("Matrix instruction is disabled skipping the matrix instruction parameter ..")
+      if currentIndexSolution["EnableMatrixInstruction"] and currentIndexSolution["MatrixInstruction"]:
+        isMatrixInsEnabled = True
+      else:
+        print1("Matrix instruction is disabled skipping the matrix instruction parameter ..")
     
     tensileYamlFileData = []   
     if args.skipMI != True and isMatrixInsEnabled:

--- a/Tensile/Tests/extended/mirror_dims/mirror_dims_2sum_mir_unroll.yaml
+++ b/Tensile/Tests/extended/mirror_dims/mirror_dims_2sum_mir_unroll.yaml
@@ -1,6 +1,3 @@
-TestParameters:
-  marks: [skip] # Failing on latest ROCm build, re-enable when passing
-
 GlobalParameters:
   EnqueuesPerSync: 1
   NumElementsToValidate: -1

--- a/Tensile/Tests/extended/mirror_dims/mirror_dims_2sum_mir_unroll_summ.yaml
+++ b/Tensile/Tests/extended/mirror_dims/mirror_dims_2sum_mir_unroll_summ.yaml
@@ -1,6 +1,3 @@
-TestParameters:
-  marks: [skip] # Failing on latest ROCm build, re-enable when passing
-
 GlobalParameters:
   EnqueuesPerSync: 1
   NumElementsToValidate: -1

--- a/Tensile/Tests/extended/mirror_dims/mirror_dims_2sum_mir_unroll_zp_other.yaml
+++ b/Tensile/Tests/extended/mirror_dims/mirror_dims_2sum_mir_unroll_zp_other.yaml
@@ -1,6 +1,3 @@
-TestParameters:
-  marks: [skip] # Failing on latest ROCm build, re-enable when passing
-
 GlobalParameters:
   EnqueuesPerSync: 1
   NumElementsToValidate: -1

--- a/Tensile/Tests/extended/mirror_dims/mirror_dims_3sum_mir_unroll.yaml
+++ b/Tensile/Tests/extended/mirror_dims/mirror_dims_3sum_mir_unroll.yaml
@@ -1,6 +1,3 @@
-TestParameters:
-  marks: [skip] # Failing on latest ROCm build, re-enable when passing
-
 GlobalParameters:
   EnqueuesPerSync: 1
   NumElementsToValidate: -1

--- a/Tensile/Tests/extended/mirror_dims/mirror_dims_3sum_mir_unroll_summ1.yaml
+++ b/Tensile/Tests/extended/mirror_dims/mirror_dims_3sum_mir_unroll_summ1.yaml
@@ -1,6 +1,3 @@
-TestParameters:
-  marks: [skip] # Failing on latest ROCm build, re-enable when passing
-
 GlobalParameters:
   EnqueuesPerSync: 1
   NumElementsToValidate: -1


### PR DESCRIPTION
Fix an issue that caused mirror dims kernels to segfault. Mirrored dimensions were creating vgpr offsets to start at the end, then modifying the buffer srd to step backwards. Some lanes in the tail loop would run off the beginning of the buffer and cause segfault in rocm 5.3 and newer.

This change modifies the way mirrored dimensions are stepped: rather than modifying the srd, the vgpr offset is now updated. This way, the tail loop can easily clamp any lanes that run out of bounds.

This PR also re-enables the mirror_dims test cases that were marked as skip when the bug appeared. Ran all pre_checkin and extended tests to verify other cases are unaffected.