### PR TITLE
Re-apply Windows compatibility fixes to command construction.

### DIFF
--- a/Tensile/cmake/TensileConfig.cmake
+++ b/Tensile/cmake/TensileConfig.cmake
@@ -215,21 +215,24 @@ function(TensileCreateLibraryFiles
     set(Options ${Options} "--architecture=${archString}")
   endif()
 
+  # We do not need to do device enumeration at library build time.
+  set(Options ${Options} "--no-enumerate")
+
   set(CommandLine ${Script} ${Options} ${Tensile_LOGIC_PATH} ${Tensile_OUTPUT_PATH} HIP)
   if (WIN32 OR (VIRTUALENV_BIN_DIR AND VIRTUALENV_PYTHON_EXENAME))
     set(CommandLine ${VIRTUALENV_BIN_DIR}/${VIRTUALENV_PYTHON_EXENAME} ${CommandLine})
   endif()
-
-  if (NOT WIN32)
-    # This removed for windows as breaking rocBLAS compilation
-    #
-    # Tensile relies on the tools from the path, so capture the configure time
-    # path. It would be better if this were explicit, but that would be a pretty
-    # big change.
-    set(CommandLine
-      "${CMAKE_COMMAND}" -E env "'PATH=$ENV{PATH}'" --
-      ${CommandLine})
+  # Tensile relies on the tools from the path, so capture the configure time
+  # path. It would be better if this were explicit, but that would be a pretty
+  # big change.
+  set(ESC_PATH "$ENV{PATH}")
+  if(WIN32)
+    string(REPLACE ";" "$<SEMICOLON>" ESC_PATH "${ESC_PATH}")
   endif()
+  set(ENV_PATH_ARG "PATH=${ESC_PATH}")
+  set(CommandLine
+    "${CMAKE_COMMAND}" -E env "PATH=${ESC_PATH}" --
+    ${CommandLine})
   message(STATUS "Tensile_CREATE_COMMAND: ${CommandLine}")
 
   if(Tensile_EMBED_LIBRARY)
@@ -263,12 +266,17 @@ function(TensileCreateLibraryFiles
         OUTPUT "${Tensile_OUTPUT_PATH}/library"
         DEPENDS ${Tensile_LOGIC_PATH}
         COMMAND ${CommandLine}
-        COMMENT "Generating libraries with TensileCreateLibrary")
+        COMMENT "Generating libraries with TensileCreateLibrary"
+        # To normalize special command line char handling between platforms.
+        VERBATIM
+        # To see progress vs buffering when built with ninja.
+        USES_TERMINAL)
 
       add_custom_target(${Tensile_VAR_PREFIX}_LIBRARY_TARGET
          DEPENDS "${Tensile_OUTPUT_PATH}/library"
          COMMAND ${CommandLine} "--verify-manifest"
-         COMMENT "Verifying files in ${Tensile_MANIFEST_FILE_PATH} were generated")
+         COMMENT "Verifying files in ${Tensile_MANIFEST_FILE_PATH} were generated"
+         VERBATIM)
   endif()
 
   if(Tensile_EMBED_LIBRARY)
@@ -284,7 +292,8 @@ function(TensileCreateLibraryFiles
           COMMAND ${CMAKE_COMMAND} -E copy
                   ${Tensile_EMBED_LIBRARY_SOURCE}
                   "${Tensile_OUTPUT_PATH}/library"
-          DEPENDS ${Tensile_EMBED_LIBRARY_SOURCE})
+          DEPENDS ${Tensile_EMBED_LIBRARY_SOURCE}
+          VERBATIM)
   endif()
 
 endfunction()


### PR DESCRIPTION
The original patch
https://github.com/ROCm/TheRock/blob/6e1bd9b82a581487712f95ef86c0ba27c77faec9/patches/amd-mainline/Tensile/0002-Capture-configure-time-PATH-when-invoking-tensile-at.patch was only partly merged into upstream with commit 204b9a4. As a result it broke Windows and got partly reverted with commit 22e594b. This re-applies to patch to fix building Tensile with TheRock, both Linux and Windows.