### PR TITLE
Re-enable miLatency opt for MI16x16 and instruction scheduling fixes

### DIFF
--- a/Tensile/KernelWriter.py
+++ b/Tensile/KernelWriter.py
@@ -258,7 +258,6 @@ class KernelWriter(metaclass=abc.ABCMeta):
       # final index definition
       self.numMfmaForNextLoopLR = min(self.numMfmaForNextLoopLR,numMfmaPerIter-1)
       self.barrierMfmaIndex = numMfmaPerIter*(kernel["LoopIters"]-self.numItersPLR+1) - self.numMfmaForNextLoopLR - 1 if self.numItersPLR else 0
-      LoopIters=kernel["LoopIters"]
       numMfmaBetweenLWandBarrier = 2 if kernel["MatrixInstM"] == 32 else 3
       # set and adjust lwEndMfmaIndex
       self.setAndAdjustLwEndMfmaIndex(kernel, tensorParametersA, tensorParametersB, numMfmaBetweenLWandBarrier, lastLoop)
@@ -1258,8 +1257,6 @@ class KernelWriter(metaclass=abc.ABCMeta):
         # apply same logic to DirectToLds (need to schedule local read as 1LDS buffer)
         # TODO: force to schedule all remaining localreads before start to schedule localwrite.
         oneBufferScheduling = kernel["1LDSBuffer"] or kernel["DirectToLdsA"] or kernel["DirectToLdsB"]
-        if localReadItemsThisLoop and oneBufferScheduling:
-          count = localWriteCode.countType(Code.LocalWriteInst)
         if mfmaIndex >= self.lwStartMfmaIndex and mfmaIndex <= max(self.lwEndMfmaIndex,self.barrierMfmaIndex) and \
           localReadItemsThisLoop and localWriteCode.countType(Code.LocalWriteInst) and oneBufferScheduling:
           self.overflowedResources = 5

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -1954,7 +1954,6 @@ class KernelWriterAssembly(KernelWriter):
     if kernel["EnableMatrixInstruction"]:
       self.miLatency = kernel["MatrixInstM"] // 2
       if (self.version == (9,4,0) or self.version == (9,4,1) or self.version == (9,4,2)) and kernel["MatrixInstB"] == 1 and \
