### PR TITLE
Disable the hardware monitor for aquavanjaram 942

### DIFF
--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -2186,6 +2186,9 @@ def assignGlobalParameters( config ):
     if os.name == "nt":
       globalParameters["CurrentISA"] = (9,0,6)
       printWarning("Failed to detect ISA so forcing (gfx906) on windows")
+  if globalParameters["CurrentISA"] == (9,4,2):
+    printWarning("HardwareMonitor currently disabled for gfx942")
+    globalParameters["HardwareMonitor"] = False
 
   # For ubuntu platforms, call dpkg to grep the version of hip-clang.  This check is platform specific, and in the future
   # additional support for yum, dnf zypper may need to be added.  On these other platforms, the default version of


### PR DESCRIPTION
There are few changes needed in ROCm SMI for aquavanjaram 942 until then hardware monitor is disabled for aquavanjaram 942.