### PR TITLE
Changes to Enable ROCm SMI for gfx940

### DIFF
--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -2167,11 +2167,6 @@ def assignGlobalParameters( config ):
       globalParameters["CurrentISA"] = (9,0,6)
       printWarning("Failed to detect ISA so forcing (gfx906) on windows")
 
-  # TODO Remove this when rocm-smi supports gfx940
-  if globalParameters["CurrentISA"] == (9,4,0) or globalParameters["CurrentISA"] == (9,4,1) or globalParameters["CurrentISA"] == (9,4,2):
-    printWarning("HardwareMonitor currently disabled for gfx940/941/942")
-    globalParameters["HardwareMonitor"] = False
-
   # For ubuntu platforms, call dpkg to grep the version of hip-clang.  This check is platform specific, and in the future
   # additional support for yum, dnf zypper may need to be added.  On these other platforms, the default version of
   # '0.0.0' will persist

--- a/Tensile/Source/client/source/HardwareMonitor.cpp
+++ b/Tensile/Source/client/source/HardwareMonitor.cpp
@@ -365,16 +365,13 @@ namespace Tensile
                 rsmi_frequencies_t freq;
 
                 auto status = rsmi_dev_gpu_clk_freq_get(m_smiDeviceIndex, m_clockMetrics[i], &freq);
-                if(status != RSMI_STATUS_SUCCESS)
+                if(status != RSMI_STATUS_SUCCESS || freq.current > RSMI_MAX_NUM_FREQUENCIES)
                 {
                     m_clockValues[i] = std::numeric_limits<uint64_t>::max();
                 }
                 else
                 {
-                    if(freq.current < RSMI_MAX_NUM_FREQUENCIES)
-                    {
-                        m_clockValues[i] += freq.frequency[freq.current];
-                    }
+                    m_clockValues[i] += freq.frequency[freq.current];
                 }
             }
 

--- a/Tensile/Source/client/source/HardwareMonitor.cpp
+++ b/Tensile/Source/client/source/HardwareMonitor.cpp
@@ -371,7 +371,10 @@ namespace Tensile
                 }
                 else
                 {
-                    m_clockValues[i] += freq.frequency[freq.current];
+                    if(freq.current < RSMI_MAX_NUM_FREQUENCIES)
+                    {
+                        m_clockValues[i] += freq.frequency[freq.current];
+					}
                 }
             }
 

--- a/Tensile/Source/client/source/HardwareMonitor.cpp
+++ b/Tensile/Source/client/source/HardwareMonitor.cpp
@@ -374,7 +374,7 @@ namespace Tensile
                     if(freq.current < RSMI_MAX_NUM_FREQUENCIES)
                     {
                         m_clockValues[i] += freq.frequency[freq.current];
-					}
+                    }
                 }
             }
 


### PR DESCRIPTION
- Enable ROCm SMI for gfx940. Validated the changes in 21b node.
- Retrieving the mem clock information has a bug for gfx940. so added a safety check in HardwareMonitor.cpp to proceed further. Submitted a ticket to ROCm SMI team as well.
