### PR TITLE
Predicate for APU libs

### DIFF
--- a/HostLibraryTests/CachingLibrary_test.cpp
+++ b/HostLibraryTests/CachingLibrary_test.cpp
@@ -255,8 +255,8 @@ TEST(Hashing, AMDGPU)
             for(int c1 : counts)
                 for(int c2 : counts)
                 {
-                    AMDGPU g1(p1, c1, "g1");
-                    AMDGPU g2(p2, c2, "g2");
+                    AMDGPU g1(p1, c1, 0, "g1");
+                    AMDGPU g2(p2, c2, 0, "g2");
 
                     if(p1 != p2 || c1 != c2)
                     {

--- a/HostLibraryTests/ContractionSelectionLibrary_test.cpp
+++ b/HostLibraryTests/ContractionSelectionLibrary_test.cpp
@@ -39,7 +39,7 @@ using namespace Tensile;
 TEST(ContractionSelectionLibraryTest, Single)
 {
     std::shared_ptr<Hardware> hardware = std::make_shared<AMDGPU>(
-        AMDGPU::Processor::gfx900, 64, "AMD Radeon Vega Frontier Edition");
+        AMDGPU::Processor::gfx900, 64, 0, "AMD Radeon Vega Frontier Edition");
 
     SingleContractionLibrary lib;
 
@@ -53,11 +53,11 @@ TEST(ContractionSelectionLibraryTest, Single)
 TEST(ContractionSelectionLibraryTest, GPUSelection)
 {
     std::shared_ptr<Hardware> v10 = std::make_shared<AMDGPU>(
-        AMDGPU::Processor::gfx900, 64, "AMD Radeon Vega Frontier Edition");
+        AMDGPU::Processor::gfx900, 64, 0, "AMD Radeon Vega Frontier Edition");
     std::shared_ptr<Hardware> v20
-        = std::make_shared<AMDGPU>(AMDGPU::Processor::gfx906, 60, "AMD Radeon Vega 7");
+        = std::make_shared<AMDGPU>(AMDGPU::Processor::gfx906, 60, 0, "AMD Radeon Vega 7");
     std::shared_ptr<Hardware> v20_64CU
-        = std::make_shared<AMDGPU>(AMDGPU::Processor::gfx906, 64, "AMD Radeon Vega 7");
+        = std::make_shared<AMDGPU>(AMDGPU::Processor::gfx906, 64, 0, "AMD Radeon Vega 7");
 
     // Create solutions
     auto v20Solution      = std::make_shared<ContractionSolution>();

--- a/HostLibraryTests/ProjectedPerformance_test.cpp
+++ b/HostLibraryTests/ProjectedPerformance_test.cpp
@@ -100,7 +100,7 @@ TEST(ContractionPerformance, Problem1)
     auto problem
         = ContractionProblem::GEMM(false, false, 1536, 1536, 64, 1536, 64, 1536, 1.5, false, 1.0);
 
-    AMDGPU hardware(Tensile::AMDGPU::Processor::gfx906, 64, "gfx906");
+    AMDGPU hardware(Tensile::AMDGPU::Processor::gfx906, 64, 0, "gfx906");
     double perf = solution->projectedPerformance(problem, hardware).speedGFlops;
 
     ASSERT_DOUBLE_EQ(perf, 3000.0);
@@ -128,7 +128,7 @@ TEST(ContractionPerformance, Problem2)
     auto problem
         = ContractionProblem::GEMM(false, false, 384, 192, 60, 384, 60, 384, 1.5, false, 1.0);
 
-    AMDGPU hardware(Tensile::AMDGPU::Processor::gfx906, 64, "gfx906");
+    AMDGPU hardware(Tensile::AMDGPU::Processor::gfx906, 64, 0, "gfx906");
     double perf = solution->projectedPerformance(problem, hardware).speedGFlops;
 
     ASSERT_DOUBLE_EQ(perf, 843.75);
@@ -156,7 +156,7 @@ TEST(ContractionPerformance, Problem3)
     auto problem
         = ContractionProblem::GEMM(false, false, 384, 192, 60, 384, 60, 384, 1.5, false, 1.0);
 
-    AMDGPU hardware(Tensile::AMDGPU::Processor::gfx906, 64, "gfx906");
+    AMDGPU hardware(Tensile::AMDGPU::Processor::gfx906, 64, 0, "gfx906");
     auto   model = solution->projectedPerformance(problem, hardware);
 
     // std::cout << model << "\n";
@@ -188,7 +188,7 @@ TEST(ContractionPerformance, Problem4)
     auto problem
         = ContractionProblem::GEMM(false, false, 1536, 1575, 64, 1536, 64, 1536, 1.5, false, 3.0);
 
-    AMDGPU hardware(Tensile::AMDGPU::Processor::gfx906, 64, "gfx906");
+    AMDGPU hardware(Tensile::AMDGPU::Processor::gfx906, 64, 0, "gfx906");
     auto   model = solution->projectedPerformance(problem, hardware);
 
     // std::cout << model << "\n";

--- a/HostLibraryTests/llvm/LibraryPerformance_test.cpp
+++ b/HostLibraryTests/llvm/LibraryPerformance_test.cpp
@@ -285,8 +285,8 @@ std::vector<LibraryPerformanceTest::ParamType> GetLibraries(std::string const& e
 {
     std::vector<LibraryPerformanceTest::ParamType> rv;
 
-    std::vector<AMDGPU> gpus{AMDGPU(AMDGPU::Processor::gfx900, 64, "Vega 10"),
-                             AMDGPU(AMDGPU::Processor::gfx906, 64, "Vega 20")};
+    std::vector<AMDGPU> gpus{AMDGPU(AMDGPU::Processor::gfx900, 64, 0, "Vega 10"),
+                             AMDGPU(AMDGPU::Processor::gfx906, 64, 0, "Vega 20")};
 
     for(auto const& gpu : gpus)
     {
@@ -298,9 +298,9 @@ std::vector<LibraryPerformanceTest::ParamType> GetLibraries(std::string const& e
     }
 
     rv.push_back(std::make_tuple(
-        AMDGPU(AMDGPU::Processor::gfx908, 64, "Arcturus"), "rocBLAS_Full." + ext, false, true));
+        AMDGPU(AMDGPU::Processor::gfx908, 64, 0, "Arcturus"), "rocBLAS_Full." + ext, false, true));
     rv.push_back(std::make_tuple(
-        AMDGPU(AMDGPU::Processor::gfx1010, 40, "Navi"), "KernelsLiteNavi." + ext, true, false));
+        AMDGPU(AMDGPU::Processor::gfx1010, 40, 0, "Navi"), "KernelsLiteNavi." + ext, true, false));
 
     return rv;
 }

