### PR TITLE
Mode to dynamically adjust number of CUs used

### DIFF
--- a/Tensile/Source/lib/include/Tensile/AMDGPU.hpp
+++ b/Tensile/Source/lib/include/Tensile/AMDGPU.hpp
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <Tensile/Tensile.hpp>
+#include <cstdlib>
 
 namespace Tensile
 {
@@ -203,6 +204,9 @@ namespace Tensile
         int         simdPerCu        = 4;
         int         computeUnitCount = 0;
         int         isAPU            = 0;
+        int         skDynamicGrid    = 0;
+        int         skMaxCUs         = 0;
+        int         skGridMultiplier = 1;
         std::string deviceName;
 
         virtual bool   runsKernelTargeting(Processor p) const;
@@ -217,6 +221,27 @@ namespace Tensile
         }
 
         virtual std::string description() const;
+
+        const int getSKDynamicGrid() const
+        {
+            static const char* envStr = std::getenv("TENSILE_STREAMK_DYNAMIC_GRID");
+            static const int value = (envStr == NULL ? 0 : (std::atoi(envStr) == 0 ? 0 : 1));
+            return value;
+        }
+
+        const int getSKMaxCUs() const
+        {
+            static const char* envStr = std::getenv("TENSILE_STREAMK_MAX_CUS");
+            static const int value = (envStr == NULL ? 0 : std::atoi(envStr));
+            return value;
+        }
+
+        const int getSKGridMultiplier() const
+        {
+            static const char* envStr = std::getenv("TENSILE_STREAMK_GRID_MULTIPLIER");
+            static const int value = (envStr == NULL ? 1 : std::atoi(envStr));
+            return value;
+        }
 
         bool operator==(AMDGPU const& rhs) const
         {

--- a/Tensile/Source/lib/include/Tensile/ContractionSolution.hpp
+++ b/Tensile/Source/lib/include/Tensile/ContractionSolution.hpp
@@ -202,6 +202,7 @@ namespace Tensile
         * Calculate required workspace size.
         */
         size_t       requiredWorkspaceSize(Problem const& problem, Hardware const& hardware) const;
+        size_t       getSKGrid(Hardware const& hardware, size_t tiles) const;
         size_t       partialTileSize(size_t skGrid) const;
         static float computeGranularity(float x);
 

--- a/Tensile/Source/lib/source/AMDGPU.cpp
+++ b/Tensile/Source/lib/source/AMDGPU.cpp
@@ -40,6 +40,9 @@ namespace Tensile
         , computeUnitCount(cus)
         , isAPU(apu)
         , deviceName(name)
+        , skDynamicGrid(getSKDynamicGrid())
+        , skMaxCUs(getSKMaxCUs())
+        , skGridMultiplier(getSKGridMultiplier())
     {
     }
 
@@ -49,6 +52,9 @@ namespace Tensile
         , computeUnitCount(cus)
         , isAPU(apu)
         , deviceName(name)
+        , skDynamicGrid(getSKDynamicGrid())
+        , skMaxCUs(getSKMaxCUs())
+        , skGridMultiplier(getSKGridMultiplier())
     {
     }
 

--- a/Tensile/Source/lib/source/ContractionSolution.cpp
+++ b/Tensile/Source/lib/source/ContractionSolution.cpp
@@ -38,8 +38,6 @@
 #include <iomanip>
 #include <regex>
 
-#define TENSILE_STREAMK_GRID 1
-
 namespace Tensile
 {
     PerfModel perf;
@@ -309,8 +307,6 @@ namespace Tensile
         rv.numWorkGroups.x = CeilDivide(rv.numWorkGroups.x, sizeMapping.macroTile.x);
         rv.numWorkGroups.y = CeilDivide(rv.numWorkGroups.y, sizeMapping.macroTile.y);
 
-        auto numTiles = rv.numWorkGroups;
-
         uint32_t problemNumGroupTiles0 = rv.numWorkGroups.x;
         uint32_t problemNumGroupTiles1 = rv.numWorkGroups.y;
         // used only when persistent kernel along batch
@@ -319,21 +315,21 @@ namespace Tensile
         rv.numWorkGroups.y *= sizeMapping.globalSplitU;
 
         size_t cuCount = 0;
+        size_t skGrid = 0;
+        auto tiles    = problem.getNumTiles(sizeMapping);
         if(sizeMapping.streamK != 0 || sizeMapping.persistentKernel != 0)
         {
             AMDGPU const* pAMDGPU = dynamic_cast<AMDGPU const*>(&hardware);
             assert(pAMDGPU != nullptr && pAMDGPU->computeUnitCount != 0);
             cuCount = pAMDGPU->computeUnitCount;
-        }
-
-        size_t skGrid = 0;
-        if(sizeMapping.streamK != 0)
-        {
-            skGrid             = cuCount * TENSILE_STREAMK_GRID;
-            rv.numWorkGroups.x = skGrid;
-            rv.numWorkGroups.y = 1;
-            if(sizeMapping.persistentKernelAlongBatch)
-                rv.numWorkGroups.z = 1;
+            if(sizeMapping.streamK != 0)
+            {
+                skGrid = getSKGrid(hardware, tiles);
+                rv.numWorkGroups.x = skGrid;
+                rv.numWorkGroups.y = 1;
+                if(sizeMapping.persistentKernelAlongBatch)
+                    rv.numWorkGroups.z = 1;
+            }
         }
 
         if(sizeMapping.persistentKernel != 0)
@@ -621,7 +617,6 @@ namespace Tensile
             if(sizeMapping.streamK != 0)
             {
                 auto     itersPerTile = problem.getItersPerTile(sizeMapping);
-                auto     tiles        = problem.getNumTiles(sizeMapping);
                 auto     totalIters   = tiles * itersPerTile;
                 uint32_t magicNumberItersPerTile;
                 uint32_t magicShiftItersPerTile;
@@ -638,15 +633,19 @@ namespace Tensile
                 }
                 else if(sizeMapping.streamK == 3) // Two-tile SK
                 {
-                    uint32_t numOutputTiles = tiles;
-                    bool     bigEnough      = numOutputTiles > skGrid;
+                    bool bigEnough = tiles > skGrid;
                     // skTiles is number of Stream-K tiles to complete
                     // Two-tile algorithm causes each WG to run an even number of Stream-K iterations,
-                    // followed by an even number of data-parllel tiles
-                    uint32_t skTiles
-                        = bigEnough ? skGrid + numOutputTiles % skGrid : numOutputTiles;
-                    // Number of data-parallel tiles on each workgroup would be:
-                    // dpTilesPerWG = bigEnough ? (numOutputTiles - skTiles) / skGrid : 0;
+                    // followed by an even number of data-parllel tiles.
+                    // If total tiles is evenly divisble by grid size,
+                    // then no Stream-K tiles are needed, all data-parallel
+                    uint32_t skTiles = skGrid;
+                    if (tiles % skGrid != 0)
+                    {
+                        // Number of data-parallel tiles on each workgroup would be:
+                        // dpTilesPerWG = bigEnough ? (tiles - skTiles) / skGrid : 0;
+                        skTiles = bigEnough ? skGrid + tiles % skGrid : tiles;
+                    }
 
                     uint32_t skItersPerWG = skTiles * itersPerTile / skGrid;
                     uint32_t skExtraIters = skTiles * itersPerTile % (skGrid);
@@ -718,10 +717,8 @@ namespace Tensile
         rv.workGroupSize.y = 1;
         rv.workGroupSize.z = 1;
 
-        AMDGPU const* pAMDGPU = dynamic_cast<AMDGPU const*>(&hardware);
-        assert(pAMDGPU != nullptr && pAMDGPU->computeUnitCount != 0);
-        size_t cuCount = pAMDGPU->computeUnitCount;
-        size_t skGrid  = cuCount * TENSILE_STREAMK_GRID;
+        auto tiles     = problem.getNumTiles(sizeMapping);
+        size_t skGrid  = getSKGrid(hardware, tiles);
         size_t wiZ     = 1;
         for(size_t i = 0; i < problem.batchIndices().size(); i++)
             wiZ *= problem.batchSize(i);
@@ -1507,10 +1504,8 @@ namespace Tensile
 
         if(sizeMapping.streamK >= 2)
         {
-            AMDGPU const* pAMDGPU = dynamic_cast<AMDGPU const*>(&hardware);
-            assert(pAMDGPU != nullptr && pAMDGPU->computeUnitCount != 0);
-            size_t cuCount = pAMDGPU->computeUnitCount;
-            size_t skGrid  = cuCount * TENSILE_STREAMK_GRID;
+            auto tiles     = problem.getNumTiles(sizeMapping);
+            size_t skGrid  = getSKGrid(hardware, tiles);
             // Get space required for partial tiles
             size += partialTileSize(skGrid);
             // Add space for flags
@@ -1522,6 +1517,21 @@ namespace Tensile
             size += problem.d().totalLogicalElements() * sizeMapping.workspaceSizePerElemC;
 
         return size;
+    }
+
+    size_t ContractionSolution::getSKGrid(Hardware const& hardware, size_t tiles) const
+    {
+        AMDGPU const* pAMDGPU = dynamic_cast<AMDGPU const*>(&hardware);
+        assert(pAMDGPU != nullptr && pAMDGPU->computeUnitCount != 0);
+        size_t cuCount = pAMDGPU->computeUnitCount;
+        size_t skGrid = cuCount;
+        if(pAMDGPU->skMaxCUs > 0)
+            skGrid = min(skGrid, pAMDGPU->skMaxCUs);
+        if(pAMDGPU->skDynamicGrid)
+            skGrid = min(skGrid, tiles);
+        if(pAMDGPU->skGridMultiplier > 1)
+            skGrid = skGrid * pAMDGPU->skGridMultiplier;
+        return skGrid;
     }
 
     size_t ContractionSolution::partialTileSize(size_t skGrid) const


### PR DESCRIPTION
This change adds 3 new environment variables to control the way stream-k kernels are run on the GPU.
TENSILE_STREAMK_DYNAMIC_GRID enables dynamic grid mode, which automatically limits the number of CUs used for small problems to a subset based on the number of output tiles. (Default mode is off)
TENSILE_STREAMK_MAX_CUS allows the user to manually set maximum number of CUs used, which could free up some CUs for other operations to run in parallel with gemm. (Default mode is use all CUs)
TENSILE_STREAMK_GRID_MULTIPLIER lets you set how many workgroups are created per CU being used. (Default is 1)

This change also includes an improvement for the two-tile algorithm that allows it to run in full data-parallel mode if the number of output tiles is evenly divided by the number of CUs.

Also includes a bit of code cleanup from previous changeset.