### PR TITLE
init code optimization

### DIFF
--- a/Tensile/KernelWriter.py
+++ b/Tensile/KernelWriter.py
@@ -1616,6 +1616,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
   ##############################################################################
   def setupNewTile(self, kernel, tensorParametersA, tensorParametersB, isPap, isOptNLL=False, forceNoTileCode=False, forceNoGRCode=False):
     kl = []
+    kl_2 = [] # generate tile assignment code + local write code separately for init code optimization
 
     if self.enable["PreLoop"]:
       ####################################
@@ -1647,10 +1648,16 @@ class KernelWriter(metaclass=abc.ABCMeta):
       self.dontAppendCode = isPap and kernel["PrefetchAcrossPersistentMode"] == 1 and ((not needShift) or self.useGlobalReadTileVgpr)
       self.dontAppendCode = self.dontAppendCode or forceNoTileCode
       # tile assignments
-      kl.append(self.comment("global read addresses: tile offset assignment a"))
-      kl.append(self.graTileAssignment(kernel, tensorParametersA))
-      kl.append(self.comment("global read addresses: tile offset assignment b"))
-      kl.append(self.graTileAssignment(kernel, tensorParametersB))
+      kl_2.append(self.comment("global read addresses: tile offset assignment a"))
+      kl_2.append(self.graTileAssignment(kernel, tensorParametersA))
+      kl_2.append(self.comment("global read addresses: tile offset assignment b"))
+      kl_2.append(self.graTileAssignment(kernel, tensorParametersB))
+      # init code optimization
+      # not init code opt case, add tile assignments code here
+      # init code opt case, not insert tile assignments code here and return tile assignments code separately for replacement
+      if not self.isInitCodeOptLW:
+        kl += kl_2
+        kl_2 = []
 
       self.dontAppendCode = isPap and (not needShift)
       self.dontAppendCode = self.dontAppendCode or forceNoTileCode
@@ -1741,39 +1748,51 @@ class KernelWriter(metaclass=abc.ABCMeta):
       ####################################
       # Local Write Addresses
       ####################################
-      kl.append(self.comment3("Local Write Addresses"))
+      kl_2.append(self.comment3("Local Write Addresses"))
 
       # tile assignments
-      kl.append(self.lwaTileAssignment(kernel, tensorParametersA))
-      kl.append(self.lwaTileAssignment(kernel, tensorParametersB))
+      kl_2.append(self.lwaTileAssignment(kernel, tensorParametersA))
+      kl_2.append(self.lwaTileAssignment(kernel, tensorParametersB))
 
       # unroll assignments
-      kl.append(self.lwaUnrollAssignment(kernel, tensorParametersA))
-      kl.append(self.lwaUnrollAssignment(kernel, tensorParametersB))
+      kl_2.append(self.lwaUnrollAssignment(kernel, tensorParametersA))
+      kl_2.append(self.lwaUnrollAssignment(kernel, tensorParametersB))
 
       # if PAP, no need to reset LWA, but if not OptNLL, we still do this (due to TailLoop)
 
       self.dontAppendCode = isPap and kernel["PrefetchAcrossPersistentMode"] == 1
       self.dontAppendCode = self.dontAppendCode or forceNoTileCode
       # first offsets
-      kl.append(self.comment("local write addresses: first offset a"))
-      kl.append(self.lwaFirstOffset(kernel, tensorParametersA))
-      kl.append(self.comment("local write addresses: first offset b"))
-      kl.append(self.lwaFirstOffset(kernel, tensorParametersB))
+      kl_2.append(self.comment("local write addresses: first offset a"))
+      kl_2.append(self.lwaFirstOffset(kernel, tensorParametersA))
+      kl_2.append(self.comment("local write addresses: first offset b"))
+      kl_2.append(self.lwaFirstOffset(kernel, tensorParametersB))
       self.dontAppendCode = False
       self.dontAppendCode = self.dontAppendCode or forceNoTileCode
 
       # final offsets
-      kl.append(self.lwaFinalOffsets(kernel, tensorParametersA))
-      kl.append(self.lwaFinalOffsets(kernel, tensorParametersB))
+      kl_2.append(self.lwaFinalOffsets(kernel, tensorParametersA))
+      kl_2.append(self.lwaFinalOffsets(kernel, tensorParametersB))
 
       # declare addresses