--- a/Tensile/Hardware.py
+++ b/Tensile/Hardware.py
@@ -1,6 +1,6 @@
 ################################################################################
 #
-# Copyright (C) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -33,20 +33,20 @@ class HardwarePredicate(Properties.Predicate):
         return cls("AMDGPU", value=cls("Processor", value=gfxArch))
 
     @classmethod
-    def FromHardware(cls, isa, cuCount=None, dmmAccessFromHost=None):
+    def FromHardware(cls, isa, cuCount=None, isAPU=None):
         gfxArch = Common.gfxName(isa)
-        if cuCount == None and dmmAccessFromHost == None:
+        if cuCount == None and isAPU == None:
             return cls("AMDGPU", value=cls("Processor", value=gfxArch))
         elif cuCount == None:
             return cls("AMDGPU", value=cls.And([cls("Processor", value=gfxArch),
-                                                cls("DMMAccessFromHost", value=dmmAccessFromHost)]))
-        elif dmmAccessFromHost == None:
+                                                cls("IsAPU", value=isAPU)]))
+        elif isAPU == None:
             return cls("AMDGPU", value=cls.And([cls("Processor", value=gfxArch),
                                                 cls("CUCount", value=cuCount)]))
         else:
             return cls("AMDGPU", value=cls.And([cls("Processor", value=gfxArch),
                                                 cls("CUCount", value=cuCount),
-                                                cls("DMMAccessFromHost", value=dmmAccessFromHost)]))
+                                                cls("IsAPU", value=isAPU)]))
 
     def __lt__(self, other):
         # Use superclass logic for TruePreds
@@ -60,26 +60,26 @@ class HardwarePredicate(Properties.Predicate):
             myProcPred = next(iter(x for x in myAndPred.value if x.tag == "Processor"), None)
             myCUPred = next(iter(x for x in myAndPred.value if x.tag == "CUCount"), None)
             myCUCount = myCUPred.value if myCUPred != None else 0
-            myDMMPred = next(iter(x for x in myAndPred.value if x.tag == "DMMAccessFromHost"), None)
-            myDMMAccessFromHost = myDMMPred.value if myDMMPred != None else -1
+            myIsAPUPred = next(iter(x for x in myAndPred.value if x.tag == "IsAPU"), None)
+            myIsAPU = myIsAPUPred.value if myIsAPUPred != None else -1
         else:
             myProcPred = self.value
             myCUCount = 0
-            myDMMAccessFromHost = -1
+            myIsAPU = -1
 
         if other.value.tag == 'And':
             otherAndPred = other.value
             otherProcPred = next(iter(x for x in otherAndPred.value if x.tag == "Processor"), None)
             otherCUPred = next(iter(x for x in otherAndPred.value if x.tag == "CUCount"), None)
             otherCUCount = otherCUPred.value if otherCUPred != None else 0
-            otherDMMPred = next(iter(x for x in otherAndPred.value if x.tag == "DMMAccessFromHost"), None)
-            otherDMMAccessFromHost = otherDMMPred.value if otherDMMPred != None else -1
+            otherIsAPUPred = next(iter(x for x in otherAndPred.value if x.tag == "IsAPU"), None)
+            otherIsAPU = otherIsAPUPred.value if otherIsAPUPred != None else -1
         else:
             otherProcPred = other.value
             otherCUCount = 0
-            otherDMMAccessFromHost = -1
+            otherIsAPUAccessFromHost = -1
 
-        if myDMMAccessFromHost == otherDMMAccessFromHost:
+        if myIsAPU == otherIsAPU:
             # If CU properties are empty, then compare processor predicates
             if myCUCount == otherCUCount == 0:
                 # Make sure that we have valid processor preds
@@ -94,4 +94,4 @@ class HardwarePredicate(Properties.Predicate):
 
             # Higher priority given to higher CU count
             return myCUCount > otherCUCount
-        return myDMMAccessFromHost > otherDMMAccessFromHost
+        return myIsAPU > otherIsAPU

--- a/Tensile/Hardware.py
+++ b/Tensile/Hardware.py
@@ -77,7 +77,7 @@ class HardwarePredicate(Properties.Predicate):
         else:
             otherProcPred = other.value
             otherCUCount = 0
-            otherIsAPUAccessFromHost = -1
+            otherIsAPU = -1
 
         if myIsAPU == otherIsAPU:
             # If CU properties are empty, then compare processor predicates

--- a/Tensile/Hardware.py
+++ b/Tensile/Hardware.py
@@ -61,11 +61,11 @@ class HardwarePredicate(Properties.Predicate):
             myCUPred = next(iter(x for x in myAndPred.value if x.tag == "CUCount"), None)
             myCUCount = myCUPred.value if myCUPred != None else 0
             myDMMPred = next(iter(x for x in myAndPred.value if x.tag == "DMMAccessFromHost"), None)
-            myDMMAccessFromHost = myDMMPred.value if myDMMPred != None else 0
+            myDMMAccessFromHost = myDMMPred.value if myDMMPred != None else -1
         else:
             myProcPred = self.value
             myCUCount = 0
-            myDMMAccessFromHost = 0
+            myDMMAccessFromHost = -1
 
         if other.value.tag == 'And':
             otherAndPred = other.value
@@ -73,13 +73,13 @@ class HardwarePredicate(Properties.Predicate):
             otherCUPred = next(iter(x for x in otherAndPred.value if x.tag == "CUCount"), None)
             otherCUCount = otherCUPred.value if otherCUPred != None else 0
             otherDMMPred = next(iter(x for x in otherAndPred.value if x.tag == "DMMAccessFromHost"), None)
