### PR TITLE
revert WIN32 breaking path change (#2131)

### DIFF
--- a/Tensile/cmake/TensileConfig.cmake
+++ b/Tensile/cmake/TensileConfig.cmake
@@ -219,12 +219,17 @@ function(TensileCreateLibraryFiles
   if (WIN32 OR (VIRTUALENV_BIN_DIR AND VIRTUALENV_PYTHON_EXENAME))
     set(CommandLine ${VIRTUALENV_BIN_DIR}/${VIRTUALENV_PYTHON_EXENAME} ${CommandLine})
   endif()
-  # Tensile relies on the tools from the path, so capture the configure time
-  # path. It would be better if this were explicit, but that would be a pretty
-  # big change.
-  set(CommandLine
-    "${CMAKE_COMMAND}" -E env "'PATH=$ENV{PATH}'" --
-    ${CommandLine})
+
+  if (NOT WIN32)
+    # This removed for windows as breaking rocBLAS compilation
+    #
+    # Tensile relies on the tools from the path, so capture the configure time
+    # path. It would be better if this were explicit, but that would be a pretty
+    # big change.
+    set(CommandLine
+      "${CMAKE_COMMAND}" -E env "'PATH=$ENV{PATH}'" --
+      ${CommandLine})
+  endif()
   message(STATUS "Tensile_CREATE_COMMAND: ${CommandLine}")
 
   if(Tensile_EMBED_LIBRARY)


### PR DESCRIPTION
(cherry picked from commit 22e594b9b9e3e710b7ed7f78ca7494429de98aed)

* fixes rocBLAS windows build unblocking all downstream  (build fix verified in https://github.com/ROCm/rocBLAS/pull/1613)
