### PR TITLE
PCIID Changes from 32bit to 64bit for ROCm SMI HW monitor

### DIFF
--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -2186,8 +2186,9 @@ def assignGlobalParameters( config ):
     if os.name == "nt":
       globalParameters["CurrentISA"] = (9,0,6)
       printWarning("Failed to detect ISA so forcing (gfx906) on windows")
-  if globalParameters["CurrentISA"] == (9,4,2):
-    printWarning("HardwareMonitor currently disabled for gfx942")
+  if globalParameters["CurrentISA"] == (9,4,2) or globalParameters["CurrentISA"] == (11,0,0) or \
+     globalParameters["CurrentISA"] == (11,0,1) or globalParameters["CurrentISA"] == (11,0,2):
+    printWarning("HardwareMonitor currently disabled for gfx942 or gfx1100/gfx1101/gfx1102")
     globalParameters["HardwareMonitor"] = False
 
   # For ubuntu platforms, call dpkg to grep the version of hip-clang.  This check is platform specific, and in the future

--- a/Tensile/Source/client/source/HardwareMonitor.cpp
+++ b/Tensile/Source/client/source/HardwareMonitor.cpp
@@ -96,11 +96,13 @@ namespace Tensile
                                                     hipDeviceIndex));
             }
 #endif
-
+            // PCIID format changes from 32bit to 64bit, Below is the new PCI format ID from ROCm 4.0.
+            // Note:FUNCTION[0:2]bits is only used by aquanjaram TPX mode. This is not supported in HIP API yet, will need modification in future.
+            // BDFID = ((DOMAIN & 0xffffffff) << 32) | ((BUS & 0xff) << 8) | ((DEVICE & 0x1f) <<3 ) | (FUNCTION & 0x7)
             uint64_t hipPCIID = 0;
-            hipPCIID |= props.pciDeviceID & 0xFF;
-            hipPCIID |= ((props.pciBusID & 0xFF) << 8);
-            hipPCIID |= (props.pciDomainID) << 16;
+            hipPCIID |= (((uint64_t)props.pciDomainID & 0xffffffff) << 32);
+            hipPCIID |= ((props.pciBusID & 0xff) << 8);
+            hipPCIID |= ((props.pciDeviceID & 0x1f) << 3);
 
             uint32_t smiCount = 0;
 


### PR DESCRIPTION
resolves #SWDEV-419897
PCIID has been changed from 32bit to 64 bit from ROCm version 4.0 onwards. This PCI ID used to get the correct device index.
if the ROCM_VISIBLE_DEVICES=2, then “hip device 0” will match “ROCm SMI device 2”, and the way to discover that is with the PCI ID.

   