-            otherDMMAccessFromHost = otherDMMPred.value if otherDMMPred != None else 0
+            otherDMMAccessFromHost = otherDMMPred.value if otherDMMPred != None else -1
         else:
             otherProcPred = other.value
             otherCUCount = 0
-            otherDMMAccessFromHost = 0
+            otherDMMAccessFromHost = -1
 
-        if myDMMAccessFromHost == otherDMMAccessFromHost == 0:
+        if myDMMAccessFromHost == otherDMMAccessFromHost:
             # If CU properties are empty, then compare processor predicates
             if myCUCount == otherCUCount == 0:
                 # Make sure that we have valid processor preds

--- a/Tensile/Hardware.py
+++ b/Tensile/Hardware.py
@@ -53,8 +53,8 @@ class HardwarePredicate(Properties.Predicate):
         if other.tag == 'TruePred' or self.tag == 'TruePred':
             return super().__lt__(other)
 
-        # Compute unit counts are embedded as 'And' with
-        # 'Processor' and 'ComputeUnitCount' as children
+        # Compute unit counts or APU/XPU versions are embedded as 'And' with
+        # 'Processor', 'CUCount', and 'IsAPU' as children
         if self.value.tag == 'And':
             myAndPred = self.value
             myProcPred = next(iter(x for x in myAndPred.value if x.tag == "Processor"), None)
@@ -79,6 +79,7 @@ class HardwarePredicate(Properties.Predicate):
             otherCUCount = 0
             otherIsAPU = -1
 
+        # If APU properties are the same, then check CU count or architecture
         if myIsAPU == otherIsAPU:
             # If CU properties are empty, then compare processor predicates
             if myCUCount == otherCUCount == 0:
@@ -94,4 +95,5 @@ class HardwarePredicate(Properties.Predicate):
 
             # Higher priority given to higher CU count
             return myCUCount > otherCUCount
+        # APU sorted before XPU, and XPU sorted before generic
         return myIsAPU > otherIsAPU

--- a/Tensile/LibraryIO.py
+++ b/Tensile/LibraryIO.py
@@ -1,6 +1,6 @@
 ################################################################################
 #
-# Copyright (C) 2016-2022 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2016-2023 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -179,8 +179,8 @@ def parseLibraryLogicData(data, srcFile="?"):
     if "CUCount" not in data:
         data["CUCount"] = None
 
-    if "DMMAccessFromHost" not in data:
-        data["DMMAccessFromHost"] = None
+    if "IsAPU" not in data:
+        data["IsAPU"] = None
 
     if "Fp16AltImpl" not in data:
         data["Fp16AltImpl"] = False
@@ -236,12 +236,12 @@ def parseLibraryLogicList(data, srcFile="?"):
         rv["ArchitectureName"] = data[2]["Architecture"]
         if "CUCount" in data[2]:
             rv["CUCount"] = data[2]["CUCount"]
-        if "DMMAccessFromHost" in data[2]:
-            rv["DMMAccessFromHost"] = data[2]["DMMAccessFromHost"]
+        if "IsAPU" in data[2]:
+            rv["IsAPU"] = data[2]["IsAPU"]
     else:
         rv["ArchitectureName"] = data[2]
         rv["CUCount"] = None
-        rv["DMMAccessFromHost"] = None
+        rv["IsAPU"] = None
 
     rv["ExactLogic"] = data[7]
     # data[8] previously contained range logic, which has been retired
