### PR TITLE
Use 'gcnArchName' device property to identify the GCN architecture

### DIFF
--- a/HostLibraryTests/ocl/OclSolutionAdapter_test.cpp
+++ b/HostLibraryTests/ocl/OclSolutionAdapter_test.cpp
@@ -605,6 +605,7 @@ TEST(OclSolutionAdapterTest, HardwareTest)
 
     // Match the hip properties interface as much as possible
     ASSERT_EQ(oclProps.name, hipProps.name);
+    ASSERT_EQ(oclProps.gcnArchName, hipProps.gcnArchName);
     ASSERT_EQ(oclProps.totalGlobalMem, hipProps.totalGlobalMem);
     ASSERT_EQ(oclProps.sharedMemPerBlock, hipProps.sharedMemPerBlock);
     ASSERT_EQ(oclProps.warpSize, hipProps.warpSize);
@@ -621,7 +622,7 @@ TEST(OclSolutionAdapterTest, HardwareTest)
     ASSERT_EQ(oclProps.pciBusID, hipProps.pciBusID);
     ASSERT_EQ(oclProps.pciDeviceID, hipProps.pciDeviceID);
     ASSERT_EQ(oclProps.maxSharedMemoryPerMultiProcessor, hipProps.maxSharedMemoryPerMultiProcessor);
-    ASSERT_EQ(oclProps.gcnArch, hipProps.gcnArch);
+    //ASSERT_EQ(oclProps.gcnArch, hipProps.gcnArch); //gcnArch is deprecated from hipDeviceProp_t
 
     // Check that AMDGPU objects match
     auto oclGPU = std::dynamic_pointer_cast<AMDGPU>(ocl::GetDevice(oclProps));

--- a/Tensile/Source/lib/include/Tensile/AMDGPU.hpp
+++ b/Tensile/Source/lib/include/Tensile/AMDGPU.hpp
@@ -121,8 +121,78 @@ namespace Tensile
             return "";
         }
 
+        AMDGPU::Processor toProcessorId(std::string const& deviceString)
+        {
+            if(deviceString.find("gfx803") != std::string::npos)
+            {
+                return AMDGPU::Processor::gfx803;
+            }
+            else if(deviceString.find("gfx900") != std::string::npos)
+            {
+                return AMDGPU::Processor::gfx900;
+            }
+            else if(deviceString.find("gfx906") != std::string::npos)
+            {
+                return AMDGPU::Processor::gfx906;
+            }
+            else if(deviceString.find("gfx908") != std::string::npos)
+            {
+                return AMDGPU::Processor::gfx908;
+            }
+            else if(deviceString.find("gfx90a") != std::string::npos)
+            {
+                return AMDGPU::Processor::gfx90a;
+            }
+            else if(deviceString.find("gfx940") != std::string::npos)
+            {
+                return AMDGPU::Processor::gfx940;
+            }
+            else if(deviceString.find("gfx941") != std::string::npos)
+            {
+                return AMDGPU::Processor::gfx941;
+            }
+            else if(deviceString.find("gfx942") != std::string::npos)
+            {
+                return AMDGPU::Processor::gfx942;
+            }
+            else if(deviceString.find("gfx1010") != std::string::npos)
+            {
+                return AMDGPU::Processor::gfx1010;
+            }
+            else if(deviceString.find("gfx1011") != std::string::npos)
+            {
+                return AMDGPU::Processor::gfx1011;
+            }
+            else if(deviceString.find("gfx1012") != std::string::npos)
+            {
+                return AMDGPU::Processor::gfx1012;
+            }
+            else if(deviceString.find("gfx1030") != std::string::npos)
+            {
+                return AMDGPU::Processor::gfx1030;
+            }
+            else if(deviceString.find("gfx1100") != std::string::npos)
+            {
+                return AMDGPU::Processor::gfx1100;
+            }
+            else if(deviceString.find("gfx1101") != std::string::npos)
+            {
+                return AMDGPU::Processor::gfx1101;
+            }
+            else if(deviceString.find("gfx1102") != std::string::npos)
+            {
+                return AMDGPU::Processor::gfx1102;
+            }
+            else
+            {
+                return static_cast<AMDGPU::Processor>(0);
+            }
+        }
+
         AMDGPU();
         AMDGPU(Processor p, int computeUnitCount, std::string const& deviceName);
+        AMDGPU(std::string const& archName, int computeUnitCount, std::string const& deviceName);
+
         ~AMDGPU();
 
         Processor   processor        = Processor::gfx900;

--- a/Tensile/Source/lib/include/Tensile/ocl/OclHardware.hpp
+++ b/Tensile/Source/lib/include/Tensile/ocl/OclHardware.hpp
@@ -37,6 +37,7 @@ namespace Tensile
         struct oclDeviceProp_t
         {
             std::string name;
+            std::string gcnArchName;
             size_t      totalGlobalMem;
             size_t      sharedMemPerBlock;
             int         warpSize;

--- a/Tensile/Source/lib/source/AMDGPU.cpp
+++ b/Tensile/Source/lib/source/AMDGPU.cpp
@@ -42,6 +42,13 @@ namespace Tensile
     {
     }
 
+    TENSILE_API AMDGPU::AMDGPU(std::string const& archName, int cus, std::string const& name)
+        : processor(toProcessorId(archName))
+        , computeUnitCount(cus)
+        , deviceName(name)
+    {
+    }
+
     TENSILE_API AMDGPU::~AMDGPU() = default;
 
     TENSILE_API bool AMDGPU::runsKernelTargeting(AMDGPU::Processor other) const

--- a/Tensile/Source/lib/source/hip/HipHardware.cpp
+++ b/Tensile/Source/lib/source/hip/HipHardware.cpp
@@ -33,9 +33,8 @@ namespace Tensile
     namespace hip
     {
         HipAMDGPU::HipAMDGPU(hipDeviceProp_t const& prop)
-            : AMDGPU(static_cast<AMDGPU::Processor>(prop.gcnArch),
-                     prop.multiProcessorCount,
-                     std::string(prop.name))
+            : AMDGPU(
+                std::string(prop.gcnArchName), prop.multiProcessorCount, std::string(prop.name))
             , properties(prop)
         {
         }

--- a/Tensile/Source/lib/source/ocl/OclUtils.cpp
+++ b/Tensile/Source/lib/source/ocl/OclUtils.cpp
@@ -201,6 +201,7 @@ namespace Tensile
             auto            maxWorkGroupSize = device.getInfo<CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS>();
             oclDeviceProp_t result           = {
                 device.getInfo<CL_DEVICE_BOARD_NAME_AMD>(), //std::string name;
+                device.getInfo<CL_DEVICE_NAME>(), // std::string gcnArchName;
                 device.getInfo<CL_DEVICE_GLOBAL_MEM_SIZE>(), // size_t totalGlobalMem;
                 device.getInfo<
                     CL_DEVICE_LOCAL_MEM_SIZE>(), // size_t sharedMemPerBlock; CL_DEVICE_LOCAL_MEM_SIZE


### PR DESCRIPTION
- [gcnArch](https://rocm.docs.amd.com/projects/HIP/en/latest/.doxygen/docBin/html/structhip_device_prop__t.html#adc5950a3d5bbe00cf59d413d8aeeee18) device property has been deprecated and planned to be removed in future release
- This PR replaces the 'gcnArch' device property  with [gcnArchName](https://docs.amd.com/projects/HIP/en/docs-5.2.0/doxygen/html/structhip_device_prop__t.html#abbafcdb62b4e72669e884353eb7c05ad) in Tensile