-      kl.append(self.lwaDeclareAddresses(kernel, tensorParametersA))
-      kl.append(self.lwaDeclareAddresses(kernel, tensorParametersB))
+      kl_2.append(self.lwaDeclareAddresses(kernel, tensorParametersA))
+      kl_2.append(self.lwaDeclareAddresses(kernel, tensorParametersB))
 
       # init pointers
-      kl.append(self.localWriteInitPointers(kernel, tensorParametersA))
-      kl.append(self.localWriteInitPointers(kernel, tensorParametersB))
+      kl_2.append(self.localWriteInitPointers(kernel, tensorParametersA))
+      kl_2.append(self.localWriteInitPointers(kernel, tensorParametersB))
+
+      # init code optimization
+      if self.isInitCodeOptLW:
+        # init code optimization case, release lwaVgpr here after all lwa code is generated
+        # (to avoid lwa vgpr overwritten by remaining lwa code)
+        self.lwaReleaseTileVgpr(kernel, tensorParametersA)
+        self.lwaReleaseTileVgpr(kernel, tensorParametersB)
+      else:
+        # not init code opt case, add local write code here
+        # init code opt case, not insert local write code here and return local write code separately for replacement
+        kl += kl_2
+        kl_2 = []
 
     ###########################################################################
     # summations loops: open
@@ -1876,7 +1895,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
 
     kl.append(self.comment3("End setupNewTile, isPap=%s") % isPap)
 
-    return kl
+    return kl, kl_2
 
 
   ##############################################################################
@@ -2204,7 +2223,8 @@ class KernelWriter(metaclass=abc.ABCMeta):
       if kernel["PrefetchGlobalRead"] == 2 and NLLlast:
         forceNoGRCode = True
 
-      newTileCodes = self.setupNewTile(kernel, self.tPA, self.tPB, isPap=True, isOptNLL=True, forceNoTileCode=forceNoTileCode, forceNoGRCode = forceNoGRCode)
+      newTileCodes, _ = self.setupNewTile(kernel, self.tPA, self.tPB, isPap=True, isOptNLL=True, \
+                                       forceNoTileCode=forceNoTileCode, forceNoGRCode = forceNoGRCode)
       codes = '\n'.join([str(x) for x in newTileCodes])
       kStr += codes
       # openPrefetchAcrossPersistent should be after newTileCodes to set correct values to ShadowLimit
@@ -2876,30 +2896,56 @@ class KernelWriter(metaclass=abc.ABCMeta):
     kl.append(self.functionSignatureSuffix(kernel))
     kl.append(self.functionBegin(kernel))
 
-    kl.append(self.comment3("Allocate Resources"))
-    kl.append(self.allocateResources(kernel))
+    # init code optimization: generate local read address code before wait for kernel arg load (in allocateResources())
+    klLR = []
 
     if self.enable["PreLoop"]:
       ####################################
       # Local Read Addresses
       ####################################
-      kl.append(self.comment3("Local Read Addresses"))
+      klLR.append(self.comment3("Local Read Addresses"))
 
       # tile assignments
-      kl.append(self.comment("local read addresses: tile assignments a/b"))
-      kl.append(self.lraTileAssignment(kernel, tensorParametersA, tensorParametersB))
+      klLR.append(self.comment("local read addresses: tile assignments a/b"))
+      klLR.append(self.lraTileAssignment(kernel, tensorParametersA, tensorParametersB))
 
       # final offsets
-      kl.append(self.comment("local read addresses: final offsets a"))
-      kl.append(self.lraFinalOffset(kernel, tensorParametersA))
-      kl.append(self.comment("local read addresses: final offsets b"))
-      kl.append(self.lraFinalOffset(kernel, tensorParametersB))
+      klLR.append(self.comment("local read addresses: final offsets a"))
+      klLR.append(self.lraFinalOffset(kernel, tensorParametersA))
+      klLR.append(self.comment("local read addresses: final offsets b"))
+      klLR.append(self.lraFinalOffset(kernel, tensorParametersB))
 
       # declare addresses