@@ -309,8 +309,8 @@ def createLibraryLogic(schedulePrefix, architectureName, deviceNames, logicTuple
         rv["ArchitectureName"] = architectureName["Architecture"]
         if "CUCount" in architectureName:
             rv["CUCount"] = architectureName["CUCount"]
-        if "DMMAccessFromHost" in architectureName:
-            rv["DMMAccessFromHost"] = architectureName["DMMAccessFromHost"]
+        if "IsAPU" in architectureName:
+            rv["IsAPU"] = architectureName["IsAPU"]
     else:
         rv["ArchitectureName"] = architectureName
 

--- a/Tensile/LibraryIO.py
+++ b/Tensile/LibraryIO.py
@@ -179,6 +179,9 @@ def parseLibraryLogicData(data, srcFile="?"):
     if "CUCount" not in data:
         data["CUCount"] = None
 
+    if "DMMAccessFromHost" not in data:
+        data["DMMAccessFromHost"] = None
+
     if "Fp16AltImpl" not in data:
         data["Fp16AltImpl"] = False
 
@@ -231,10 +234,14 @@ def parseLibraryLogicList(data, srcFile="?"):
 
     if type(data[2]) is dict:
         rv["ArchitectureName"] = data[2]["Architecture"]
-        rv["CUCount"] = data[2]["CUCount"]
+        if "CUCount" in data[2]:
+            rv["CUCount"] = data[2]["CUCount"]
+        if "DMMAccessFromHost" in data[2]:
+            rv["DMMAccessFromHost"] = data[2]["DMMAccessFromHost"]
     else:
         rv["ArchitectureName"] = data[2]
         rv["CUCount"] = None
+        rv["DMMAccessFromHost"] = None
 
     rv["ExactLogic"] = data[7]
     # data[8] previously contained range logic, which has been retired
@@ -300,7 +307,10 @@ def createLibraryLogic(schedulePrefix, architectureName, deviceNames, logicTuple
     # architecture
     if type(architectureName) is dict:
         rv["ArchitectureName"] = architectureName["Architecture"]
-        rv["CUCount"] = architectureName["CUCount"]
+        if "CUCount" in architectureName:
+            rv["CUCount"] = architectureName["CUCount"]
+        if "DMMAccessFromHost" in architectureName:
+            rv["DMMAccessFromHost"] = architectureName["DMMAccessFromHost"]
     else:
         rv["ArchitectureName"] = architectureName
 

--- a/Tensile/SolutionLibrary.py
+++ b/Tensile/SolutionLibrary.py
@@ -288,7 +288,7 @@ class MasterSolutionLibrary:
 
             if lazyLibrary:
                 if cuCount: placeholderName += "_CU" + str(cuCount)
-                if dmmAccessFromHost: placeholderName += "_DMM" + str(dmmAccessFromHost)
+                if dmmAccessFromHost is not None: placeholderName += "_DMM" + str(dmmAccessFromHost)
                 placeholderName += "_" + str(devicePart)
 
             return newLib, placeholderName

--- a/Tensile/SolutionLibrary.py
+++ b/Tensile/SolutionLibrary.py
@@ -1,6 +1,6 @@
 ################################################################################
 #
-# Copyright (C) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -276,19 +276,21 @@ class MasterSolutionLibrary:
         def hardware(d, problemType, solutions, library, placeholderName):
             devicePart = d["ArchitectureName"]
             cuCount = d["CUCount"]
-            dmmAccessFromHost = d["DMMAccessFromHost"]
+            isAPU = d["IsAPU"]
 
             newLib = PredicateLibrary(tag="Hardware")
             if devicePart == "fallback":
                 pred = Hardware.HardwarePredicate("TruePred")
             else:
-                pred = Hardware.HardwarePredicate.FromHardware(Common.gfxArch(devicePart), cuCount, dmmAccessFromHost)
+                pred = Hardware.HardwarePredicate.FromHardware(Common.gfxArch(devicePart), cuCount, isAPU)
 
             newLib.rows.append({"predicate": pred, "library": library})
 
             if lazyLibrary:
-                if cuCount: placeholderName += "_CU" + str(cuCount)
-                if dmmAccessFromHost is not None: placeholderName += "_DMM" + str(dmmAccessFromHost)
+                if cuCount:
+                    placeholderName += "_CU" + str(cuCount)
+                if isAPU is not None:
+                    placeholderName += "_APU" if isAPU == 1 else "_XPU"
                 placeholderName += "_" + str(devicePart)
 
             return newLib, placeholderName

--- a/Tensile/SolutionLibrary.py
+++ b/Tensile/SolutionLibrary.py
@@ -276,17 +276,19 @@ class MasterSolutionLibrary:
         def hardware(d, problemType, solutions, library, placeholderName):
             devicePart = d["ArchitectureName"]
             cuCount = d["CUCount"]
+            dmmAccessFromHost = d["DMMAccessFromHost"]
 
             newLib = PredicateLibrary(tag="Hardware")
             if devicePart == "fallback":
                 pred = Hardware.HardwarePredicate("TruePred")
             else:
-                pred = Hardware.HardwarePredicate.FromHardware(Common.gfxArch(devicePart), cuCount)
+                pred = Hardware.HardwarePredicate.FromHardware(Common.gfxArch(devicePart), cuCount, dmmAccessFromHost)
 
             newLib.rows.append({"predicate": pred, "library": library})
 
             if lazyLibrary:
                 if cuCount: placeholderName += "_CU" + str(cuCount)
+                if dmmAccessFromHost: placeholderName += "_DMM" + str(dmmAccessFromHost)
                 placeholderName += "_" + str(devicePart)
 
             return newLib, placeholderName

--- a/Tensile/Source/lib/include/Tensile/AMDGPU.hpp
+++ b/Tensile/Source/lib/include/Tensile/AMDGPU.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -190,8 +190,8 @@ namespace Tensile
         }
 
         AMDGPU();
-        AMDGPU(Processor p, int computeUnitCount, int dmmAccessFromHost, std::string const& deviceName);
-        AMDGPU(std::string const& archName, int computeUnitCount, int dmmAccessFromHost, std::string const& deviceName);
+        AMDGPU(Processor p, int computeUnitCount, int isAPU, std::string const& deviceName);
+        AMDGPU(std::string const& archName, int computeUnitCount, int isAPU, std::string const& deviceName);
 
         ~AMDGPU();
 
@@ -199,7 +199,7 @@ namespace Tensile
         int         wavefrontSize    = 64;
         int         simdPerCu        = 4;
         int         computeUnitCount = 0;
-        int         dmmAccessFromHost = 0;
+        int         isAPU            = 0;
         std::string deviceName;
 
         virtual bool   runsKernelTargeting(Processor p) const;

--- a/Tensile/Source/lib/include/Tensile/AMDGPU.hpp
+++ b/Tensile/Source/lib/include/Tensile/AMDGPU.hpp
@@ -191,7 +191,10 @@ namespace Tensile
 
         AMDGPU();
         AMDGPU(Processor p, int computeUnitCount, int isAPU, std::string const& deviceName);
-        AMDGPU(std::string const& archName, int computeUnitCount, int isAPU, std::string const& deviceName);
+        AMDGPU(std::string const& archName,
+               int                computeUnitCount,
+               int                isAPU,
+               std::string const& deviceName);
 
         ~AMDGPU();
 

--- a/Tensile/Source/lib/include/Tensile/AMDGPU.hpp
+++ b/Tensile/Source/lib/include/Tensile/AMDGPU.hpp
@@ -190,8 +190,8 @@ namespace Tensile
         }
 
         AMDGPU();
-        AMDGPU(Processor p, int computeUnitCount, std::string const& deviceName);
-        AMDGPU(std::string const& archName, int computeUnitCount, std::string const& deviceName);
+        AMDGPU(Processor p, int computeUnitCount, int dmmAccessFromHost, std::string const& deviceName);
+        AMDGPU(std::string const& archName, int computeUnitCount, int dmmAccessFromHost, std::string const& deviceName);
 
         ~AMDGPU();
 
@@ -199,6 +199,7 @@ namespace Tensile
         int         wavefrontSize    = 64;
         int         simdPerCu        = 4;
         int         computeUnitCount = 0;
+        int         dmmAccessFromHost = 0;
         std::string deviceName;
 
         virtual bool   runsKernelTargeting(Processor p) const;

--- a/Tensile/Source/lib/include/Tensile/AMDGPUPredicates.hpp
+++ b/Tensile/Source/lib/include/Tensile/AMDGPUPredicates.hpp
@@ -96,6 +96,32 @@ namespace Tensile
                 }
             };
 
