### PR TITLE
another vcpkg version package name fix

### DIFF
--- a/Tensile/Source/lib/CMakeLists.txt
+++ b/Tensile/Source/lib/CMakeLists.txt
@@ -98,7 +98,7 @@ if(TENSILE_USE_LLVM OR TENSILE_USE_MSGPACK)
 endif()
 
 if(TENSILE_USE_MSGPACK)
-    find_package(msgpack REQUIRED NAMES msgpack msgpack-c)
+    find_package(msgpack REQUIRED NAMES msgpack msgpack-cxx msgpack-c)
     target_compile_definitions(TensileHost PUBLIC -DTENSILE_MSGPACK=1)
 
     if(TARGET msgpackc-cxx)

--- a/Tensile/Source/lib/CMakeLists.txt
+++ b/Tensile/Source/lib/CMakeLists.txt
@@ -105,6 +105,8 @@ if(TENSILE_USE_MSGPACK)
         get_target_property(msgpack_inc msgpackc-cxx INTERFACE_INCLUDE_DIRECTORIES)
     elseif(TARGET msgpackc)
         get_target_property(msgpack_inc msgpackc INTERFACE_INCLUDE_DIRECTORIES)
+    elseif(TARGET msgpack-cxx)
+        get_target_property(msgpack_inc msgpack-cxx INTERFACE_INCLUDE_DIRECTORIES)
     endif()
 
     if(DEFINED msgpack_inc)


### PR DESCRIPTION
* For use windows with vcpkg 2023.10.19 msgpack with target msgpack-cxx 