-      kl.append(self.comment("local read addresses: declare addresses a"))
-      kl.append(self.lraDeclareAddresses(kernel, tensorParametersA))
-      kl.append(self.comment("local read addresses: declare addresses b"))
-      kl.append(self.lraDeclareAddresses(kernel, tensorParametersB))
+      klLR.append(self.comment("local read addresses: declare addresses a"))
+      klLR.append(self.lraDeclareAddresses(kernel, tensorParametersA))
+      klLR.append(self.comment("local read addresses: declare addresses b"))
+      klLR.append(self.lraDeclareAddresses(kernel, tensorParametersB))
+
+    # init code optimization : allocate resource
+    self.lwaInitOptAllocate()
+
+    lraCode=None
+    placeholderInitCodeOpt=None
+    if self.isInitCodeOptLR:
+      if self.isInitCodeOptLW:
+        placeholderInitCodeOpt = "__placeholderInitCodeOpt__" # placeholder for local write code (for future replacement)
+
+      # string for local read code
+      lraCode = '\n'.join([str(x) for x in klLR])
+      # local write code is generated later. Here, just add placeholder to replace with local write code
+      if self.isInitCodeOptLW:
+        lraCode += '\n' + placeholderInitCodeOpt + '\n' 
+      klLR = [] # clean up after use
+
+    kl.append(self.comment3("Allocate Resources"))
+    kl.append(self.allocateResources(kernel, lraCode))
+    lraCode = None # clean up after use
+
+    if not self.isInitCodeOptLR:
+      # not init code optimization case
+      # add local read address code to kl after allocateResources()
+      kl += klLR
+      klLR = [] # clean up after use
 
     # doShadowInit performs initialization in the 'shadow' of the global mem prefetch
     self.doShadowInit = 0
@@ -2922,12 +2968,17 @@ class KernelWriter(metaclass=abc.ABCMeta):
 
       # first prefetch is outside persistent loop, subsequent prefetch will
       # be integrated into no-load-loop
-      kl += self.setupNewTile(kernel, tensorParametersA, tensorParametersB, isPap=False, isOptNLL=False)
+      kl_1, kl_LW = self.setupNewTile(kernel, tensorParametersA, tensorParametersB, isPap=False, isOptNLL=False)
+      kl += kl_1
       kl.append(self.openPersistentLoop(kernel))
     else:
       # prefetch is inside persistent loop
       kl.append(self.openPersistentLoop(kernel))
-      kl += self.setupNewTile(kernel, tensorParametersA, tensorParametersB, isPap=False, isOptNLL=False)
+      kl_1, kl_LW = self.setupNewTile(kernel, tensorParametersA, tensorParametersB, isPap=False, isOptNLL=False)
+      kl += kl_1
+
+    # init code optimization : release resource
+    self.lwaInitOptRelease()
 
     pack = [ Code.Module() for i in range (self.numVgprBuffer+1) ]
     self.preLoopLocalWriteCode = None
@@ -3347,7 +3398,8 @@ class KernelWriter(metaclass=abc.ABCMeta):
 
     if self.prefetchAcrossPersistent and kernel["PrefetchAcrossPersistentMode"] != 1:
       kl.append(str(self.openPrefetchAcrossPersistent(kernel, isOptNLL=False)))
-      kl += self.setupNewTile(kernel, self.tPA, self.tPB, isPap=True, isOptNLL=False)
+      kl_1, _ = self.setupNewTile(kernel, self.tPA, self.tPB, isPap=True, isOptNLL=False)
+      kl += kl_1
       kl.append(str(self.closePrefetchAcrossPersistent(kernel, isOptNLL=False)))
 
     kl.append(self.endSummation(kernel))
@@ -3432,6 +3484,11 @@ class KernelWriter(metaclass=abc.ABCMeta):
 
     kl.append(self.closeString(kernel))
     kStr = '\n'.join([str(x) for x in kl])
+    # init code opt
+    if placeholderInitCodeOpt != None:
+      # replace placeholder with localWriteCode
+      kStrLW = '\n'.join([str(x) for x in kl_LW])
+      kStr = kStr.replace(placeholderInitCodeOpt, kStrLW)
     afterFunctionSignature = kStr
 
     error = self.overflowedResources
@@ -4065,6 +4122,12 @@ class KernelWriter(metaclass=abc.ABCMeta):
       #if kernel["DirectToVgprA"] or kernel["DirectToVgprB"]:
       #  self.enableSingleNLLOpt = True
 
+    # init code optimization
+    # generate local read/write address code and global read tile offset code before wait for kernel arg load (if applicable)
+    # set False here for source kernel (enable only for Asm)
+    self.isInitCodeOptLR = False
+    self.isInitCodeOptLW = False
+
   @staticmethod
   def zpForSumIdx(sumIdx, zeroPad):
      """ Returns zero-pad for specified sumIdx if it matches or None if not """
@@ -4124,7 +4187,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
   # Allocate Resources
   ##############################################################################
   @abc.abstractmethod
-  def allocateResources(self, kernel):
+  def allocateResources(self, kernel, lraCode=None):
     return ""
 
 