-         kernel["MatrixInstM"] == 32 and \
          (kernel["EnableF32XdlMathOp"] or \
           kernel["ProblemType"]["DataType"].is8bitFloat() or \
           kernel["ProblemType"]["DataType"].isHalf() or kernel["ProblemType"]["DataType"].isBFloat16() or \
@@ -1963,7 +1962,7 @@ class KernelWriterAssembly(KernelWriter):
       miIssueLatency = 2
       # give 1 quad-cycle buffer to prevend bubble from sync
       miLatencyBuffer = 1
-      self.miLatencyLeft = max(self.miLatency - miLatencyBuffer - miIssueLatency,0)
+      self.miLatencyLeft = max(self.miLatency - miLatencyBuffer - miIssueLatency, 1) # minimum 1 to make scheduling work
 
     # pre-determine labels in order
     unrollChar = self.indexChars[ \
@@ -2972,7 +2971,10 @@ class KernelWriterAssembly(KernelWriter):
       elif self.overflowedResources == 4:
         msg = "Occupancy limit"
       elif self.overflowedResources == 5:
-        msg = "reading and writing LDS at same time require 2 LDS buffer"
+        if kernel["DirectToLdsA"] or kernel["DirectToLdsB"]:
+          msg = "cannot schedule local read with DirectToLds"
+        else:
+          msg = "reading and writing LDS at same time require 2 LDS buffer"
       elif self.overflowedResources == 6:
         msg = "SIA2 better with occupancy 2"
       else:
@@ -6730,18 +6732,15 @@ class KernelWriterAssembly(KernelWriter):
     for iui in range(0, innerUnroll):
       zgemmVaddSrcCheck = [[], [], []] # to avoid generating redundant v_add
       outer = 1
-      loopSwap = False
-      # complex case, swap inner loop and outer loop so that idxA comes outer
-      # this is to re-use same tmp vgpr to nagate ai or ar
-      if kernel["ProblemType"]["DataType"].isComplex() and self.tPB["tile01Idx"]:
+      # swap inner loop and outer loop so that idxA comes outer
+      if self.swapMfmaInnerLoop:
         outer = 0
-        loopSwap = True
       inner = 1 - outer # inner is the opposite of outer
       for idxOuter in range(0, kernel["MIWaveTile"][outer]):
         for idxInner in range(0, kernel["MIWaveTile"][inner]):
           idx0 = idxInner
           idx1 = idxOuter
-          if loopSwap:
+          if self.swapMfmaInnerLoop:
             idx0, idx1 = idx1, idx0
           accIdx   = idx1 * kernel["MIWaveTile"][0] + idx0
           accStart = accIdx * accs_per_wave
@@ -8128,7 +8127,7 @@ class KernelWriterAssembly(KernelWriter):
     # set the first tc for below wait code for DirectToLds
     # if DirectToVgpr is enabled and swapGlobalRead is true, change the first to B
     tc1st = 'A'
-    if self.isSwapGlobalReadOrderForDirectToVgpr(kernel):
+    if self.isSwapGlobalReadOrderForDtvOrDtl(kernel):
       tc1st = 'B'
 
     if tc == tc1st and (kernel["DirectToLdsA"] or kernel["DirectToLdsB"]) and not kernel["PrefetchGlobalRead"]==2:
@@ -14286,16 +14285,19 @@ class KernelWriterAssembly(KernelWriter):
     return kStr
 
   ##############################################################################
-  # isSwapGlobalReadOrderForDirectToVgpr
+  # isSwapGlobalReadOrderForDtvOrDtl
   ##############################################################################
-  def isSwapGlobalReadOrderForDirectToVgpr(self, kernel):
+  def isSwapGlobalReadOrderForDtvOrDtl(self, kernel):
     # swap global read order (from A, B to B, A) if the following condition is true
     #  - DirectToVgprA and B are true and number of global read B >= number of global read A
     #  - if DirectToVgprA is true and DirectToVgprB is false
+    #  - if DirectToLdsA=False and DirectToLdsB=True (need to put DTLB first)
     if kernel["DirectToVgprA"] and kernel["DirectToVgprB"]:
       if kernel["NumLoadsB"] >= kernel["NumLoadsA"]:
         return True
     elif kernel["DirectToVgprA"]:
+      return True
+    elif (not kernel["DirectToLdsA"]) and kernel["DirectToLdsB"]:
       return True
     return False
 

--- a/Tensile/KernelWriterSource.py
+++ b/Tensile/KernelWriterSource.py
@@ -3466,8 +3466,8 @@ class KernelWriterSource(KernelWriter):
     return ""
 
   ##############################################################################
-  # isSwapGlobalReadOrderForDirectToVgpr
+  # isSwapGlobalReadOrderForDtvOrDtl
   ##############################################################################
-  def isSwapGlobalReadOrderForDirectToVgpr(self, kernel):
+  def isSwapGlobalReadOrderForDtvOrDtl(self, kernel):
     return False
 

--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -2525,7 +2525,6 @@ class Solution(collections.abc.Mapping):
     numBytes = state["ProblemType"]["DataType"].numBytes()
     asem = state["AssertSummationElementMultiple"]
     gsu = state["GlobalSplitU"]
-    tcOther = "B" if tc == "A" else "A"
 
     # x2/x4 support for directToLds (no longer supported)
 

--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -2636,11 +2636,6 @@ class Solution(collections.abc.Mapping):
       reject(state, "DirectToLds%c does not work with PrefetchGlobalRead=2 and MatrixInstB > 1"%(tc))
       return False
 
-    # Does not work with PrefetchGlobalRead=2 and the other side of DirectToLds and DirectToVgpr are false
-    if state["PrefetchGlobalRead"] == 2 and state["DirectToLds%c"%tcOther] == False and state["DirectToVgpr%c"%tcOther] == False:
-      reject(state, "DirectToLds%c does not work with PrefetchGlobalRead=2 and DirectToLds%c and DirectToVgpr%c "%(tc, tcOther, tcOther))
-      return False
-
     # DirectToLds does not work if MacroTile is not power of 2
     # LDS offset swap/rotate logic works only when MacroTile is power of 2
     mt = state["MacroTile%c"%tc]
@@ -3250,6 +3245,18 @@ class Solution(collections.abc.Mapping):
 
     state["_DepthULds"] = state["DepthU"]//state["DepthULdsDivisor"] # internal
 
+    # Default LocalReadVectorWidth
+    if state["LocalReadVectorWidth"] == -1:
+      if state["EnableMatrixInstruction"]:
+        state["LocalReadVectorWidth"] = state["MIInputPerThread"]
+        # enable less than state["MIInputPerThread"] 
+        # for fp64 this means ds_read_b32 
+        if ((state["DirectToLdsA"] and state["ProblemType"]["TLUA"]) or \
+            (state["DirectToLdsB"] and state["ProblemType"]["TLUB"])): 
+             state["LocalReadVectorWidth"] = 1 if (state["ProblemType"]["DataType"].numBytes() >= 4) else state["LocalReadVectorWidth"]
+      else:
+        state["LocalReadVectorWidth"] = state["VectorWidth"]
+
     ########################################
     # Search DepthU
     # Inputs:
@@ -3398,20 +3405,25 @@ class Solution(collections.abc.Mapping):
       if validDepthU:
         # check depthU and ThreadSeparateGlobalReadA==1 depthU*bpe <= 64 bytes reject ThreadSeparateGlobalRead =1 (TLU=0 only)
         # reject depthU for cases requiring < minimum lanes per fragment. depthU * bpe  must be multiple of cache-line sizes(l2)
-        # minimum lane is 2 for bpe < 4, 1 for bpe >= 4
-        minLanes = 2 if state["ProblemType"]["DataType"].numBytes() < 4 else 1
-        bpr = 4 # all registers are 32bit
+        # minimum lane is 4//bpe for bpe < 4, 1 for bpe >= 4
+        minLanes = max( 4 // state["ProblemType"]["DataType"].numBytes(), 1)
         depthULds = depthU // state["DepthULdsDivisor"]
         if state["ThreadSeparateGlobalReadA"] and (not state["ProblemType"]["TLUA"]):
           #if state["ThreadSeparateGlobalReadA"] and (((depthU//state["GlobalLoadVectorWidthA"])// (2 * state["ThreadSeparateGlobalReadA"])) < 2):
-          if (depthU * state["ProblemType"]["DataType"].numBytes() < minLanes * state["GlobalLoadVectorWidthA"] * (2 * state["ThreadSeparateGlobalReadA"]) * bpr):
+          if (depthU < minLanes * state["GlobalLoadVectorWidthA"] * (2 * state["ThreadSeparateGlobalReadA"])):
+            validDepthU= False
+          # reject if KelementsPerMFrag (= (_DepthULds  // (ThreadSeparateGlobalRead * 2))) < inputPerThread = max(lrvwA,lrvwB)
+          if (depthULds  // (2 * state["ThreadSeparateGlobalReadA"])) < state["LocalReadVectorWidth"]:
             validDepthU= False
         if state["ThreadSeparateGlobalReadB"] and (not state["ProblemType"]["TLUB"]):
           #if state["ThreadSeparateGlobalReadB"] and (((depthU//state["GlobalLoadVectorWidthB"])// (2 * state["ThreadSeparateGlobalReadB"])) < 2):
-          if (depthU * state["ProblemType"]["DataType"].numBytes() < minLanes * state["GlobalLoadVectorWidthB"] * (2 * state["ThreadSeparateGlobalReadB"]) * bpr):
+          if (depthU < minLanes * state["GlobalLoadVectorWidthB"] * (2 * state["ThreadSeparateGlobalReadB"])):
             validDepthU= False
           # reject if NblockSizePerLoad (= (waveWidth * GlobalLoadVectorWidthB // depthULds)) > MatrixInstN
           if (state["WavefrontSize"] * state["GlobalLoadVectorWidthB"] // depthULds  > state["MatrixInstN"]):
+            validDepthU= False
+          # reject if KelementsPerMFrag (= (_DepthULds  // (ThreadSeparateGlobalRead * 2))) < inputPerThread = max(lrvwA,lrvwB)
+          if (depthULds  // (2 * state["ThreadSeparateGlobalReadB"])) < state["LocalReadVectorWidth"]:
             validDepthU= False
 
       # this depthU is valid, done unless user wants to double (for TN)
@@ -3555,18 +3567,6 @@ class Solution(collections.abc.Mapping):
         reject(state, "didn't support UnrollMajorLDS in VALU mode yet")
       if state["LdsBlockSizePerPadA"] != 0 or state["LdsBlockSizePerPadB"] != 0:
         reject(state, "didn't support LdsBlockSizePerPad in VALU mode yet")
-
-    # Default LocalReadVectorWidth
-    if state["LocalReadVectorWidth"] == -1:
-      if state["EnableMatrixInstruction"]:
-        state["LocalReadVectorWidth"] = state["MIInputPerThread"]
-        # enable less than state["MIInputPerThread"] 
-        # for fp64 this means ds_read_b32 
-        if ((state["DirectToLdsA"] and state["ProblemType"]["TLUA"]) or \
-            (state["DirectToLdsB"] and state["ProblemType"]["TLUB"])): 
-             state["LocalReadVectorWidth"] = 1 if (state["ProblemType"]["DataType"].numBytes() >= 4) else state["LocalReadVectorWidth"]
-      else:
-        state["LocalReadVectorWidth"] = state["VectorWidth"]
 
     # allow LocalReadVectorWidthB > 1 for TLUB + MatrixInstruction (this is applicable for B only)
     # some more limitations necessary to make this logic work

--- a/Tensile/Tests/extended/direct_to_lds/dtl_tsgr_f8.yaml
+++ b/Tensile/Tests/extended/direct_to_lds/dtl_tsgr_f8.yaml
@@ -1,21 +1,21 @@
 TestParameters:
-  marks: [skip-gfx900, skip-gfx906, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102] # not supported by arch
+  marks: [skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx90a, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102] # not supported by arch
 
 GlobalParameters:
   NumElementsToValidate: -1
   BoundsCheck: True
   KernelTime: True
-  #PrintSolutionRejectionReason: True
-  #MaxFileName: 256
+  sPrintSolutionRejectionReason: True
+  MaxFileName: 256
 
 BenchmarkProblems:
   ########################################
   # TN
   ########################################
-  - # hgemm TN
+  - # f8 TN
     - # ProblemType
       OperationType: GEMM
-      DataType: h
+      DataType: f8
       ComputeDataType: s
       HighPrecisionAccumulate: True
       TransposeA: True
@@ -30,44 +30,36 @@ BenchmarkProblems:
         - EdgeType: ["ShiftPtr"]
       ForkParameters:
         - MatrixInstruction:
-          - [16, 16, 16, 1, 1, 4,4, 2,2]
-          - [16, 16, 16, 1, 1, 4,4, 1,4]
-          - [16, 16, 16, 1, 1, 4,4, 4,1]
-          - [16, 16, 4, 4, 1, 4,4, 2,2]
-          - [16, 16, 4, 4, 2, 4,4, 2,2]
-          - [16, 16, 4, 4, 4, 4,4, 2,2]
-          - [4, 4, 4, 16, 1, 4,4, 2,2]
-          - [4, 4, 4, 16, 2, 4,4, 2,2]
-          - [4, 4, 4, 16, 4, 4,4, 2,2]
-          - [4, 4, 4, 16, 8, 4,4, 2,2]
-          - [4, 4, 4, 16, 16, 4,4, 2,2]
+          #- [16, 16, 32, 1, 1, 4,4, 2,2]
+          - [16, 16, 32, 1, 1, 4,4, 1,4]
+          - [16, 16, 32, 1, 1, 4,4, 4,1]
         - ThreadTile:
           - [  8, 32 ]
         - WorkGroup:
           - [ 16, 16, 1 ]
         - SourceSwap: [True]
-        - PrefetchGlobalRead: [1]#[1, 2]
-        #- AssertFree0ElementMultiple: [2]
-        # - AssertFree1ElementMultiple: [2]
+        - PrefetchGlobalRead: [1, 2]
+        #- AssertFree0ElementMultiple: [4]
+        # - AssertFree1ElementMultiple: [4]
         - WorkGroupMapping: [8]
-        - PrefetchLocalRead: [1]#[1, 2, 3]
+        - PrefetchLocalRead: [1,3,5]#[1, 2, 3]
         - GlobalSplitU: [1]
-        - DepthU:  [16, 32, 64] # 128 is rejected
-        - VectorWidth: [2,4]
-        #- GlobalReadVectorWidth: [2,4]
-        - LocalReadVectorWidth: [4]
+        - DepthU:  [64, 128]
+        - VectorWidth: [2]#[2,4]
+        - GlobalReadVectorWidth: [8,16]
+        - LocalReadVectorWidth: [8,16]
         - DirectToLdsA: [False, True]
         - DirectToLdsB: [False, True]
         - DirectToVgprA: [False, True]
         - DirectToVgprB: [False, True]
         #- WaveSeparateGlobalReadA: [1]
         #- WaveSeparateGlobalReadB: [1]
-        - ThreadSeparateGlobalReadA: [0, 1, 2, 4]
-        - ThreadSeparateGlobalReadB: [0, 1, 2, 4]
-        #- NumLoadsCoalescedA: [1,2] # NLC=2 not working
-        #- NumLoadsCoalescedB: [1] # NLC=2 not working
+        - ThreadSeparateGlobalReadA: [0, 1, 2]#[0, 1, 2, 4]
+        - ThreadSeparateGlobalReadB: [0, 1, 2]#[0, 1, 2, 4]
+        #- NumLoadsCoalescedA: [1,2]
+        #- NumLoadsCoalescedB: [1,2]
         - ScheduleIterAlg: [3]
-        - AssertSummationElementMultiple: [4]
+        - AssertSummationElementMultiple: [16]
         - StaggerU: [0]
         - NumElementsPerBatchStore: [0]
         #- FractionalLoad: [0, 1, 2]
@@ -78,7 +70,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [511, 511, 1, 252]
+          - Exact: [511, 511, 1, 240]
 
     - # MFMA 32x32, VW = 2
       InitialSolutionParameters:
@@ -87,39 +79,37 @@ BenchmarkProblems:
         - EdgeType: ["ShiftPtr"]
       ForkParameters:
         - MatrixInstruction:
-          - [32, 32, 4, 2, 1, 2,2, 2,2]
-          - [32, 32, 4, 2, 2, 2,2, 2,2]
-          - [32, 32, 8, 1, 1, 2,2, 2,2]
-          - [32, 32, 8, 1, 1, 2,2, 1,4]
-          - [32, 32, 8, 1, 1, 2,2, 4,1]
+          - [32, 32, 16, 1, 1, 2,2, 2,2]
+          - [32, 32, 16, 1, 1, 2,2, 1,4]
+          - [32, 32, 16, 1, 1, 2,2, 4,1]
         - ThreadTile:
           - [  8, 32 ]
         - WorkGroup:
           - [ 16, 16, 1 ]
         - SourceSwap: [True]
         - PrefetchGlobalRead: [1, 2]
-        #- AssertFree0ElementMultiple: [2]
-        # - AssertFree1ElementMultiple: [2]
+        #- AssertFree0ElementMultiple: [4]
+        # - AssertFree1ElementMultiple: [4]
         - WorkGroupMapping: [8]
-        - PrefetchLocalRead: [1, 2, 3]
+        - PrefetchLocalRead: [1,3,5,9]#[1, 2, 3]
         - GlobalSplitU: [1]
-        - DepthU:  [16, 32, 64] # 128 is rejected
+        - DepthU:  [32, 64, 128]
         - StoreVectorWidth: [2]
         - VectorWidth: [2]
-        - GlobalReadVectorWidth: [2,4]
-        - LocalReadVectorWidth: [4]
+        - GlobalReadVectorWidth: [4,8]
+        - LocalReadVectorWidth: [8]
         - DirectToLdsA: [False, True]
         - DirectToLdsB: [False, True]
         - DirectToVgprA: [False, True]
-        - DirectToVgprB: [False]
+        - DirectToVgprB: [False, True]
         #- WaveSeparateGlobalReadA: [0, 1]
         #- WaveSeparateGlobalReadB: [0, 1]
-        - ThreadSeparateGlobalReadA: [0, 1, 2, 4]
-        - ThreadSeparateGlobalReadB: [0, 1, 2, 4]
-        #- NumLoadsCoalescedA: [1,2] # NLC=2 not working
-        #- NumLoadsCoalescedB: [1] # NLC=2 not working
+        - ThreadSeparateGlobalReadA: [0, 1, 2]#[0, 1, 2, 4]
+        - ThreadSeparateGlobalReadB: [0, 1, 2]#[0, 1, 2, 4]
+        #- NumLoadsCoalescedA: [1,2]
+        #- NumLoadsCoalescedB: [1,2]
         - ScheduleIterAlg: [3]
-        - AssertSummationElementMultiple: [2]
+        - AssertSummationElementMultiple: [8]
         - StaggerU: [0]
         - NumElementsPerBatchStore: [0]
         #- FractionalLoad: [0, 1, 2]
@@ -130,15 +120,15 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [511, 511, 1, 250]
+          - Exact: [511, 511, 1, 248]
 
   ########################################
   # NN
   ########################################
-  - # hgemm NN
+  - # f8 NN
     - # ProblemType
       OperationType: GEMM
-      DataType: h
+      DataType: f8
       ComputeDataType: s
       HighPrecisionAccumulate: True
       TransposeA: False
@@ -153,33 +143,25 @@ BenchmarkProblems:
         - EdgeType: ["ShiftPtr"]
       ForkParameters:
         - MatrixInstruction:
-          - [16, 16, 16, 1, 1, 4,4, 2,2]
-          - [16, 16, 16, 1, 1, 4,4, 1,4]
-          - [16, 16, 16, 1, 1, 4,4, 4,1]
-          - [16, 16, 4, 4, 1, 4,4, 2,2]
-          - [16, 16, 4, 4, 2, 4,4, 2,2]
-          - [16, 16, 4, 4, 4, 4,4, 2,2]
-          - [4, 4, 4, 16, 1, 4,4, 2,2]
-          - [4, 4, 4, 16, 2, 4,4, 2,2]
-          - [4, 4, 4, 16, 4, 4,4, 2,2]
-          - [4, 4, 4, 16, 8, 4,4, 2,2]
-          - [4, 4, 4, 16, 16, 4,4, 2,2]
+          - [16, 16, 32, 1, 1, 4,4, 2,2]
+          - [16, 16, 32, 1, 1, 4,4, 1,4]
+          - [16, 16, 32, 1, 1, 4,4, 4,1]
         - ThreadTile:
           - [  8, 32 ]
         - WorkGroup:
           - [ 16, 16, 1 ]
         - SourceSwap: [True]
-        - PrefetchGlobalRead: [1]#[1, 2]
-        - AssertFree0ElementMultiple: [2]
-        # - AssertFree1ElementMultiple: [2]
+        - PrefetchGlobalRead: [1, 2]
+        - AssertFree0ElementMultiple: [4]
+        # - AssertFree1ElementMultiple: [4]
         - WorkGroupMapping: [8]
-        - PrefetchLocalRead: [1]#[1, 2, 3]
+        - PrefetchLocalRead: [1,3,5]#[1, 2, 3]
         - GlobalSplitU: [1]
-        - DepthU:  [16, 32, 64] # 128 is rejected
-        - StoreVectorWidth: [4]
-        - VectorWidth: [2,4]
-        #- GlobalReadVectorWidth: [2,4]
-        - LocalReadVectorWidth: [4]
+        - DepthU:  [64, 128]
+        - StoreVectorWidth: [2]
+        - VectorWidth: [2]
+        - GlobalReadVectorWidth: [4,8]
+        - LocalReadVectorWidth: [8]
         - DirectToLdsA: [False, True]
         - DirectToLdsB: [False, True]
         - DirectToVgprA: [False]
@@ -187,9 +169,9 @@ BenchmarkProblems:
         - WaveSeparateGlobalReadA: [1]
         - WaveSeparateGlobalReadB: [1]
         - ThreadSeparateGlobalReadA: [0, 1]#[0, 1, 2, 4]
-        - ThreadSeparateGlobalReadB: [0, 1, 2, 4]
-        - NumLoadsCoalescedA: [1] # NLC=2 not working
-        - NumLoadsCoalescedB: [1] # NLC=2 not working
+        - ThreadSeparateGlobalReadB: [0, 1, 2]#[0, 1, 2, 4]
+        #- NumLoadsCoalescedA: [1,2]
+        #- NumLoadsCoalescedB: [1,2]
         - ScheduleIterAlg: [3]
         - AssertSummationElementMultiple: [2]
         - StaggerU: [0]
@@ -202,7 +184,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [510, 511, 1, 250]
+          - Exact: [508, 511, 1, 250]
 
     - # MFMA 32x32, VW = 2
       InitialSolutionParameters:
@@ -211,27 +193,25 @@ BenchmarkProblems:
         - EdgeType: ["ShiftPtr"]
       ForkParameters:
         - MatrixInstruction:
-          - [32, 32, 4, 2, 1, 2,2, 2,2]
-          - [32, 32, 4, 2, 2, 2,2, 2,2]
-          - [32, 32, 8, 1, 1, 2,2, 2,2]
-          - [32, 32, 8, 1, 1, 2,2, 1,4]
-          - [32, 32, 8, 1, 1, 2,2, 4,1]
+          - [32, 32, 16, 1, 1, 2,2, 2,2]
+          - [32, 32, 16, 1, 1, 2,2, 1,4]
+          - [32, 32, 16, 1, 1, 2,2, 4,1]
         - ThreadTile:
           - [  8, 32 ]
         - WorkGroup:
           - [ 16, 16, 1 ]
         - SourceSwap: [True]
         - PrefetchGlobalRead: [1, 2]
-        - AssertFree0ElementMultiple: [2]
-        # - AssertFree1ElementMultiple: [2]
+        - AssertFree0ElementMultiple: [4]
+        # - AssertFree1ElementMultiple: [4]
         - WorkGroupMapping: [8]
-        - PrefetchLocalRead: [1, 2, 3]
+        - PrefetchLocalRead: [1,3,5,9]#[1, 2, 3]
         - GlobalSplitU: [1]
-        - DepthU:  [16, 32, 64] # 128 is rejected
+        - DepthU:  [32, 64, 128]
         - StoreVectorWidth: [2]
         - VectorWidth: [2]
-        - GlobalReadVectorWidth: [2,4]
-        - LocalReadVectorWidth: [4]
+        - GlobalReadVectorWidth: [4,8]
+        - LocalReadVectorWidth: [8]
         - DirectToLdsA: [False, True]
         - DirectToLdsB: [False, True]
         - DirectToVgprA: [False]
@@ -239,9 +219,9 @@ BenchmarkProblems:
         #- WaveSeparateGlobalReadA: [0, 1]
         #- WaveSeparateGlobalReadB: [0, 1]
         - ThreadSeparateGlobalReadA: [0, 1]#[0, 1, 2, 4]
-        - ThreadSeparateGlobalReadB: [0, 1, 2, 4]
-        - NumLoadsCoalescedA: [1] # NLC=2 not working
-        - NumLoadsCoalescedB: [1] # NLC=2 not working
+        - ThreadSeparateGlobalReadB: [0, 1, 2]#[0, 1, 2, 4]
+        #- NumLoadsCoalescedA: [1,2]
+        #- NumLoadsCoalescedB: [1,2]
         - ScheduleIterAlg: [3]
         - AssertSummationElementMultiple: [2]
         - StaggerU: [0]
@@ -254,15 +234,15 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [510, 511, 1, 250]
+          - Exact: [508, 511, 1, 250]
 
   ########################################
   # TT
   ########################################
-  - # hgemm TT
+  - # f8 TT
     - # ProblemType
       OperationType: GEMM
-      DataType: h
+      DataType: f8
       ComputeDataType: s
       HighPrecisionAccumulate: True
       TransposeA: True
@@ -277,43 +257,35 @@ BenchmarkProblems:
         - EdgeType: ["ShiftPtr"]
       ForkParameters:
         - MatrixInstruction:
-          - [16, 16, 16, 1, 1, 4,4, 2,2]
-          - [16, 16, 16, 1, 1, 4,4, 1,4]
-          - [16, 16, 16, 1, 1, 4,4, 4,1]
-          - [16, 16, 4, 4, 1, 4,4, 2,2]
-          - [16, 16, 4, 4, 2, 4,4, 2,2]
-          - [16, 16, 4, 4, 4, 4,4, 2,2]
-          - [4, 4, 4, 16, 1, 4,4, 2,2]
-          - [4, 4, 4, 16, 2, 4,4, 2,2]
-          - [4, 4, 4, 16, 4, 4,4, 2,2]
-          - [4, 4, 4, 16, 8, 4,4, 2,2]
-          - [4, 4, 4, 16, 16, 4,4, 2,2]
+          - [16, 16, 32, 1, 1, 4,4, 2,2]
+          - [16, 16, 32, 1, 1, 4,4, 1,4]
+          - [16, 16, 32, 1, 1, 4,4, 4,1]
         - ThreadTile:
           - [  8, 32 ]
         - WorkGroup:
           - [ 16, 16, 1 ]
         - SourceSwap: [True]
-        - PrefetchGlobalRead: [1]#[1, 2]
-        #- AssertFree0ElementMultiple: [2]
-        - AssertFree1ElementMultiple: [2]
+        - PrefetchGlobalRead: [1, 2]
+        #- AssertFree0ElementMultiple: [4]
+        - AssertFree1ElementMultiple: [4]
         - WorkGroupMapping: [8]
-        - PrefetchLocalRead: [1]#[1, 2, 3]
+        - PrefetchLocalRead: [1,3,5]#[1, 2, 3]
         - GlobalSplitU: [1]
-        - DepthU:  [16, 32, 64] # 128 is rejected
-        - StoreVectorWidth: [4]
-        - VectorWidth: [4]
-        - GlobalReadVectorWidth: [2,4]
-        - LocalReadVectorWidth: [4]
+        - DepthU:  [64, 128]
+        - StoreVectorWidth: [2]
+        - VectorWidth: [2]
+        - GlobalReadVectorWidth: [4,8]
+        - LocalReadVectorWidth: [8]
         - DirectToLdsA: [False, True]
         - DirectToLdsB: [False, True]
         - DirectToVgprA: [False]
         - DirectToVgprB: [False]
         - WaveSeparateGlobalReadA: [1]
         - WaveSeparateGlobalReadB: [1]
-        - ThreadSeparateGlobalReadA: [0, 1, 2, 4]
+        - ThreadSeparateGlobalReadA: [0, 1, 2]#[0, 1, 2, 4]
         - ThreadSeparateGlobalReadB: [0, 1]#[0, 1, 2, 4]
-        - NumLoadsCoalescedA: [1] # NLC=2 not working
-        - NumLoadsCoalescedB: [1] # NLC=2 not working
+        #- NumLoadsCoalescedA: [1,2]
+        #- NumLoadsCoalescedB: [1,2]
         - ScheduleIterAlg: [3]
         - AssertSummationElementMultiple: [2]
         - StaggerU: [0]
@@ -326,7 +298,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [511, 510, 1, 250]
+          - Exact: [511, 508, 1, 250]
 
     - # MFMA 32x32, VW = 2
       InitialSolutionParameters:
@@ -335,37 +307,35 @@ BenchmarkProblems:
         - EdgeType: ["ShiftPtr"]
       ForkParameters:
         - MatrixInstruction:
-          - [32, 32, 4, 2, 1, 2,2, 2,2]
-          - [32, 32, 4, 2, 2, 2,2, 2,2]
-          - [32, 32, 8, 1, 1, 2,2, 2,2]
-          - [32, 32, 8, 1, 1, 2,2, 1,4]
-          - [32, 32, 8, 1, 1, 2,2, 4,1]
+          - [32, 32, 16, 1, 1, 2,2, 2,2]
+          - [32, 32, 16, 1, 1, 2,2, 1,4]
+          - [32, 32, 16, 1, 1, 2,2, 4,1]
         - ThreadTile:
           - [  8, 32 ]
         - WorkGroup:
           - [ 16, 16, 1 ]
         - SourceSwap: [True]
         - PrefetchGlobalRead: [1, 2]
-        #- AssertFree0ElementMultiple: [2]
-        - AssertFree1ElementMultiple: [2]
+        #- AssertFree0ElementMultiple: [4]
+        - AssertFree1ElementMultiple: [4]
         - WorkGroupMapping: [8]
-        - PrefetchLocalRead: [1, 2, 3]
+        - PrefetchLocalRead: [1,3,5,9]#[1, 2, 3]
         - GlobalSplitU: [1]
-        - DepthU:  [16, 32, 64] # 128 is rejected
+        - DepthU:  [32, 64, 128]
         - StoreVectorWidth: [2]
         - VectorWidth: [2]
-        - GlobalReadVectorWidth: [2,4]
-        - LocalReadVectorWidth: [4]
+        - GlobalReadVectorWidth: [4,8]
+        - LocalReadVectorWidth: [8]
         - DirectToLdsA: [False, True]
         - DirectToLdsB: [False, True]
         - DirectToVgprA: [False]
         - DirectToVgprB: [False]
-        #- WaveSeparateGlobalReadA: [0, 1]
+        - WaveSeparateGlobalReadA: [0, 1]
         #- WaveSeparateGlobalReadB: [0, 1]
-        - ThreadSeparateGlobalReadA: [0, 1, 2, 4]
+        - ThreadSeparateGlobalReadA: [0, 1, 2]#[0, 1, 2, 4]
         - ThreadSeparateGlobalReadB: [0, 1]#[0, 1, 2, 4]
-        - NumLoadsCoalescedA: [1] # NLC=2 not working
-        - NumLoadsCoalescedB: [1] # NLC=2 not working
+        #- NumLoadsCoalescedA: [1,2]
+        #- NumLoadsCoalescedB: [1,2]
         - ScheduleIterAlg: [3]
         - AssertSummationElementMultiple: [2]
         - StaggerU: [0]
@@ -378,15 +348,15 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [511, 510, 1, 250]
+          - Exact: [511, 508, 1, 250]
 
   ########################################
   # NT
   ########################################
-  - # hgemm NT
+  - # f8 NT
     - # ProblemType
       OperationType: GEMM
-      DataType: h
+      DataType: f8
       ComputeDataType: s
       HighPrecisionAccumulate: True
       TransposeA: False
@@ -401,33 +371,25 @@ BenchmarkProblems:
         - EdgeType: ["ShiftPtr"]
       ForkParameters:
         - MatrixInstruction:
-          - [16, 16, 16, 1, 1, 4,4, 2,2]
-          - [16, 16, 16, 1, 1, 4,4, 1,4]
-          - [16, 16, 16, 1, 1, 4,4, 4,1]
-          - [16, 16, 4, 4, 1, 4,4, 2,2]
-          - [16, 16, 4, 4, 2, 4,4, 2,2]
-          - [16, 16, 4, 4, 4, 4,4, 2,2]
-          - [4, 4, 4, 16, 1, 4,4, 2,2]
-          - [4, 4, 4, 16, 2, 4,4, 2,2]
-          - [4, 4, 4, 16, 4, 4,4, 2,2]
-          - [4, 4, 4, 16, 8, 4,4, 2,2]
-          - [4, 4, 4, 16, 16, 4,4, 2,2]
+          - [16, 16, 32, 1, 1, 4,4, 2,2]
+          - [16, 16, 32, 1, 1, 4,4, 1,4]
+          - [16, 16, 32, 1, 1, 4,4, 4,1]
         - ThreadTile:
           - [  8, 32 ]
         - WorkGroup:
           - [ 16, 16, 1 ]
         - SourceSwap: [True]
-        - PrefetchGlobalRead: [1]#[1, 2]
-        - AssertFree0ElementMultiple: [2]
-        - AssertFree1ElementMultiple: [2]
+        - PrefetchGlobalRead: [1, 2]
+        - AssertFree0ElementMultiple: [4]
+        - AssertFree1ElementMultiple: [4]
         - WorkGroupMapping: [8]
-        - PrefetchLocalRead: [1]#[1, 2, 3]
+        - PrefetchLocalRead: [1,3,5]#[1, 2, 3]
         - GlobalSplitU: [1]
-        - DepthU:  [16, 32, 64] # 128 is rejected
-        - StoreVectorWidth: [4]
-        - VectorWidth: [4]
-        - GlobalReadVectorWidth: [2,4]
-        - LocalReadVectorWidth: [4]
+        - DepthU:  [64, 128]
+        - StoreVectorWidth: [2]
+        - VectorWidth: [2]
+        - GlobalReadVectorWidth: [4,8]
+        - LocalReadVectorWidth: [8]
         - DirectToLdsA: [False, True]
         - DirectToLdsB: [False, True]
         - DirectToVgprA: [False]
@@ -436,8 +398,8 @@ BenchmarkProblems:
         - WaveSeparateGlobalReadB: [1]
         - ThreadSeparateGlobalReadA: [0, 1]#[0, 1, 2, 4]
         - ThreadSeparateGlobalReadB: [0, 1]#[0, 1, 2, 4]
-        - NumLoadsCoalescedA: [1] # NLC=2 not working
-        - NumLoadsCoalescedB: [1] # NLC=2 not working
+        #- NumLoadsCoalescedA: [1,2]
+        #- NumLoadsCoalescedB: [1,2]
         - ScheduleIterAlg: [3]
         #- AssertSummationElementMultiple: [8]
         - StaggerU: [0]
@@ -450,7 +412,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [510, 510, 1, 249]
+          - Exact: [508, 508, 1, 249]
 
     - # MFMA 32x32, VW = 2
       InitialSolutionParameters:
@@ -459,27 +421,25 @@ BenchmarkProblems:
         - EdgeType: ["ShiftPtr"]
       ForkParameters:
         - MatrixInstruction:
-          - [32, 32, 4, 2, 1, 2,2, 2,2]
-          - [32, 32, 4, 2, 2, 2,2, 2,2]
-          - [32, 32, 8, 1, 1, 2,2, 2,2]
-          - [32, 32, 8, 1, 1, 2,2, 1,4]
-          - [32, 32, 8, 1, 1, 2,2, 4,1]
+          - [32, 32, 16, 1, 1, 2,2, 2,2]
+          - [32, 32, 16, 1, 1, 2,2, 1,4]
+          - [32, 32, 16, 1, 1, 2,2, 4,1]
         - ThreadTile:
           - [  8, 32 ]
         - WorkGroup:
           - [ 16, 16, 1 ]
         - SourceSwap: [True]
-        - PrefetchGlobalRead: [1]#[1, 2]
-        - AssertFree0ElementMultiple: [2]
-        - AssertFree1ElementMultiple: [2]
+        - PrefetchGlobalRead: [1, 2]
+        - AssertFree0ElementMultiple: [4]
+        - AssertFree1ElementMultiple: [4]
         - WorkGroupMapping: [8]
-        - PrefetchLocalRead: [1]#[1, 2, 3]
+        - PrefetchLocalRead: [1,3,5,9]#[1, 2, 3]
         - GlobalSplitU: [1]
-        - DepthU:  [16, 32, 64] # 128 is rejected
+        - DepthU:  [32, 64, 128]
         - StoreVectorWidth: [2]
         - VectorWidth: [2]
-        - GlobalReadVectorWidth: [2,4]
-        - LocalReadVectorWidth: [4]
+        - GlobalReadVectorWidth: [4,8]
+        - LocalReadVectorWidth: [8]
         - DirectToLdsA: [False, True]
         - DirectToLdsB: [False, True]
         - DirectToVgprA: [False]
@@ -488,8 +448,8 @@ BenchmarkProblems:
         #- WaveSeparateGlobalReadB: [0, 1]
         - ThreadSeparateGlobalReadA: [0, 1]#[0, 1, 2, 4]
         - ThreadSeparateGlobalReadB: [0, 1]#[0, 1, 2, 4]
-        - NumLoadsCoalescedA: [1] # NLC=2 not working
-        - NumLoadsCoalescedB: [1] # NLC=2 not working
+        #- NumLoadsCoalescedA: [1,2]
+        #- NumLoadsCoalescedB: [1,2]
         - ScheduleIterAlg: [3]
         #- AssertSummationElementMultiple: [8]
         - StaggerU: [0]
@@ -502,4 +462,4 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [510, 510, 1, 255]
+          - Exact: [508, 508, 1, 255]


### PR DESCRIPTION
- re-enabled miLatency opt for MI16x16 and fixed mismatch issue
- fixed mismatch issues with DirectToLds
- fixed mismatch issues with DirectToVgpr
- improved scheduling for DirectToVgprA load + PGR2 (swap inner/outer iteration in mfmaIter)
- improved the accuracy of auto-scheduling (doubled PRECISION)
- added auto-adjustment for LocalWritePerMfma!=-1 + PGR2
- improved reject conditions for ThreadSeparateGlobalRead
- removed reject conditions for PGR2 + DTLA/B + (no DTL/DTV for the other side (B/A))
- improved test coverage for ThreadSeparateGlobalRead