### PR TITLE
Limit number of Tensile workers to 61 on Windows due to system limit.

### DIFF
--- a/Tensile/Parallel.py
+++ b/Tensile/Parallel.py
@@ -36,7 +36,10 @@ def CPUThreadCount(enable=True):
         return 1
     else:
         if os.name == "nt":
-            cpu_count = os.cpu_count()
+            # Windows supports at most 61 workers because the scheduler uses
+            # WaitForMultipleObjects directly, which has the limit (the limit
+            # is actually 64, but some handles are needed for accounting).
+            cpu_count = min(os.cpu_count(), 61)
         else:
             cpu_count = len(os.sched_getaffinity(0))
         cpuThreads = globalParameters["CpuThreads"]


### PR DESCRIPTION
**Summary:**

Windows supports at most 61 workers because the scheduler uses WaitForMultipleObjects directly, which has the limit (the limit is actually 64, but some handles are needed for accounting).

Ensure `cpu_count` is at most 61 to account for this.