@@ -4318,7 +4381,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
   # Global Read Addresses: Final Offsets A/B
   ##############################################################################
   @abc.abstractmethod
-  def graFinalOffsets(self, kernel, tP):
+  def graFinalOffsets(self, kernel, tP, releaseResource=False):
     return ""
 
   ##############################################################################
@@ -4351,10 +4414,17 @@ class KernelWriter(metaclass=abc.ABCMeta):
     return ""
 
   ##############################################################################
+  # Local Write Addresses: Release tile related vgpr
+  ##############################################################################
+  @abc.abstractmethod
+  def lwaReleaseTileVgpr(self, kernel, tP):
+    return ""
+
+  ##############################################################################
   # Local Write Addresses: First Offset A/B
   ##############################################################################
   @abc.abstractmethod
-  def lwaFirstOffset(self, kernel, tP, uDu):
+  def lwaFirstOffset(self, kernel, tP, uDu=0):
     return ""
 
   ##############################################################################
@@ -4369,6 +4439,20 @@ class KernelWriter(metaclass=abc.ABCMeta):
   ##############################################################################
   @abc.abstractmethod
   def lwaDeclareAddresses(self, kernel, tP):
+    return ""
+
+  ##############################################################################
+  # Local Write Addresses: Allocate tmpSgpr for initOpt
+  ##############################################################################
+  @abc.abstractmethod
+  def lwaInitOptAllocate(self):
+    return ""
+
+  ##############################################################################
+  # Local Write Addresses: Release tmpSgpr for initOpt
+  ##############################################################################
+  @abc.abstractmethod
+  def lwaInitOptRelease(self):
     return ""
 
   ##############################################################################

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -574,11 +574,13 @@ class KernelWriterAssembly(KernelWriter):
         if kernel["PackSummationDims"]:
           self.defineSgpr("Iter%s"%(sumDimChar),1)
 
-    if kernel["FractionalLoad"] == 2:
-      if kernel["fractionalPerpOverhangA"]:
-        self.defineSgpr("PerpOverhangVccA", 2, 2)
-      if kernel["fractionalPerpOverhangB"]:
-        self.defineSgpr("PerpOverhangVccB", 2, 2)
+    if not self.isInitCodeOptLW:
+      # init code optimization: define PerpOverhangVccA, B just after kernel args (need this before undef OFFSET)
+      if kernel["FractionalLoad"] == 2:
+        if kernel["fractionalPerpOverhangA"]:
+          self.defineSgpr("PerpOverhangVccA", 2, 2)
+        if kernel["fractionalPerpOverhangB"]:
+          self.defineSgpr("PerpOverhangVccB", 2, 2)
     if self.use64bShadowLimit:
       # If need more SGPR could overlap this with the Tensor2dSize regs
       self.defineSgpr("ShadowLimitA", 2, 2)
@@ -611,10 +613,12 @@ class KernelWriterAssembly(KernelWriter):
     self.defineSgpr("GlobalReadIncsA", self.numSgprGlobalReadIncsA)
     self.defineSgpr("GlobalReadIncsB", self.numSgprGlobalReadIncsB)
 
-    if kernel["LocalWriteUseSgprA"]:
-        self.defineSgpr("LocalWriteAddrA", 1)
-    if kernel["LocalWriteUseSgprB"]:
-        self.defineSgpr("LocalWriteAddrB", 1)
+    if not self.isInitCodeOptLW:
+      # init code optimization: define LocalWriteUseSgprA, B just after kernel args (need this before undef OFFSET)
+      if kernel["LocalWriteUseSgprA"]:
+          self.defineSgpr("LocalWriteAddrA", 1)
+      if kernel["LocalWriteUseSgprB"]:
+          self.defineSgpr("LocalWriteAddrB", 1)
 
     if kernel["_UseSgprForGRO"]:
       needFirstSgprOffset = kernel["DirectToLdsA"] and kernel["UseInstOffsetForGRO"]
@@ -726,6 +730,23 @@ class KernelWriterAssembly(KernelWriter):
     # checkGRO requires useSgprForGRO=0 so that code allocates and uses
     # the VGPRs that are used for the GRO offset checking
     assert not (kernel["_UseSgprForGRO"] and self.checkGRO)