+            struct DMMAccessFromHost : public Predicate_CRTP<DMMAccessFromHost, AMDGPU>
+            {
+                enum
+                {
+                    HasIndex = false,
+                    HasValue = true
+                };
+                int value;
+
+                DMMAccessFromHost() = default;
+                DMMAccessFromHost(int val)
+                    : value(val)
+                {
+                }
+
+                static std::string Type()
+                {
+                    return "DMMAccessFromHost";
+                }
+
+                virtual bool operator()(AMDGPU const& gpu) const
+                {
+                    return gpu.dmmAccessFromHost == value;
+                }
+            };
+
             struct RunsKernelTargeting : public Predicate_CRTP<RunsKernelTargeting, AMDGPU>
             {
                 enum

--- a/Tensile/Source/lib/include/Tensile/AMDGPUPredicates.hpp
+++ b/Tensile/Source/lib/include/Tensile/AMDGPUPredicates.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -96,7 +96,7 @@ namespace Tensile
                 }
             };
 
-            struct DMMAccessFromHost : public Predicate_CRTP<DMMAccessFromHost, AMDGPU>
+            struct IsAPU : public Predicate_CRTP<IsAPU, AMDGPU>
             {
                 enum
                 {
@@ -105,20 +105,20 @@ namespace Tensile
                 };
                 int value;
 
-                DMMAccessFromHost() = default;
-                DMMAccessFromHost(int val)
+                IsAPU() = default;
+                IsAPU(int val)
                     : value(val)
                 {
                 }
 
                 static std::string Type()
                 {
-                    return "DMMAccessFromHost";
+                    return "IsAPU";
                 }
 
                 virtual bool operator()(AMDGPU const& gpu) const
                 {
-                    return gpu.dmmAccessFromHost == value;
+                    return gpu.isAPU == value;
                 }
             };
 

--- a/Tensile/Source/lib/include/Tensile/Serialization/Predicates.hpp
+++ b/Tensile/Source/lib/include/Tensile/Serialization/Predicates.hpp
@@ -165,6 +165,7 @@ namespace Tensile
             {
                 SubclassMap rv({Base::template Pair<Predicates::GPU::ProcessorEqual>(),
                                 Base::template Pair<Predicates::GPU::CUCountEqual>(),
+                                Base::template Pair<Predicates::GPU::DMMAccessFromHost>(),
                                 Base::template Pair<Predicates::GPU::RunsKernelTargeting>()});
 
                 auto gmap = Generic::GetSubclasses();
@@ -190,6 +191,12 @@ namespace Tensile
         template <typename IO>
         struct MappingTraits<Predicates::GPU::CUCountEqual, IO>
             : public AutoMappingTraits<Predicates::GPU::CUCountEqual, IO>
+        {
+        };
+
+        template <typename IO>
+        struct MappingTraits<Predicates::GPU::DMMAccessFromHost, IO>
+            : public AutoMappingTraits<Predicates::GPU::DMMAccessFromHost, IO>
         {
         };
 

--- a/Tensile/Source/lib/include/Tensile/Serialization/Predicates.hpp
+++ b/Tensile/Source/lib/include/Tensile/Serialization/Predicates.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -165,7 +165,7 @@ namespace Tensile
             {
                 SubclassMap rv({Base::template Pair<Predicates::GPU::ProcessorEqual>(),
                                 Base::template Pair<Predicates::GPU::CUCountEqual>(),
-                                Base::template Pair<Predicates::GPU::DMMAccessFromHost>(),
+                                Base::template Pair<Predicates::GPU::IsAPU>(),
                                 Base::template Pair<Predicates::GPU::RunsKernelTargeting>()});
 
                 auto gmap = Generic::GetSubclasses();
@@ -195,8 +195,8 @@ namespace Tensile
         };
 
         template <typename IO>
-        struct MappingTraits<Predicates::GPU::DMMAccessFromHost, IO>
-            : public AutoMappingTraits<Predicates::GPU::DMMAccessFromHost, IO>
+        struct MappingTraits<Predicates::GPU::IsAPU, IO>
+            : public AutoMappingTraits<Predicates::GPU::IsAPU, IO>
         {
         };
 

--- a/Tensile/Source/lib/source/AMDGPU.cpp
+++ b/Tensile/Source/lib/source/AMDGPU.cpp
@@ -43,7 +43,8 @@ namespace Tensile
     {
     }
 
-    TENSILE_API AMDGPU::AMDGPU(std::string const& archName, int cus, int apu, std::string const& name)
+    TENSILE_API
+        AMDGPU::AMDGPU(std::string const& archName, int cus, int apu, std::string const& name)
         : processor(toProcessorId(archName))
         , computeUnitCount(cus)
         , isAPU(apu)

--- a/Tensile/Source/lib/source/AMDGPU.cpp
+++ b/Tensile/Source/lib/source/AMDGPU.cpp
@@ -44,7 +44,7 @@ namespace Tensile
     }
 
     TENSILE_API
-        AMDGPU::AMDGPU(std::string const& archName, int cus, int apu, std::string const& name)
+    AMDGPU::AMDGPU(std::string const& archName, int cus, int apu, std::string const& name)
         : processor(toProcessorId(archName))
         , computeUnitCount(cus)
         , isAPU(apu)

--- a/Tensile/Source/lib/source/AMDGPU.cpp
+++ b/Tensile/Source/lib/source/AMDGPU.cpp
@@ -35,16 +35,18 @@ namespace Tensile
 
     TENSILE_API AMDGPU::AMDGPU() {}
 
-    TENSILE_API AMDGPU::AMDGPU(AMDGPU::Processor p, int cus, std::string const& name)
+    TENSILE_API AMDGPU::AMDGPU(AMDGPU::Processor p, int cus, int dmm, std::string const& name)
         : processor(p)
         , computeUnitCount(cus)
+        , dmmAccessFromHost(dmm)
         , deviceName(name)
     {
     }
 
-    TENSILE_API AMDGPU::AMDGPU(std::string const& archName, int cus, std::string const& name)
+    TENSILE_API AMDGPU::AMDGPU(std::string const& archName, int cus, int dmm, std::string const& name)
         : processor(toProcessorId(archName))
         , computeUnitCount(cus)
+        , dmmAccessFromHost(dmm)
         , deviceName(name)
     {
     }

--- a/Tensile/Source/lib/source/AMDGPU.cpp
+++ b/Tensile/Source/lib/source/AMDGPU.cpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -35,18 +35,18 @@ namespace Tensile
 
     TENSILE_API AMDGPU::AMDGPU() {}
 
