### PR TITLE
Disable HW monitor for 9fx1101 and gfx1102 products

### DIFF
--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -2186,8 +2186,9 @@ def assignGlobalParameters( config ):
     if os.name == "nt":
       globalParameters["CurrentISA"] = (9,0,6)
       printWarning("Failed to detect ISA so forcing (gfx906) on windows")
-  if globalParameters["CurrentISA"] == (9,4,2):
-    printWarning("HardwareMonitor currently disabled for gfx942")
+  if globalParameters["CurrentISA"] == (9,4,2) or globalParameters["CurrentISA"] == (11,0,0) or \
+     globalParameters["CurrentISA"] == (11,0,1) or globalParameters["CurrentISA"] == (11,0,2):
+    printWarning("HardwareMonitor currently disabled for gfx942 or gfx1100/gfx1101/gfx1102")
     globalParameters["HardwareMonitor"] = False
 
   # For ubuntu platforms, call dpkg to grep the version of hip-clang.  This check is platform specific, and in the future


### PR DESCRIPTION
ROCm SMI HW monitor has been disabled for 9fx1101 and gfx1102 products.