+
+    # init code optimization setting
+    # generate local read/write address code before wait for kernel arg load
+    # enable only for Asm
+    self.isInitCodeOptLR = True
+    self.isInitCodeOptLW = self.isInitCodeOptLR
+    # disable init code opt for the following conditions
+    # - enabledSplitLDS and UnrollMajorLDSA or B: uReg will be overwritten (cannot move local write code before global read offset code)
+    # - PersistentKernel: need local write and tile code inside PK loop (cannot move to before wait for kernel arg load)
+    # - not BufferLoad: requires WorkGroup0,1 (means need to calculate WGM)
+    #-  groOffsetInMacroTile=0: requires WorkGroup0,1 (means need to calculate WGM)
+    if ((kernel.enabledSplitLDS and (kernel["UnrollMajorLDSA"] or kernel["UnrollMajorLDSB"])) or \
+        kernel["PersistentKernel"] or \
+        (not kernel["BufferLoad"]) or \
+        self.groOffsetInMacroTile == 0):
+      # disable init opt for local write
+      self.isInitCodeOptLW = False
 
     # Debug mode to explore combining VGPRs.
     # Saves VGPRs but doesn't generate correct answer
@@ -1817,6 +1838,19 @@ class KernelWriterAssembly(KernelWriter):
     if kernel["ProblemType"]["DataType"].is8bitFloat():
       if kernel["ProblemType"]["StochasticRounding"]: # in-device, only RNDSeed
         self.defineSgpr("RNDSeed", 1)  # seed for random number generation
+
+    if self.isInitCodeOptLW:
+      # init code optimization: define PerpOverhangVccA, B just after kernel args (need this before undef OFFSET)
+      if kernel["FractionalLoad"] == 2:
+        if kernel["fractionalPerpOverhangA"]:
+          self.defineSgpr("PerpOverhangVccA", 2, 2)
+        if kernel["fractionalPerpOverhangB"]:
+          self.defineSgpr("PerpOverhangVccB", 2, 2)
+      # init code optimization: define LocalWriteUseSgprA, B just after kernel args (need this before undef OFFSET)
+      if kernel["LocalWriteUseSgprA"]:
+          self.defineSgpr("LocalWriteAddrA", 1)
+      if kernel["LocalWriteUseSgprB"]:
+          self.defineSgpr("LocalWriteAddrB", 1)
 
     # dedicated sgpr(S) for storeC VGPR indexing
     # sgpr semaphore for message synchronization between different part of code section
@@ -3098,7 +3132,7 @@ class KernelWriterAssembly(KernelWriter):
     return kStr
 
   ##############################################################################
-  def allocateResources(self, kernel):
+  def allocateResources(self, kernel, lraCode=None):
     kStr = ""
 
     if kernel["StorePriorityOpt"]:
@@ -3181,6 +3215,12 @@ class KernelWriterAssembly(KernelWriter):
 
       if kernel.enabledSetPrioSplitLDS:
         kStr += inst("s_setprio", "1", "prioritize init code so as to issue load sooner")
+
+      # init code optimization
+      # add local read/write code (before wait for kernel arg load)
+      if lraCode != None :
+        kStr += lraCode
+
       kStr += inst("s_waitcnt", "lgkmcnt(0)", "wait for %u bytes of kern args" % self.kernArgOffset )
 
       if not kernel["ProblemType"]["StridedBatched"]:
@@ -3709,7 +3749,7 @@ class KernelWriterAssembly(KernelWriter):
     kStr += self.comment1("%s = gro%s-unroll = serial%s%s" \
         % (vgpr(uReg), tc, uOpStr, divisorName) )
 
-    tmpSgpr = self.getTmpSgpr(1).idx()
+    tmpSgpr = self.getTmpSgpr(1).idx() if self.initOptLwaTmpSgpr == None else self.initOptLwaTmpSgpr
 
     dividendReg = "Serial" # local serial
 
@@ -4942,6 +4982,23 @@ class KernelWriterAssembly(KernelWriter):
     return kStr
 
   ##############################################################################
+  # Local Write Addresses: Release tile related vgpr
+  ##############################################################################
+  def lwaReleaseTileVgpr(self, kernel, tP):
+    self.vgprPool.checkIn(tP["gpr"]["lwoT"])
+    tP["gpr"]["lwoT"] = None
+    if kernel["GlobalSplitU"] > 1:
+      self.vgprPool.checkIn(tP["gpr"]["uReg2"])
+      tP["gpr"]["uReg2"] = None
+    self.vgprPool.checkIn(tP["gpr"]["uReg"])
+    tP["gpr"]["uReg"] = None
+    if "subIterReg" in tP["gpr"]:
+      if tP["gpr"]["subIterReg"] is not None:
+        self.vgprPool.checkIn(tP["gpr"]["subIterReg"])
+      tP["gpr"]["subIterReg"] = None
+    return ""
+
+  ##############################################################################
   # Local Write Addresses: First Offset A/B
   # uDu: which part of G2L buffer to write to LDS
   ##############################################################################
