### PR TITLE
CI: limit compile to 16 threads

### DIFF
--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -63,8 +63,8 @@ def runCompileCommand(platform, project, jobName, boolean debug=false)
 
             export PATH=/opt/rocm/bin:\$PATH
             cmake -DCMAKE_BUILD_TYPE=${buildType} -DCMAKE_CXX_COMPILER=${compiler} -DTensile_ROOT=\$(pwd)/../Tensile ../HostLibraryTests
-            NPROC_BUILD=8
-            if [ `nproc` -lt 8 ]
+            NPROC_BUILD=16
+            if [ `nproc` -lt 16 ]
             then
               NPROC_BUILD=`nproc`
             fi

--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -63,7 +63,12 @@ def runCompileCommand(platform, project, jobName, boolean debug=false)
 
             export PATH=/opt/rocm/bin:\$PATH
             cmake -DCMAKE_BUILD_TYPE=${buildType} -DCMAKE_CXX_COMPILER=${compiler} -DTensile_ROOT=\$(pwd)/../Tensile ../HostLibraryTests
-            make -j\$(nproc)
+            NPROC_BUILD=8
+            if [ `nproc` -lt 8 ]
+            then
+              NPROC_BUILD=`nproc`
+            fi
+            make -j\$NPROC_BUILD
 
             popd
             """


### PR DESCRIPTION
Limit to 16 threads or the number of threads available to the executor, whichever is smaller