-    TENSILE_API AMDGPU::AMDGPU(AMDGPU::Processor p, int cus, int dmm, std::string const& name)
+    TENSILE_API AMDGPU::AMDGPU(AMDGPU::Processor p, int cus, int apu, std::string const& name)
         : processor(p)
         , computeUnitCount(cus)
-        , dmmAccessFromHost(dmm)
+        , isAPU(apu)
         , deviceName(name)
     {
     }
 
-    TENSILE_API AMDGPU::AMDGPU(std::string const& archName, int cus, int dmm, std::string const& name)
+    TENSILE_API AMDGPU::AMDGPU(std::string const& archName, int cus, int apu, std::string const& name)
         : processor(toProcessorId(archName))
         , computeUnitCount(cus)
-        , dmmAccessFromHost(dmm)
+        , isAPU(apu)
         , deviceName(name)
     {
     }

--- a/Tensile/Source/lib/source/hip/HipHardware.cpp
+++ b/Tensile/Source/lib/source/hip/HipHardware.cpp
@@ -34,7 +34,7 @@ namespace Tensile
     {
         HipAMDGPU::HipAMDGPU(hipDeviceProp_t const& prop)
             : AMDGPU(
-                std::string(prop.gcnArchName), prop.multiProcessorCount, std::string(prop.name))
+                std::string(prop.gcnArchName), prop.multiProcessorCount, prop.directManagedMemAccessFromHost, std::string(prop.name))
             , properties(prop)
         {
         }
@@ -62,6 +62,9 @@ namespace Tensile
             {
                 HIP_CHECK_EXC(hipDeviceGetAttribute(&prop.multiProcessorCount,
                                                     hipDeviceAttributePhysicalMultiProcessorCount,
+                                                    deviceId));
+                HIP_CHECK_EXC(hipDeviceGetAttribute(&prop.directManagedMemAccessFromHost,
+                                                    hipDeviceAttributeDirectManagedMemAccessFromHost,
                                                     deviceId));
             }
 #endif

--- a/Tensile/Source/lib/source/hip/HipHardware.cpp
+++ b/Tensile/Source/lib/source/hip/HipHardware.cpp
@@ -33,8 +33,10 @@ namespace Tensile
     namespace hip
     {
         HipAMDGPU::HipAMDGPU(hipDeviceProp_t const& prop)
-            : AMDGPU(
-                std::string(prop.gcnArchName), prop.multiProcessorCount, prop.directManagedMemAccessFromHost, std::string(prop.name))
+            : AMDGPU(std::string(prop.gcnArchName),
+                     prop.multiProcessorCount,
+                     prop.directManagedMemAccessFromHost,
+                     std::string(prop.name))
             , properties(prop)
         {
         }
@@ -63,9 +65,10 @@ namespace Tensile
                 HIP_CHECK_EXC(hipDeviceGetAttribute(&prop.multiProcessorCount,
                                                     hipDeviceAttributePhysicalMultiProcessorCount,
                                                     deviceId));
-                HIP_CHECK_EXC(hipDeviceGetAttribute(&prop.directManagedMemAccessFromHost,
-                                                    hipDeviceAttributeDirectManagedMemAccessFromHost,
-                                                    deviceId));
+                HIP_CHECK_EXC(
+                    hipDeviceGetAttribute(&prop.directManagedMemAccessFromHost,
+                                          hipDeviceAttributeDirectManagedMemAccessFromHost,
+                                          deviceId));
             }
 #endif
 