@@ -4986,16 +5043,30 @@ class KernelWriterAssembly(KernelWriter):
 
       # LdsBlockSizePerPad: add padding
       if kernel["LdsBlockSizePerPad%s"%tc] != 0 and kernel["LdsPad%s"%tc] != 0:
-        tmpSgpr = self.getTmpSgpr(1).idx()
-        kStr += vectorStaticDivide(uReg, destVgpr, kernel["LdsBlockSizePerPad%s"%tc], tmpSgpr, \
+        tmpSgpr = self.getTmpSgpr(1).idx() if self.initOptLwaTmpSgpr == None else self.initOptLwaTmpSgpr
+        if self.isInitCodeOptLW:
+          # init code opt case, cannot reuse ureg (it will be used later)
+          tmpVgpr = self.vgprPool.checkOut(1, "tmpVgpr", self.preventVgprOverflowDuringNewTile)
+        else:
+          # reuse uReg
+          tmpVgpr = uReg
+        kStr += vectorStaticDivide(tmpVgpr, destVgpr, kernel["LdsBlockSizePerPad%s"%tc], tmpSgpr, \
           "padding %u per block %u" % (kernel["LdsPad%s"%tc], kernel["LdsBlockSizePerPad%s"%tc]))
-        kStr += staticMultiply(vgpr(uReg), vgpr(uReg), kernel["LdsPad%s"%tc] * tP["bpe"], sgpr(tmpSgpr), \
+        kStr += staticMultiply(vgpr(tmpVgpr), vgpr(tmpVgpr), kernel["LdsPad%s"%tc] * tP["bpe"], sgpr(tmpSgpr), \
           "padding %u per block %u" % (kernel["LdsPad%s"%tc], kernel["LdsBlockSizePerPad%s"%tc]))
-        kStr += inst("_v_add_u32", vgpr(destVgpr), vgpr(uReg), vgpr(destVgpr), \
+        kStr += inst("_v_add_u32", vgpr(destVgpr), vgpr(tmpVgpr), vgpr(destVgpr), \
           "add padding %u per block %u" % (kernel["LdsPad%s"%tc], kernel["LdsBlockSizePerPad%s"%tc]))
+        if tmpVgpr != uReg:
+          self.vgprPool.checkIn(tmpVgpr)
     else:
       ldlOffsetVgpr = self.vgprPool.checkOut(1, "ldlOffsetVgpr", self.preventVgprOverflowDuringNewTile)
       uRegScrap = self.vgprPool.checkOut(1, "uRegScrap", self.preventVgprOverflowDuringNewTile)
+      if self.isInitCodeOptLW:
+        # init code opt case, cannot reuse ureg (it will be used later)
+        tmpVgpr = self.vgprPool.checkOut(1, "tmpVgpr", self.preventVgprOverflowDuringNewTile)
+      else:
+        # reuse uReg
+        tmpVgpr = uReg
       # likely broken for dot4, revisit
       # odd tiles will write to MT, even tiles to normal location
       bpeOffsetLDL = tP["bpe"] if useEarlyBpeCalc else 1 # glvw<1 case, need to multiply bpe here
@@ -5013,7 +5084,7 @@ class KernelWriterAssembly(KernelWriter):
           vgpr(uReg), \
           "uReg & (LDL-1)%s)"%bpeComment)
       kStr += inst("v_and_b32", \
-          vgpr(uReg), \
+          vgpr(tmpVgpr), \
           ~(LdlMinus1Bpe), \
           vgpr(uReg), \
           "uReg & (LDL-1)%s)"%bpeComment)
@@ -5023,37 +5094,39 @@ class KernelWriterAssembly(KernelWriter):
           vgpr(tP["gpr"]["lwoT"]), \
           "lwoT & (LDL-1)%s)"%bpeComment)
       kStr += inst("_v_lshl_add_u32", \
-          vgpr(uReg), \
+          vgpr(tmpVgpr), \
           vgpr(ldlOffsetVgpr), \
           #log2(kernel["LocalDotLayout"]), \
           0, \
-          vgpr(uReg), \
+          vgpr(tmpVgpr), \
           "shift scrap by LDL")
       kStr += inst("v_mul_u32_u24", \
-          vgpr(uReg), \
+          vgpr(tmpVgpr), \
           hex(kernel["MacroTile%s"%tP["tensorChar"]] + LdsPad), \
-          vgpr(uReg), \
+          vgpr(tmpVgpr), \
           "lw%s%s**(MT%s + PAD)"%(tP["tensorChar"], self.unrollChar, tP["tensorChar"]))
       kStr += inst("_v_add_co_u32", \
-          vgpr(uReg), \
+          vgpr(tmpVgpr), \
           self.vcc, \
           vgpr(uRegScrap), \
-          vgpr(uReg), \
+          vgpr(tmpVgpr), \
           "add scraps from LDL masking")
       if useEarlyBpeCalc:
         kStr += inst("_v_add_u32", \
             vgpr(destVgpr), \
-            vgpr(uReg), \
+            vgpr(tmpVgpr), \
             vgpr(destVgpr), \
             "")
       else:
         kStr += inst("_v_add_lshl_u32", \
             vgpr(destVgpr), \
-            vgpr(uReg), \
+            vgpr(tmpVgpr), \
             vgpr(destVgpr), \
             hex(log2(tP["bpe"])), \
             " *= bpe")
       self.vgprPool.checkIn(uRegScrap)
+      if tmpVgpr != uReg:
+        self.vgprPool.checkIn(tmpVgpr)
       self.vgprPool.checkIn(ldlOffsetVgpr)
 
     if tP["isB"]:
@@ -5066,11 +5139,13 @@ class KernelWriterAssembly(KernelWriter):
             "lwFOB = lwB%s + lwB%s*MT%s + LDS_OFFSET_B=%u*%u" % (tP["tileChar"], \
             self.unrollChar, tP["tileChar"], kernel["LdsOffsetB"], self.bpeAB) )
 
