### PR TITLE
Clear hipErrorNotFound error code since it is an expected part of the search

### DIFF
--- a/Tensile/Source/lib/source/hip/HipSolutionAdapter.cpp
+++ b/Tensile/Source/lib/source/hip/HipSolutionAdapter.cpp
@@ -230,6 +230,10 @@ namespace Tensile
                 {
                     return err;
                 }
+                else
+                {
+                    (void)hipGetLastError(); // clear hipErrorNotFound
+                }
             }
 
             return err;


### PR DESCRIPTION
We expect to encounter hipErrorNotFound occasionally while searching for a kernel, and this error case is already handled. We need to call hipGetLastError to reset the stored error code so other apps don't assume an error was generated on one of their hip calls.