### PR TITLE
Loosen check for CLI compiler choices

### DIFF
--- a/Tensile/Tensile.py
+++ b/Tensile/Tensile.py
@@ -132,7 +132,7 @@ def addCommonArguments(argParser):
         type=str,
         help="C++ compiler used when generating binaries."
         "On Linux, amdclang++ (default) or hipcc. On Windows clang++ (default) or hipcc. "
-        "On Windows, file extensions will be searched according to the PATHEXT environment variable. "
+        "On Windows, include the file extension, or extensions will be searched according to the PATHEXT environment variable. "
         "Pass a fully-qualified path to override environment inspection when searching for the compiler."
     )
     argParser.add_argument(

--- a/Tensile/Tensile.py
+++ b/Tensile/Tensile.py
@@ -131,9 +131,9 @@ def addCommonArguments(argParser):
         default=ToolchainDefaults.CXX_COMPILER,
         type=str,
         help="C++ compiler used when generating binaries."
-        "On linux, amdclang++ (default) or hipcc. On Windows clang++.exe (default) or hipcc. "
-        "Pass a fully-qualified path to override environment inspection when searching for the compiler. "
-        "If clang++.exe is specified, it must include the extension `.exe`.",
+        "On Linux, amdclang++ (default) or hipcc. On Windows clang++ (default) or hipcc. "
+        "On Windows, file extensions will be searched according to the PATHEXT environment variable. "
+        "Pass a fully-qualified path to override environment inspection when searching for the compiler."
     )
     argParser.add_argument(
         "--c-compiler",

--- a/Tensile/Tensile.py
+++ b/Tensile/Tensile.py
@@ -128,11 +128,12 @@ def addCommonArguments(argParser):
     argParser.add_argument(
         "--cxx-compiler",
         dest="CxxCompiler",
-        choices=[ToolchainDefaults.CXX_COMPILER, "hipcc"],
         default=ToolchainDefaults.CXX_COMPILER,
         type=str,
         help="C++ compiler used when generating binaries."
-        " On linux, amdclang++ (default) or hipcc. On Windows clang++ (default) or hipcc.",
+        "On linux, amdclang++ (default) or hipcc. On Windows clang++.exe (default) or hipcc. "
+        "Pass a fully-qualified path to override environment inspection when searching for the compiler. "
+        "If clang++.exe is specified, it must include the extension `.exe`.",
     )
     argParser.add_argument(
         "--c-compiler",

--- a/Tensile/TensileCreateLib/ParseArguments.py
+++ b/Tensile/TensileCreateLib/ParseArguments.py
@@ -80,7 +80,7 @@ def parseArguments(input: Optional[List[str]] = None) -> Dict[str, Any]:
         help="C++ compiler used when generating binaries."
         "On Linux, amdclang++ (default) or hipcc. On Windows clang++ (default) or hipcc. "
         "On Windows, file extensions will be searched according to the PATHEXT environment variable. "
-        "Pass a fully-qualified path to override environment inspection when searching for the compiler."
+        "Pass a fully-qualified path to override environment inspection when searching for the compiler.",
     )
     parser.add_argument(
         "--c-compiler",

--- a/Tensile/TensileCreateLib/ParseArguments.py
+++ b/Tensile/TensileCreateLib/ParseArguments.py
@@ -78,9 +78,9 @@ def parseArguments(input: Optional[List[str]] = None) -> Dict[str, Any]:
         default=ToolchainDefaults.CXX_COMPILER,
         type=str,
         help="C++ compiler used when generating binaries."
-        "On linux, amdclang++ (default) or hipcc. On Windows clang++.exe (default) or hipcc. "
-        "Pass a fully-qualified path to override environment inspection when searching for the compiler. "
-        "If clang++.exe is specified, it must include the extension `.exe`.",
+        "On Linux, amdclang++ (default) or hipcc. On Windows clang++ (default) or hipcc. "
+        "On Windows, file extensions will be searched according to the PATHEXT environment variable. "
+        "Pass a fully-qualified path to override environment inspection when searching for the compiler."
     )
     parser.add_argument(
         "--c-compiler",

--- a/Tensile/TensileCreateLib/ParseArguments.py
+++ b/Tensile/TensileCreateLib/ParseArguments.py
@@ -79,7 +79,7 @@ def parseArguments(input: Optional[List[str]] = None) -> Dict[str, Any]:
         type=str,
         help="C++ compiler used when generating binaries."
         "On Linux, amdclang++ (default) or hipcc. On Windows clang++ (default) or hipcc. "
-        "On Windows, file extensions will be searched according to the PATHEXT environment variable. "
+        "On Windows, include the file extension, or extensions will be searched according to the PATHEXT environment variable. "
         "Pass a fully-qualified path to override environment inspection when searching for the compiler.",
     )
     parser.add_argument(


### PR DESCRIPTION
Resolves #2112 

**Summary:**

Removes overly restrictive choices for `--cxx-compiler` when invoking Tensile.

**Outcomes:**

The user can pass fully qualified paths to Tensile. There is still a validation check that occurs during program initialization, but this validation is significantly less restrictive compared to setting choices directly in the argument parser.