--- a/Tensile/Source/lib/source/ocl/OclHardware.cpp
+++ b/Tensile/Source/lib/source/ocl/OclHardware.cpp
@@ -38,6 +38,7 @@ namespace Tensile
         OclAMDGPU::OclAMDGPU(oclDeviceProp_t const& prop)
             : AMDGPU(static_cast<AMDGPU::Processor>(prop.gcnArch),
                      prop.multiProcessorCount,
+                     0, // hipDeviceAttributeDirectManagedMemAccessFromHost not accessible through OCL interface
                      std::string(prop.name))
             , properties(prop)
         {

--- a/Tensile/Source/lib/source/ocl/OclHardware.cpp
+++ b/Tensile/Source/lib/source/ocl/OclHardware.cpp
@@ -36,10 +36,11 @@ namespace Tensile
     namespace ocl
     {
         OclAMDGPU::OclAMDGPU(oclDeviceProp_t const& prop)
-            : AMDGPU(static_cast<AMDGPU::Processor>(prop.gcnArch),
-                     prop.multiProcessorCount,
-                     0, // hipDeviceAttributeDirectManagedMemAccessFromHost not accessible through OCL interface
-                     std::string(prop.name))
+            : AMDGPU(
+                static_cast<AMDGPU::Processor>(prop.gcnArch),
+                prop.multiProcessorCount,
+                0, // hipDeviceAttributeDirectManagedMemAccessFromHost not accessible through OCL interface
+                std::string(prop.name))
             , properties(prop)
         {
         }

--- a/Tensile/Tests/unit/test_HardwarePredicates.py
+++ b/Tensile/Tests/unit/test_HardwarePredicates.py
@@ -35,8 +35,9 @@ def test_hardware_predicate_comparison():
     c = HardwarePredicate("TruePred")
     d = HardwarePredicate.FromHardware((9,0,8), 60)
     e = HardwarePredicate.FromHardware((9,0,8), 64)
-    f = HardwarePredicate.FromHardware((9,4,2), dmmAccessFromHost=0)
-    g = HardwarePredicate.FromHardware((9,4,2), dmmAccessFromHost=1)
+    f = HardwarePredicate.FromHardware((9,4,2))
+    g = HardwarePredicate.FromHardware((9,4,2), dmmAccessFromHost=0)
+    h = HardwarePredicate.FromHardware((9,4,2), dmmAccessFromHost=1)
 
     assert a < b
     assert a < c
@@ -51,7 +52,20 @@ def test_hardware_predicate_comparison():
     assert e < c
     assert e < d
 
-    assert f < g
+    assert g < a
+    assert g < b
+    assert g < c
+    assert g < d
+    assert g < e
+    assert g < f
+
+    assert h < a
+    assert h < b
+    assert h < c
+    assert h < d
+    assert h < e
+    assert h < f
+    assert h < g
 
     assert not b < a
     assert not c < a
@@ -60,7 +74,8 @@ def test_hardware_predicate_comparison():
     assert not b < e
     assert not c < e
     assert not d < e
-    assert not g < f
+    assert not f < g
+    assert not g < h
 
     assert not a < a
     assert not b < b
@@ -69,12 +84,14 @@ def test_hardware_predicate_comparison():
     assert not e < e
     assert not f < f
     assert not g < g
+    assert not h < h
 
 def hardware_library_objects_order():
     objs = [PredicateLibrary('Hardware', [{'predicate': HardwarePredicate.FromISA((9,0,0))}]),
             PredicateLibrary('Hardware', [{'predicate': HardwarePredicate.FromISA((9,0,6))}]),
             PredicateLibrary('Hardware', [{'predicate': HardwarePredicate.FromISA((9,0,8))}]),
             PredicateLibrary('Hardware', [{'predicate': HardwarePredicate.FromISA((9,0,10))}]),
+            PredicateLibrary('Hardware', [{'predicate': HardwarePredicate.FromHardware((9,4,2))}]),
             PredicateLibrary('Hardware', [{'predicate': HardwarePredicate.FromHardware((9,0,8), 60)}]),
             PredicateLibrary('Hardware', [{'predicate': HardwarePredicate.FromHardware((9,0,8), 64)}]),
             PredicateLibrary('Hardware', [{'predicate': HardwarePredicate.FromHardware((9,4,2), dmmAccessFromHost=0)}]),
@@ -91,8 +108,13 @@ def test_hardware_library_merge_order(libraries):
         lib.merge(lib2)
 
     assert lib.rows[-1]['predicate'] == HardwarePredicate('TruePred')
-    assert lib.rows[0]['predicate'] == HardwarePredicate.FromHardware((9,0,8), 64)
-    assert lib.rows[1]['predicate'] == HardwarePredicate.FromHardware((9,0,8), 60)
+    # assert lib.rows[0]['predicate'] == HardwarePredicate.FromHardware((9,0,8), 64)
+    # assert lib.rows[1]['predicate'] == HardwarePredicate.FromHardware((9,0,8), 60)
+    assert lib.rows[0]['predicate'] == HardwarePredicate.FromHardware((9,4,2), dmmAccessFromHost=1)
+    assert lib.rows[1]['predicate'] == HardwarePredicate.FromHardware((9,4,2), dmmAccessFromHost=0)
+    assert lib.rows[2]['predicate'] == HardwarePredicate.FromHardware((9,0,8), 64)
+    assert lib.rows[3]['predicate'] == HardwarePredicate.FromHardware((9,0,8), 60)
+    assert lib.rows[4]['predicate'] == HardwarePredicate.FromHardware((9,4,2))
     for r in lib.rows[:-1]:
         assert r['predicate'] != HardwarePredicate('TruePred')
 

--- a/Tensile/Tests/unit/test_HardwarePredicates.py
+++ b/Tensile/Tests/unit/test_HardwarePredicates.py
@@ -35,6 +35,8 @@ def test_hardware_predicate_comparison():
     c = HardwarePredicate("TruePred")
     d = HardwarePredicate.FromHardware((9,0,8), 60)
     e = HardwarePredicate.FromHardware((9,0,8), 64)
+    f = HardwarePredicate.FromHardware((9,4,2), dmmAccessFromHost=0)
+    g = HardwarePredicate.FromHardware((9,4,2), dmmAccessFromHost=1)
 
     assert a < b
     assert a < c
@@ -49,6 +51,8 @@ def test_hardware_predicate_comparison():
     assert e < c
     assert e < d
 
+    assert f < g
+
     assert not b < a
     assert not c < a
     assert not c < b
@@ -56,12 +60,15 @@ def test_hardware_predicate_comparison():
     assert not b < e
     assert not c < e
     assert not d < e
+    assert not g < f
 
     assert not a < a
     assert not b < b
     assert not c < c
     assert not d < d
     assert not e < e
+    assert not f < f
+    assert not g < g
 
 def hardware_library_objects_order():
     objs = [PredicateLibrary('Hardware', [{'predicate': HardwarePredicate.FromISA((9,0,0))}]),
@@ -70,6 +77,8 @@ def hardware_library_objects_order():
             PredicateLibrary('Hardware', [{'predicate': HardwarePredicate.FromISA((9,0,10))}]),
             PredicateLibrary('Hardware', [{'predicate': HardwarePredicate.FromHardware((9,0,8), 60)}]),
             PredicateLibrary('Hardware', [{'predicate': HardwarePredicate.FromHardware((9,0,8), 64)}]),
+            PredicateLibrary('Hardware', [{'predicate': HardwarePredicate.FromHardware((9,4,2), dmmAccessFromHost=0)}]),
+            PredicateLibrary('Hardware', [{'predicate': HardwarePredicate.FromHardware((9,4,2), dmmAccessFromHost=1)}]),
             PredicateLibrary('Hardware', [{'predicate': HardwarePredicate('TruePred')}])
     ]
 

--- a/Tensile/Tests/unit/test_HardwarePredicates.py
+++ b/Tensile/Tests/unit/test_HardwarePredicates.py
@@ -1,6 +1,6 @@
 ################################################################################
 #
-# Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -36,8 +36,8 @@ def test_hardware_predicate_comparison():
     d = HardwarePredicate.FromHardware((9,0,8), 60)
     e = HardwarePredicate.FromHardware((9,0,8), 64)
     f = HardwarePredicate.FromHardware((9,4,2))
-    g = HardwarePredicate.FromHardware((9,4,2), dmmAccessFromHost=0)
-    h = HardwarePredicate.FromHardware((9,4,2), dmmAccessFromHost=1)
+    g = HardwarePredicate.FromHardware((9,4,2), isAPU=0)
+    h = HardwarePredicate.FromHardware((9,4,2), isAPU=1)
 
     assert a < b
     assert a < c
@@ -94,8 +94,8 @@ def hardware_library_objects_order():
             PredicateLibrary('Hardware', [{'predicate': HardwarePredicate.FromHardware((9,4,2))}]),
             PredicateLibrary('Hardware', [{'predicate': HardwarePredicate.FromHardware((9,0,8), 60)}]),
             PredicateLibrary('Hardware', [{'predicate': HardwarePredicate.FromHardware((9,0,8), 64)}]),
-            PredicateLibrary('Hardware', [{'predicate': HardwarePredicate.FromHardware((9,4,2), dmmAccessFromHost=0)}]),
-            PredicateLibrary('Hardware', [{'predicate': HardwarePredicate.FromHardware((9,4,2), dmmAccessFromHost=1)}]),
+            PredicateLibrary('Hardware', [{'predicate': HardwarePredicate.FromHardware((9,4,2), isAPU=0)}]),
+            PredicateLibrary('Hardware', [{'predicate': HardwarePredicate.FromHardware((9,4,2), isAPU=1)}]),
             PredicateLibrary('Hardware', [{'predicate': HardwarePredicate('TruePred')}])
     ]
 
@@ -110,8 +110,8 @@ def test_hardware_library_merge_order(libraries):
     assert lib.rows[-1]['predicate'] == HardwarePredicate('TruePred')
     # assert lib.rows[0]['predicate'] == HardwarePredicate.FromHardware((9,0,8), 64)
     # assert lib.rows[1]['predicate'] == HardwarePredicate.FromHardware((9,0,8), 60)
-    assert lib.rows[0]['predicate'] == HardwarePredicate.FromHardware((9,4,2), dmmAccessFromHost=1)
-    assert lib.rows[1]['predicate'] == HardwarePredicate.FromHardware((9,4,2), dmmAccessFromHost=0)
+    assert lib.rows[0]['predicate'] == HardwarePredicate.FromHardware((9,4,2), isAPU=1)
+    assert lib.rows[1]['predicate'] == HardwarePredicate.FromHardware((9,4,2), isAPU=0)
     assert lib.rows[2]['predicate'] == HardwarePredicate.FromHardware((9,0,8), 64)
     assert lib.rows[3]['predicate'] == HardwarePredicate.FromHardware((9,0,8), 60)
     assert lib.rows[4]['predicate'] == HardwarePredicate.FromHardware((9,4,2))

--- a/Tensile/Tests/unit/test_HardwarePredicates.py
+++ b/Tensile/Tests/unit/test_HardwarePredicates.py
@@ -91,11 +91,8 @@ def hardware_library_objects_order():
             PredicateLibrary('Hardware', [{'predicate': HardwarePredicate.FromISA((9,0,6))}]),
             PredicateLibrary('Hardware', [{'predicate': HardwarePredicate.FromISA((9,0,8))}]),
             PredicateLibrary('Hardware', [{'predicate': HardwarePredicate.FromISA((9,0,10))}]),
-            PredicateLibrary('Hardware', [{'predicate': HardwarePredicate.FromHardware((9,4,2))}]),
             PredicateLibrary('Hardware', [{'predicate': HardwarePredicate.FromHardware((9,0,8), 60)}]),
             PredicateLibrary('Hardware', [{'predicate': HardwarePredicate.FromHardware((9,0,8), 64)}]),
-            PredicateLibrary('Hardware', [{'predicate': HardwarePredicate.FromHardware((9,4,2), isAPU=0)}]),
-            PredicateLibrary('Hardware', [{'predicate': HardwarePredicate.FromHardware((9,4,2), isAPU=1)}]),
             PredicateLibrary('Hardware', [{'predicate': HardwarePredicate('TruePred')}])
     ]
 
@@ -108,13 +105,31 @@ def test_hardware_library_merge_order(libraries):
         lib.merge(lib2)
 
     assert lib.rows[-1]['predicate'] == HardwarePredicate('TruePred')
-    # assert lib.rows[0]['predicate'] == HardwarePredicate.FromHardware((9,0,8), 64)
-    # assert lib.rows[1]['predicate'] == HardwarePredicate.FromHardware((9,0,8), 60)
+    assert lib.rows[0]['predicate'] == HardwarePredicate.FromHardware((9,0,8), 64)
+    assert lib.rows[1]['predicate'] == HardwarePredicate.FromHardware((9,0,8), 60)
+    for r in lib.rows[:-1]:
+        assert r['predicate'] != HardwarePredicate('TruePred')
+
+def hardware_library_objects_order2():
+    objs = [PredicateLibrary('Hardware', [{'predicate': HardwarePredicate.FromISA((9,0,6))}]),
+            PredicateLibrary('Hardware', [{'predicate': HardwarePredicate.FromHardware((9,4,2))}]),
+            PredicateLibrary('Hardware', [{'predicate': HardwarePredicate.FromHardware((9,4,2), isAPU=0)}]),
+            PredicateLibrary('Hardware', [{'predicate': HardwarePredicate.FromHardware((9,4,2), isAPU=1)}]),
+            PredicateLibrary('Hardware', [{'predicate': HardwarePredicate('TruePred')}])
+    ]
+
+    return [copy.deepcopy(libs) for libs in itertools.permutations(objs)]
+
+@pytest.mark.parametrize("libraries", hardware_library_objects_order2())
+def test_hardware_library_merge_order2(libraries):
+    lib = libraries[0]
+    for lib2 in libraries[1:]:
+        lib.merge(lib2)
+
+    assert lib.rows[-1]['predicate'] == HardwarePredicate('TruePred')
     assert lib.rows[0]['predicate'] == HardwarePredicate.FromHardware((9,4,2), isAPU=1)
     assert lib.rows[1]['predicate'] == HardwarePredicate.FromHardware((9,4,2), isAPU=0)
-    assert lib.rows[2]['predicate'] == HardwarePredicate.FromHardware((9,0,8), 64)
-    assert lib.rows[3]['predicate'] == HardwarePredicate.FromHardware((9,0,8), 60)
-    assert lib.rows[4]['predicate'] == HardwarePredicate.FromHardware((9,4,2))
+    assert lib.rows[3]['predicate'] == HardwarePredicate.FromHardware((9,4,2))
     for r in lib.rows[:-1]:
         assert r['predicate'] != HardwarePredicate('TruePred')
 


### PR DESCRIPTION
Adds new predicate to identify APU libraries. Specialized libraries that set a value (0 or 1) have higher sort priority over general libraries that only specify architecture. Added some basic unit tests, and validated correct function using a sample library on hardware.