### PR TITLE
[next-cmake] Update supported archs

### DIFF
--- a/next-cmake/CMakeLists.txt
+++ b/next-cmake/CMakeLists.txt
@@ -48,9 +48,10 @@ set_property(CACHE TENSILE_CXX_STANDARD PROPERTY STRINGS "14" "17" "20")
 set(GPU_TARGETS "" CACHE STRING "AMD GFX targets to cross-compile")
 
 if(NOT GPU_TARGETS OR GPU_TARGETS STREQUAL "all")
-    set(GPU_TARGETS "${SUPPORTED_ARCHITECTURES}")
+    tensile_get_base_architectures(GPU_TARGETS)
+else()
+    tensile_validate_gpu_targets("${GPU_TARGETS}")
 endif()
-tensile_validate_gpu_targets("${GPU_TARGETS}")
 message(STATUS "Building for GPU targets: ${GPU_TARGETS}")
 
 find_package(OpenMP REQUIRED)

--- a/next-cmake/cmake/TensileSupportedArchitectures.cmake
+++ b/next-cmake/cmake/TensileSupportedArchitectures.cmake
@@ -22,14 +22,13 @@
 #
 # ##############################################################################
 
-# Base architectures - used when "all" is specified
+# Base architectures - used when "all" is specified for GPU_TARGETS
 set(BASE_ARCHITECTURES "")
 
-# All supported architectures including xnack variants - used for validation
+# All supported architectures including xnack variants - used for validation of GPU_TARGETS
 set(SUPPORTED_ARCHITECTURES "")
 
 if(NOT BUILD_ADDRESS_SANITIZER)
-    # Base architectures (default when "all" is used)
     list(APPEND BASE_ARCHITECTURES 
         "gfx803"
         "gfx900"
@@ -50,7 +49,6 @@ if(NOT BUILD_ADDRESS_SANITIZER)
         "gfx1151"
         "gfx1200;gfx1201")
     
-    # Supported architectures include base + xnack variants
     set(SUPPORTED_ARCHITECTURES ${BASE_ARCHITECTURES})
     list(APPEND SUPPORTED_ARCHITECTURES 
         "gfx906:xnack+"

--- a/next-cmake/cmake/TensileSupportedArchitectures.cmake
+++ b/next-cmake/cmake/TensileSupportedArchitectures.cmake
@@ -22,24 +22,54 @@
 #
 # ##############################################################################
 
+# Base architectures - used when "all" is specified
+set(BASE_ARCHITECTURES "")
+
+# All supported architectures including xnack variants - used for validation
 set(SUPPORTED_ARCHITECTURES "")
 
 if(NOT BUILD_ADDRESS_SANITIZER)
-    list(APPEND SUPPORTED_ARCHITECTURES 
+    # Base architectures (default when "all" is used)
+    list(APPEND BASE_ARCHITECTURES 
         "gfx803"
-        "gfx900;gfx906;gfx908;gfx90a"
+        "gfx900"
+        "gfx906"
+        "gfx908"
+        "gfx90a"
         "gfx942"
         "gfx950"
-        "gfx1010;gfx1011;gfx1012"
-        "gfx1030;gfx1031;gfx1032;gfx1034;gfx1035"
-        "gfx1100;gfx1101;gfx1102"
+        "gfx1010"
+        "gfx1011"
+        "gfx1012"
+        "gfx1030"
+        "gfx1031"
+        "gfx1032"
+        "gfx1034"
+        "gfx1035"
+        "gfx1100"
         "gfx1151"
         "gfx1200;gfx1201")
-else()
+    
+    # Supported architectures include base + xnack variants
+    set(SUPPORTED_ARCHITECTURES ${BASE_ARCHITECTURES})
     list(APPEND SUPPORTED_ARCHITECTURES 
+        "gfx906:xnack+"
+        "gfx906:xnack-"
+        "gfx908:xnack+"
+        "gfx908:xnack-"
+        "gfx90a:xnack+"
+        "gfx90a:xnack-"
+        "gfx942:xnack+"
+        "gfx942:xnack-"
+        "gfx950:xnack+"
+        "gfx950:xnack-")
+else()
+    # For address sanitizer builds, base and supported are the same
+    list(APPEND BASE_ARCHITECTURES 
         "gfx908:xnack+;gfx90a:xnack+"
         "gfx942:xnack+"
         "gfx950:xnack+")
+    set(SUPPORTED_ARCHITECTURES ${BASE_ARCHITECTURES})
 endif()
 
 function(tensile_validate_gpu_targets targets)
@@ -58,5 +88,13 @@ function(tensile_validate_gpu_targets targets)
             message(FATAL_ERROR "Unsupported GPU target: ${target}\nSupported targets are: ${supported_list}")
         endif()
     endforeach()
+endfunction()
+
+function(tensile_get_base_architectures output_var)
+    set(${output_var} ${BASE_ARCHITECTURES} PARENT_SCOPE)
+endfunction()
+
+function(tensile_get_supported_architectures output_var)
+    set(${output_var} ${SUPPORTED_ARCHITECTURES} PARENT_SCOPE)
 endfunction()
 

--- a/next-cmake/cmake/TensileSupportedArchitectures.cmake
+++ b/next-cmake/cmake/TensileSupportedArchitectures.cmake
@@ -65,7 +65,8 @@ if(NOT BUILD_ADDRESS_SANITIZER)
 else()
     # For address sanitizer builds, base and supported are the same
     list(APPEND BASE_ARCHITECTURES 
-        "gfx908:xnack+;gfx90a:xnack+"
+        "gfx908:xnack+"
+        "gfx90a:xnack+"
         "gfx942:xnack+"
         "gfx950:xnack+")
     set(SUPPORTED_ARCHITECTURES ${BASE_ARCHITECTURES})

--- a/next-cmake/cmake/TensileSupportedArchitectures.cmake
+++ b/next-cmake/cmake/TensileSupportedArchitectures.cmake
@@ -47,7 +47,8 @@ if(NOT BUILD_ADDRESS_SANITIZER)
         "gfx1035"
         "gfx1100"
         "gfx1151"
-        "gfx1200;gfx1201")
+        "gfx1200"
+        "gfx1201")
     
     set(SUPPORTED_ARCHITECTURES ${BASE_ARCHITECTURES})
     list(APPEND SUPPORTED_ARCHITECTURES 


### PR DESCRIPTION
Allow `:xnack-` and `:xnack+` style variants when set on GPU_TARGETS.