-    self.vgprPool.checkIn(tP["gpr"]["lwoT"])
-    tP["gpr"]["lwoT"] = None
-    if kernel["GlobalSplitU"] > 1:
-      self.vgprPool.checkIn(tP["gpr"]["uReg2"])
-      tP["gpr"]["uReg2"] = None
+    # skip releasing tile related vreg here in init code opt case
+    if not self.isInitCodeOptLW:
+      self.vgprPool.checkIn(tP["gpr"]["lwoT"])
+      tP["gpr"]["lwoT"] = None
+      if kernel["GlobalSplitU"] > 1:
+        self.vgprPool.checkIn(tP["gpr"]["uReg2"])
+        tP["gpr"]["uReg2"] = None
     #LSC_ * LSP_
     numBytesPerElement = kernel["ProblemType"]["DataType"].numBytes()
     validWIPerLoad     = int(kernel[tP["lsc"]] * kernel[tP["lsp"]]/tP["glvw"])
@@ -5084,7 +5159,7 @@ class KernelWriterAssembly(KernelWriter):
     assert (tP["glvw"] < 1 or kernel[tP["lsc"]] * kernel[tP["lsp"]] % tP["glvw"] == 0)
 
     if validBytesPerLoad != maxBytesPerLoad:
-      tmpSgpr = self.getTmpSgpr(1).idx()
+      tmpSgpr = self.getTmpSgpr(1).idx() if self.initOptLwaTmpSgpr == None else self.initOptLwaTmpSgpr
       kStr += inst("s_mov_b32", sgpr(tmpSgpr), validWIPerLoad, \
           "lsc*lsp=%u*%u"%(kernel[tP["lsc"]],kernel[tP["lsp"]] ))
       kStr += inst("v_cmp_lt_u32", \
@@ -5103,7 +5178,7 @@ class KernelWriterAssembly(KernelWriter):
       self.vgprPool.checkIn(tmpVgpr)
 
     elif self.inTailLoop and kernel.enabledSplitLDS: # where (DepthU for global read) != (DepthU for compute)
-      tmpSgpr = self.getTmpSgpr(1).idx()
+      tmpSgpr = self.getTmpSgpr(1).idx() if self.initOptLwaTmpSgpr == None else self.initOptLwaTmpSgpr
 
       # only for TN tensor + TN lds layout
       assert tP["tlu"] == 0
@@ -5135,7 +5210,7 @@ class KernelWriterAssembly(KernelWriter):
       if kernel["FractionalLoad"] == 2:
         mask = "PerpOverhangVcc%s"%tc
       else:
-        mask = self.getTmpSgpr(2).idx()
+        mask = self.getTmpSgpr(2).idx() if self.initOptLwaTmpSgpr == None else self.initOptLwaTmpSgpr
       kStr += self.comment1("Compute fractional overhang")
       kStr += inst("s_mov_b32", sgpr(mask), validWI, \
           "overhang=%u, validWI=%u" % (overhang, validWI))
@@ -5153,12 +5228,14 @@ class KernelWriterAssembly(KernelWriter):
                     "Mask load so out-of-gr-tile bounds returns 0. Note 1.0f=0x3f80000 which is large non-neg int")
 
 
-    self.vgprPool.checkIn(tP["gpr"]["uReg"])
-    tP["gpr"]["uReg"] = None
-    if "subIterReg" in tP["gpr"]:
-      if tP["gpr"]["subIterReg"] is not None:
-        self.vgprPool.checkIn(tP["gpr"]["subIterReg"])
-      tP["gpr"]["subIterReg"] = None
+    # skip releasing tile related vreg here in init code opt case
+    if not self.isInitCodeOptLW:
+      self.vgprPool.checkIn(tP["gpr"]["uReg"])
+      tP["gpr"]["uReg"] = None
+      if "subIterReg" in tP["gpr"]:
+        if tP["gpr"]["subIterReg"] is not None:
+          self.vgprPool.checkIn(tP["gpr"]["subIterReg"])
+        tP["gpr"]["subIterReg"] = None
     # dump lds write offsets
     #if tP["isA"]:
       #kStr += self.dump(vgpr("LocalWriteAddr%s"%tP["tensorChar"]))
@@ -5177,6 +5254,23 @@ class KernelWriterAssembly(KernelWriter):
   ##############################################################################
   def lwaDeclareAddresses(self, kernel, tP):
     return ""
+
+  ##############################################################################
+  # Local Write Addresses: Allocate tmpSgpr for initOpt
+  ##############################################################################
+  def lwaInitOptAllocate(self):
+    maxTmpRegNum = 2
+    self.initOptLwaTmpSgpr = None
+    if self.isInitCodeOptLW:
+      self.initOptLwaTmpSgpr = self.sgprPool.checkOutAligned(maxTmpRegNum, 2, preventOverflow=0)
+
+  ##############################################################################
+  # Local Write Addresses: Release tmpSgpr for initOpt
+  ##############################################################################
+  def lwaInitOptRelease(self):
+    if self.initOptLwaTmpSgpr:
+      self.sgprPool.checkIn(self.initOptLwaTmpSgpr)
+      self.initOptLwaTmpSgpr = None
 
   ##############################################################################
   # Local Read Addresses: Tile Assignment

--- a/Tensile/KernelWriterSource.py
+++ b/Tensile/KernelWriterSource.py
@@ -951,7 +951,7 @@ class KernelWriterSource(KernelWriter):
   ##############################################################################
   # Allocate Resources
   ##############################################################################
-  def allocateResources(self, kernel):
+  def allocateResources(self, kernel, lraCode=None):
     kStr = ""
 
     kStr += "  unsigned int serial = %s(0);%s" \
@@ -1687,6 +1687,12 @@ class KernelWriterSource(KernelWriter):
     return kStr
 
   ##############################################################################
+  # Local Write Addresses: Release tile related vgpr
+  ##############################################################################
+  def lwaReleaseTileVgpr(self, kernel, tP):
+    return ""
+
+  ##############################################################################
   # Local Write Addresses: First Offset A/B
   ##############################################################################
   def lwaFirstOffset(self, kernel, tP, uDu=0):
@@ -1733,6 +1739,18 @@ class KernelWriterSource(KernelWriter):
                 % (self.sharedPtrStr, tP["tensorChar"], \
                 para, sPara, perp, sPerp, self.endLine )
     return kStr
+
+  ##############################################################################
+  # Local Write Addresses: Allocate tmpSgpr for initOpt
+  ##############################################################################
+  def lwaInitOptAllocate(self):
+    return ""
+
+  ##############################################################################
+  # Local Write Addresses: Release tmpSgpr for initOpt
+  ##############################################################################
+  def lwaInitOptRelease(self):
+    return ""
 
   ##############################################################################
   # Local Read Addresses: Tile Assignment A/B


### PR DESCRIPTION
- moved local read address code before waitcnt for kernel argument
- moved local write address and global read tile offset assignment code before waitcnt for kernel argument under certain conditions
- allocated some registers before undefining OffsetA,B,C,D (can be used before finishing kernel argument load)